### PR TITLE
retain elf files between runs using PRECIOUS target

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -260,6 +260,7 @@ TEST_FILES        = $(filter %.c %.S,$(wildcard $(dir $*)*))
 # Patterned targets to generate ELF.  Used only if explicit targets do not match.
 #
 # This target selected if both %.c and %.S exist
+.PRECIOUS : %.elf
 %.elf: %.c
 	make clean-bsp
 	make bsp


### PR DESCRIPTION
otherwise elf is deleted after running test and will not be rebuilt on subsequent runs because hex file is already present in the prereq

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>