### PR TITLE
Latest RTL and ci_check  update

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -9,10 +9,10 @@ repository.
 <br><br>
 The command `./ci_check -h` should tell you everything you need to know to run
 a user-level regression.  Note that the script has the ability to specify the
-URL, branch and hash of the RTL to be regressed (usually this is picked up in
-`../cv32/sim/Common.mk`.  An example command is:
+URL, branch and hash of the RTL to be regressed (the defaults for this are defined in
+`../cv32/sim/Common.mk`).  An example command is:
 <br>
-`./ci_check -s xrun --repo https://github.com/MikeOpenHWGroup/cv32e40p --branch dev1 --hash=12345` 
+`./ci_check -s xrun --repo https://github.com/MikeOpenHWGroup/cv32e40p --branch dev1 --hash=1234567` 
 <br>
 If ci_check is not working for you, create an issue and assign it to @mikeopenhwgroup.
 <br><br>

--- a/ci/ci_check
+++ b/ci/ci_check
@@ -260,11 +260,20 @@ if (uvm):
                     run_cmd = ' '.join(run_cmd_list[0:-2]) # See TODO #3
                     if (run_cmd != ''):
                         run_cmd = run_cmd.replace('dsim', svtool)
-                        if (prcmd or debug):
-                            print(run_cmd)
+                        # Only DSIM can run corev-dv (riscv-dv) at present
+                        if ( svtool == 'dsim' ):
+                            if (prcmd or debug):
+                                print(run_cmd)
+                            else:
+                                os.system(run_cmd)
+                                os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
                         else:
-                            os.system(run_cmd)
-                            os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
+                            if not ( re.search('corev_', run_cmd) ):
+                                if (prcmd or debug):
+                                    print(run_cmd)
+                                else:
+                                    os.system(run_cmd)
+                                    os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
                     else:
                         print ('ERROR: cannot find run command in .metrics.json')
                         exit(0)

--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -54,7 +54,9 @@
 # Head of the master branch as of 2020-05-29
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= 8e22c994198ad08f4cacf239d56d98e1cc25627b
+#CV32E40P_HASH   ?= 8e22c994198ad08f4cacf239d56d98e1cc25627b
+#2020-07-07
+CV32E40P_HASH   ?= 8a3345cd80db4097cd007697233e54f020245bfb
 
 FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
 FPNEW_BRANCH    ?= master

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -178,6 +178,7 @@ clean_core_tests:
 	find $(CORE_TEST_DIR) -name *.map     -exec rm {} \;
 	find $(CORE_TEST_DIR) -name *.readelf -exec rm {} \;
 	find $(CORE_TEST_DIR) -name *.objdump -exec rm {} \;
+	find $(CORE_TEST_DIR) -name corev_*.S -exec rm {} \;
 
 clean_test_programs:
 	find ../../tests/uvmt_cv32/test-programs -name *.o       -exec rm {} \;

--- a/cv32/sim/uvmt_cv32/dsim.mk
+++ b/cv32/sim/uvmt_cv32/dsim.mk
@@ -321,11 +321,11 @@ gen_corev_jump_stress_test:
 	mv *.S $(CORE_TEST_DIR)/custom
 
 corev-dv: clean_riscv-dv \
-	        clone_riscv-dv \
-	        comp_riscv-dv \
-	        gen_corev_arithmetic_base_test \
-	        gen_corev_rand_instr_test \
-	        gen_corev_jump_stress_test
+	  clone_riscv-dv \
+	  comp_riscv-dv \
+	  gen_corev_arithmetic_base_test \
+	  gen_corev_rand_instr_test \
+	  gen_corev_jump_stress_test
 
 ###############################################################################
 # Clean up your mess!

--- a/cv32/sim/uvmt_cv32/vcs.mk
+++ b/cv32/sim/uvmt_cv32/vcs.mk
@@ -159,6 +159,11 @@ cv32-firmware: comp $(FIRMWARE)/firmware.hex $(FIRMWARE)/firmware.elf
 		+firmware=$(FIRMWARE)/firmware.hex \
 		+elf_file=$(FIRMWARE)/firmware.elf
 
+# Placeholder for future testing via Google ISG (riscv-dv)
+# These targets are defined in ./Makefile
+corev-dv: clean_riscv-dv \
+	  clone_riscv-dv
+
 clean:
 	rm -f simv
 	rm -rf simv.*

--- a/cv32/sim/uvmt_cv32/vsim.mk
+++ b/cv32/sim/uvmt_cv32/vsim.mk
@@ -168,6 +168,12 @@ questa-unit-test-gui:  $(FIRMWARE)/firmware_unit_test.hex
 questa-unit-test-gui: ALL_VSIM_FLAGS += "+firmware=$(FIRMWARE)/firmware_unit_test.hex"
 questa-unit-test-gui: vsim-run-gui
 
+##############################################################################
+# Placeholder for future testing via Google ISG (riscv-dv)
+# These targets are defined in ./Makefile
+corev-dv: clean_riscv-dv \
+	  clone_riscv-dv
+
 ###############################################################################
 # Clean up your mess!
 

--- a/cv32/tb/core/riscv_wrapper.sv
+++ b/cv32/tb/core/riscv_wrapper.sv
@@ -77,7 +77,7 @@ module riscv_wrapper
          .clk_i                  ( clk_i                 ),
          .rst_ni                 ( rst_ni                ),
 
-         .clock_en_i             ( '1                    ),
+         .pulp_clock_en_i        ( '1                    ),
          .scan_cg_en_i           ( '0                    ),
 
          .boot_addr_i            ( BOOT_ADDR             ),
@@ -124,7 +124,7 @@ module riscv_wrapper
          .debug_req_i            ( debug_req             ),
 
          .fetch_enable_i         ( fetch_enable_i        ),
-         .core_busy_o            ( core_busy_o           )
+         .core_sleep_o           ( core_sleep_o          )
        );
 
     // this handles read to RAM and memory mapped pseudo peripherals

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_dut_wrap.sv
@@ -146,7 +146,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .clk_i                  ( clknrst_if.clk                 ),
          .rst_ni                 ( clknrst_if.reset_n             ),
 
-         .clock_en_i             ( core_cntrl_if.clock_en         ),
+         .pulp_clock_en_i        ( core_cntrl_if.clock_en         ),
          .scan_cg_en_i           ( core_cntrl_if.scan_cg_en       ),
 
          .boot_addr_i            ( core_cntrl_if.boot_addr        ),
@@ -197,7 +197,7 @@ module uvmt_cv32_dut_wrap #(// DUT (riscv_core) parameters.
          .debug_req_i            ( debug_req                         ),
 
          .fetch_enable_i         ( core_cntrl_if.fetch_en            ),
-         .core_busy_o            ( core_status_if.core_busy          )
+         .core_sleep_o           ( core_status_if.core_busy          )
         ); //riscv_core_i
 
     // this handles read to RAM and memory mapped virtual (pseudo) peripherals


### PR DESCRIPTION
This PR updates the `core` testbench and `uvmt_cv32` verification environment to pick up the latest RTL as of 2020-07-07.  It also includes a few updates to ci/ci_check and various Makefiles to improve user regressions.