### PR TITLE
Update RISC-V compliance testsuite #46

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cv32/tests/core/riscv-compliance"]
+	path = cv32/tests/core/riscv-compliance
+	url = https://github.com/riscv/riscv-compliance


### PR DESCRIPTION
Updated compliance testsuite installed to cv32/tests/riscv-compliance as a git submodule
Warning: previous version of the compliance test suite _riscv_compliance_tests_ and firmware _cv32_riscv_compliance_tests_firmware_ will have to be removed after validation of the task 

Successful compile and regression of the compliance suite in the uvmt_cv32 validated with Questa
- please type 'make help' for a description of the commands to use to launch the tests
- a Makefile target '%.${SIMULATOR}-run' is required to launch the tests (e.g. make SIMULATOR=vsim /path/to/my/program.vsim-run will run the program '/path/to/my/program' using Questa). This target has been added in the file 'vsim.mk' for Questa. It has to be defined for others simulators.

4 test fails: I-ECALL-01, I-EBREAK-01, I-MISALIGN_JMP-01, I-MISALIGN_LDST-01
- the tests I-MISALIGN_JMP-01, I-MISALIGN_LDST-01 were already disabled in the previous version of the compliance tests
- the tests I-ECALL-01, I-EBREAK-01 fail when they are compiled for the rv32i architecture, but pass when compiled for the rv32imc architecture

Compilation of the UVM library in the Makefile for Questa has been removed to use UVM built-in library of Questa
-> it was not required by the task, so the merge of this part is optional