### PR TITLE
Fix warnings in hello-world.c

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -214,7 +214,7 @@ $(CUSTOM_DIR)/$(CUSTOM_PROG).elf: $(CUSTOM_DIR)/$(CUSTOM_PROG).c
 
 # HELLO WORLD: custom/hello_world.elf: ../../tests/core/custom/hello_world.c
 $(CUSTOM)/hello_world.elf: $(CUSTOM)/hello_world.c
-	$(RISCV_EXE_PREFIX)gcc -mabi=ilp32 -march=rv32imc -o $@ -w -Os -g -nostdlib \
+	$(RISCV_EXE_PREFIX)gcc -mabi=ilp32 -march=rv32imc -o $@ -Wall -pedantic -Os -g -nostdlib \
 		-T $(CUSTOM)/link.ld  \
 		-static \
 		$(CUSTOM)/crt0.S \

--- a/cv32/tests/core/custom/hello_world.c
+++ b/cv32/tests/core/custom/hello_world.c
@@ -28,7 +28,7 @@
 
 int main(int argc, char *argv[])
 {
-    unsigned int mvendorid_rval, misa_rval, mxl;
+    unsigned int misa_rval, mxl;
              int reserved, tentative, nonstd, user, super;
 
     mxl = 0; reserved = 0; tentative = 0; nonstd = 0; user = 0; super = 0;
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     printf("\nHELLO WORLD!!!\n");
     printf("This is the OpenHW Group CV32E40P CORE-V processor core.\n");
     printf("CV32E40P is a RISC-V ISA compliant core with the following attributes:\n");
-    printf("\tmvendorid = 0x%0x\n", mvendorid_rval);
+    // printf("\tmvendorid = 0x%0x\n", mvendorid_rval);
     printf("\tmisa      = 0x%0x\n", misa_rval);
     mxl = ((misa_rval & 0xC0000000) >> 30); // MXL == MISA[31:30]
     switch (mxl) {
@@ -68,7 +68,10 @@ int main(int argc, char *argv[])
     printf("\tSupported Instructions: ");
     if ((misa_rval >> 25) & 0x00000001) ++reserved;
     if ((misa_rval >> 24) & 0x00000001) ++reserved;
-    if ((misa_rval >> 23) & 0x00000001) printf("X"); ++nonstd;
+    if ((misa_rval >> 23) & 0x00000001) {
+      printf("X");
+      ++nonstd;
+    }
     if ((misa_rval >> 22) & 0x00000001) ++reserved;
     if ((misa_rval >> 21) & 0x00000001) ++tentative;
     if ((misa_rval >> 20) & 0x00000001) ++user;


### PR DESCRIPTION
All tests are currently compiled with `-w` which was hiding some existing warnings and risks new warnings creeping in.

I changed hello world to build with `-Wall -pedantic` and found warnings in `cv32/tests/core/custom/{hello-world,syscalls}.c`. This PR fixes the `hello-world.c` warnings only. I have not touched the warnings in `cv32/tests/custom/core/syscalls.c`, because they are fixed in the new bsp `cv32/bsp/syscalls.c` (#120). Once tests start using the new bsp, these warnings will disappear.

This process should be repeated for the other tests.