### PR TITLE
Fix to assign enum to string

### DIFF
--- a/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
@@ -137,7 +137,10 @@ function string uvml_logs_rs_json_c::compose_report_message(uvm_report_message r
    string severity_str;
    string verbosity_str;
    
-   severity_str  = report_message.get_severity();
+   uvm_severity temp_sev;
+
+   temp_sev = report_message.get_severity();
+   severity_str  = temp_sev.name();
    verbosity_str = convert_verbosity_to_string(report_message.get_verbosity());
    
    final_msg_str = {"{",


### PR DESCRIPTION
Hey!
This pull request is for assign enum to string. Correct way to do this is to use method name():
`The name() method returns the string representation of the given enumeration value. If the given value is not a member of the enumeration, the name() method returns the empty string`