### PR TITLE
Update to latest RTL (744e507)

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -55,7 +55,7 @@
 #CV32E40P_HASH   ?= head
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= 62073bb3c8c5073203b16a24df9f6cef8958cba6 
+CV32E40P_HASH   ?= 744e507907cb9af832a9573314e16f55ef4264b9
 
 FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
 FPNEW_BRANCH    ?= master

--- a/cv32/tb/core/tb_top.sv
+++ b/cv32/tb/core/tb_top.sv
@@ -14,7 +14,7 @@
 //              Jeremy Bennett <jeremy.bennett@embecosm.com>
 
 module tb_top
-    #(parameter INSTR_RDATA_WIDTH = 128,
+    #(parameter INSTR_RDATA_WIDTH = 32,
       parameter RAM_ADDR_WIDTH = 22,
       parameter BOOT_ADDR  = 'h80);
 
@@ -139,19 +139,21 @@ module tb_top
 
     // wrapper for riscv, the memory system and stdout peripheral
     riscv_wrapper
-        #(.INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-          .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
-          .BOOT_ADDR (BOOT_ADDR),
-          .PULP_SECURE (1))
-
+        #(
+          .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
+          .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
+          .BOOT_ADDR         (BOOT_ADDR)
+         )
     riscv_wrapper_i
-        (.clk_i          ( clk          ),
+        (
+         .clk_i          ( clk          ),
          .rst_ni         ( rst_n        ),
          .fetch_enable_i ( fetch_enable ),
          .tests_passed_o ( tests_passed ),
          .tests_failed_o ( tests_failed ),
          .exit_valid_o   ( exit_valid   ),
-         .exit_value_o   ( exit_value   ));
+         .exit_value_o   ( exit_value   )
+        );
 
 `ifndef VERILATOR
     initial begin

--- a/cv32/tb/core/tb_top_verilator.sv
+++ b/cv32/tb/core/tb_top_verilator.sv
@@ -87,11 +87,13 @@ module tb_top_verilator
     // wrapper for riscv, the memory system and stdout peripheral
     riscv_wrapper
         #(.INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
-          .RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
-          .BOOT_ADDR (BOOT_ADDR),
-          .PULP_SECURE (1)) // need to enable -Wno-BLKANDNBLK to silence warnin
-                            // about assignment from blk to non-blk
-
+          .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
+          .BOOT_ADDR         (BOOT_ADDR),
+          .PULP_CLUSTER      (0),
+          .FPU               (0),
+          .PULP_ZFINX        (0),
+          .DM_HALTADDRESS    (32'h1A110800)
+         )
     riscv_wrapper_i
         (.clk_i          ( clk_i          ),
          .rst_ni         ( rst_ni         ),

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
@@ -40,29 +40,13 @@
  */
 module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
                             // https://github.com/openhwgroup/core-v-docs/blob/master/cores/cv32e40p/CV32E40P_and%20CV32E40_Features_Parameters.pdf
-                            parameter N_EXT_PERF_COUNTERS =   1, // TODO: this is 0 in riscv_core, which is wrong
-                                      INSTR_RDATA_WIDTH   =  32,
-                                      PULP_SECURE         =   0,
-                                      N_PMP_ENTRIES       =  16,
-                                      USE_PMP             =   1, //if PULP_SECURE is 1, you can still not use the PMP
-                                      PULP_CLUSTER        =   1,
-                                      A_EXTENSION         =   0,
+                            parameter PULP_CLUSTER        =   0, //changed
                                       FPU                 =   0,
-                                      Zfinx               =   0,
-                                      FP_DIVSQRT          =   1,
-                                      SHARED_FP           =   0,
-                                      SHARED_DSP_MULT     =   0,
-                                      SHARED_INT_MULT     =   0,
-                                      SHARED_INT_DIV      =   0,
-                                      SHARED_FP_DIVSQRT   =   0,
-                                      WAPUTYPE            =   0,
-                                      APU_NARGS_CPU       =   3,
-                                      APU_WOP_CPU         =   6,
-                                      APU_NDSFLAGS_CPU    =  15,
-                                      APU_NUSFLAGS_CPU    =   5,
-                                      DM_HaltAddress      =  32'h1A110800,
+                                      PULP_ZFINX          =   0,
+                                      DM_HALTADDRESS      =  32'h1A110800,
                             // Remaining parameters are used by TB components only
                                       INSTR_ADDR_WIDTH    =  32,
+                                      INSTR_RDATA_WIDTH   =  32,
                                       RAM_ADDR_WIDTH      =  20
                            )
 
@@ -127,27 +111,10 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
 
     // instantiate the core
     riscv_core #(
-                 .N_EXT_PERF_COUNTERS    (N_EXT_PERF_COUNTERS),
-                 .INSTR_RDATA_WIDTH      (INSTR_RDATA_WIDTH),
-                 .PULP_SECURE            (PULP_SECURE),
-                 .N_PMP_ENTRIES          (N_PMP_ENTRIES),
-                 .USE_PMP                (USE_PMP),
-                 .PULP_CLUSTER           (PULP_CLUSTER),
-                 .A_EXTENSION            (A_EXTENSION),
-                 .FPU                    (FPU),
-                 .Zfinx                  (Zfinx),
-                 .FP_DIVSQRT             (FP_DIVSQRT),
-                 .SHARED_FP              (SHARED_FP),
-                 .SHARED_DSP_MULT        (SHARED_DSP_MULT),
-                 .SHARED_INT_MULT        (SHARED_INT_MULT),
-                 .SHARED_INT_DIV         (SHARED_INT_DIV),
-                 .SHARED_FP_DIVSQRT      (SHARED_FP_DIVSQRT),
-                 .WAPUTYPE               (WAPUTYPE),
-                 .APU_NARGS_CPU          (APU_NARGS_CPU),
-                 .APU_WOP_CPU            (APU_WOP_CPU),
-                 .APU_NDSFLAGS_CPU       (APU_NDSFLAGS_CPU),
-                 .APU_NUSFLAGS_CPU       (APU_NUSFLAGS_CPU),
-                 .DM_HaltAddress         (DM_HaltAddress)
+                 .PULP_CLUSTER    (PULP_CLUSTER),
+                 .FPU             (FPU),
+                 .PULP_ZFINX      (PULP_ZFINX),
+                 .DM_HALTADDRESS  (DM_HALTADDRESS)
                 )
     riscv_core_i
         (
@@ -157,24 +124,26 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .clock_en_i             ( core_cntrl_if.clock_en         ),
          .test_en_i              ( core_cntrl_if.test_en          ),
 
+         .fregfile_disable_i     ( core_cntrl_if.fregfile_disable ),
+
          .boot_addr_i            ( core_cntrl_if.boot_addr        ),
          .core_id_i              ( core_cntrl_if.core_id          ),
          .cluster_id_i           ( core_cntrl_if.cluster_id       ),
 
-         .instr_addr_o           ( instr_addr                     ),
          .instr_req_o            ( instr_req                      ),
-         .instr_rdata_i          ( instr_rdata                    ),
          .instr_gnt_i            ( instr_gnt                      ),
          .instr_rvalid_i         ( instr_rvalid                   ),
+         .instr_addr_o           ( instr_addr                     ),
+         .instr_rdata_i          ( instr_rdata                    ),
 
-         .data_addr_o            ( data_addr                      ),
-         .data_wdata_o           ( data_wdata                     ),
-         .data_we_o              ( data_we                        ),
          .data_req_o             ( data_req                       ),
-         .data_be_o              ( data_be                        ),
-         .data_rdata_i           ( data_rdata                     ),
          .data_gnt_i             ( data_gnt                       ),
          .data_rvalid_i          ( data_rvalid                    ),
+         .data_we_o              ( data_we                        ),
+         .data_be_o              ( data_be                        ),
+         .data_addr_o            ( data_addr                      ),
+         .data_wdata_o           ( data_wdata                     ),
+         .data_rdata_i           ( data_rdata                     ),
 
          .apu_master_req_o       (                                ),
          .apu_master_ready_o     (                                ),
@@ -192,9 +161,9 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          //       and pass to ENV for an INTERRUPT AGENT to drive/monitor.
          //.irq_i                  ( irq                            ),
          //.irq_id_i               ( irq_id_in                      ),
+         //.irq_sec_i              ( (core_interrupts_if.irq_sec||irq) ),
          .irq_ack_o              ( irq_ack                           ),
          .irq_id_o               ( irq_id_out                        ),
-         .irq_sec_i              ( (core_interrupts_if.irq_sec||irq) ),
          .irq_software_i         ( core_interrupts_if.irq_software   ),
          .irq_timer_i            ( core_interrupts_if.irq_timer      ),
          .irq_external_i         ( core_interrupts_if.irq_external   ),
@@ -202,15 +171,10 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .irq_nmi_i              ( core_interrupts_if.irq_nmi        ),
          .irq_fastx_i            ( core_interrupts_if.irq_fastx      ),
 
-         .sec_lvl_o              ( core_status_if.sec_lvl            ),
-
          .debug_req_i            ( core_cntrl_if.debug_req           ),
 
          .fetch_enable_i         ( core_cntrl_if.fetch_en            ),
-         .core_busy_o            ( core_status_if.core_busy          ),
-
-         .ext_perf_counters_i    ( core_cntrl_if.ext_perf_counters   ),
-         .fregfile_disable_i     ( core_cntrl_if.fregfile_disable    )
+         .core_busy_o            ( core_status_if.core_busy          )
         ); //riscv_core_i
 
     // this handles read to RAM and memory mapped virtual (pseudo) peripherals

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -51,9 +51,9 @@ module uvmt_cv32_tb;
    * a few mods to bring unused ports from the CORE to this level using SV interfaces.
    */
    uvmt_cv32_dut_wrap  #(
-                         .INSTR_RDATA_WIDTH ( 128),
-                         .RAM_ADDR_WIDTH    (  20),
-                         .PULP_SECURE       (   1)
+                         .INSTR_ADDR_WIDTH  (32),
+                         .INSTR_RDATA_WIDTH (32),
+                         .RAM_ADDR_WIDTH    (20)
                         )
                         dut_wrap (.*);
    


### PR DESCRIPTION
This PR brings the `uvmt_cv32` environment and `core` testbench up-to-date with the latest RTL as of 2020-04-26.
Signed-off-by: Mike Thompson <mike@openhwgroup.org>