### PR TITLE
Parameter and pinout cleanup: take2

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -54,11 +54,13 @@
 #CV32E40P_HASH   ?= tbd
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= 9cdf35c8c460a933496b84c5b51f88652981fd5d
+CV32E40P_HASH   ?= 74262e8f1fde682c2db71e6ad7e7ed143b6409a0
+#OLDCV32E40P_HASH   ?= 9cdf35c8c460a933496b84c5b51f88652981fd5d
 
 FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
 FPNEW_BRANCH    ?= master
-FPNEW_HASH      ?= da5fd4f0140c45f652c4a82a193f017484e3c72e
+FPNEW_HASH      ?= c15c54887b3bc6d0965606c487e9f1bf43237e45
+#OLDFPNEW_HASH      ?= da5fd4f0140c45f652c4a82a193f017484e3c72e
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master

--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -23,7 +23,7 @@
 
 XRUN              = xrun
 XRUN_UVMHOME_ARG ?= CDNS-1.2-ML
-XRUN_FLAGS       ?= -64bit -access +rwc -q -clean -sv -uvm -uvmhome $(XRUN_UVMHOME_ARG) $(TIMESCALE) $(SV_CMP_FLAGS)
+XRUN_FLAGS       ?= -64bit -disable_sem2009 -access +rwc -q -clean -sv -uvm -uvmhome $(XRUN_UVMHOME_ARG) $(TIMESCALE) $(SV_CMP_FLAGS)
 XRUN_DIR         ?= xcelium.d
 
 no_rule:

--- a/cv32/tb/core/mm_ram.sv
+++ b/cv32/tb/core/mm_ram.sv
@@ -16,9 +16,13 @@
 // processor core and some pseudo peripherals
 
 module mm_ram
-    #(parameter RAM_ADDR_WIDTH = 16,
-      parameter INSTR_RDATA_WIDTH = 128)
-    (input logic                          clk_i,
+ #(
+     parameter RAM_ADDR_WIDTH    =  16,
+               INSTR_RDATA_WIDTH = 128, // width of read_data on instruction bus
+               DATA_RDATA_WIDTH  =  32  // width of read_data on data bus
+  )
+  (
+     input logic                          clk_i,
      input logic                          rst_ni,
 
      input logic                          instr_req_i,
@@ -566,7 +570,10 @@ module mm_ram
 
 `ifndef VERILATOR
   riscv_random_stall
-  #(.DATA_WIDTH(INSTR_RDATA_WIDTH))
+  #(
+    .DATA_WIDTH     (INSTR_RDATA_WIDTH),
+    .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH   )
+   )
   instr_random_stalls
   (
     .clk_i              ( clk_i                  ),
@@ -602,7 +609,10 @@ module mm_ram
     );
 
   riscv_random_stall
-  #(.DATA_WIDTH(32))
+  #(
+    .DATA_WIDTH     (DATA_RDATA_WIDTH),
+    .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH  )
+   )
   data_random_stalls
   (
     .clk_i              ( clk_i                  ),

--- a/cv32/tb/core/mm_ram.sv
+++ b/cv32/tb/core/mm_ram.sv
@@ -296,7 +296,7 @@ module mm_ram
       || data_addr_i == 32'h2000_000c
       || data_addr_i == 32'h2000_0010
       || data_addr_i[31:16] == 16'h1600))
-        else $fatal("out of bounds write to %08x with %08x",
+        else $fatal(1, "out of bounds write to %08x with %08x",
                     data_addr_i, data_wdata_i);
 `endif
 

--- a/cv32/tb/tb_riscv/riscv_random_stall.sv
+++ b/cv32/tb/tb_riscv/riscv_random_stall.sv
@@ -28,10 +28,11 @@ import perturbation_defines::*;
 
 module riscv_random_stall
 
-#(
-    parameter MAX_STALL_N = 1,
-    parameter DATA_WIDTH  = 32
-)
+ #(
+    parameter MAX_STALL_N    = 1,
+              RAM_ADDR_WIDTH = 32,
+              DATA_WIDTH     = 32
+  )
 
 (
     input logic                             clk_i,
@@ -48,8 +49,8 @@ module riscv_random_stall
     input logic                             req_core_i,
     output logic                            req_mem_o,
 
-    input logic [31:0]                      addr_core_i,
-    output logic [31:0]                     addr_mem_o,
+    input logic  [RAM_ADDR_WIDTH-1:0]       addr_core_i,
+    output logic [RAM_ADDR_WIDTH-1:0]       addr_mem_o,
 
     input logic [DATA_WIDTH-1:0]            wdata_core_i,
     output logic [DATA_WIDTH-1:0]           wdata_mem_o,
@@ -89,30 +90,33 @@ mailbox #(stall_mem_t) core_resps         = new (4);
 mailbox #(logic)       core_resps_granted = new (4);
 mailbox #(stall_mem_t) memory_transfers   = new (4);
 
- always_latch
- begin
-   if (req_core_i)
-       req_per_q    <= 1'b1;
-   else
-       req_per_q    <= 1'b0;
+ always_comb begin
+   if (req_core_i) begin
+     req_per_q <= 1'b1;
+   end
+   else begin
+     req_per_q <= 1'b0;
+   end
  end
 
- always_latch
- begin
-   if (rvalid_mem_i)
-       rvalid_per_q    <= 1'b1;
-   else
-       rvalid_per_q    <= 1'b0;
+ always_comb begin
+   if (rvalid_mem_i) begin
+     rvalid_per_q <= 1'b1;
+   end
+   else begin
+     rvalid_per_q <= 1'b0;
+   end
  end
 
 
-always_latch
- begin
-   if (grant_mem_i)
-       grant_per_q    <= 1'b1;
-   else
-       grant_per_q    <= 1'b0;
- end
+ always_comb begin
+   if (grant_mem_i) begin
+     grant_per_q <= 1'b1;
+   end
+   else begin
+     grant_per_q <= 1'b0;
+   end
+  end
 
 
 

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
@@ -38,12 +38,36 @@
 /**
  * Module wrapper for CV32 RTL DUT.
  */
-module uvmt_cv32_dut_wrap #(parameter INSTR_RDATA_WIDTH =  128,
-                                      RAM_ADDR_WIDTH    =   20,
-                                      PULP_SECURE       =    1
+module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
+                            // https://github.com/openhwgroup/core-v-docs/blob/master/cores/cv32e40p/CV32E40P_and%20CV32E40_Features_Parameters.pdf
+                            parameter N_EXT_PERF_COUNTERS =   1, // TODO: this is 0 in riscv_core, which is wrong
+                                      INSTR_RDATA_WIDTH   = 128,
+                                      PULP_SECURE         =   0,
+                                      N_PMP_ENTRIES       =  16,
+                                      USE_PMP             =   1, //if PULP_SECURE is 1, you can still not use the PMP
+                                      PULP_CLUSTER        =   1,
+                                      A_EXTENSION         =   0,
+                                      FPU                 =   0,
+                                      Zfinx               =   0,
+                                      FP_DIVSQRT          =   1,
+                                      SHARED_FP           =   0,
+                                      SHARED_DSP_MULT     =   0,
+                                      SHARED_INT_MULT     =   0,
+                                      SHARED_INT_DIV      =   0,
+                                      SHARED_FP_DIVSQRT   =   0,
+                                      WAPUTYPE            =   0,
+                                      APU_NARGS_CPU       =   3,
+                                      APU_WOP_CPU         =   6,
+                                      APU_NDSFLAGS_CPU    =  15,
+                                      APU_NUSFLAGS_CPU    =   5,
+                                      DM_HaltAddress      =  32'h1A110800,
+                            // Remaining parameters are used by TB components only
+                                      INSTR_ADDR_WIDTH    =  32,
+                                      RAM_ADDR_WIDTH      =  20
                            )
+
                            (
-			    uvma_clknrst_if              clknrst_if,
+                            uvma_clknrst_if              clknrst_if,
                             uvmt_cv32_vp_status_if       vp_status_if,
                             uvmt_cv32_core_cntrl_if      core_cntrl_if,
                             uvmt_cv32_core_status_if     core_status_if,
@@ -56,7 +80,7 @@ module uvmt_cv32_dut_wrap #(parameter INSTR_RDATA_WIDTH =  128,
     logic                         instr_req;
     logic                         instr_gnt;
     logic                         instr_rvalid;
-    logic [31:0]                  instr_addr;
+    logic [INSTR_ADDR_WIDTH-1 :0] instr_addr;
     logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
 
     logic                         data_req;
@@ -68,6 +92,8 @@ module uvmt_cv32_dut_wrap #(parameter INSTR_RDATA_WIDTH =  128,
     logic [31:0]                  data_rdata;
     logic [31:0]                  data_wdata;
 
+    logic [ 4:0]                  irq_id_out;
+    logic [ 4:0]                  irq_id_in;
 
     // Load the Instruction Memory 
     initial begin: load_instruction_memory
@@ -100,9 +126,28 @@ module uvmt_cv32_dut_wrap #(parameter INSTR_RDATA_WIDTH =  128,
     end
 
     // instantiate the core
-    riscv_core #(.INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-                 .PULP_SECURE       (PULP_SECURE),
-                 .FPU               (0)
+    riscv_core #(
+                 .N_EXT_PERF_COUNTERS    (N_EXT_PERF_COUNTERS),
+                 .INSTR_RDATA_WIDTH      (INSTR_RDATA_WIDTH),
+                 .PULP_SECURE            (PULP_SECURE),
+                 .N_PMP_ENTRIES          (N_PMP_ENTRIES),
+                 .USE_PMP                (USE_PMP),
+                 .PULP_CLUSTER           (PULP_CLUSTER),
+                 .A_EXTENSION            (A_EXTENSION),
+                 .FPU                    (FPU),
+                 .Zfinx                  (Zfinx),
+                 .FP_DIVSQRT             (FP_DIVSQRT),
+                 .SHARED_FP              (SHARED_FP),
+                 .SHARED_DSP_MULT        (SHARED_DSP_MULT),
+                 .SHARED_INT_MULT        (SHARED_INT_MULT),
+                 .SHARED_INT_DIV         (SHARED_INT_DIV),
+                 .SHARED_FP_DIVSQRT      (SHARED_FP_DIVSQRT),
+                 .WAPUTYPE               (WAPUTYPE),
+                 .APU_NARGS_CPU          (APU_NARGS_CPU),
+                 .APU_WOP_CPU            (APU_WOP_CPU),
+                 .APU_NDSFLAGS_CPU       (APU_NDSFLAGS_CPU),
+                 .APU_NUSFLAGS_CPU       (APU_NUSFLAGS_CPU),
+                 .DM_HaltAddress         (DM_HaltAddress)
                 )
     riscv_core_i
         (

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -79,7 +79,7 @@ module uvmt_cv32_tb;
      uvm_config_db#(bit[31:0])::set(.cntxt(null), .inst_name("*"), .field_name("evalue"), .value(32'h00000000));
       
      // Run test
-     uvm_top.enable_print_topology = 1;
+     uvm_top.enable_print_topology = 0; // ENV coders enable this as a debug aid
      uvm_top.finish_on_completion  = 1;
      uvm_top.run_test();
    end : test_bench_entry_point

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -98,19 +98,19 @@ endinterface : uvmt_cv32_vp_status_if
  * Quasi-static core control signals.
  */
 interface uvmt_cv32_core_cntrl_if (
-                                    output logic       fetch_en,
-                                    output logic       fregfile_disable,
-                                    output logic       ext_perf_counters,
+                                    output logic        fetch_en,
+                                    output logic        fregfile_disable,
+                                    output logic        ext_perf_counters,
                                     // quasi static values
-                                    output logic       clock_en,
-                                    output logic       test_en,
+                                    output logic        clock_en,
+                                    output logic        test_en,
                                     output logic [31:0] boot_addr,
-                                    output logic [3:0] core_id,
-                                    output logic [5:0] cluster_id,
+                                    output logic [ 3:0] core_id,
+                                    output logic [ 5:0] cluster_id,
                                     // To be driven by future debug module (DM)
-                                    output logic       debug_req,
+                                    output logic        debug_req,
                                     // Testcase asserts this to load memory (not really a core control signal)
-                                    output logic       load_instr_mem
+                                    output logic        load_instr_mem
                                   );
 
   import uvm_pkg::*;
@@ -149,17 +149,23 @@ endinterface : uvmt_cv32_core_cntrl_if
 /**
  * Core interrupts
  */
-interface uvmt_cv32_core_interrupts_if (
-                                    input  logic        irq_ack,        // dut output
-                                    input  logic        irq_id,         // dut output
-                                    output logic        irq_sec,        // dut input
-                                    output logic        irq_software,   // dut input
-                                    output logic        irq_timer,      // dut input
-                                    output logic        irq_external,   // dut input
-                                    output logic [14:0] irq_fast,       // dut input
-                                    output logic        irq_nmi,        // dut input
-                                    output logic [31:0] irq_fastx       // dut input
-                                   );
+interface uvmt_cv32_core_interrupts_if
+ #(
+   parameter NUM_FAST_INTR   = 15, //TODO: pass these in from the TB/DUT_WRAP
+             NUM_XFASTX_INTR = 32  // _XFASTX_ deliberately choosen to make it visually distinct from _FAST_
+  )
+  (
+   input  logic                       irq_ack,        // dut output
+   input  logic                       irq_id,         // dut output
+   output logic                       irq_sec,        // dut input
+   output logic                       irq_software,   // dut input
+   output logic                       irq_timer,      // dut input
+   output logic                       irq_external,   // dut input
+   output logic [NUM_FAST_INTR-1:0]   irq_fast,       // dut input
+   output logic                       irq_nmi,        // dut input
+   output logic [NUM_XFASTX_INTR-1:0] irq_fastx       // dut input
+  );
+
   import uvm_pkg::*;
 
   initial begin
@@ -167,9 +173,9 @@ interface uvmt_cv32_core_interrupts_if (
     irq_software = 1'b0;
     irq_timer    = 1'b0;
     irq_external = 1'b0;
-    irq_fast     = {14{1'b0}};
+    irq_fast     = {NUM_FAST_INTR{1'b0}};
     irq_nmi      = 1'b0;
-    irq_fastx    = {32{1'b0}};
+    irq_fastx    = {NUM_XFASTX_INTR{1'b0}};
     `uvm_info("CORE_INTERRUPT_IF", "Interrupt inputs to CORE all tied low (for now).", UVM_NONE)
   end
 

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -156,7 +156,7 @@ interface uvmt_cv32_core_interrupts_if (
                                     output logic        irq_software,   // dut input
                                     output logic        irq_timer,      // dut input
                                     output logic        irq_external,   // dut input
-                                    output logic [15:0] irq_fast,       // dut input
+                                    output logic [14:0] irq_fast,       // dut input
                                     output logic        irq_nmi,        // dut input
                                     output logic [31:0] irq_fastx       // dut input
                                    );
@@ -167,7 +167,7 @@ interface uvmt_cv32_core_interrupts_if (
     irq_software = 1'b0;
     irq_timer    = 1'b0;
     irq_external = 1'b0;
-    irq_fast     = {15{1'b0}};
+    irq_fast     = {14{1'b0}};
     irq_nmi      = 1'b0;
     irq_fastx    = {32{1'b0}};
     `uvm_info("CORE_INTERRUPT_IF", "Interrupt inputs to CORE all tied low (for now).", UVM_NONE)


### PR DESCRIPTION
Hi Arjan.  This is directly related to #277.  I believe it addresses all you issues in that pull-request, plus a few other items I've been meaning to clean up.  It also updates the CV32E40P_HASH and FPNEW_HASH variables to point to the latest RTL (which Davide has indicated is good ready for verif to use).

If you approve this PR I will kill #277.