### PR TITLE
Update for the latest RTL (101f455de)

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -54,11 +54,14 @@
 # Head of the master branch as of 2020-05-29
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH    ?= 9135b2f8caf7364141fbb70358badbdc86162d77
+CV32E40P_HASH   ?= 101f455de120d14421f1dffa30a9e119a6bb2597
 
 FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
 FPNEW_BRANCH    ?= master
-FPNEW_HASH      ?= c15c54887b3bc6d0965606c487e9f1bf43237e45
+#Note: this is one merge behind the head (as of 2020-06-11)
+FPNEW_HASH      ?= f108dfdd84f7c24dcdefb35790fafb3905bce552
+#Note: this is head (as of 2020-06-11).  Can't use it because of the worm
+#FPNEW_HASH      ?= babffe88fcf6d2931a7afa8d121b6a6ba4f532f7
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
@@ -77,7 +77,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
     logic [31:0]                  data_rdata;
     logic [31:0]                  data_wdata;
 
-    logic [ 4:0]                  irq_id_out;
+    logic [ 5:0]                  irq_id_out;
     logic [ 4:0]                  irq_id_in;
 
     // Load the Instruction Memory 
@@ -125,7 +125,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
     end
 
     // instantiate the core
-    riscv_core #(
+    cv32e40p_core #(
                  .PULP_HWLP        (PULP_HWLP),
                  .PULP_CLUSTER     (PULP_CLUSTER),
                  .FPU              (FPU),
@@ -182,8 +182,8 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .irq_timer_i            ( core_interrupts_if.irq_timer      ),
          .irq_external_i         ( core_interrupts_if.irq_external   ),
          .irq_fast_i             ( core_interrupts_if.irq_fast       ),
-         .irq_nmi_i              ( core_interrupts_if.irq_nmi        ),
-         .irq_fastx_i            ( core_interrupts_if.irq_fastx      ),
+         //.irq_nmi_i              ( core_interrupts_if.irq_nmi        ),
+         //.irq_fastx_i            ( core_interrupts_if.irq_fastx      ),
 
          .debug_req_i            ( core_cntrl_if.debug_req           ),
 
@@ -214,7 +214,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .data_rvalid_o  ( data_rvalid                    ),
          .data_gnt_o     ( data_gnt                       ),
 
-         .irq_id_i       ( irq_id_out                     ),
+         .irq_id_i       ( irq_id_out[4:0]                ),
          .irq_ack_i      ( irq_ack                        ),
          .irq_id_o       ( irq_id_in                      ),
          .irq_o          ( irq                            ),

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
@@ -147,7 +147,8 @@ module uvmt_cv32_step_compare
                                     3'b0,
                                     $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mie_q.irq_software,
                                     3'b0};
-             "miex"    : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.miex_q;
+             // MT: 2020-06-11
+             //"miex"    : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.miex_q;
              "mtvec"   : csr_val = {$root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mtvec_q, 6'h0, 2'b01};
              "mtvecx"  : csr_val = {$root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mtvec_q, 6'h0, 2'b01};
              "mscratch": csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mscratch_q;
@@ -155,16 +156,17 @@ module uvmt_cv32_step_compare
              "mcause"  : csr_val = {$root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mcause_q[6], 
                                     25'b0, 
                                     $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mcause_q[5:0]};
-             "mip"     : csr_val = {$root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_nmi,  
-                                    $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_fast,
-                                    4'b0, // [15:12] not defined
-                                    $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_external,
-                                    3'b0, // [10:8] not defined
-                                    $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_timer,
-                                    3'b0, // [6:4] not defined
-                                    $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_software,
-                                    3'b0}; // [2:0] not defined
-             "mipx"    : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mipx;
+             // MT: 2020-06-11
+             //"mip"     : csr_val = {$root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_nmi,  
+             //                       $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_fast,
+             //                       4'b0, // [15:12] not defined
+             //                       $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_external,
+             //                       3'b0, // [10:8] not defined
+             //                       $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_timer,
+             //                       3'b0, // [6:4] not defined
+             //                       $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mip.irq_software,
+             //                       3'b0}; // [2:0] not defined
+             //"mipx"    : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.mipx;
              "mhartid" : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.hart_id_i; 
              //"mhartid" : csr_val = {21'b0, 
              //                       $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.cluster_id_i[5:0], 
@@ -180,7 +182,7 @@ module uvmt_cv32_step_compare
              "pmpcfg3"   : csr_val = $root.uvmt_cv32_tb.dut_wrap.riscv_core_i.cs_registers_i.pmp_reg_q.pmpcfg_packed[3];
              "time"   : ignore = 1;
              default: begin
-                $display("%0t: ERROR: index=%s does not match a CSR name", $time, index);
+                `uvm_error("STEP_COMPARE", $sformatf("index=%s does not match a CSR name", index))
                 ignore = 1;
              end
            endcase // case (index)

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -179,8 +179,8 @@ endinterface : uvmt_cv32_core_cntrl_if
  */
 interface uvmt_cv32_core_interrupts_if
  #(
-   parameter NUM_FAST_INTR   = 15, //TODO: pass these in from the TB/DUT_WRAP
-             NUM_XFASTX_INTR = 32  // _XFASTX_ deliberately choosen to make it visually distinct from _FAST_
+   parameter NUM_FAST_INTR   = 48 //TODO: pass these in from the TB/DUT_WRAP
+             //NUM_XFASTX_INTR = 32  // _XFASTX_ deliberately choosen to make it visually distinct from _FAST_
   )
   (
    input  logic                       irq_ack,        // dut output
@@ -189,9 +189,9 @@ interface uvmt_cv32_core_interrupts_if
    output logic                       irq_software,   // dut input
    output logic                       irq_timer,      // dut input
    output logic                       irq_external,   // dut input
-   output logic [NUM_FAST_INTR-1:0]   irq_fast,       // dut input
-   output logic                       irq_nmi,        // dut input
-   output logic [NUM_XFASTX_INTR-1:0] irq_fastx       // dut input
+   output logic [NUM_FAST_INTR-1:0]   irq_fast        // dut input
+   //output logic                       irq_nmi,        // dut input
+   //output logic [NUM_XFASTX_INTR-1:0] irq_fastx       // dut input
   );
 
   import uvm_pkg::*;
@@ -202,8 +202,8 @@ interface uvmt_cv32_core_interrupts_if
     irq_timer    = 1'b0;
     irq_external = 1'b0;
     irq_fast     = {NUM_FAST_INTR{1'b0}};
-    irq_nmi      = 1'b0;
-    irq_fastx    = {NUM_XFASTX_INTR{1'b0}};
+    //irq_nmi      = 1'b0;
+    //irq_fastx    = {NUM_XFASTX_INTR{1'b0}};
     `uvm_info("CORE_INTERRUPT_IF", "Interrupt inputs to CORE all tied low (for now).", UVM_NONE)
   end
 


### PR DESCRIPTION
Signed-off-by: Mike Thompson <mike@openhwgroup.org>

Hi @GTumbush.  This is an update to point to the current head of the RTL (hash 101f455de).  As expected, a couple of changes to top-level interrupt pins was required.   There are also changes to the CSRs and I am worried that this will impact the ability of the OVPsim ISS to serve as a reference model when we add verification of interrupts.

I do not yet know if we should merge in this update, but I wanted you to be aware of the implications of the latest changes to the RTL.