### PR TITLE
Changed makefile and dp_ram.sv files to compile with xcelium

### DIFF
--- a/cv32/tb/core/dp_ram.sv
+++ b/cv32/tb/core/dp_ram.sv
@@ -73,7 +73,7 @@ module dp_ram
         read_byte = mem[byte_addr];
     endfunction
 
-    task write_byte(input integer byte_addr, logic [7:0] val, output logic [7:0] other);
+    task write_byte(input logic [ADDR_WIDTH-1:0] byte_addr, logic [7:0] val, output logic [7:0] other);
         mem[byte_addr] = val;
         other          = mem[byte_addr];
 

--- a/cv32/tests/core/Makefile
+++ b/cv32/tests/core/Makefile
@@ -85,8 +85,8 @@ RTLSRC_VERI_TB          := $(filter-out tb_top.sv, $(wildcard *.sv))
 RTLSRC_HOME             := ../../../rtl
 RTLSRC_INCDIR           := $(RTLSRC_HOME)/include
 RTLSRC_PKG		:= $(addprefix $(RTLSRC_HOME)/include/,\
-				apu_core_package.sv riscv_defines.sv \
-				riscv_tracer_defines.sv fpnew_pkg.sv)
+				apu_core_package.sv fpnew_pkg.sv \
+				riscv_defines.sv riscv_tracer_defines.sv)
 RTLSRC			:= $(filter-out $(RTLSRC_HOME)/riscv_register_file_latch.sv,\
 				$(wildcard $(RTLSRC_HOME)/*.sv))
 


### PR DESCRIPTION
Modified cv32/tb/core/dp_ram.sv and cv32/tests/core/Makefile to be able to compile with xcelium and run simulations.
