### PR TITLE
This is an infrastructure to verify the CV64 core with the help of ri…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 *.o
 dsim.env
 *.swp
+cv64
+uvm/riscv-dv
+tools
+tests/riscv-compliance

--- a/ci/cv64.patch
+++ b/ci/cv64.patch
@@ -1,0 +1,175 @@
+diff --git a/Makefile b/Makefile
+index e95899d..9228a2a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -192,6 +192,7 @@ src :=  $(filter-out src/ariane_regfile.sv, $(wildcard src/*.sv))              \
+         src/tech_cells_generic/src/pulp_clock_mux2.sv                          \
+         tb/ariane_testharness.sv                                               \
+         tb/ariane_peripherals.sv                                               \
++        tb/trace_ip.sv                                                         \
+         tb/common/uart.sv                                                      \
+         tb/common/SimDTM.sv                                                    \
+         tb/common/SimJTAG.sv
+@@ -401,7 +402,7 @@ verilate:
+ 	cd $(ver-library) && $(MAKE) -j${NUM_JOBS} -f Variane_testharness.mk
+ 
+ sim-verilator: verilate
+-	$(ver-library)/Variane_testharness $(elf-bin)
++	$(ver-library)/Variane_testharness $(elf-bin) | sed 's/^.*core/core/'| spike-dasm
+ 
+ $(addsuffix -verilator,$(riscv-asm-tests)): verilate
+ 	$(ver-library)/Variane_testharness $(riscv-test-dir)/$(subst -verilator,,$@)
+diff --git a/tb/ariane_testharness.sv b/tb/ariane_testharness.sv
+index 075a305..bd24177 100644
+--- a/tb/ariane_testharness.sv
++++ b/tb/ariane_testharness.sv
+@@ -704,6 +704,22 @@ module ariane_testharness #(
+     end
+   end
+ 
++  logic [63:0] cycles;
++  always_ff @(posedge clk_i or negedge ndmreset_n) begin
++    if (~ndmreset_n) begin
++      cycles <= 0;
++    end else begin
++      cycles <= cycles+1;
++    end
++  end
++
++  trace_ip  #(
++    .InclSimDTM(InclSimDTM),
++    .SIM_FINISH(1000000)
++  ) trace_ip_i (
++    .cycles(cycles)
++  ) ;
++
+ `ifdef AXI_SVA
+   // AXI 4 Assertion IP integration - You will need to get your own copy of this IP if you want
+   // to use it
+diff --git a/tb/trace_ip.sv b/tb/trace_ip.sv
+new file mode 100644
+index 0000000..aebecac
+--- /dev/null
++++ b/tb/trace_ip.sv
+@@ -0,0 +1,121 @@
++//#############################################################################
++//#
++//# Copyright 2020 Thales
++//#
++//# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
++//# you may not use this file except in compliance with the License.
++//# You may obtain a copy of the License at
++//#
++//#     https://solderpad.org/licenses/
++//#
++//# Unless required by applicable law or agreed to in writing, software
++//# distributed under the License is distributed on an "AS IS" BASIS,
++//# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++//# See the License for the specific language governing permissions and
++//# limitations under the License.
++//#
++//#############################################################################
++//#
++//# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
++//#
++//#############################################################################
++
++import ariane_pkg::*;
++
++module trace_ip #(
++  parameter bit          InclSimDTM = 1'b0,
++  parameter int unsigned SIM_FINISH = 1000000
++)(
++  input logic [63:0]                    cycles
++);
++
++  // synthesis translate_off
++
++  int f;
++  logic [63:0] cycles_to_print;
++  logic [63:0] pc64;
++  logic [31:0] address_host;
++  logic [63:0] data_host;
++
++  typedef struct packed {
++    logic [DCACHE_TAG_WIDTH+DCACHE_INDEX_WIDTH-1:0] address;
++    logic [63:0] data;
++  } access_t;
++
++  access_t store, load;
++  access_t load_to_print, store_to_print;
++
++  always_ff @(posedge i_ariane.clk_i or negedge i_ariane.rst_ni) begin
++    if (~i_ariane.rst_ni) begin
++    end else begin
++      string mode = "";
++      if (i_ariane.debug_mode) mode = "D";
++      else begin
++        case (i_ariane.priv_lvl)
++        riscv::PRIV_LVL_M: mode = "M";
++        riscv::PRIV_LVL_S: mode = "S";
++        riscv::PRIV_LVL_U: mode = "U";
++        endcase
++      end
++      for (int i = 0; i < NR_COMMIT_PORTS; i++) begin
++        pc64 = i_ariane.commit_instr_id_commit[i].pc;
++        if (i_ariane.commit_ack[i] && !i_ariane.commit_instr_id_commit[i].ex.valid) begin
++          $display("%d core   0: 0x%h (0x%h) DASM(%h)",
++                cycles_to_print,
++                pc64,
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0],
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0]);
++          if (ariane_pkg::is_rd_fpr(i_ariane.commit_instr_id_commit[i].op) == 0)
++            if (i_ariane.commit_instr_id_commit[i].rd[4:0] == 0)
++              $display("%h 0x%h (0x%h)",
++                i_ariane.priv_lvl,
++                pc64,
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0]);
++            else
++              $display("%h 0x%h (0x%h) x%d 0x%h",
++                i_ariane.priv_lvl,
++                pc64,
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0],
++                i_ariane.commit_instr_id_commit[i].rd[4:0],
++                i_ariane.wdata_commit_id[i][63:0]);
++          else
++            $display("%h 0x%h (0x%h) f%d 0x%h",
++              i_ariane.priv_lvl,
++              pc64,
++              i_ariane.commit_instr_id_commit[i].ex.tval[31:0],
++              i_ariane.commit_instr_id_commit[i].rd[4:0],
++              i_ariane.commit_instr_id_commit[i].result[63:0]);
++        end else if (i_ariane.commit_instr_id_commit[i].valid && i_ariane.commit_instr_id_commit[i].ex.valid && i_ariane.ex_commit.valid) begin
++          if (i_ariane.commit_instr_id_commit[i].ex.cause == 2) begin
++          end else begin
++            if (i_ariane.debug_mode) begin
++              $display("%d 0x%0h %s (0x%h) DASM(%h)", cycles_to_print, pc64, mode, i_ariane.commit_instr_id_commit[i].ex.tval[31:0], i_ariane.commit_instr_id_commit[i].ex.tval[31:0]);
++            end else if (i_ariane.commit_instr_id_commit[i].ex.cause != 24) begin
++              $display("%d core   0: 0x%h (0x%h) DASM(%h)",
++                cycles_to_print,
++                pc64,
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0],
++                i_ariane.commit_instr_id_commit[i].ex.tval[31:0]);
++              $display("core   0: exception %5d, epc 0x%h", i_ariane.commit_instr_id_commit[i].ex.cause, pc64);
++            end
++          end
++        end
++      end
++      cycles_to_print <= cycles;
++      if (cycles > SIM_FINISH) $finish(1);
++      if (i_ariane.ex_stage_i.lsu_i.dcache_req_ports_o[2].data_req) begin
++        address_host={i_ariane.ex_stage_i.lsu_i.dcache_req_ports_o[2].address_tag[DCACHE_TAG_WIDTH-1:0],
++                      i_ariane.ex_stage_i.lsu_i.dcache_req_ports_o[2].address_index[DCACHE_INDEX_WIDTH-1:0]};
++        data_host=i_ariane.ex_stage_i.lsu_i.dcache_req_ports_o[2].data_wdata[63:0];
++        if (address_host==64'h80100000 && !InclSimDTM) begin
++          $display("write to host addr=%h data=%h", address_host, data_host);
++          $finish(0);
++        end
++      end
++    end
++  end
++
++  // synthesis translate_on
++
++endmodule // trace_ip
++

--- a/ci/install-cv64.sh
+++ b/ci/install-cv64.sh
@@ -1,0 +1,65 @@
+###############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+#
+###############################################################################
+
+# Customise this to a fast local disk
+export ROOT_PROJECT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)
+export TOP=$ROOT_PROJECT/tools
+
+# where to install the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+# install Verilator 
+if ! [ -n "$VERILATOR_ROOT" ]; then
+  export VERILATOR_ROOT=$TOP/verilator-4.014/
+fi
+ci/install-verilator.sh
+
+export PATH=$RISCV/bin:$VERILATOR_ROOT/bin:$PATH
+export LIBRARY_PATH=$RISCV/lib
+export LD_LIBRARY_PATH=$RISCV/lib
+export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
+export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
+
+# number of parallel jobs to use for make commands and simulation
+export NUM_JOBS=24
+
+# install the required tools for cv64
+if ! [ -n "$CV64_REPO" ]; then
+  CV64_REPO="https://github.com/pulp-platform/ariane.git"
+  CV64_BRANCH="master"
+  CV64_HASH="1793be633e096bacbbef7fc75fbe5b35da59c91b"
+fi
+echo $CV64_REPO
+echo $CV64_BRANCH
+echo $CV64_HASH
+
+if ! [ -e cv64 ]; then
+  git clone --recursive $CV64_REPO -b $CV64_BRANCH cv64
+  cd cv64; git checkout $CV64_HASH; git apply ../ci/cv64.patch; cd -
+fi
+
+# install Spike
+export SPIKE_ROOT=$TOP/spike/
+ci/install-spike.sh

--- a/ci/install-riscv-dv.sh
+++ b/ci/install-riscv-dv.sh
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+#
+###############################################################################
+
+# riscv-dv env variables
+export RISCV_TOOLCHAIN=$RISCV
+export RISCV_GCC="$RISCV_TOOLCHAIN/bin/riscv64-unknown-elf-gcc"
+export RISCV_OBJCOPY="$RISCV_TOOLCHAIN/bin/riscv64-unknown-elf-objcopy"
+export SPIKE_PATH=$SPIKE_ROOT/bin
+export RTL_PATH=$ROOT_PROJECT/cv64
+export TESTS_PATH=$ROOT_PROJECT/tests
+
+if ! [ -n "$DV_REPO" ]; then
+  export DV_REPO="https://github.com/google/riscv-dv.git"
+  export DV_BRANCH="master"
+  export DV_HASH="0ce85d3187689855cd2b3b9e3fae21ca32de2248"
+fi
+echo $DV_REPO
+echo $DV_BRANCH
+echo $DV_HASH
+
+mkdir -p uvm
+if ! [ -e uvm/riscv-dv ]; then
+  git clone $DV_REPO -b $DV_BRANCH uvm/riscv-dv
+  cd uvm/riscv-dv; git checkout $DV_HASH; git apply ../../ci/riscv-dv.patch; cd -
+fi
+
+# install riscv-dv dependencies
+cd uvm/riscv-dv; pip3 install --user -e .; cd -

--- a/ci/install-spike.sh
+++ b/ci/install-spike.sh
@@ -1,0 +1,47 @@
+###############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+#
+###############################################################################
+
+set -e
+VERSION="59a9277ac1e3f9aca630fb035d1dbacaa091e375"
+
+if [ -z ${NUM_JOBS} ]; then
+    NUM_JOBS=1
+fi
+
+if [ ! -e "$SPIKE_ROOT/bin/spike"  ]; then
+    echo "Installing Spike"
+    mkdir -p $SPIKE_ROOT
+    cd $SPIKE_ROOT
+    git clone https://github.com/riscv/riscv-isa-sim.git 
+    cd riscv-isa-sim
+    git checkout $VERSION
+    mkdir -p build
+    cd build
+    ../configure --enable-commitlog --prefix="$SPIKE_ROOT"
+    make -j${NUM_JOBS}
+    make install
+else
+    echo "Using Spike from cached directory."
+fi
+
+
+

--- a/ci/install-tests.sh
+++ b/ci/install-tests.sh
@@ -1,0 +1,36 @@
+###############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+#
+###############################################################################
+
+if ! [ -n "$TESTS_REPO" ]; then
+  TESTS_REPO="https://github.com/riscv/riscv-compliance.git"
+  TESTS_BRANCH="master"
+  TESTS_HASH="220e78542da4510e40eac31e31fdd4e77cdae437"
+fi
+echo $TESTS_REPO
+echo $TESTS_BRANCH
+echo $TESTS_HASH
+
+mkdir -p tests
+if ! [ -e tests/riscv-compliance ]; then
+  git clone $TESTS_REPO -b $TESTS_BRANCH tests/riscv-compliance
+  cd tests/riscv-compliance; git checkout $TESTS_HASH; git apply ../../ci/riscv-compliance.patch; cd -
+fi

--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ -z ${NUM_JOBS} ]; then
+    NUM_JOBS=1
+fi
+
+if [ ! -e "$VERILATOR_ROOT/bin/verilator" ]; then
+    echo "Installing Verilator"
+    mkdir -p $VERILATOR_ROOT
+    cd $VERILATOR_ROOT
+    rm -f verilator*.tgz
+    wget https://www.veripool.org/ftp/verilator-4.014.tgz
+    tar xzf verilator*.tgz
+    rm -f verilator*.tgz
+    cd verilator-4.014
+    mkdir -p $VERILATOR_ROOT
+    # copy scripts
+    autoconf && ./configure --prefix="$VERILATOR_ROOT" && make -j${NUM_JOBS}
+    cp -r * $VERILATOR_ROOT/
+    make test
+else
+    echo "Using Verilator from cached directory."
+fi

--- a/ci/riscv-compliance.patch
+++ b/ci/riscv-compliance.patch
@@ -1,0 +1,15 @@
+diff --git a/riscv-test-env/p/riscv_test.h b/riscv-test-env/p/riscv_test.h
+index eaa6758..67fea76 100644
+--- a/riscv-test-env/p/riscv_test.h
++++ b/riscv-test-env/p/riscv_test.h
+@@ -56,10 +56,6 @@
+ #define INIT_PMP                                                        \
+   la t0, 1f;                                                            \
+   csrw mtvec, t0;                                                       \
+-  li t0, -1;        /* Set up a PMP to permit all accesses */           \
+-  csrw pmpaddr0, t0;                                                    \
+-  li t0, PMP_NAPOT | PMP_R | PMP_W | PMP_X;                             \
+-  csrw pmpcfg0, t0;                                                     \
+   .align 2;                                                             \
+ 1:
+

--- a/ci/riscv-dv.patch
+++ b/ci/riscv-dv.patch
@@ -1,0 +1,318 @@
+diff --git a/run.py b/run.py
+index bae34b7..4e84f69 100644
+--- a/run.py
++++ b/run.py
+@@ -23,6 +23,7 @@ import sys
+ import logging
+ 
+ from scripts.lib import *
++from scripts.verilator_log_to_trace_csv import *
+ from scripts.spike_log_to_trace_csv import *
+ from scripts.ovpsim_log_to_trace_csv import *
+ from scripts.whisper_log_trace_csv import *
+@@ -414,7 +415,7 @@ def run_assembly(asm_test, iss_yaml, isa, mabi, gcc_opts, iss_opts, output_dir,
+     base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+     logging.info("[%0s] Running ISS simulation: %s" % (iss, elf))
+     cmd = get_iss_cmd(base_cmd, elf, log)
+-    run_cmd(cmd, 10, debug_cmd = debug_cmd)
++    run_cmd(cmd, 1500, debug_cmd = debug_cmd)
+     logging.info("[%0s] Running ISS simulation: %s ...done" % (iss, elf))
+   if len(iss_list) == 2:
+     compare_iss_log(iss_list, log_list, report)
+@@ -596,7 +597,6 @@ def iss_cmp(test_list, iss, output_dir, stop_on_first_error, exp, debug_cmd):
+   if len(iss_list) != 2:
+     return
+   report = ("%s/iss_regr.log" % output_dir).rstrip()
+-  run_cmd("rm -rf %s" % report)
+   for test in test_list:
+     for i in range(0, test['iterations']):
+       elf = ("%s/asm_tests/%s_%d.o" % (output_dir, test['test'], i))
+@@ -622,6 +622,8 @@ def compare_iss_log(iss_list, log_list, report, stop_on_first_error=0, exp=False
+       csv_list.append(csv)
+       if iss == "spike":
+         process_spike_sim_log(log, csv)
++      elif iss == "verilator":
++        process_verilator_sim_log(log, csv)
+       elif iss == "ovpsim":
+         process_ovpsim_sim_log(log, csv, stop_on_first_error)
+       elif iss == "sail":
+@@ -817,7 +819,7 @@ def main():
+     # Load configuration from the command line and the configuration file.
+     cfg = load_config(args, cwd)
+     # Create output directory
+-    output_dir = create_output(args.o, args.noclean)
++    output_dir = create_output(args.o, args.noclean, cwd+"/out_")
+ 
+     if args.verilog_style_check:
+       logging.debug("Run style check")
+diff --git a/scripts/lib.py b/scripts/lib.py
+index b974637..90aef00 100644
+--- a/scripts/lib.py
++++ b/scripts/lib.py
+@@ -230,6 +230,8 @@ def process_regression_list(testlist, test, iterations, matched_list, riscv_dv_r
+         if (iterations > 0 and  entry['iterations'] > 0):
+           entry['iterations'] = iterations
+         if entry['iterations'] > 0:
++          entry['asm_tests'] = re.sub("\<path_var\>", get_env_var(entry['path_var']), entry['asm_tests'])
++          entry['gcc_opts'] = re.sub("\<path_var\>", get_env_var(entry['path_var']), entry['gcc_opts'])
+           logging.info("Found matched tests: %s, iterations:%0d" %
+                       (entry['test'], entry['iterations']))
+           matched_list.append(entry)
+diff --git a/scripts/verilator_log_to_trace_csv.py b/scripts/verilator_log_to_trace_csv.py
+new file mode 100644
+index 0000000..2be83ae
+--- /dev/null
++++ b/scripts/verilator_log_to_trace_csv.py
+@@ -0,0 +1,236 @@
++"""
++Copyright 2019 Google LLC
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++     http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++
++Convert verilator sim log to standard riscv instruction trace format
++"""
++
++import argparse
++import os
++import re
++import sys
++import logging
++
++sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
++
++from riscv_trace_csv import *
++from lib import *
++
++RD_RE    = re.compile(r"(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
++                      "\((?P<bin>.*?)\) (?P<reg>[xf]\s*\d*?) 0x(?P<val>[a-f0-9]+)")
++CORE_RE  = re.compile(r"core.*0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
++ILLE_RE  = re.compile(r"trap_illegal_instruction")
++
++LOGGER = logging.getLogger()
++
++
++def process_instr(trace):
++  if trace.instr == "jal":
++    # Spike jal format jal rd, -0xf -> jal rd, -15
++    idx = trace.operand.rfind(",")
++    imm = trace.operand[idx+1:]
++    if imm[0] == "-":
++      imm = "-" + str(int(imm[1:], 16))
++    else:
++      imm = str(int(imm, 16))
++    trace.operand = trace.operand[0:idx+1] + imm
++  trace.operand = trace.operand.replace("(", ",")
++  trace.operand = trace.operand.replace(")", "")
++
++
++def read_verilator_instr(match, full_trace):
++  '''Unpack a regex match for CORE_RE to a RiscvInstructionTraceEntry
++
++  If full_trace is true, extract operand data from the disassembled
++  instruction.
++
++  '''
++
++  # Extract the disassembled instruction.
++  disasm = match.group('instr')
++
++  # Spike's disassembler shows a relative jump as something like "j pc +
++  # 0x123" or "j pc - 0x123". We just want the relative offset.
++  disasm = disasm.replace('pc + ', '').replace('pc - ', '-')
++
++  instr = RiscvInstructionTraceEntry()
++  instr.pc = match.group('addr')
++  instr.instr_str = disasm
++  instr.binary = match.group('bin')
++
++  if full_trace:
++    opcode = disasm.split(' ')[0]
++    operand = disasm[len(opcode):].replace(' ', '')
++    instr.instr, instr.operand = \
++      convert_pseudo_instr(opcode, operand, instr.binary)
++
++    process_instr(instr)
++
++  return instr
++
++
++def read_verilator_trace(path, full_trace):
++  '''Read a Spike simulation log at <path>, yielding executed instructions.
++
++  This assumes that the log was generated with the -l and --log-commits options
++  to Spike.
++
++  If full_trace is true, extract operands from the disassembled instructions.
++
++  Since Spike has a strange trampoline that always runs at the start, we skip
++  instructions up to and including the one at PC 0x1010 (the end of the
++  trampoline). At the end of a DV program, there's an ECALL instruction, which
++  we take as a signal to stop checking, so we ditch everything that follows
++  that instruction.
++
++  This function yields instructions as it parses them as tuples of the form
++  (entry, illegal). entry is a RiscvInstructionTraceEntry. illegal is a
++  boolean, which is true if the instruction caused an illegal instruction trap.
++
++  '''
++
++  # This loop is a simple FSM with states TRAMPOLINE, INSTR, EFFECT. The idea
++  # is that we're in state TRAMPOLINE until we get to the end of Spike's
++  # trampoline, then we switch between INSTR (where we expect to read an
++  # instruction) and EFFECT (where we expect to read commit information).
++  #
++  # We yield a RiscvInstructionTraceEntry object each time we leave EFFECT
++  # (going back to INSTR), we loop back from INSTR to itself, or we get to the
++  # end of the file and have an instruction in hand.
++  #
++  # On entry to the loop body, we are in state TRAMPOLINE if in_trampoline is
++  # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
++  # are in state INSTR.
++
++  end_trampoline_re = re.compile(r'core.*: 0x0000000080000000 ')
++
++  in_trampoline = True
++  instr = None
++
++  with open(path, 'r') as handle:
++    for line in handle:
++      if in_trampoline:
++        # The TRAMPOLINE state
++        if end_trampoline_re.match(line):
++          in_trampoline = False
++        continue
++
++      if instr is None:
++        # The INSTR state. We expect to see a line matching CORE_RE. We'll
++        # discard any other lines.
++        instr_match = CORE_RE.match(line)
++        if not instr_match:
++          continue
++
++        instr = read_verilator_instr(instr_match, full_trace)
++
++        # If instr.instr_str is 'ecall', we should stop.
++        if instr.instr_str == 'ecall':
++          break
++
++        continue
++
++      # The EFFECT state. If the line matches CORE_RE, we should have been in
++      # state INSTR, so we yield the instruction we had, read the new
++      # instruction and continue. As above, if the new instruction is 'ecall',
++      # we need to stop immediately.
++      instr_match = CORE_RE.match(line)
++      if instr_match:
++        yield (instr, False)
++        instr = read_verilator_instr(instr_match, full_trace)
++        if instr.instr_str == 'ecall':
++          break
++        continue
++
++      # The line doesn't match CORE_RE, so we are definitely on a follow-on
++      # line in the log. First, check for illegal instructions
++      if 'trap_illegal_instruction' in line:
++        yield (instr, True)
++        instr = None
++        continue
++
++      # The instruction seems to have been fine. Do we have commit data (from
++      # the --log-commits Spike option)?
++      commit_match = RD_RE.match(line)
++      if commit_match:
++        instr.gpr.append(gpr_to_abi(commit_match.group('reg')
++                                    .replace(' ', '')) +
++                         ':' + commit_match.group('val'))
++        instr.mode = commit_match.group('pri')
++
++    # At EOF, we might have an instruction in hand. Yield it if so.
++    if instr is not None:
++      yield (instr, False)
++
++
++def process_verilator_sim_log(verilator_log, csv, full_trace = 0):
++  """Process VERILATOR simulation log.
++
++  Extract instruction and affected register information from verilator simulation
++  log and write the results to a CSV file at csv. Returns the number of
++  instructions written.
++
++  """
++  logging.info("Processing verilator log : %s" % verilator_log)
++
++  instrs_in = 0
++  instrs_out = 0
++
++  with open(csv, "w") as csv_fd:
++    trace_csv = RiscvInstructionTraceCsv(csv_fd)
++    trace_csv.start_new_trace()
++
++    for (entry, illegal) in read_verilator_trace(verilator_log, full_trace):
++      instrs_in += 1
++
++      if illegal and full_trace:
++        logging.debug("Illegal instruction: {}, opcode:{}"
++                      .format(entry.instr_str, entry.binary))
++
++      # Instructions that cause no architectural update (which includes illegal
++      # instructions) are ignored if full_trace is false.
++      #
++      # We say that an instruction caused an architectural update if either we
++      # saw a commit line (in which case, entry.gpr will contain a single
++      # entry) or the instruction was 'wfi' or 'ecall'.
++      if not (full_trace or entry.gpr or entry.instr_str in ['wfi', 'ecall']):
++        continue
++
++      trace_csv.write_trace_entry(entry)
++      instrs_out += 1
++
++  logging.info("Processed instruction count : %d" % instrs_in)
++  logging.info("CSV saved to : %s" % csv)
++  return instrs_out
++
++
++def main():
++  # Parse input arguments
++  parser = argparse.ArgumentParser()
++  parser.add_argument("--log", type=str, help="Input verilator simulation log")
++  parser.add_argument("--csv", type=str, help="Output trace csv_buf file")
++  parser.add_argument("-f", "--full_trace", dest="full_trace", action="store_true",
++                                         help="Generate the full trace")
++  parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
++                                         help="Verbose logging")
++  parser.set_defaults(full_trace=False)
++  parser.set_defaults(verbose=False)
++  args = parser.parse_args()
++  setup_logging(args.verbose)
++  # Process verilator log
++  process_verilator_sim_log(args.log, args.csv, args.full_trace)
++
++
++if __name__ == "__main__":
++  main()
+diff --git a/yaml/iss.yaml b/yaml/iss.yaml
+index 344ef79..d2a5dc5 100644
+--- a/yaml/iss.yaml
++++ b/yaml/iss.yaml
+@@ -17,6 +17,11 @@
+   cmd: >
+     <path_var>/spike --log-commits --isa=<variant> -l <elf>
+ 
++- iss: verilator
++  path_var: RTL_PATH
++  cmd: >
++    make -C <path_var> sim-verilator elf-bin=<elf>
++
+ - iss: ovpsim
+   path_var: OVPSIM_PATH
+   cmd: >

--- a/ci/smoke-tests.sh
+++ b/ci/smoke-tests.sh
@@ -1,0 +1,37 @@
+###############################################################################
+#
+# Copyright 2020 Thales
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# Original Author: Jean-Roch COULON (jean-roch.coulon@invia.fr)
+#
+###############################################################################
+
+# where are the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+# install the required tools
+source ./ci/install-cv64.sh
+source ./ci/install-riscv-dv.sh
+source ./ci/install-tests.sh
+
+#run verilator without preload
+cd uvm/riscv-dv
+run --testlist=../../tests/testlist_riscv-compliance-withoutFPU.yaml --test rv32i-I-ADD-01 --target rv64gc --iss=verilator,spike
+cd ../..

--- a/cv64/README.md
+++ b/cv64/README.md
@@ -1,4 +1,0 @@
-# CV64: Verification Environment for the CV64 CORE-V processor core.
-
-Currently just a placeholder.
-

--- a/tests/testlist_riscv-compliance-withoutFPU.yaml
+++ b/tests/testlist_riscv-compliance-withoutFPU.yaml
@@ -1,0 +1,1014 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+#- import: <riscv_dv_root>/target/rv64imc/testlist.yaml
+
+- test: rv64im-REMUW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64im/src/REMUW.S
+
+- test: rv64im-MULW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64im/src/MULW.S
+
+- test: rv64i-SRAW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRAW.S
+
+- test: rv64i-ADDW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/ADDW.S
+
+- test: rv64i-ADDIW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/ADDIW.S
+
+- test: rv64i-SLLW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SLLW.S
+
+- test: rv64i-SUBW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SUBW.S
+
+- test: rv64i-SRLW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRLW.S
+
+- test: rv64i-SLLIW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SLLIW.S
+
+- test: rv64i-SRLIW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRLIW.S
+
+- test: rv64i-SRAIW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv64i/src/SRAIW.S
+
+- test: rv32uc-rvc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32uc/src/rvc.S
+
+- test: rv32Zifencei-I-FENCE.I-01   spike is FAILed
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S
+
+- test: rv32im-MULHSU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHSU.S
+
+- test: rv32im-DIVU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIVU.S
+
+- test: rv32im-REMU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REMU.S
+
+- test: rv32im-MUL
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
+
+- test: rv32im-DIV
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
+
+- test: rv32im-MULH
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULH.S
+
+- test: rv32im-MULHU
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
+
+- test: rv32im-REM
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S
+
+- test: rv32ui-jal
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/jal.S
+
+- test: rv32ui-bge
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bge.S
+
+- test: rv32ui-blt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/blt.S
+
+- test: rv32ui-bgeu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bgeu.S
+
+- test: rv32ui-sw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sw.S
+  
+- test: rv32ui-lbu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lbu.S
+  
+- test: rv32ui-sb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sb.S
+  
+- test: rv32ui-sw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slti.S
+  
+- test: rv32ui-sra
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sra.S
+  
+- test: rv32ui-srl
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srl.S
+  
+- test: rv32ui-sh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sh.S
+  
+- test: rv32ui-lw
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lw.S
+  
+- test: rv32ui-andi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/andi.S
+  
+- test: rv32ui-srli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srli.S
+  
+- test: rv32ui-slli
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slli.S
+  
+- test: rv32ui-beq
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/beq.S
+  
+- test: rv32ui-sll
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sll.S
+  
+- test: rv32ui-addi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/addi.S
+  
+- test: rv32ui-lh
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lh.S
+  
+- test: rv32ui-and
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/and.S
+  
+- test: rv32ui-xori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/xori.S
+  
+- test: rv32ui-sub
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sub.S
+  
+- test: rv32ui-slt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/slt.S
+  
+- test: rv32ui-lb
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lb.S
+  
+- test: rv32ui-or
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/or.S
+  
+- test: rv32ui-lui
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lui.S
+  
+- test: rv32ui-ori
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/ori.S
+  
+- test: rv32ui-bltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bltu.S
+  
+- test: rv32ui-fence_i
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/fence_i.S
+  
+- test: rv32ui-auipc
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/auipc.S
+  
+- test: rv32ui-srai
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/srai.S
+  
+- test: rv32ui-jalr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/jalr.S
+  
+- test: rv32ui-xor
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/xor.S
+  
+- test: rv32ui-simple
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/simple.S
+  
+- test: rv32ui-lhu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/lhu.S
+  
+- test: rv32ui-bne
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/bne.S
+  
+- test: rv32ui-add
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/add.S
+  
+- test: rv32ui-sltiu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sltiu.S
+  
+- test: rv32ui-sltu
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ui/src/sltu.S
+  
+- test: rv32mi-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/sbreak.S
+  
+- test: rv32mi-breakpoint
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/breakpoint.S
+  
+- test: rv32mi-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/scall.S
+  
+- test: rv32mi-ma_addr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/ma_addr.S
+  
+- test: rv32mi-mcsr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/mcsr.S
+  
+- test: rv32mi-ma_fetch
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/ma_fetch.S
+  
+- test: rv32mi-shamt
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/shamt.S
+  
+- test: rv32mi-illegal
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/illegal.S
+  
+- test: rv32mi-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32mi/src/csr.S
+  
+- test: rv32i-I-AND-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-AND-01.S
+  
+- test: rv32i-I-BNE-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BNE-01.S
+  
+- test: rv32i-I-IO
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-IO.S
+  
+- test: rv32i-I-BLT-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BLT-01.S
+  
+- test: rv32i-I-SB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SB-01.S
+  
+- test: rv32i-I-MISALIGN_LDST-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-MISALIGN_LDST-01.S
+  
+- test: rv32i-I-ECALL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ECALL-01.S
+  
+- test: rv32i-I-LHU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LHU-01.S
+  
+- test: rv32i-I-SRLI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRLI-01.S
+  
+- test: rv32i-I-BLTU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BLTU-01.S
+  
+- test: rv32i-I-LH-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LH-01.S
+  
+- test: rv32i-I-AUIPC-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-AUIPC-01.S
+  
+- test: rv32i-I-ORI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ORI-01.S
+  
+- test: rv32i-I-SLLI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLLI-01.S
+  
+- test: rv32i-I-RF_width-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_width-01.S
+  
+- test: rv32i-I-XOR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-XOR-01.S
+  
+- test: rv32i-I-DELAY_SLOTS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-DELAY_SLOTS-01.S
+  
+- test: rv32i-I-EBREAK-01 spike is looping infinitely
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-EBREAK-01.S
+
+- test: rv32i-I-SRAI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRAI-01.S
+  
+- test: rv32i-I-SLTU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTU-01.S
+  
+- test: rv32i-I-OR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-OR-01.S
+  
+- test: rv32i-I-MISALIGN_JMP-01 spike is looping infinitely
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S
+
+- test: rv32i-I-JALR-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-JALR-01.S
+  
+- test: rv32i-I-XORI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-XORI-01.S
+  
+- test: rv32i-I-ADDI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ADDI-01.S
+  
+- test: rv32i-I-BGE-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BGE-01.S
+  
+- test: rv32i-I-ANDI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ANDI-01.S
+  
+- test: rv32i-I-SH-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SH-01.S
+  
+- test: rv32i-I-SLT-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLT-01.S
+  
+- test: rv32i-I-SLTIU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTIU-01.S
+  
+- test: rv32i-I-SLL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLL-01.S
+  
+- test: rv32i-I-SRL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRL-01.S
+  
+- test: rv32i-I-LUI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LUI-01.S
+  
+- test: rv32i-I-SUB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SUB-01.S
+  
+- test: rv32i-I-LB-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LB-01.S
+  
+- test: rv32i-I-LW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LW-01.S
+  
+- test: rv32i-I-SW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SW-01.S
+  
+- test: rv32i-I-SLTI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SLTI-01.S
+  
+- test: rv32i-I-SRA-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-SRA-01.S
+  
+- test: rv32i-I-RF_size-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_size-01.S
+  
+- test: rv32i-I-BEQ-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BEQ-01.S
+  
+- test: rv32i-I-BGEU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-BGEU-01.S
+  
+- test: rv32i-I-JAL-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-JAL-01.S
+  
+- test: rv32i-I-LBU-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-LBU-01.S
+  
+- test: rv32i-I-ENDIANESS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ENDIANESS-01.S
+  
+- test: rv32i-I-RF_x0-01
+  iterations: 0
+  path_var: TESTS_PATH
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-RF_x0-01.S
+
+- test: rv32i-I-NOP-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-NOP-01.S
+  
+- test: rv32i-I-ADD-01
+  iterations: 1
+  path_var: TESTS_PATH
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32i/src/I-ADD-01.S
+  
+- test: rv32si-sbreak
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/sbreak.S
+  
+- test: rv32si-scall
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/scall.S
+  
+- test: rv32si-ma_fetch
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/ma_fetch.S
+  
+- test: rv32si-wfi
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/wfi.S
+  
+- test: rv32si-dirty
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/dirty.S
+  
+- test: rv32si-csr
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32si/src/csr.S
+  
+- test: rv32imc-C-LW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LW.S
+  
+- test: rv32imc-C-LWSP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LWSP.S
+  
+- test: rv32imc-C-ADD
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADD.S
+  
+- test: rv32imc-C-JAL
+  iterations: 0
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JAL.S
+
+- test: rv32imc-C-SRAI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SRAI.S
+  
+- test: rv32imc-C-JALR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JALR.S
+  
+- test: rv32imc-C-XOR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-XOR.S
+  
+- test: rv32imc-C-SUB
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SUB.S
+  
+- test: rv32imc-C-ADDI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI.S
+  
+- test: rv32imc-C-BEQZ
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-BEQZ.S
+  
+- test: rv32imc-C-ADDI16SP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI16SP.S
+  
+- test: rv32imc-C-LI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LI.S
+  
+- test: rv32imc-C-SW
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SW.S
+  
+- test: rv32imc-C-OR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-OR.S
+  
+- test: rv32imc-C-ADDI4SPN
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ADDI4SPN.S
+  
+- test: rv32imc-C-AND
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-AND.S
+  
+- test: rv32imc-C-SRLI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SRLI.S
+  
+- test: rv32imc-C-SWSP
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SWSP.S
+  
+- test: rv32imc-C-SLLI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-SLLI.S
+  
+- test: rv32imc-C-JR
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-JR.S
+  
+- test: rv32imc-C-BNEZ
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-BNEZ.S
+  
+- test: rv32imc-C-MV
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-MV.S
+  
+- test: rv32imc-C-LUI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-LUI.S
+  
+- test: rv32imc-C-J
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-J.S
+  
+- test: rv32imc-C-ANDI
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32imc/src/C-ANDI.S
+  
+- test: rv32Zicsr-I-CSRRC-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRC-01.S
+  
+- test: rv32Zicsr-I-CSRRS-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRS-01.S
+  
+- test: rv32Zicsr-I-CSRRSI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRSI-01.S
+  
+- test: rv32Zicsr-I-CSRRW-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRW-01.S
+  
+- test: rv32Zicsr-I-CSRRCI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRCI-01.S
+  
+- test: rv32Zicsr-I-CSRRWI-01
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32Zicsr/src/I-CSRRWI-01.S
+  
+- test: rv32ua-amoxor_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoxor_w.S
+  
+- test: rv32ua-amoadd_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoadd_w.S
+  
+- test: rv32ua-amoor_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoor_w.S
+  
+- test: rv32ua-amomin_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomin_w.S
+  
+- test: rv32ua-amoand_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoand_w.S
+  
+- test: rv32ua-amomaxu_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomaxu_w.S
+  
+- test: rv32ua-amoswap_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amoswap_w.S
+  
+- test: rv32ua-amominu_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amominu_w.S
+  
+- test: rv32ua-amomax_w
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32ua/src/amomax_w.S


### PR DESCRIPTION
…scv-dv Google project.

Scripts have been added to the repository inside ci dir to install the needed tools and clone three main  projects: cv64, riscv-dv and riscv-compliance.
Verilator and Spike iss can be used to simulate. Compare between Spike and verilator outcomes is done, result can be PASS or FAIL.

To get start with the project, please execute the ci/smoke-tests.sh script.

Please use it, feedbacks are welcome !