### PR TITLE
uvmt_cv32_tb_ifs.sv: use wire to make VCS happy. Fix #122

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -213,7 +213,7 @@ endinterface : uvmt_cv32_core_interrupts_if
  * Core status signals.
  */
 interface uvmt_cv32_core_status_if (
-                                    input  logic       core_busy,
+                                    input  wire        core_busy,
                                     input  logic       sec_lvl
                                    );
 


### PR DESCRIPTION
Fix to remove VCS compilation error.