### PR TITLE
Add debug control to OVPsim RM

### DIFF
--- a/cv32/sim/uvmt_cv32/dsim.mk
+++ b/cv32/sim/uvmt_cv32/dsim.mk
@@ -35,7 +35,7 @@ DSIM_FILE_LIST ?= -f $(DV_UVMT_CV32_PATH)/uvmt_cv32.flist
 ifeq ($(USE_ISS),YES)
     DSIM_FILE_LIST         += -f $(DV_UVMT_CV32_PATH)/imperas_iss.flist
     DSIM_USER_COMPILE_ARGS += "+define+ISS"
-    DSIM_RUN_FLAGS         +="+USE_ISS"
+    DSIM_RUN_FLAGS         += +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
 endif
 
 

--- a/vendor_lib/imperas/design/riscv_CV32E40P.ic
+++ b/vendor_lib/imperas/design/riscv_CV32E40P.ic
@@ -1,6 +1,18 @@
-# Control file for RI5CY configuration
---output simulate.log
-# --showoverrides
+# Control file for CV32E40P configuration
+--output ovpsim_simulate.log
+# Specify how Debug mode is implemented (none, vector, interrupt or halt)
+--override root/cpu0/debug_mode=halt
+# Specify address to which to jump to enter debug in vectored mode (Uns64)
+--override root/cpu0/debug_address=0x1A110800
+# Specify address to which to jump on debug exception in vectored mode (Uns64)
+--override root/cpu0/dexc_address=0
+# Specify verbose output messages (Boolean: F or T)
+--override root/cpu0/verbose=T
+# This shows *all* parameters that can be overridden.
+# Is there a way to dump only the parameter that were
+# actually overridden?
+#--showoverrides
+
 
 #
 # taken from riscv_cs_registers.sv MISA_VALUE


### PR DESCRIPTION
Hi @eroom1966.  I took an action to enable dumping of OVPsim parameters at run-time.  This PR is my attempt at that.  I also made an attempt to align the simulator debug parameters with the RTL+TB setup.  To wit;
```
# Specify how Debug mode is implemented (none, vector, interrupt or halt)
--override root/cpu0/debug_mode=halt
# Specify address to which to jump to enter debug in vectored mode (Uns64)
--override root/cpu0/debug_address=0x1A110800
# Specify address to which to jump on debug exception in vectored mode (Uns64)
--override root/cpu0/dexc_address=0
```
I believe what this does is the following:
- configure the model to entry debug mode when the halt input is asserted.
- set the dm_halt_address
- set the dm_exception_address (need to set that to something that matches the TB setup).

Can you confirm that this is all correct?

Also, a couple of dumb user questions:
First, this doesn't seem to have any affect:
```
# Specify verbose output messages (Boolean: F or T)
--override root/cpu0/verbose=T
```
Second, this does what you'd expect, but it shows *all* parameters that can be overridden. Is there a way to dump only the parameter that were actually overridden?
```
#--showoverrides
```

Signed-off-by: Mike Thompson <mike@openhwgroup.org>