### PR TITLE
Add debug test

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -224,7 +224,9 @@ $(DEBUG_TEST)/debug_test.elf: $(DEBUG_TEST)/debug_test.c
 		-L $(RISCV)/riscv32-unknown-elf/lib \
 		-lc -lm -lgcc
 	$(RISCV_EXE_PREFIX)objcopy -O verilog --remove-section=.debugger $(DEBUG_TEST)/debug_test.elf $(DEBUG_TEST)/debug_test.hex
-	$(RISCV_EXE_PREFIX)objcopy -O verilog   --only-section=.debugger --change-section-address .debugger=0x0  $(DEBUG_TEST)/debug_test.elf $(DEBUG_TEST)/debug_test_debugger.hex
+	$(RISCV_EXE_PREFIX)objcopy -O verilog --only-section=.debugger           --change-section-address .debugger=0x0             \
+	                                      --only-section=.debugger_exception --change-section-address .debugger_exception=0x400 \
+	                            $(DEBUG_TEST)/debug_test.elf $(DEBUG_TEST)/debug_test_debugger.hex
 
 custom-clean:
 	rm -rf $(CUSTOM)/hello_world.elf $(CUSTOM)/hello_world.hex

--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -128,6 +128,7 @@ VERI_FIRMWARE                        = ../../tests/core/firmware
 CUSTOM                               = $(CORE_TEST_DIR)/custom
 CUSTOM_DIR                          ?= $(CUSTOM)
 CUSTOM_PROG                         ?= my_hello_world
+DEBUG_TEST                           = $(CORE_TEST_DIR)/debug_test
 VERI_CUSTOM                          = ../../tests/core/custom
 CV32_RISCV_TESTS_FIRMWARE            = $(CORE_TEST_DIR)/cv32_riscv_tests_firmware
 CV32_RISCV_COMPLIANCE_TESTS_FIRMWARE = $(CORE_TEST_DIR)/cv32_riscv_compliance_tests_firmware
@@ -211,6 +212,20 @@ $(CUSTOM)/hello_world.elf: $(CUSTOM)/hello_world.c
 		-I $(RISCV)/riscv32-unknown-elf/include \
 		-L $(RISCV)/riscv32-unknown-elf/lib \
 		-lc -lm -lgcc
+
+# DEBUG TEST: 
+$(DEBUG_TEST)/debug_test.elf: $(DEBUG_TEST)/debug_test.c
+	$(RISCV_EXE_PREFIX)gcc -march=rv32imc -o $@ -w -Os -g -nostdlib \
+		-T $(DEBUG_TEST)/link.ld  \
+		-static \
+		$(DEBUG_TEST)/*.S \
+		$(DEBUG_TEST)/*.c \
+		-I $(RISCV)/riscv32-unknown-elf/include \
+		-L $(RISCV)/riscv32-unknown-elf/lib \
+		-lc -lm -lgcc
+	$(RISCV_EXE_PREFIX)objcopy -O verilog --remove-section=.debugger $(DEBUG_TEST)/debug_test.elf $(DEBUG_TEST)/debug_test.hex
+	$(RISCV_EXE_PREFIX)objcopy -O verilog   --only-section=.debugger --change-section-address .debugger=0x0  $(DEBUG_TEST)/debug_test.elf $(DEBUG_TEST)/debug_test_debugger.hex
+
 custom-clean:
 	rm -rf $(CUSTOM)/hello_world.elf $(CUSTOM)/hello_world.hex
 

--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -71,6 +71,34 @@ debug_test: comp $(DEBUG_TEST)/debug_test.elf
 		+firmware=$(DEBUG_TEST)/debug_test.hex \
 		+debugger=$(DEBUG_TEST)/debug_test_debugger.hex
 
+misalign: comp $(CUSTOM)/misalign.hex
+	$(XRUN) -l xrun-misalign.log $(XRUN_RUN_FLAGS) \
+		+elf_file=$(CUSTOM)/misalign.elf \
+		+nm_file=$(CUSTOM)/misalign.nm \
+		+UVM_TESTNAME=uvmt_cv32_firmware_test_c \
+		+firmware=$(CUSTOM)/misalign.hex
+
+illegal: comp $(CUSTOM)/illegal.hex
+	$(XRUN) -l xrun-illegal.log $(XRUN_RUN_FLAGS) \
+		+elf_file=$(CUSTOM)/illegal.elf \
+		+nm_file=$(CUSTOM)/illegal.nm \
+		+UVM_TESTNAME=uvmt_cv32_firmware_test_c \
+		+firmware=$(CUSTOM)/illegal.hex
+
+fibonacci: comp $(CUSTOM)/fibonacci.hex
+	$(XRUN) -l xrun-fibonacci.log $(XRUN_RUN_FLAGS) \
+		+elf_file=$(CUSTOM)/fibonacci.elf \
+		+nm_file=$(CUSTOM)/fibonacci.nm \
+		+UVM_TESTNAME=uvmt_cv32_firmware_test_c \
+		+firmware=$(CUSTOM)/fibonacci.hex
+
+dhrystone: comp $(CUSTOM)/dhrystone.hex
+	$(XRUN) -l xrun-dhrystone.log $(XRUN_RUN_FLAGS) \
+		+elf_file=$(CUSTOM)/dhrystone.elf \
+		+nm_file=$(CUSTOM)/dhrystone.nm \
+		+UVM_TESTNAME=uvmt_cv32_firmware_test_c \
+		+firmware=$(CUSTOM)/dhrystone.hex
+
 # Runs tests in cv32_riscv_tests/ only
 cv32-riscv-tests: comp $(CV32_RISCV_TESTS_FIRMWARE)/cv32_riscv_tests_firmware.hex
 	$(XRUN) -R -l xrun-riscv-tests.log \

--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -65,6 +65,12 @@ hello-world: comp $(CUSTOM)/hello_world.hex
 		+UVM_TESTNAME=uvmt_cv32_firmware_test_c \
 		+firmware=$(CUSTOM)/hello_world.hex
 
+debug_test: comp $(DEBUG_TEST)/debug_test.elf
+	$(XRUN) -R -l xrun_debug_test.log \
+		+UVM_TESTNAME=$(UVM_TESTNAME) \
+		+firmware=$(DEBUG_TEST)/debug_test.hex \
+		+debugger=$(DEBUG_TEST)/debug_test_debugger.hex
+
 # Runs tests in cv32_riscv_tests/ only
 cv32-riscv-tests: comp $(CV32_RISCV_TESTS_FIRMWARE)/cv32_riscv_tests_firmware.hex
 	$(XRUN) -R -l xrun-riscv-tests.log \

--- a/cv32/tb/core/riscv_wrapper.sv
+++ b/cv32/tb/core/riscv_wrapper.sv
@@ -46,7 +46,7 @@ module riscv_wrapper
     logic [31:0]                  data_wdata;
 
     // signals to debug unit
-    logic                         debug_req_i;
+    logic                         debug_req;
 
     // irq signals (not used)
     logic                         irq;
@@ -58,8 +58,6 @@ module riscv_wrapper
 
     // interrupts (only timer for now)
     assign irq_sec     = '0;
-
-    assign debug_req_i = 1'b0;
 
     // instantiate the core
     riscv_core #(
@@ -117,7 +115,7 @@ module riscv_wrapper
          .irq_nmi_i              (1'b0                   ),
          .irq_fastx_i            ({32{1'b0}}             ),
 
-         .debug_req_i            ( debug_req_i           ),
+         .debug_req_i            ( debug_req             ),
 
          .fetch_enable_i         ( fetch_enable_i        ),
          .core_busy_o            ( core_busy_o           )
@@ -150,6 +148,8 @@ module riscv_wrapper
          .irq_ack_i      ( irq_ack                        ),
          .irq_id_o       ( irq_id_in                      ),
          .irq_o          ( irq                            ),
+
+         .debug_req_o    ( debug_req                      ),
 
          .pc_core_id_i   ( riscv_core_i.pc_id             ),
 

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
@@ -43,7 +43,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
                             parameter PULP_CLUSTER        =   0, //changed
                                       FPU                 =   0,
                                       PULP_ZFINX          =   0,
-                                      DM_HALTADDRESS      =  32'h1A110800,
+                                      DM_HALTADDRESS      =  32'h000F_0000,
                             // Remaining parameters are used by TB components only
                                       INSTR_ADDR_WIDTH    =  32,
                                       INSTR_RDATA_WIDTH   =  32,
@@ -79,6 +79,8 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
     logic [ 4:0]                  irq_id_out;
     logic [ 4:0]                  irq_id_in;
 
+    logic                         debug_req;
+   
     // Load the Instruction Memory 
     initial begin: load_instruction_memory
       string firmware;
@@ -111,8 +113,8 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
 
     // instantiate the core
     riscv_core #(
-                 .PULP_CLUSTER    (PULP_CLUSTER),
-                 .FPU             (FPU),
+                 .PULP_CLUSTER           (PULP_CLUSTER),
+                 .FPU                    (FPU),
                  .PULP_ZFINX      (PULP_ZFINX),
                  .DM_HALTADDRESS  (DM_HALTADDRESS)
                 )
@@ -171,7 +173,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .irq_nmi_i              ( core_interrupts_if.irq_nmi        ),
          .irq_fastx_i            ( core_interrupts_if.irq_fastx      ),
 
-         .debug_req_i            ( core_cntrl_if.debug_req           ),
+         .debug_req_i            ( debug_req                         ),
 
          .fetch_enable_i         ( core_cntrl_if.fetch_en            ),
          .core_busy_o            ( core_status_if.core_busy          )
@@ -204,6 +206,8 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .irq_ack_i      ( irq_ack                        ),
          .irq_id_o       ( irq_id_in                      ),
          .irq_o          ( irq                            ),
+
+         .debug_req_o    ( debug_req                            ),
 
          .pc_core_id_i   ( riscv_core_i.pc_id             ),
 

--- a/cv32/tests/core/debug_test/crt0.S
+++ b/cv32/tests/core/debug_test/crt0.S
@@ -1,0 +1,63 @@
+/* Copyright (c) 2017  SiFive Inc. All rights reserved.
+ * Copyright (c) 2019  ETH Zürich and University of Bologna
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the FreeBSD License.   This program is distributed in the hope that
+ * it will be useful, but WITHOUT ANY WARRANTY expressed or implied,
+ * including the implied warranties of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  A copy of this license is available at
+ * http://www.opensource.org/licenses.
+ */
+
+/* Entry point for bare metal programs */
+.section .text.start
+.global _start
+.type _start, @function
+
+_start:
+/* initialize global pointer */
+.option push
+.option norelax
+1:	auipc gp, %pcrel_hi(__global_pointer$)
+	addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
+/* initialize stack pointer */
+	la sp, _sp
+
+/* set vector table address */
+	la a0, __vector_start
+	csrw mtvec, a0
+
+/* clear the bss segment */
+	la a0, __bss_start
+	la a2, __bss_end
+	sub a2, a2, a0
+	li a1, 0
+	call memset
+
+/* new-style constructors and destructors */
+	la a0, __libc_fini_array
+	call atexit
+	call __libc_init_array
+
+/* call main */
+	lw a0, 0(sp)                    /* a0 = argc */
+	addi a1, sp, __SIZEOF_POINTER__ /* a1 = argv */
+	li a2, 0                        /* a2 = envp = NULL */
+	call main
+	tail exit
+
+.size  _start, .-_start
+
+.global _init
+.type   _init, @function
+.global _fini
+.type   _fini, @function
+_init:
+_fini:
+ /* These don't have to do anything since we use init_array/fini_array. Prevent
+    missing symbol error */
+	ret
+.size  _init, .-_init
+.size _fini, .-_fini

--- a/cv32/tests/core/debug_test/debug_test.c
+++ b/cv32/tests/core/debug_test/debug_test.c
@@ -1,0 +1,289 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+** Basic debugger test. Needs more work and bugs fixed
+** It will launch a debug request and have debugger code execute (debugger.S)
+*******************************************************************************
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int glb_hart_status  = 0; // Written by main code only, read by debug code
+int glb_debug_status = 0; // Written by debug code only, read by main code
+int glb_ebreak_status = 0; // Written by ebreak code only, read by main code
+int glb_illegal_insn_status = 0; // Written by illegal instruction code only, read by main code
+int glb_expect_illegal_insn = 0;
+int glb_expect_ebreak_handler = 0;
+
+
+#define TEST_FAILED  *(volatile int *)0x20000000 = 1
+#define TEST_PASSED  *(volatile int *)0x20000000 = 123456789
+
+extern int __stack_start; 
+
+typedef union {
+  struct {
+    unsigned int start_delay      : 15; // 14: 0
+    unsigned int rand_start_delay : 1;  //    15
+    unsigned int pulse_width      : 13; // 28:16
+    unsigned int rand_pulse_width : 1;  //    29
+    unsigned int pulse_mode       : 1;  //    30    0 = level, 1 = pulse
+    unsigned int value            : 1;  //    31
+  } fields;
+  unsigned int bits;
+}  debug_req_control_t;
+
+#define DEBUG_REQ_CONTROL_REG *(volatile int *)0x15000008
+
+
+
+typedef union {
+  struct {
+    unsigned int uie   : 1;  //     0 // Implemented if USER mode enabled
+    unsigned int sie   : 1;  //     1
+    unsigned int wpri  : 1;  //     2
+    unsigned int mie   : 1;  //     3 // Implemented
+    unsigned int upie  : 1;  //     4 // Implemented if USER mode enabled
+    unsigned int spie  : 1;  //     5
+    unsigned int wpri0 : 1;  //     6
+    unsigned int mpie  : 1;  //     7 // Implemented
+    unsigned int spp   : 1;  //     8
+    unsigned int wpri1 : 2;  // 10: 9
+    unsigned int mpp   : 2;  // 12:11 // Implemented
+    unsigned int fs    : 2;  // 14:13
+    unsigned int xs    : 2;  // 16:15
+    unsigned int mprv  : 1;  //    17
+    unsigned int sum   : 1;  //    18
+    unsigned int mxr   : 1;  //    19
+    unsigned int tvm   : 1;  //    20
+    unsigned int tw    : 1;  //    21
+    unsigned int tsr   : 1;  //    22
+    unsigned int wpri3 : 8;  // 30:23
+    unsigned int sd    : 1;  //    31
+  } fields;
+  unsigned int bits;
+}  mstatus_t;
+
+typedef union {
+  struct {
+    unsigned int prv       : 2; //  1: 0
+    unsigned int step      : 1; //     2
+    unsigned int nmip      : 1; //     3
+    unsigned int mprven    : 1; //     4
+    unsigned int rsvd5     : 1; //     5
+    unsigned int cause     : 3; //  8: 6
+    unsigned int stoptime  : 1; //     9
+    unsigned int stopcount : 1; //    10
+    unsigned int stepie    : 1; //    11
+    unsigned int ebreaku   : 1; //    12
+    unsigned int ebreaks   : 1; //    13
+    unsigned int rsvd14    : 1; //    14
+    unsigned int ebreakm   : 1; //    15
+    unsigned int rsvd27_16 :12; // 27:16
+    unsigned int xdebugver : 4; // 31:28
+  } fields;
+  unsigned int bits;
+}  dcsr_t;
+
+// Tag is simply to help debug and determine where the failure came from
+void check_debug_status(int tag, int value)
+{
+  if(glb_debug_status != value){
+    printf("ERROR: check_debug_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
+           tag, value, tag, glb_debug_status, value);
+    TEST_FAILED;
+  }
+}
+void check_hart_status(int tag, int value)
+{
+  if(glb_hart_status != value){
+    printf("ERROR: check_hart_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
+           tag, value, tag, glb_hart_status, value);
+    TEST_FAILED;
+  }
+}
+void check_ebreak_status(int tag, int value)
+{
+  if(glb_ebreak_status != value){
+    printf("ERROR: check_ebreak_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
+           tag, value, tag, glb_ebreak_status, value);
+    TEST_FAILED;
+  }
+}
+void check_illegal_insn_status(int tag, int value)
+{
+  if(glb_illegal_insn_status != value){
+    printf("ERROR: check_illegal_insn_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
+           tag, value, tag, glb_illegal_insn_status, value);
+    TEST_FAILED;
+  }
+}
+
+
+#define MACHINE 3
+int main(int argc, char *argv[])
+{
+   //dcsr_cmp = (dcsr_t) {
+   //  .fields.prv       = MACHINE, // Privelege Machine Level
+   //  .fields.xdebugver = 4        // External debug support matches version 13.2
+   //};
+    //FIXME: BUG: bug xdebugver: if(dcsr_cmp.bits != dcsr.bits) {printf("ERROR: init dcsr mismatch exp=%x val=%x\n",
+    //               dcsr_cmp.bits, dcsr.bits); TEST_FAILED;}
+  //   dcsr_t dcsr, dcsr_cmp;
+  // __asm__ volatile("csrr %0, dcsr"    : "=r"(dcsr.bits));
+
+  unsigned int temp,temp1,temp2;
+    debug_req_control_t debug_req_control;
+    mstatus_t mstatus, mstatus_cmp;
+    dcsr_t dcsr, dcsr_cmp;
+
+    printf("\nBasic test checking debug functionality.\n");
+
+    printf("------------------------\n");
+    printf(" Test1: check initilazation values\n");
+    check_debug_status(0,0);
+
+    /* get relevant CSRs and compare init values*/
+    __asm__ volatile("csrr %0, mstatus" : "=r"(mstatus.bits));
+    printf("\tmstats_rval = 0x%0x\n",mstatus.bits);
+    
+    printf("------------------------\n");
+    printf(" Test2: check access to Debug and Trigger registers\n");
+    // debug specifcation 13.2: 4.8 Core Debug Registers are not accessable unless in debug mode
+    // debug specifcation 13.2: 5.2 Trigger Registers are not accessable unless in debug mode and machine mode
+
+    // Attempt to access each debug and trigger csr. We should expect an illegal instruction
+    // on each access attempt. The illegal instruction will increment the glb_hart_status.
+    // After each access, we check in the main line code to see if the glb_hart_status was incremented
+
+    // Check Read Access
+    temp1 = glb_illegal_insn_status+1;
+    glb_expect_illegal_insn = 1;
+    __asm__ volatile("csrr %0, dcsr"     : "=r"(temp)); // Debug DCSR
+    //FIXME: BUG: check_illegal_insn_status(1,temp1++);
+    __asm__ volatile("csrr %0, dpc"      : "=r"(temp)); // Debug DPC
+    //FIXME: BUG: check_illegal_insn_status(2,temp1++);
+    __asm__ volatile("csrr %0, dscratch" : "=r"(temp)); // Debug DSCRATCH0
+    //FIXME: BUG: check_illegal_insn_status(3,temp1++);
+    __asm__ volatile("csrr %0, 0x7b3" : "=r"(temp));    // Debug DSCRATCH1
+    //FIXME: BUG: check_illegal_insn_status(4,temp1++);
+
+    __asm__ volatile("csrr %0, 0x7a0"     : "=r"(temp)); // Trigger TSELECT
+    //FIXME: BUG: check_illegal_insn_status(5,temp1++);
+    __asm__ volatile("csrr %0, 0x7a1"     : "=r"(temp)); // Trigger TDATA1
+    //FIXME: BUG: check_illegal_insn_status(6,temp1++);
+    __asm__ volatile("csrr %0, 0x7a2"     : "=r"(temp)); // Trigger TDATA2
+    //FIXME: BUG: check_illegal_insn_status(7,temp1++);
+    __asm__ volatile("csrr %0, 0x7a3"     : "=r"(temp)); // Trigger TDATA3
+    //FIXME: BUG: check_illegal_insn_status(8,temp1++);
+    __asm__ volatile("csrr %0, 0x7a8"     : "=r"(temp)); // Trigger MCONTEXT
+    //FIXME: BUG: check_illegal_insn_status(9,temp1++);
+    __asm__ volatile("csrr %0, 0x7aa"     : "=r"(temp)); // Trigger SCONTEXT
+    //FIXME: BUG: check_illegal_insn_status(10,temp1++);
+
+    // ----------------------
+    // Check Write Access
+    temp = 0xFFFFFFFF;
+    __asm__ volatile("csrw  dcsr, %0"     : "=r"(temp)); // Debug DCSR     
+    //FIXME: BUG: check_illegal_insn_status(11,temp1++);                           
+    __asm__ volatile("csrw  dpc, %0"      : "=r"(temp)); // Debug DPC      
+    //FIXME: BUG: check_illegal_insn_status(12,temp1++);                           
+    __asm__ volatile("csrw  dscratch, %0" : "=r"(temp)); // Debug DSCRATCH0
+    //FIXME: BUG: check_illegal_insn_status(13,temp1++);                           
+    __asm__ volatile("csrw  0x7b3, %0" : "=r"(temp));    // Debug DSCRATCH1
+    //FIXME: BUG: check_illegal_insn_status(14,temp1++);
+
+    __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
+    //FIXME: BUG: check_illegal_insn_status(15,temp1++);
+    __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
+    //FIXME: BUG: check_illegal_insn_status(16,temp1++);
+    __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
+    //FIXME: BUG: check_illegal_insn_status(17,temp1++);
+    __asm__ volatile("csrw  0x7a3, %0"     : "=r"(temp)); // Trigger TDATA3
+    //FIXME: BUG: check_illegal_insn_status(18,temp1++);
+    __asm__ volatile("csrw  0x7a8, %0"     : "=r"(temp)); // Trigger MCONTEXT
+    //FIXME: BUG: check_illegal_insn_status(19,temp1++);
+    __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
+    //FIXME: BUG: check_illegal_insn_status(20,temp1++);
+    glb_expect_illegal_insn = 0;
+
+    mstatus_cmp = (mstatus_t) {
+    .fields.mpp   = MACHINE  // 
+    };
+    if(mstatus_cmp.bits != mstatus.bits) {printf("ERROR: init mstatus mismatch exp=%x val=%x\n",
+                                           mstatus_cmp.bits, mstatus.bits); TEST_FAILED;}
+
+    printf("------------------------\n");
+    printf(" Test3: check hart ebreak executes ebreak handler but does not execute debugger code\n");
+    check_debug_status(31,0);
+    glb_expect_ebreak_handler = 1;
+    asm volatile("c.ebreak");
+    glb_expect_ebreak_handler = 0;
+    check_ebreak_status(32,1);
+    check_debug_status(33,0);
+
+    //FIXME: complier cannot generate 32 ebreak instruction
+    //  Need to test both 16bit and 32bit ebreak instruction
+
+    printf("------------------------\n");
+    printf(" Test4: request hardware debugger\n");
+
+    glb_hart_status = 0; // Basic test
+    debug_req_control = (debug_req_control_t) {
+      .fields.value            = 1,
+      .fields.pulse_mode       = 1, //PULSE Mode
+      .fields.rand_pulse_width = 0,
+      .fields.pulse_width      = 4,// FIXME: BUG: one clock pulse cause core to lock up
+      .fields.rand_start_delay = 1,
+      .fields.start_delay      = 200
+    };
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+
+    while(!glb_debug_status){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(41,1);
+
+    printf("------------------------\n");
+    printf(" Test5: have debugger execute ebreak 3 more times\n");
+
+    glb_hart_status = 1;
+    debug_req_control = (debug_req_control_t) {
+      .fields.value            = 1,
+      .fields.pulse_mode       = 1, //PULSE Mode
+      .fields.rand_pulse_width = 0,
+      .fields.pulse_width      = 3,
+      .fields.rand_start_delay = 1,
+      .fields.start_delay      = 100
+    };
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+
+    
+    while(glb_debug_status != 4){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(41,4);
+    check_ebreak_status(35,1);
+
+
+    //--------------------------------
+    //return EXIT_FAILURE;
+    printf("------------------------\n");
+    printf("Finished \n");
+    return EXIT_SUCCESS;
+}

--- a/cv32/tests/core/debug_test/debug_test.c
+++ b/cv32/tests/core/debug_test/debug_test.c
@@ -23,12 +23,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int glb_hart_status  = 0; // Written by main code only, read by debug code
-int glb_debug_status = 0; // Written by debug code only, read by main code
-int glb_ebreak_status = 0; // Written by ebreak code only, read by main code
-int glb_illegal_insn_status = 0; // Written by illegal instruction code only, read by main code
-int glb_expect_illegal_insn = 0;
-int glb_expect_ebreak_handler = 0;
+volatile int glb_hart_status  = 0; // Written by main code only, read by debug code
+volatile int glb_debug_status = 0; // Written by debug code only, read by main code
+volatile int glb_ebreak_status = 0; // Written by ebreak code only, read by main code
+volatile int glb_illegal_insn_status = 0; // Written by illegal instruction code only, read by main code
+volatile int glb_expect_illegal_insn = 0;
+volatile int glb_expect_ebreak_handler = 0;
 
 
 #define TEST_FAILED  *(volatile int *)0x20000000 = 1
@@ -147,7 +147,8 @@ int main(int argc, char *argv[])
   //   dcsr_t dcsr, dcsr_cmp;
   // __asm__ volatile("csrr %0, dcsr"    : "=r"(dcsr.bits));
 
-  unsigned int temp,temp1,temp2;
+    unsigned int temp,temp1,temp2,temp3;
+
     debug_req_control_t debug_req_control;
     mstatus_t mstatus, mstatus_cmp;
     dcsr_t dcsr, dcsr_cmp;
@@ -156,71 +157,80 @@ int main(int argc, char *argv[])
 
     printf("------------------------\n");
     printf(" Test1: check initilazation values\n");
-    check_debug_status(0,0);
+    //check_debug_status(0,0);
 
+    temp1 = 0xFFFFFFFF;
     /* get relevant CSRs and compare init values*/
+    __asm__ volatile("csrr %0, mstatus" : "=r"(temp1));
+    __asm__ volatile("csrw mstatus, %0 " : "=r"(temp1));
     __asm__ volatile("csrr %0, mstatus" : "=r"(mstatus.bits));
-    printf("\tmstats_rval = 0x%0x\n",mstatus.bits);
+    __asm__ volatile("csrr %0, mie" : "=r"(temp));
+    __asm__ volatile("csrw mie, %0 " : "=r"(temp1));
+    __asm__ volatile("csrr %0, mie" : "=r"(temp1));
+    printf("\tmstats_rval = 0x%0x 0x%0x 0x%0x 0x%0x\n",temp2,mstatus.bits,temp,temp1);
     
+    check_debug_status(0,0);
     printf("------------------------\n");
     printf(" Test2: check access to Debug and Trigger registers\n");
     // debug specifcation 13.2: 4.8 Core Debug Registers are not accessable unless in debug mode
     // debug specifcation 13.2: 5.2 Trigger Registers are not accessable unless in debug mode and machine mode
 
     // Attempt to access each debug and trigger csr. We should expect an illegal instruction
-    // on each access attempt. The illegal instruction will increment the glb_hart_status.
-    // After each access, we check in the main line code to see if the glb_hart_status was incremented
+    // on each access attempt. The illegal instruction will increment the glb_illegal_insn_status.
 
     // Check Read Access
     temp1 = glb_illegal_insn_status+1;
+    // Allow illegal instruction handler to run
     glb_expect_illegal_insn = 1;
-    __asm__ volatile("csrr %0, dcsr"     : "=r"(temp)); // Debug DCSR
-    //FIXME: BUG: check_illegal_insn_status(1,temp1++);
-    __asm__ volatile("csrr %0, dpc"      : "=r"(temp)); // Debug DPC
-    //FIXME: BUG: check_illegal_insn_status(2,temp1++);
-    __asm__ volatile("csrr %0, dscratch" : "=r"(temp)); // Debug DSCRATCH0
-    //FIXME: BUG: check_illegal_insn_status(3,temp1++);
-    __asm__ volatile("csrr %0, 0x7b3" : "=r"(temp));    // Debug DSCRATCH1
-    //FIXME: BUG: check_illegal_insn_status(4,temp1++);
+    __asm__ volatile("csrr %0, dcsr"    : "=r"(temp)); // Debug DCSR
+    check_illegal_insn_status(1,temp1++);
+    __asm__ volatile("csrr %0, dpc"     : "=r"(temp)); // Debug DPC
+    check_illegal_insn_status(2,temp1++);
+    __asm__ volatile("csrr %0, dscratch": "=r"(temp)); // Debug DSCRATCH0
+    check_illegal_insn_status(3,temp1++);
+    __asm__ volatile("csrr %0, 0x7b3"   : "=r"(temp)); // Debug DSCRATCH1
+    check_illegal_insn_status(4,temp1++);
 
-    __asm__ volatile("csrr %0, 0x7a0"     : "=r"(temp)); // Trigger TSELECT
-    //FIXME: BUG: check_illegal_insn_status(5,temp1++);
-    __asm__ volatile("csrr %0, 0x7a1"     : "=r"(temp)); // Trigger TDATA1
-    //FIXME: BUG: check_illegal_insn_status(6,temp1++);
-    __asm__ volatile("csrr %0, 0x7a2"     : "=r"(temp)); // Trigger TDATA2
-    //FIXME: BUG: check_illegal_insn_status(7,temp1++);
-    __asm__ volatile("csrr %0, 0x7a3"     : "=r"(temp)); // Trigger TDATA3
-    //FIXME: BUG: check_illegal_insn_status(8,temp1++);
-    __asm__ volatile("csrr %0, 0x7a8"     : "=r"(temp)); // Trigger MCONTEXT
-    //FIXME: BUG: check_illegal_insn_status(9,temp1++);
-    __asm__ volatile("csrr %0, 0x7aa"     : "=r"(temp)); // Trigger SCONTEXT
-    //FIXME: BUG: check_illegal_insn_status(10,temp1++);
+    __asm__ volatile("csrr %0, 0x7a0"   : "=r"(temp)); // Trigger TSELECT
+    check_illegal_insn_status(5,temp1++);
+    __asm__ volatile("csrr %0, 0x7a1"   : "=r"(temp)); // Trigger TDATA1
+    check_illegal_insn_status(6,temp1++);
+    __asm__ volatile("csrr %0, 0x7a2"   : "=r"(temp)); // Trigger TDATA2
+    check_illegal_insn_status(7,temp1++);
+    __asm__ volatile("csrr %0, 0x7a3"   : "=r"(temp)); // Trigger TDATA3
+    check_illegal_insn_status(8,temp1++);
+    __asm__ volatile("csrr %0, 0x7a8"   : "=r"(temp)); // Trigger MCONTEXT
+    check_illegal_insn_status(9,temp1++);
+    __asm__ volatile("csrr %0, 0x7aa"   : "=r"(temp)); // Trigger SCONTEXT
+    check_illegal_insn_status(10,temp1++);
 
     // ----------------------
     // Check Write Access
     temp = 0xFFFFFFFF;
     __asm__ volatile("csrw  dcsr, %0"     : "=r"(temp)); // Debug DCSR     
-    //FIXME: BUG: check_illegal_insn_status(11,temp1++);                           
+     check_illegal_insn_status(11,temp1++);
     __asm__ volatile("csrw  dpc, %0"      : "=r"(temp)); // Debug DPC      
-    //FIXME: BUG: check_illegal_insn_status(12,temp1++);                           
+    check_illegal_insn_status(12,temp1++);
     __asm__ volatile("csrw  dscratch, %0" : "=r"(temp)); // Debug DSCRATCH0
-    //FIXME: BUG: check_illegal_insn_status(13,temp1++);                           
+    check_illegal_insn_status(13,temp1++);
     __asm__ volatile("csrw  0x7b3, %0" : "=r"(temp));    // Debug DSCRATCH1
-    //FIXME: BUG: check_illegal_insn_status(14,temp1++);
+    check_illegal_insn_status(14,temp1++);
 
     __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
-    //FIXME: BUG: check_illegal_insn_status(15,temp1++);
+    check_illegal_insn_status(15,temp1++);
     __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
-    //FIXME: BUG: check_illegal_insn_status(16,temp1++);
+    check_illegal_insn_status(16,temp1++);
     __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
-    //FIXME: BUG: check_illegal_insn_status(17,temp1++);
+    check_illegal_insn_status(17,temp1++);
     __asm__ volatile("csrw  0x7a3, %0"     : "=r"(temp)); // Trigger TDATA3
-    //FIXME: BUG: check_illegal_insn_status(18,temp1++);
+    check_illegal_insn_status(18,temp1++);
     __asm__ volatile("csrw  0x7a8, %0"     : "=r"(temp)); // Trigger MCONTEXT
-    //FIXME: BUG: check_illegal_insn_status(19,temp1++);
+    check_illegal_insn_status(19,temp1++);
     __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
-    //FIXME: BUG: check_illegal_insn_status(20,temp1++);
+    check_illegal_insn_status(20,temp1++);
+    // Do not expect or allow any more illegal instructions
     glb_expect_illegal_insn = 0;
+
 
     mstatus_cmp = (mstatus_t) {
     .fields.mpp   = MACHINE  // 
@@ -243,12 +253,12 @@ int main(int argc, char *argv[])
     printf("------------------------\n");
     printf(" Test4: request hardware debugger\n");
 
-    glb_hart_status = 0; // Basic test
+    glb_hart_status = 4; // Basic test
     debug_req_control = (debug_req_control_t) {
       .fields.value            = 1,
       .fields.pulse_mode       = 1, //PULSE Mode
       .fields.rand_pulse_width = 0,
-      .fields.pulse_width      = 4,// FIXME: BUG: one clock pulse cause core to lock up
+      .fields.pulse_width      = 5,// FIXME: BUG: one clock pulse cause core to lock up
       .fields.rand_start_delay = 1,
       .fields.start_delay      = 200
     };
@@ -262,24 +272,56 @@ int main(int argc, char *argv[])
     printf("------------------------\n");
     printf(" Test5: have debugger execute ebreak 3 more times\n");
 
-    glb_hart_status = 1;
-    debug_req_control = (debug_req_control_t) {
-      .fields.value            = 1,
-      .fields.pulse_mode       = 1, //PULSE Mode
-      .fields.rand_pulse_width = 0,
-      .fields.pulse_width      = 3,
-      .fields.rand_start_delay = 1,
-      .fields.start_delay      = 100
-    };
+    glb_hart_status = 5;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
-
-    
     while(glb_debug_status != 4){
       printf("Wait for Debugger\n");
     }
     check_debug_status(41,4);
     check_ebreak_status(35,1);
 
+    printf("------------------------\n");
+    printf(" Test6: Test CSR access and default values in debug mode\n");
+    glb_hart_status = 6;
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != 5){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(61,5);
+
+    printf("------------------------\n");
+    printf(" Test7: Test Trigger\n");
+    glb_hart_status = 7;
+
+    printf("  test7.1: Don't expect trigger\n");
+    _trigger_test(0); // don't expect trigger match
+
+    printf("  test7.2: setup trigger in debugger\n");
+    // Setup trigger for _trigger_code function address
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != 6){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(72,6);
+
+    printf("  test7.3: Expect Trigger\n");
+    glb_hart_status = 8;
+    _trigger_test(1); //  trigger match enabled
+    // We should have also incremented debug status
+    check_debug_status(73,7);
+
+
+    printf("  test7.4: Disable Trigger\n");
+    glb_hart_status = 9;
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != 8){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(74,8);
+    _trigger_test(0); //  trigger disabled
+
+    // Don't expect to enter debug (debug status stays the same value)
+    check_debug_status(75,8);
 
     //--------------------------------
     //return EXIT_FAILURE;

--- a/cv32/tests/core/debug_test/debug_test.c
+++ b/cv32/tests/core/debug_test/debug_test.c
@@ -27,8 +27,13 @@ volatile int glb_hart_status  = 0; // Written by main code only, read by debug c
 volatile int glb_debug_status = 0; // Written by debug code only, read by main code
 volatile int glb_ebreak_status = 0; // Written by ebreak code only, read by main code
 volatile int glb_illegal_insn_status = 0; // Written by illegal instruction code only, read by main code
-volatile int glb_expect_illegal_insn = 0;
-volatile int glb_expect_ebreak_handler = 0;
+volatile int glb_debug_exception_status = 0; // Written by debug code during exception only
+
+// Expectation flags. Raise an error if handler or routine is enterred when not expected,
+volatile int glb_expect_illegal_insn    = 0;
+volatile int glb_expect_ebreak_handler  = 0;
+volatile int glb_expect_debug_entry     = 0;
+volatile int glb_expect_debug_exception = 0;
 
 
 #define TEST_FAILED  *(volatile int *)0x20000000 = 1
@@ -79,26 +84,6 @@ typedef union {
   unsigned int bits;
 }  mstatus_t;
 
-typedef union {
-  struct {
-    unsigned int prv       : 2; //  1: 0
-    unsigned int step      : 1; //     2
-    unsigned int nmip      : 1; //     3
-    unsigned int mprven    : 1; //     4
-    unsigned int rsvd5     : 1; //     5
-    unsigned int cause     : 3; //  8: 6
-    unsigned int stoptime  : 1; //     9
-    unsigned int stopcount : 1; //    10
-    unsigned int stepie    : 1; //    11
-    unsigned int ebreaku   : 1; //    12
-    unsigned int ebreaks   : 1; //    13
-    unsigned int rsvd14    : 1; //    14
-    unsigned int ebreakm   : 1; //    15
-    unsigned int rsvd27_16 :12; // 27:16
-    unsigned int xdebugver : 4; // 31:28
-  } fields;
-  unsigned int bits;
-}  dcsr_t;
 
 // Tag is simply to help debug and determine where the failure came from
 void check_debug_status(int tag, int value)
@@ -106,6 +91,14 @@ void check_debug_status(int tag, int value)
   if(glb_debug_status != value){
     printf("ERROR: check_debug_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
            tag, value, tag, glb_debug_status, value);
+    TEST_FAILED;
+  }
+}
+void check_debug_exception_status(int tag, int value)
+{
+  if(glb_debug_exception_status != value){
+    printf("ERROR: check_debug_exception_status(%d, %d): Tag=% status=%d, exp=%d \n\n",
+           tag, value, tag, glb_debug_exception_status, value);
     TEST_FAILED;
   }
 }
@@ -138,20 +131,10 @@ void check_illegal_insn_status(int tag, int value)
 #define MACHINE 3
 int main(int argc, char *argv[])
 {
-   //dcsr_cmp = (dcsr_t) {
-   //  .fields.prv       = MACHINE, // Privelege Machine Level
-   //  .fields.xdebugver = 4        // External debug support matches version 13.2
-   //};
-    //FIXME: BUG: bug xdebugver: if(dcsr_cmp.bits != dcsr.bits) {printf("ERROR: init dcsr mismatch exp=%x val=%x\n",
-    //               dcsr_cmp.bits, dcsr.bits); TEST_FAILED;}
-  //   dcsr_t dcsr, dcsr_cmp;
-  // __asm__ volatile("csrr %0, dcsr"    : "=r"(dcsr.bits));
-
     unsigned int temp,temp1,temp2,temp3;
 
     debug_req_control_t debug_req_control;
     mstatus_t mstatus, mstatus_cmp;
-    dcsr_t dcsr, dcsr_cmp;
 
     printf("\nBasic test checking debug functionality.\n");
 
@@ -173,7 +156,7 @@ int main(int argc, char *argv[])
     printf("------------------------\n");
     printf(" Test2: check access to Debug and Trigger registers\n");
     // debug specifcation 13.2: 4.8 Core Debug Registers are not accessable unless in debug mode
-    // debug specifcation 13.2: 5.2 Trigger Registers are not accessable unless in debug mode and machine mode
+    // Trigger Registers are not accessable due to dmode==DEBUG access only
 
     // Attempt to access each debug and trigger csr. We should expect an illegal instruction
     // on each access attempt. The illegal instruction will increment the glb_illegal_insn_status.
@@ -184,52 +167,70 @@ int main(int argc, char *argv[])
     glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, dcsr"    : "=r"(temp)); // Debug DCSR
     check_illegal_insn_status(1,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, dpc"     : "=r"(temp)); // Debug DPC
     check_illegal_insn_status(2,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, dscratch": "=r"(temp)); // Debug DSCRATCH0
     check_illegal_insn_status(3,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7b3"   : "=r"(temp)); // Debug DSCRATCH1
     check_illegal_insn_status(4,temp1++);
 
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7a0"   : "=r"(temp)); // Trigger TSELECT
     check_illegal_insn_status(5,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7a1"   : "=r"(temp)); // Trigger TDATA1
     check_illegal_insn_status(6,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7a2"   : "=r"(temp)); // Trigger TDATA2
     check_illegal_insn_status(7,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7a3"   : "=r"(temp)); // Trigger TDATA3
     check_illegal_insn_status(8,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7a8"   : "=r"(temp)); // Trigger MCONTEXT
     check_illegal_insn_status(9,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrr %0, 0x7aa"   : "=r"(temp)); // Trigger SCONTEXT
     check_illegal_insn_status(10,temp1++);
 
     // ----------------------
     // Check Write Access
     temp = 0xFFFFFFFF;
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  dcsr, %0"     : "=r"(temp)); // Debug DCSR     
      check_illegal_insn_status(11,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  dpc, %0"      : "=r"(temp)); // Debug DPC      
     check_illegal_insn_status(12,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  dscratch, %0" : "=r"(temp)); // Debug DSCRATCH0
     check_illegal_insn_status(13,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7b3, %0" : "=r"(temp));    // Debug DSCRATCH1
     check_illegal_insn_status(14,temp1++);
 
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
     check_illegal_insn_status(15,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
     check_illegal_insn_status(16,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
     check_illegal_insn_status(17,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7a3, %0"     : "=r"(temp)); // Trigger TDATA3
     check_illegal_insn_status(18,temp1++);
+    glb_expect_illegal_insn = 1;
     __asm__ volatile("csrw  0x7a8, %0"     : "=r"(temp)); // Trigger MCONTEXT
     check_illegal_insn_status(19,temp1++);
-    __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
+     glb_expect_illegal_insn = 1;
+   __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
     check_illegal_insn_status(20,temp1++);
     // Do not expect or allow any more illegal instructions
-    glb_expect_illegal_insn = 0;
 
 
     mstatus_cmp = (mstatus_t) {
@@ -240,12 +241,9 @@ int main(int argc, char *argv[])
 
     printf("------------------------\n");
     printf(" Test3: check hart ebreak executes ebreak handler but does not execute debugger code\n");
-    check_debug_status(31,0);
     glb_expect_ebreak_handler = 1;
     asm volatile("c.ebreak");
-    glb_expect_ebreak_handler = 0;
     check_ebreak_status(32,1);
-    check_debug_status(33,0);
 
     //FIXME: complier cannot generate 32 ebreak instruction
     //  Need to test both 16bit and 32bit ebreak instruction
@@ -253,7 +251,6 @@ int main(int argc, char *argv[])
     printf("------------------------\n");
     printf(" Test4: request hardware debugger\n");
 
-    glb_hart_status = 4; // Basic test
     debug_req_control = (debug_req_control_t) {
       .fields.value            = 1,
       .fields.pulse_mode       = 1, //PULSE Mode
@@ -262,66 +259,121 @@ int main(int argc, char *argv[])
       .fields.rand_start_delay = 1,
       .fields.start_delay      = 200
     };
+    glb_expect_debug_entry = 1;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
 
-    while(!glb_debug_status){
+    glb_hart_status = 4; // Basic test
+    while(glb_debug_status != glb_hart_status){
       printf("Wait for Debugger\n");
     }
-    check_debug_status(41,1);
+    check_debug_status(41,glb_hart_status);
 
     printf("------------------------\n");
     printf(" Test5: have debugger execute ebreak 3 more times\n");
 
     glb_hart_status = 5;
+    glb_expect_debug_entry = 1;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
-    while(glb_debug_status != 4){
+    while(glb_debug_status != (5+3)){
       printf("Wait for Debugger\n");
     }
-    check_debug_status(41,4);
-    check_ebreak_status(35,1);
+    check_debug_status(51,(5+3));
 
     printf("------------------------\n");
     printf(" Test6: Test CSR access and default values in debug mode\n");
     glb_hart_status = 6;
+    glb_expect_debug_entry = 1;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
-    while(glb_debug_status != 5){
+    while(glb_debug_status != glb_hart_status){
       printf("Wait for Debugger\n");
     }
-    check_debug_status(61,5);
+    check_debug_status(61,glb_hart_status);
+
+
 
     printf("------------------------\n");
     printf(" Test7: Test Trigger\n");
-    glb_hart_status = 7;
 
     printf("  test7.1: Don't expect trigger\n");
-    _trigger_test(0); // don't expect trigger match
+    _trigger_test(0); // 0 = don't expect trigger match
 
     printf("  test7.2: setup trigger in debugger\n");
     // Setup trigger for _trigger_code function address
+    glb_hart_status = 7;
+    glb_expect_debug_entry = 1;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
-    while(glb_debug_status != 6){
+    while(glb_debug_status != glb_hart_status){
       printf("Wait for Debugger\n");
     }
-    check_debug_status(72,6);
+    check_debug_status(72,glb_hart_status);
 
     printf("  test7.3: Expect Trigger\n");
     glb_hart_status = 8;
+    glb_expect_debug_entry = 1;
     _trigger_test(1); //  trigger match enabled
     // We should have also incremented debug status
-    check_debug_status(73,7);
+    check_debug_status(73,glb_hart_status);
 
 
     printf("  test7.4: Disable Trigger\n");
     glb_hart_status = 9;
+    glb_expect_debug_entry = 1;
     DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
-    while(glb_debug_status != 8){
+    while(glb_debug_status != glb_hart_status){
       printf("Wait for Debugger\n");
     }
-    check_debug_status(74,8);
+    check_debug_status(74,glb_hart_status);
     _trigger_test(0); //  trigger disabled
 
     // Don't expect to enter debug (debug status stays the same value)
-    check_debug_status(75,8);
+    check_debug_status(75,glb_hart_status);
+
+
+    printf("------------------------\n");
+    printf(" Test10: check hart ebreak executes debugger code\n");
+    glb_hart_status = 10;
+    glb_expect_debug_entry = 1;
+    asm volatile("c.ebreak");
+    check_debug_status(33,glb_hart_status);
+
+    printf("------------------------\n");
+    printf(" Test11: check illegal csr exception during debug launches debugger exception and no csr modified\n");
+    glb_hart_status = 11;
+    glb_expect_debug_entry = 1;
+    glb_expect_debug_exception = 1;
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != glb_hart_status){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(111,glb_hart_status);
+    check_debug_exception_status(111,glb_hart_status);
+    //FIXME TBD BUG : need to update test to check actual csrs not modified.
+
+    printf("------------------------\n");
+    printf(" Test12: check ecall exception during debug launches debugger exception and no csr modified\n");
+    glb_hart_status = 12;
+    glb_expect_debug_entry = 1;
+    glb_expect_debug_exception = 1;
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != glb_hart_status){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(112,glb_hart_status);
+    check_debug_exception_status(112,glb_hart_status);
+    //FIXME TBD BUG : need to update test to check actual csrs not modified.
+
+    printf("------------------------\n");
+    printf(" Test13: check mret during debug launches debugger exception and no csr modified\n");
+    glb_hart_status = 13;
+    glb_expect_debug_entry = 1;
+    glb_expect_debug_exception = 1;
+    DEBUG_REQ_CONTROL_REG = debug_req_control.bits;
+    while(glb_debug_status != glb_hart_status){
+      printf("Wait for Debugger\n");
+    }
+    check_debug_status(113,glb_hart_status);
+    check_debug_exception_status(113,glb_hart_status);
+    //FIXME TBD BUG : need to update test to check actual csrs not modified.
 
     //--------------------------------
     //return EXIT_FAILURE;

--- a/cv32/tests/core/debug_test/debugger.S
+++ b/cv32/tests/core/debug_test/debugger.S
@@ -1,0 +1,89 @@
+
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+** Debugger code
+*******************************************************************************
+*/
+
+.section .debugger, "ax"
+.global _debugger_start
+.global glb_debug_status
+.global glb_hart_status
+.global __debugger_stack_start
+        
+_debugger_start:        
+        // Debugger Stack
+        csrw dscratch, a0       // dscratch0
+        la a0, __debugger_stack_start
+        //sw t0, 0(a0)
+        csrw 0x7b3, t0      	// dscratch1
+        sw t1, 4(a0)
+        sw t2, 8(a0)
+        sw a1, 12(a0)
+        sw a2, 16(a0)
+        // Increment glb_debug_status
+        la a1, glb_debug_status
+        lw t1, 0(a1)
+        addi t1,t1,1
+        sw t1, 0(a1)
+        // Determine Test to execute in debugger code
+        la a2, glb_hart_status
+        lw t2, 0(a2)
+	li t0, 0
+	beq t2,t0,_debugger_end // Test 0
+	li t0,1
+	beq t2,t0,_debugger_ebreak // Test 1
+_debugger_ebreak:
+	// Repeat executing debug code until debug status = 4
+	li t0, 4
+	beq t1,t0,_debugger_end
+        csrr t0, 0x7b3
+	lw t1, 4(a0)
+        lw t2, 8(a0)
+        lw a1, 12(a0)
+        lw a2, 16(a0)
+        csrr a0, dscratch
+        ebreak
+_debugger_end:	
+        // Debugger Stack
+        //lw t0, 0(a0)
+        csrr t0, 0x7b3
+        lw t1, 4(a0)
+        lw t2, 8(a0)
+        lw a1, 12(a0)
+        lw a2, 16(a0)
+        csrr a0, dscratch
+        dret
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        nop
+        

--- a/cv32/tests/core/debug_test/debugger.S
+++ b/cv32/tests/core/debug_test/debugger.S
@@ -24,7 +24,10 @@
 .global _debugger_start
 .global glb_debug_status
 .global glb_hart_status
+.global glb_expect_debug_entry
 .global __debugger_stack_start
+.global _debugger_fail
+.global _debugger_end
 .set test_ret_val, 0x20000000
 .set test_fail, 0x1
         
@@ -38,28 +41,83 @@ _debugger_start:
         sw t2, 8(a0)
         sw a1, 12(a0)
         sw a2, 16(a0)
-        // Increment glb_debug_status
-        la a1, glb_debug_status
+        // Check if expecting debug entry
+        la a1, glb_expect_debug_entry
         lw t1, 0(a1)
-        addi t1,t1,1
-        sw t1, 0(a1)
-        // Determine Test to execute in debugger code
+        beq x0,t1,_debugger_fail
+
+        // Determine Test to execute in debugger code based on glb_hart_status
         la a2, glb_hart_status
         lw t2, 0(a2)
-	li t0, 4
-	beq t2,t0,_debugger_end    // Test 4
+
+	// ebreak test will loop in debugger code over several iterations
+	//  and will increment the global status each time
 	li t0,5
 	beq t2,t0,_debugger_ebreak // Test 5
+
+	// For all other tests,
+	// Set debug status = hart status
+        la a1, glb_debug_status
+	sw t2, 0(a1)
+
+	li t0, 4
+	beq t2,t0,_debugger_simple    // Test 4
+
 	li t0,6
 	beq t2,t0,_debugger_csr    // Test 6
+
 	li t0,7
 	beq t2,t0,_debugger_trigger_setup    // Test 7
+
 	li t0,8
 	beq t2,t0,_debugger_trigger_match    // Test 8
+
 	li t0,9
 	beq t2,t0,_debugger_trigger_disable    // Test 9
+
+	li t0,10
+	beq t2,t0,_debugger_ebreak_entry    // Test 10
+
+	li t0,11
+	beq t2,t0,_debugger_csr_exception    // Test 11
+
+	li t0,12
+	beq t2,t0,_debugger_ecall_exception    // Test 12
+
+	li t0,13
+	beq t2,t0,_debugger_mret_call    // Test 13
+
+_debugger_csr_exception:
+	csrr t2,0xea8 // illegal insn
+
+_debugger_ecall_exception:
+	ecall // exception
+
+_debugger_mret_call:
+	mret // will invoke debugger exception routine
+
+_debugger_ebreak_entry:
+        la a1, glb_debug_status
+	li   t1, 4<<28 | 1<<6 | 3<<0 | 1<<15
+	csrr t2,dcsr
+	bne  t1,t2,_debugger_fail
+        csrr a1,dpc
+        addi a1,a1,2
+        csrw dpc,a1
+        //sw t1, 0(a1)
+        j  _debugger_end
+
+_debugger_simple:
+        la a1, glb_debug_status
+	//csrr t2,0xea8 // illegal insn
+        li t1, 1
+        //sw t1, 0(a1)
+        j  _debugger_end
+
 _debugger_csr:
 	// Check CSR access
+	// When done, set the ebreakm bit to allow next test to enter debug with ebreak
+
 	// TBD BUG FIXME : make sure appropriate list of CSR (from sspecifications)
 	//csrr t2,mvendorid
 	//csrr t2,marchid
@@ -71,6 +129,7 @@ _debugger_csr:
 	csrr t2,misa
 	csrr t2,mie
 	csrr t2,mtvec
+	//FIXME csrr t2,mtval
 
 	// machine trap handling
 	csrr t2,mscratch
@@ -93,6 +152,10 @@ _debugger_csr:
 	beq  x0,t2,_debugger_fail
 	//Already test this csrr t2,dscratch  //dscratch0
 	//Already test this csrr t2,0x7b3    //dscratch1
+
+        // Set ebreakm in dcsr
+	li   t1, 4<<28 | 3<<6 | 3<<0| 1<<15
+	csrw dcsr, t1
 
 	// ----------------------
 	// Trigger CSRs
@@ -133,7 +196,7 @@ _debugger_trigger_match:
 	//    8:6   Cause           = 2 Trigger
 	//    1:0   Privelege       = 3 Machine
 	// TBD FIXME BUG documentation update needed
-	li   t1, 4<<28 | 2<<6 | 3<<0
+	li   t1, 4<<28 | 2<<6 | 3<<0 | 1<<15
 	csrr t2,dcsr
 	bne  t1,t2,_debugger_fail
 
@@ -149,7 +212,7 @@ _debugger_trigger_disable:
 	//    8:6   Cause           = 3 debugger
 	//    1:0   Privelege       = 3 Machine
 	// TBD FIXME BUG documentation update needed
-	li   t1, 4<<28 | 3<<6 | 3<<0
+	li   t1, 4<<28 | 3<<6 | 3<<0 | 1<<15
 	csrr t2,dcsr
 	bne  t1,t2,_debugger_fail
 
@@ -158,10 +221,17 @@ _debugger_trigger_disable:
 	csrr t2,tdata1
 	bne  t1,t2,_debugger_fail
 	j    _debugger_end
+
 _debugger_ebreak:
-	// Repeat executing debug code until debug status = 4
-	li   t0, 4
-	beq  t1,t0,_debugger_end
+        // Increment glb_debug_status
+        la a1, glb_debug_status
+        lw t1, 0(a1)
+        addi t1,t1,1
+        sw t1, 0(a1)
+	// Repeat executing debug code until debug status = hart_status + 3
+	addi t0, t2, 3
+	beq  t1, t0, _debugger_end
+	// Debugger Un-Stack and call debugger code from start using ebreak
         csrr t0, 0x7b3
 	lw   t1, 4(a0)
         lw   t2, 8(a0)
@@ -170,7 +240,10 @@ _debugger_ebreak:
         csrr a0, dscratch
         ebreak
 _debugger_end:	
-        // Debugger Stack
+        // Clear debug entry expectation flag
+        la a1, glb_expect_debug_entry
+        sw x0, 0(a1)
+        // Debugger Un-Stack
         //lw t0, 0(a0)
         csrr t0, 0x7b3
         lw   t1, 4(a0)

--- a/cv32/tests/core/debug_test/debugger.S
+++ b/cv32/tests/core/debug_test/debugger.S
@@ -25,6 +25,8 @@
 .global glb_debug_status
 .global glb_hart_status
 .global __debugger_stack_start
+.set test_ret_val, 0x20000000
+.set test_fail, 0x1
         
 _debugger_start:        
         // Debugger Stack
@@ -44,45 +46,144 @@ _debugger_start:
         // Determine Test to execute in debugger code
         la a2, glb_hart_status
         lw t2, 0(a2)
-	li t0, 0
-	beq t2,t0,_debugger_end // Test 0
-	li t0,1
-	beq t2,t0,_debugger_ebreak // Test 1
+	li t0, 4
+	beq t2,t0,_debugger_end    // Test 4
+	li t0,5
+	beq t2,t0,_debugger_ebreak // Test 5
+	li t0,6
+	beq t2,t0,_debugger_csr    // Test 6
+	li t0,7
+	beq t2,t0,_debugger_trigger_setup    // Test 7
+	li t0,8
+	beq t2,t0,_debugger_trigger_match    // Test 8
+	li t0,9
+	beq t2,t0,_debugger_trigger_disable    // Test 9
+_debugger_csr:
+	// Check CSR access
+	// TBD BUG FIXME : make sure appropriate list of CSR (from sspecifications)
+	//csrr t2,mvendorid
+	//csrr t2,marchid
+	//csrr t2,mimpid
+	csrr t2,mhartid
+
+	// machine trap setup
+	csrr t2,mstatus
+	csrr t2,misa
+	csrr t2,mie
+	csrr t2,mtvec
+
+	// machine trap handling
+	csrr t2,mscratch
+	csrr t2,mepc
+	csrr t2,mcause
+	csrr t2,mip
+
+	// -----------------------
+	// Debug CSRs
+
+	// Expect DCSR
+	//   31:28 XDEBUGER Version = 4
+	//    8:6   Cause           = 3 debugger
+	//    1:0   Privelege       = 3 Machine
+	// TBD FIXME BUG documentation update needed
+	li   t1, 4<<28 | 3<<6 | 3<<0
+	csrr t2,dcsr
+	bne  t1,t2,_debugger_fail
+	csrr t2,dpc
+	beq  x0,t2,_debugger_fail
+	//Already test this csrr t2,dscratch  //dscratch0
+	//Already test this csrr t2,0x7b3    //dscratch1
+
+	// ----------------------
+	// Trigger CSRs
+
+	// Expect TMATCH=TDATA1
+	//   31:28 type      = 2
+	//      27 dmode     = 1
+	//   15:12 action    = 1
+	//      6  m(achine) = 1
+	li   t1, 2<<28 | 1<<27 | 1<<12 | 1<<6
+	csrr t2,tdata1
+	bne  t1,t2,_debugger_fail
+	csrr t2,tselect
+	bne  x0,t2,_debugger_fail
+	csrr t2,tdata2
+	bne  x0,t2,_debugger_fail
+	csrr t2,tdata3
+	bne  x0,t2,_debugger_fail
+	csrr t2,0x7a8 //mcontext
+	bne  x0,t2,_debugger_fail
+	csrr t2,0x7aa //scontext
+	bne  x0,t2,_debugger_fail
+
+	j _debugger_end
+_debugger_trigger_setup:
+	// setup address to trigger on
+	la   a1,_trigger_code
+	csrw tdata2,a1
+	li   t1, 1<<2
+	csrw tdata1,t1
+	li   t1, 2<<28 | 1<<27 | 1<<12 | 1<<6 | 1 <<2
+	csrr t2,tdata1
+	bne  t1,t2,_debugger_fail
+	j    _debugger_end
+_debugger_trigger_match:
+	// Expect DCSR
+	//   31:28 XDEBUGER Version = 4
+	//    8:6   Cause           = 2 Trigger
+	//    1:0   Privelege       = 3 Machine
+	// TBD FIXME BUG documentation update needed
+	li   t1, 4<<28 | 2<<6 | 3<<0
+	csrr t2,dcsr
+	bne  t1,t2,_debugger_fail
+
+	la   a1,_trigger_code
+	csrr a2,dpc
+	bne  a1,a2,_debugger_fail
+	la   a1,_trigger_exit
+	csrw dpc,a1
+	j   _debugger_end
+_debugger_trigger_disable:
+	// Expect DCSR
+	//   31:28 XDEBUGER Version = 4
+	//    8:6   Cause           = 3 debugger
+	//    1:0   Privelege       = 3 Machine
+	// TBD FIXME BUG documentation update needed
+	li   t1, 4<<28 | 3<<6 | 3<<0
+	csrr t2,dcsr
+	bne  t1,t2,_debugger_fail
+
+	csrw tdata1,x0
+	li   t1, 2<<28 | 1<<27 | 1<<12 | 1<<6
+	csrr t2,tdata1
+	bne  t1,t2,_debugger_fail
+	j    _debugger_end
 _debugger_ebreak:
 	// Repeat executing debug code until debug status = 4
-	li t0, 4
-	beq t1,t0,_debugger_end
+	li   t0, 4
+	beq  t1,t0,_debugger_end
         csrr t0, 0x7b3
-	lw t1, 4(a0)
-        lw t2, 8(a0)
-        lw a1, 12(a0)
-        lw a2, 16(a0)
+	lw   t1, 4(a0)
+        lw   t2, 8(a0)
+        lw   a1, 12(a0)
+        lw   a2, 16(a0)
         csrr a0, dscratch
         ebreak
 _debugger_end:	
         // Debugger Stack
         //lw t0, 0(a0)
         csrr t0, 0x7b3
-        lw t1, 4(a0)
-        lw t2, 8(a0)
-        lw a1, 12(a0)
-        lw a2, 16(a0)
+        lw   t1, 4(a0)
+        lw   t2, 8(a0)
+        lw   a1, 12(a0)
+        lw   a2, 16(a0)
         csrr a0, dscratch
         dret
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
-        nop
+_debugger_fail: //Test Failed
+        li a0, test_ret_val
+        li t0, test_fail
+        sw t0, 0(a0)
+	nop
         nop
         nop
         nop

--- a/cv32/tests/core/debug_test/link.ld
+++ b/cv32/tests/core/debug_test/link.ld
@@ -1,0 +1,165 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+** This linker description file has two memory regions
+**  1) debugger code is placed in dbg memory under the .debugger section
+**  2) main memory is placed into ram memory
+*******************************************************************************
+*/
+
+
+OUTPUT_FORMAT("elf32-littleriscv", "elf32-littleriscv",
+	      "elf32-littleriscv")
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+MEMORY
+{
+	/* All sections are placed into ram. */
+
+	dbg (rwxai) : ORIGIN = 0x1A110800, LENGTH = 0x800
+}
+
+SECTIONS
+{
+        /* ----------------------------------------*/
+        /* Debugger Code : This section address must be the same
+           as the DM_HaltAddress parameter in the RTL*/
+        .debugger (ORIGIN(dbg)):
+        {
+          KEEP(*(.debugger));
+        } >dbg
+        /* Debugger Stack*/
+        .debugger_stack         : ALIGN(16)
+        {
+         PROVIDE(__debugger_stack_start = .);
+         . = 0x80;
+        } >dbg
+}
+
+MEMORY
+{
+	/* All sections are placed into ram. */
+
+	ram (rwxai) : ORIGIN = 0x00000000, LENGTH = 0x400000
+}
+
+SECTIONS
+{
+
+        /* ----------------------------------------*/
+        /* we want a fixed entry point */
+        PROVIDE(__boot_address = 0x80);
+
+        /* stack and heap related settings */
+        __stack_size = DEFINED(__stack_size) ? __stack_size : 0x400;
+        PROVIDE(__stack_size = __stack_size);
+        __heap_size = DEFINED(__heap_size) ? __heap_size : 0x400;
+
+
+        /* Read-only sections, merged into text segment: */
+        PROVIDE (__executable_start = SEGMENT_START("text-segment", 0x10000)); . = SEGMENT_START("text-segment", 0x10000) + SIZEOF_HEADERS;
+
+        /* interrupt vectors */
+        .vectors (ORIGIN(ram)):
+        {
+          PROVIDE(__vector_start = .);
+          KEEP(*(.vectors));
+        } >ram
+
+
+        /* crt0 init code */
+        .init (__boot_address):
+        {
+          KEEP (*(SORT_NONE(.init)))
+          KEEP (*(.text.start))
+        } >ram
+
+
+	.text.init :
+	{
+		*(.text.init);
+	} > ram
+
+        /* the bulk of the program: main, libc, functions etc. */
+	.text :
+	{
+		__ram_start = .;
+		start*(.text);
+		*(.text);
+		__ram_end = .;
+	} > ram
+	_etext = .;
+
+	.data :
+	{
+		__data_begin = .;
+    		*(.data .data.* .gnu.linkonce.d.*)
+	} > ram
+
+	.data.string :
+	{
+		*(.data.string)
+	} > ram
+
+	.sdata :
+	{
+		__sdata_begin = .;
+		*(.sdata .sdata.* .gnu.linkonce.s.*)
+	} > ram
+	_edata = .;
+
+	. = ALIGN(4);
+	__bss_start = .;
+	.bss :
+	{
+		*(.bss)
+	} > ram
+
+	/* elf special section */
+	.sbss :
+	{
+		*(.sbss)
+	} > ram
+
+	. = ALIGN(4);
+	__bss_end = .;
+	__global_pointer$ = MIN(__sdata_begin + 0x800,
+			    MAX(__data_begin + 0x800, __bss_end - 0x800));
+	_end = .;
+        PROVIDE (end = .);
+
+        /* heap: we should consider putting this to the bottom of the address space */
+        .heap          :
+        {
+         PROVIDE(__heap_start = .);
+         . = __heap_size;
+         PROVIDE(__heap_end = .);
+        } >ram
+
+
+        /* stack: we should consider putting this further to the top of the address
+          space */
+        .stack         : ALIGN(16) /* this is a requirement of the ABI(?) */
+        {
+         PROVIDE(__stack_start = .);
+         . = __stack_size;
+         PROVIDE(_sp = .);
+         PROVIDE(__stack_end = .);
+        } >ram
+
+        
+}

--- a/cv32/tests/core/debug_test/link.ld
+++ b/cv32/tests/core/debug_test/link.ld
@@ -42,6 +42,10 @@ SECTIONS
         {
           KEEP(*(.debugger));
         } >dbg
+        .debugger_exception (0x1A110C00):
+        {
+          KEEP(*(.debugger_exception));
+        } >dbg
         /* Debugger Stack*/
         .debugger_stack         : ALIGN(16)
         {

--- a/cv32/tests/core/debug_test/syscalls.c
+++ b/cv32/tests/core/debug_test/syscalls.c
@@ -1,0 +1,270 @@
+/* An extremely minimalist syscalls.c for newlib
+ * Based on riscv newlib libgloss/riscv/sys_*.c
+ *
+ * Copyright 2019 Clifford Wolf
+ * Copyright 2019 ETH Zürich and University of Bologna
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/stat.h>
+#include <newlib.h>
+#include <unistd.h>
+#include <errno.h>
+#undef errno
+extern int errno;
+
+/* write to this reg for outputting strings */
+#define STDOUT_REG 0x10000000
+/* write test result of program to this reg */
+#define RESULT_REG 0x20000000
+/* write exit value of program to this reg */
+#define EXIT_REG 0x20000004
+
+#define STDOUT_FILENO 1
+
+/* It turns out that older newlib versions use different symbol names which goes
+ * against newlib recommendations. Anyway this is fixed in later version.
+ */
+#if __NEWLIB__ <= 2 && __NEWLIB_MINOR__ <= 5
+#    define _sbrk sbrk
+#    define _write write
+#    define _close close
+#    define _lseek lseek
+#    define _read read
+#    define _fstat fstat
+#    define _isatty isatty
+#endif
+
+void unimplemented_syscall()
+{
+    const char *p = "Unimplemented system call called!\n";
+    while (*p)
+        *(volatile int *)STDOUT_REG = *(p++);
+}
+
+int nanosleep(const struct timespec *rqtp, struct timespec *rmtp)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _access(const char *file, int mode)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _chdir(const char *path)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _chmod(const char *path, mode_t mode)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _chown(const char *path, uid_t owner, gid_t group)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _close(int file)
+{
+    return -1;
+}
+
+int _execve(const char *name, char *const argv[], char *const env[])
+{
+    errno = ENOMEM;
+    return -1;
+}
+
+void _exit(int exit_status)
+{
+    *(volatile int *)EXIT_REG = exit_status;
+    asm volatile("wfi");
+}
+
+int _faccessat(int dirfd, const char *file, int mode, int flags)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _fork(void)
+{
+    errno = EAGAIN;
+    return -1;
+}
+
+int _fstat(int file, struct stat *st)
+{
+    st->st_mode = S_IFCHR;
+    return 0;
+    // errno = -ENOSYS;
+    // return -1;
+}
+
+int _fstatat(int dirfd, const char *file, struct stat *st, int flags)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _ftime(struct timeb *tp)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+char *_getcwd(char *buf, size_t size)
+{
+    errno = -ENOSYS;
+    return NULL;
+}
+
+int _getpid()
+{
+    return 1;
+}
+
+int _gettimeofday(struct timeval *tp, void *tzp)
+{
+    errno = -ENOSYS;
+    return -1;
+}
+
+int _isatty(int file)
+{
+    return (file == STDOUT_FILENO);
+}
+
+int _kill(int pid, int sig)
+{
+    errno = EINVAL;
+    return -1;
+}
+
+int _link(const char *old_name, const char *new_name)
+{
+    errno = EMLINK;
+    return -1;
+}
+
+off_t _lseek(int file, off_t ptr, int dir)
+{
+    return 0;
+}
+
+int _lstat(const char *file, struct stat *st)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _open(const char *name, int flags, int mode)
+{
+    return -1;
+}
+
+int _openat(int dirfd, const char *name, int flags, int mode)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+ssize_t _read(int file, void *ptr, size_t len)
+{
+    return 0;
+}
+
+int _stat(const char *file, struct stat *st)
+{
+    st->st_mode = S_IFCHR;
+    return 0;
+    // errno = ENOSYS;
+    // return -1;
+}
+
+long _sysconf(int name)
+{
+
+    return -1;
+}
+
+clock_t _times(struct tms *buf)
+{
+    return -1;
+}
+
+int _unlink(const char *name)
+{
+    errno = ENOENT;
+    return -1;
+}
+
+int _utime(const char *path, const struct utimbuf *times)
+{
+    errno = ENOSYS;
+    return -1;
+}
+
+int _wait(int *status)
+{
+    errno = ECHILD;
+    return -1;
+}
+
+ssize_t _write(int file, const void *ptr, size_t len)
+{
+    if (file != STDOUT_FILENO) {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    const void *eptr = ptr + len;
+    while (ptr != eptr)
+        *(volatile int *)STDOUT_REG = *(char *)(ptr++);
+    return len;
+}
+
+extern char __heap_start[];
+extern char __heap_end[];
+static char *brk = __heap_start;
+
+int _brk(void *addr)
+{
+    brk = addr;
+    return 0;
+}
+
+void *_sbrk(ptrdiff_t incr)
+{
+    char *old_brk = brk;
+
+    if (__heap_start == __heap_end) {
+        return NULL;
+    }
+
+    if ((brk += incr) < __heap_end) {
+        brk += incr;
+    } else {
+        brk = __heap_end;
+    }
+    return old_brk;
+}

--- a/cv32/tests/core/debug_test/trigger_code.S
+++ b/cv32/tests/core/debug_test/trigger_code.S
@@ -1,0 +1,61 @@
+.section .trigger_code_sect, "ax"
+.set test_ret_val, 0x20000000
+.set test_fail, 0x1
+
+.global _trigger_exit
+.global _trigger_test
+.global _trigger_code
+.type _trigger_code, @function
+     // We will trigger on the _trigger_code addess
+	// We should not expect the first instruction to execute
+	// The debugger code will move the PC to the trigger_exit_code
+	// Which essentially avoid executing all of the code in the trigger_code
+_trigger_code:        
+        add a2,a0,a1
+        ret
+_trigger_exit:        
+        ret
+_trigger_test:        
+        addi sp,sp,-30
+        sw t0, 0(sp)
+        sw t1, 4(sp)
+        sw a0, 8(sp)
+        sw a1, 12(sp)
+        sw a2, 16(sp)
+        sw ra, 20(sp)
+
+	// a0 holds input to function (expect trigger)
+	mv t1, a0
+
+	// Load up some random data to add
+	li a0, 7893
+	li a1, 1452
+	li a2,  191 // a2 value will be overwrriten by _trigger_code
+	mv t2,  a2  // keep a copy of the value to compare against
+	
+	// Call function that will have a trigger match
+	//   If no trigger match, then a2=a0+a1
+	//   Else if trigger matched, then a2 is not modified
+	jal ra, _trigger_code
+
+	// if (expect trigger) check against original value (in t2)
+	bne t1 ,x0, __trigger_check
+	// else
+	// trigger match not expected, function executes as normal
+	// set execpted value to t2 = a0 + a1
+	add t2, a0, a1
+__trigger_check:	
+	beq t2,a2,__trigger_done
+__trigger_fail:	
+        li a0, test_ret_val
+        li t0, 1
+        sw t0, 0(a0)
+__trigger_done:	
+        lw t0, 0(sp)
+        lw t1, 4(sp)
+        lw a0, 8(sp)
+        lw a1, 12(sp)
+        lw a2, 16(sp)
+        lw ra, 20(sp)
+        addi sp,sp,30
+	ret

--- a/cv32/tests/core/debug_test/vectors.S
+++ b/cv32/tests/core/debug_test/vectors.S
@@ -1,0 +1,187 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+** 
+*******************************************************************************
+*/
+
+.section .vectors, "ax"
+.option norvc
+.global glb_illegal_insn_status
+.global glb_ebreak_status
+.global glb_expect_illegal_insn
+.global glb_expect_ebreak_handler
+.set test_ret_val, 0x20000000
+.set test_fail, 0x1
+        
+vector_table:
+	j sw_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j verification_irq_handler
+
+/* this is fixed to 0x8000, used for PULP_SECURE=0. We redirect this entry to the
+new vector table (which is at mtvec) */
+/* .section .legacy_irq, "ax" */
+/*	j vector_table */
+/*	j __no_irq_handler */
+/*	j __no_irq_handler */
+/*	j __no_irq_handler */
+
+.section .text.vecs
+/* exception handling */
+__no_irq_handler:
+	la a0, no_exception_handler_msg
+	jal ra, puts
+	j __no_irq_handler
+
+
+sw_irq_handler:
+        addi sp,sp,-44
+        sw t0, 0(sp)
+        sw t1, 4(sp)
+        sw a0, 8(sp)
+        sw a1, 12(sp)
+        sw a2, 16(sp)
+        sw a3, 20(sp)
+        sw a4, 24(sp)
+        sw a5, 28(sp)
+        sw a6, 32(sp)
+        sw a7, 36(sp)
+        sw ra, 40(sp)
+	csrr t0, mcause
+	slli t0, t0, 1  /* shift off the high bit */
+	srli t0, t0, 1
+	li t1, 2
+	beq t0, t1, handle_illegal_insn
+	li t1, 11
+	beq t0, t1, handle_ecall
+	li t1, 3
+	beq t0, t1, handle_ebreak
+	j handle_unknown
+
+handle_ecall:
+	la a0, ecall_msg
+	jal ra, puts
+	j end_handler
+
+handle_ebreak:
+	la a0, ebreak_msg
+	jal ra, puts
+        // Check if expecting ebreak handler
+        la a0, glb_expect_ebreak_handler 
+        lw t0, 0(a0)
+        bne t0, x0, cont_handle_ebreak
+        // Not expecting ebreak, assert test failed
+        li a0, test_ret_val
+        li t0, 1
+        sw t0, 0(a0)
+	j end_handler
+cont_handle_ebreak:
+        //increment hart status     
+        la a0, glb_ebreak_status  
+        lw t0, 0(a0)
+        addi t0,t0,1
+        sw t0, 0(a0)
+	j end_handler
+
+handle_illegal_insn:
+	la a0, illegal_insn_msg
+	jal ra, puts
+        // Check if expecting illegal instruction
+        la a0, glb_expect_illegal_insn 
+        lw t0, 0(a0)
+        bne t0, x0, cont_illegal_insn 
+        li a0, test_ret_val
+        li t0, 1
+        sw t0, 0(a0)            //Test Failed
+	j end_handler
+cont_illegal_insn:
+        //increment hart status     
+        la a0, glb_illegal_insn_status  
+        lw t0, 0(a0)
+        addi t0,t0,1
+        sw t0, 0(a0)
+	j end_handler
+
+
+        
+handle_unknown:
+	la a0, unknown_msg
+	jal ra, puts
+	j end_handler
+
+end_handler:
+	csrr a0, mepc
+	addi a0, a0, 2
+	csrw mepc, a0
+        lw t0, 0(sp)
+        lw t1, 4(sp)
+        lw a0, 8(sp)
+        lw a1, 12(sp)
+        lw a2, 16(sp)
+        lw a3, 20(sp)
+        lw a4, 24(sp)
+        lw a5, 28(sp)
+        lw a6, 32(sp)
+        lw a7, 36(sp)
+        lw ra, 40(sp)
+        addi sp,sp,44
+	mret
+/* this interrupt can be generated for verification purposes, random or when the PC is equal to a given value*/
+verification_irq_handler:
+	mret
+
+.section .rodata
+illegal_insn_msg:
+	.string "illegal instruction exception handler entered\n"
+ecall_msg:
+	.string "ecall exception handler entered\n"
+ebreak_msg:
+	.string "ebreak exception handler entered\n"
+unknown_msg:
+	.string "unknown exception handler entered\n"
+no_exception_handler_msg:
+	.string "no exception handler installed\n"

--- a/cv32/tests/core/debug_test/vectors.S
+++ b/cv32/tests/core/debug_test/vectors.S
@@ -121,6 +121,7 @@ handle_ebreak:
 	j end_handler
 cont_handle_ebreak:
         //increment hart status     
+        sw x0, 0(a0)
         la a0, glb_ebreak_status  
         lw t0, 0(a0)
         addi t0,t0,1
@@ -140,6 +141,7 @@ handle_illegal_insn:
 	j end_handler
 cont_illegal_insn:
         //increment hart status     
+        sw x0, 0(a0)
         la a0, glb_illegal_insn_status  
         lw t0, 0(a0)
         addi t0,t0,1

--- a/cv32/tests/core/debug_test/vectors.S
+++ b/cv32/tests/core/debug_test/vectors.S
@@ -155,7 +155,13 @@ handle_unknown:
 
 end_handler:
 	csrr a0, mepc
+	lb t0, 0(a0)
+	li t1,0x3
+	and t0,t0,t1
 	addi a0, a0, 2
+	bne t0,t1,end_handler_cont
+	addi a0, a0, 2
+end_handler_cont:
 	csrw mepc, a0
         lw t0, 0(sp)
         lw t1, 4(sp)


### PR DESCRIPTION
Adding a basic debug test in the core/debug_test directory.

- It will test debug and trigger CSR access from main code and debugger code
- Ensure `ebreak` from main code launches proper exception handler
- Launch `debug_req` signal and start debugger code
- Ensure `ebreak` call while the core is in `debug_mode` will restart debugger code
- Basic trigger test, causing entry into `debug_mode` when matching specific address


