### PR TITLE
added pulp tests, added capability for pulp compilation

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -136,6 +136,10 @@ RISCV_EXE_PREFIX ?= $(RISCV)/bin/riscv32-unknown-elf-
 
 CFLAGS ?= -Os -g -static -mabi=ilp32 -march=rv32imc -Wall -pedantic
 
+ifeq ($(firstword $(subst _, ,$(CUSTOM_PROG))),pulp)
+  CFLAGS = -Os -g -D__riscv__=1 -D__LITTLE_ENDIAN__=1 -march=rv32imcxpulpv2 -Wa,-march=rv32imcxpulpv2 -fdata-sections -ffunction-sections -fdiagnostics-color=always
+endif
+
 # CORE FIRMWARE vars. All of the C and assembler programs under CORE_TEST_DIR
 # are collectively known as "Core Firmware".  Yes, this is confusing because
 # one of sub-directories of CORE_TEST_DIR is called "firmware".

--- a/cv32/tests/core/custom/pulp_bit_manipulation.S
+++ b/cv32/tests/core/custom/pulp_bit_manipulation.S
@@ -1,0 +1,762 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests all bit manipulation instructions. NOTE: value of register x15 at the end of the test is the error count
+#NOTE: value loaded into x19 prior to the beq instruction in each test is the expected output value
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x200
+    li x14, 0x210
+    li x15, 0x0
+    li x16, 0xff7811b4
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0xc356d985
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the p.extract instruction. values loaded in and compared to are expected output values
+#p.extract instruction is of format "p.extract rD, rs1, ls3, ls2". ls2 defines the location of the LSB
+#that is extracted, while ls3 defines the number of bits that are extracted. answer is sign extended
+#based upon the MSB of the extracted value rD = Sext((rs1 & ((1 << (ls3 + 1)) - 1) << ls2) >> ls2), (ls2+ls3)<=32
+test1:
+    li x20, 0x12577823
+    p.extract x18, x20, 7, 24
+    li x19, 0x12
+    beq x18, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x20, 0x85763245
+    p.extract x18, x20, 0, 31
+    li x19, 0xffffffff
+    beq x18, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x20, 0x69879573
+    p.extract x18, x20, 7, 0
+    li x19, 0x73
+    beq x18, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x20, 0x12577823
+    p.extract x18, x20, 0, 0
+    li x19, 0xffffffff
+    beq x18, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x20, 0x34667485
+    p.extract x18, x20, 7, 16
+    li x19, 0x66
+    beq x18, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x20, 0x78729209
+    p.extract x18, x20, 15, 2
+    li x19, 0xffffa482
+    beq x18, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the p.extractu instruction. values loaded in and compared to are expected output values
+#p.extractu instruction is of format "p.extractu rD, rs1, ls3, ls2". ls2 defines the location of the LSB
+#that is extracted, while ls3 defines the number of bits that are extracted. answer is zero extended
+#based upon the MSB of the extracted value rD = Zext((rs1 & ((1 << (ls3 + 1)) -1) << ls2) >> ls2), (ls2+ls3)<=32
+test7:
+    li x20, 0x12577823
+    p.extractu x18, x20, 7, 24
+    li x19, 0x12
+    beq x18, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x20, 0x85763245
+    p.extractu x18, x20, 0, 31
+    li x19, 0x1
+    beq x18, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x20, 0x69879573
+    p.extractu x18, x20, 7, 0
+    li x19, 0x73
+    beq x18, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x20, 0x12577823
+    p.extractu x18, x20, 0, 0
+    li x19, 0x1
+    beq x18, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x20, 0x34667485
+    p.extractu x18, x20, 7, 16
+    li x19, 0x66
+    beq x18, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x20, 0x78729209
+    p.extractu x18, x20, 15, 2
+    li x19, 0xa482
+    beq x18, x19, test13
+    c.addi x15, 0x1
+    j test13
+#tests13-18 test the p.extractr instruction. values loaded in and compared to are expected output values
+#p.extractr instruction is of format "p.extractu rD, rs1, rs2". rs2[4:0] defines the location of the LSB
+#that is extracted, while rs2[9:5] defines the number of bits that are extracted. answer is sign extended
+#based upon the MSB of the extracted value rD = Zext((rs1 & ((1 << (rs2[9:5] + 1)) -1) << rs2[4:0]) >> rs2[4:0]), (rs2[9:5]+rs2[4:0])<=32
+test13: #equivalent of p.extract x18, x20, 11, 3
+    li x20, 0x23198519
+    li x21, 0x79820963
+    p.extractr x18, x20, x21
+    li x19, 0x0a3
+    beq x18, x19, test14
+    c.addi x15, 0x1
+test14: #equivalent of p.extract x18, x20, 9, 18 
+    li x20, 0xb6459987
+    li x21, 0x28736532
+    p.extractr x18, x20, x21
+    li x19, 0x00000191
+    beq x18, x19, test15
+    c.addi x15, 0x1
+test15: #equivalent of p.extract x18, x20, 8, 7
+    li x20, 0x27384928
+    li x21, 0x16385907
+    p.extractr x18, x20, x21
+    li x19, 0x092
+    beq x18, x19, test16
+    c.addi x15, 0x1
+test16: #equivalent of p.extract x18, x20, 17, 3
+    li x20, 0x56391846
+    li x21, 0x37197223
+    p.extractr x18, x20, x21
+    li x19, 0xffff2308
+    beq x18, x19, test17
+    c.addi x15, 0x1
+test17: #equivalent of p.extract x18, x20, 16, 3
+    li x20, 0x02374920
+    li x21, 0x57723603
+    p.extractr x18, x20, x21
+    li x19, 0x0e924
+    beq x18, x19, test18
+    c.addi x15, 0x1
+test18: #equivalent of p.extract x18, x20, 0, 20
+    li x20, 0x37592873
+    li x21, 0x21829814
+    p.extractr x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test19
+    c.addi x15, 0x1
+    j test19
+#tests19-24 test the p.extractr instruction. values loaded in and compared to are expected output values
+#p.extractr instruction is of format "p.extractu rD, rs1, rs2". rs2[4:0] defines the location of the LSB
+#that is extracted, while rs2[9:5] defines the number of bits that are extracted. answer is sign extended
+#based upon the MSB of the extracted value rD = Zext((rs1 & ((1 << (rs2[9:5] + 1)) -1) << rs2[4:0]) >> rs2[4:0]), (rs2[9:5]+rs2[4:0])<=32
+test19: #equivalent of p.extractu x18, x20, 11, 3
+    li x20, 0x23198519
+    li x21, 0x79820963
+    p.extractur x18, x20, x21
+    li x19, 0x0a3
+    beq x18, x19, test20
+    c.addi x15, 0x1
+test20: #equivalent of p.extractu x18, x20, 9, 18 
+    li x20, 0xb6459987
+    li x21, 0x28736532
+    p.extractur x18, x20, x21
+    li x19, 0x191
+    beq x18, x19, test21
+    c.addi x15, 0x1
+test21: #equivalent of p.extractu x18, x20, 8, 7
+    li x20, 0x27384928
+    li x21, 0x16385907
+    p.extractur x18, x20, x21
+    li x19, 0x092
+    beq x18, x19, test22
+    c.addi x15, 0x1
+test22: #equivalent of p.extractu x18, x20, 17, 3
+    li x20, 0x56391846
+    li x21, 0x37197223
+    p.extractur x18, x20, x21
+    li x19, 0x32308
+    beq x18, x19, test23
+    c.addi x15, 0x1
+test23: #equivalent of p.extractu x18, x20, 16, 3
+    li x20, 0x02374920
+    li x21, 0x57723603
+    p.extractur x18, x20, x21
+    li x19, 0x0e924
+    beq x18, x19, test24
+    c.addi x15, 0x1
+test24: #equivalent of p.extractu x18, x20, 0, 20
+    li x20, 0x37592873
+    li x21, 0x21829814
+    p.extractur x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test25
+    c.addi x15, 0x1
+    j test25
+#tests25-30 test the p.insert instruction. values loaded in and compared to are expected values
+#p.insert instruction is of format "p.insert rD, rs1, ls3, ls2". ls3 determines which bits [ls3:0]
+#are inserted, while ls2 defines the magnitude of the left shift. All bits of rD not inserted to are passed
+#through unchanged. rD = (rD & ~(rs1[ls3:0]<<ls2))|(rs1[ls3:0]<<ls2), (ls3+ls2)<=32
+test25:
+    li x18, 0xffffffff
+    li x20, 0x12577823
+    p.insert x18, x20, 8, 24
+    li x19, 0x23ffffff
+    beq x18, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x18, 0x00000000
+    li x20, 0x85763245
+    p.insert x18, x20, 1, 31
+    li x19, 0x80000000
+    beq x18, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x18, 0xffffffff
+    li x20, 0x69879573
+    p.insert x18, x20, 8, 0
+    li x19, 0xffffff73
+    beq x18, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x18, 0x00000000
+    li x20, 0x12577823
+    p.insert x18, x20, 1, 0
+    li x19, 0x3
+    beq x18, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x18, 0xffffffff
+    li x20, 0x34667485
+    p.insert x18, x20, 7, 16
+    li x19, 0xff85ffff
+    beq x18, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x18, 0x00000000
+    li x20, 0x78729209
+    p.insert x18, x20, 16, 2
+    li x19, 0x24824
+    beq x18, x19, test31
+    c.addi x15, 0x1
+    j test31
+#tests31-36 test the p.insertr instruction. values loaded in and compared to are expected values
+#p.insertr instruction is of format "p.insertr rD, rs1, rs2". rs2[9:5] determines which bits [rs2[9:5]:0]
+#are inserted, while rs2[4:0] defines the magnitude of the left shift. All bits of rD not inserted to are passed
+#through unchanged. rD = (rD & ~(rs1[rs2[9:5]:0]<<ls2))|(rs1[rs2[9:5]:0]<<rs2[4:0]), (rs2[9:5]+rs2[4:0])<=32
+test31:
+    li x18, 0xffffffff
+    li x20, 0x37492846
+    li x21, 0x01927326
+    p.insertr x18, x20, x21
+    li x19, 0xd24a11bf
+    beq x18, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x18, 0x00000000
+    li x20, 0x11049275
+    li x21, 0x27402831
+    p.insertr x18, x20, x21
+    li x19, 0x00020000
+    beq x18, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x18, 0xffffffff
+    li x20, 0x27493857
+    li x21, 0x28039740
+    p.insertr x18, x20, x21
+    li x19, 0xff493857
+    beq x18, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x18, 0x00000000
+    li x20, 0x82068834
+    li x21, 0x01926875
+    p.insertr x18, x20, x21
+    li x19, 0x00800000
+    beq x18, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x18, 0xffffffff
+    li x20, 0x28407279
+    li x21, 0x34562167
+    p.insertr x18, x20, x21
+    li x19, 0xfff93cff
+    beq x18, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x18, 0x00000000
+    li x20, 0x27049709
+    li x21, 0x27070193
+    p.insertr x18, x20, x21
+    li x19, 0xb8480000
+    beq x18, x19, test37
+    c.addi x15, 0x1
+    j test37
+#tests37-42 test the p.bclr instruction. values loaded in and compared to are expected values
+#p.bclr instruction is of format "p.bclr rD, rs1, ls3, ls2". ls3 determines how many bits are cleared
+#while ls2 determines the left shift of the cleared bit range. All bits of rs1 not cleared are passed
+#through unchanged. rD = rs1 & ~(((1 << (ls3+1)) - 1) << ls2), (ls3+ls2) <= 32
+test37:
+    li x20, 0x12577823
+    p.bclr x18, x20, 8, 24
+    li x19, 0x00577823
+    beq x18, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x20, 0x85763245
+    p.bclr x18, x20, 1, 31
+    li x19, 0x05763245
+    beq x18, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x20, 0x69879573
+    p.bclr x18, x20, 8, 0
+    li x19, 0x69879400
+    beq x18, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x20, 0x12577823
+    p.bclr x18, x20, 1, 0
+    li x19, 0x12577820
+    beq x18, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x20, 0x34667485
+    p.bclr x18, x20, 7, 16
+    li x19, 0x34007485
+    beq x18, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x20, 0x78729209
+    p.bclr x18, x20, 16, 2
+    li x19, 0x78700001
+    beq x18, x19, test43
+    c.addi x15, 0x1
+    j test43
+#tests43-48 test the p.bclrr instruction. values loaded in and compared to are expected values
+#p.bclrr instruction is of format "p.bclrr rD, rs1, rs2". rs2[9:5] determines how many bits are cleared
+#while rs2[4:0] determines the left shift of the cleared bit range. All bits of rs1 not cleared are passed
+#through unchanged. rD = rs1 & ~(((1 << (rs2[9:5]+1)) - 1) << rs2[4:0]), (rs2[9:5]+rs2[4:0]) <= 32
+test43:
+    li x20, 0x37492846
+    li x21, 0x01927326
+    p.bclrr x18, x20, x21
+    li x19, 0x00000006
+    beq x18, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x20, 0x11049275
+    li x21, 0x27402831
+    p.bclrr x18, x20, x21
+    li x19, 0x11009275
+    beq x18, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x20, 0x27493857
+    li x21, 0x28039740
+    p.bclrr x18, x20, x21
+    li x19, 0x20000000
+    beq x18, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x20, 0x82068834
+    li x21, 0x01926875
+    p.bclrr x18, x20, x21
+    li x19, 0x82068834
+    beq x18, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x20, 0x28407279
+    li x21, 0x34562167
+    p.bclrr x18, x20, x21
+    li x19, 0x28400079
+    beq x18, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x20, 0x27049709
+    li x21, 0x27070193
+    p.bclrr x18, x20, x21
+    li x19, 0x00049709
+    beq x18, x19, test49
+    c.addi x15, 0x1
+    j test49
+#tests49-54 test the p.bset instruction. values loaded in and compared to are expected values
+#p.bset instruction is of format "p.bset rD, rs1, ls3, ls2". ls3 determines how many bits are set
+#while ls2 determines the left shift of the set bit range. All bits of rs1 not set are passed
+#through unchanged. rD = rs1 | (((1 << (ls3+1)) - 1) << ls2), (ls3+ls2) <= 32
+test49:
+    li x20, 0x12577823
+    p.bset x18, x20, 8, 24
+    li x19, 0xff577823
+    beq x18, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x20, 0x85763245
+    p.bset x18, x20, 1, 31
+    li x19, 0x85763245
+    beq x18, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x20, 0x69879573
+    p.bset x18, x20, 8, 0
+    li x19, 0x698795ff
+    beq x18, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x20, 0x12577823
+    p.bset x18, x20, 1, 0
+    li x19, 0x12577823
+    beq x18, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x20, 0x34667485
+    p.bset x18, x20, 7, 16
+    li x19, 0x34ff7485
+    beq x18, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x20, 0x78729209
+    p.bset x18, x20, 16, 2
+    li x19, 0x7877fffd
+    beq x18, x19, test55
+    c.addi x15, 0x1
+    j test55
+#tests55-60 test the p.bsetr instruction. values loaded in and compared to are expected values
+#p.bsetr instruction is of format "p.bsetr rD, rs1, rs2". rs2[9:5] determines how many bits are set
+#while rs2[4:0] determines the left shift of the set bit range. All bits of rs1 not set are passed
+#through unchanged. rD = rs1 | (((1 << (rs2[9:5]+1)) - 1) << rs2[4:0]), (rs2[9:5]+rs2[4:0]) <= 32
+test55:
+    li x20, 0x37492846
+    li x21, 0x01927326
+    p.bsetr x18, x20, x21
+    li x19, 0xffffffc6
+    beq x18, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x20, 0x11049275
+    li x21, 0x27402831
+    p.bsetr x18, x20, x21
+    li x19, 0x11069275
+    beq x18, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x20, 0x27493857
+    li x21, 0x28039740
+    p.bsetr x18, x20, x21
+    li x19, 0x27ffffff
+    beq x18, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x20, 0x82068834
+    li x21, 0x01926875
+    p.bsetr x18, x20, x21
+    li x19, 0x83e68834
+    beq x18, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x20, 0x28407279
+    li x21, 0x34562167
+    p.bsetr x18, x20, x21
+    li x19, 0x2847fff9
+    beq x18, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x20, 0x27049709
+    li x21, 0x27070193
+    p.bsetr x18, x20, x21
+    li x19, 0xfffc9709
+    beq x18, x19, test61
+    c.addi x15, 0x1
+    j test61
+#tests61-66 test the p.ff1 instruction. values loaded in and compared to are expected values
+#p.ff1 instruction is of format "p.ff1 rD, rs1". rD is set to the value of the bit of rs1 with
+#least signifigance that is set. If no bits are set, rD is set to 32
+test61:
+    li x20, 0x00000000
+    p.ff1 x19, x20
+    li x18, 0x20
+    beq x18, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x20, 0xffffffff
+    p.ff1 x19, x20
+    li x18, 0x0
+    beq x18, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x20, 0x00000001
+    p.ff1 x19, x20
+    li x18, 0x0
+    beq x18, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x20, 0x80000000
+    p.ff1 x19, x20
+    li x18, 0x1f
+    beq x18, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x20, 0x00455400
+    p.ff1 x19, x20
+    li x18, 0xa
+    beq x18, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x20, 0x00022000
+    p.ff1 x19, x20
+    li x18, 0xd
+    beq x18, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the p.fl1 instruction. values loaded in and compared to are expected values
+#p.fl1 instruction is of format "p.fl1 rD, rs1". rD is set to the value of the last bit of rs1
+#that is set starting from MSB
+test67:
+    li x20, 0x00000000
+    p.fl1 x19, x20
+    li x18, 0x20
+    beq x18, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x20, 0xffffffff
+    p.fl1 x19, x20
+    li x18, 0x1f
+    beq x18, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x20, 0x00000001
+    p.fl1 x19, x20
+    li x18, 0x0
+    beq x18, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x20, 0x80000000
+    p.fl1 x19, x20
+    li x18, 0x1f
+    beq x18, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x20, 0x00455400
+    p.fl1 x19, x20
+    li x18, 0x16
+    beq x18, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x20, 0x00022000
+    p.fl1 x19, x20
+    li x18, 0x11
+    beq x18, x19, test73
+    c.addi x15, 0x1
+#tests 73-78 test the p.clb instruction. values loaded in and compared to are expected values
+#p.clb instruction is of format "p.clb rD, rs1". rD is set to the value of the total of leading
+#bits that match (length of starting string of 1's or 0's starting from MSB). If rs1=0, then rD=0
+test73:
+    li x20, 0x00000000
+    p.clb x19, x20
+    li x18, 0x0
+    beq x18, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x20, 0xffffffff
+    p.clb x19, x20
+    li x18, 0x1f
+    beq x18, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x20, 0x90723073
+    p.clb x19, x20
+    li x18, 0x0
+    beq x18, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x20, 0xff092736
+    p.clb x19, x20
+    li x18, 0x7
+    beq x18, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x20, 0x00455400
+    p.clb x19, x20
+    li x18, 0x8
+    beq x18, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x20, 0x00009276
+    p.clb x19, x20
+    li x18, 0xf
+    beq x18, x19, test79
+    c.addi x15, 0x1
+#tests 79-84 test the p.cnt instruction. values loaded in and compared to are expected values
+#p.cnt instruction is of format "p.clb rD, rs1". rD is set to the population of rs1, wherein the
+#population is defined as the number of bits that are set in rs1
+test79:
+    li x20, 0x00000000
+    p.cnt x19, x20
+    li x18, 0x0
+    beq x18, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x20, 0xffffffff
+    p.cnt x19, x20
+    li x18, 0x20
+    beq x18, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x20, 0x90723073
+    p.cnt x19, x20
+    li x18, 0xd
+    beq x18, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x20, 0xff092736
+    p.cnt x19, x20
+    li x18, 0x12
+    beq x18, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x20, 0x00455400
+    p.cnt x19, x20
+    li x18, 0x6
+    beq x18, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x20, 0x00009276
+    p.cnt x19, x20
+    li x18, 0x8
+    beq x18, x19, test85
+    c.addi x15, 0x1
+#tests 85-90 test the p.ror instruction. values loaded in and compared to are expected values
+#p.ror instruction is of format "p.ror rD, rs1, rs2". rD is set to the value of rs1 rotated right
+#by the value defined in rs2
+test85:
+    li x20, 0x00000000
+    li x21, 0x09450702
+    p.ror x19, x20, x21
+    li x18, 0x0
+    beq x18, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x20, 0xffffffff
+    li x21, 0x70923608
+    p.ror x19, x20, x21
+    li x18, 0xffffffff
+    beq x18, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x20, 0x0f0f0f0f
+    li x21, 0x00000004
+    p.ror x19, x20, x21
+    li x18, 0xf0f0f0f0
+    beq x18, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x20, 0x0000ffff
+    li x21, 0x00000010
+    p.ror x19, x20, x21
+    li x18, 0xffff0000
+    beq x18, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x20, 0xa5a5a5a5
+    li x21, 0x00000001
+    p.ror x19, x20, x21
+    li x18, 0xd2d2d2d2
+    beq x18, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x20, 0x5a5a5a5a
+    li x21, 0x00000001
+    p.ror x19, x20, x21
+    li x18, 0x2d2d2d2d
+    beq x18, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the p.bitrev instruction. values loaded in and compared to are expected values
+#p.bitrev instruction is of format "p.bitrev rD, rs1, ls3, ls2". returns a bit reversed representation
+#assuming a FFT with input rs1 on 2^ls2 points in radix 2^ls3 where ls3 is 1, 2, or 3.
+test91:
+    li x20, 0x32f0edf4
+    .word 0xc44a5933    #p.bitrev x18, x20, 4, 2
+    li x19, 0x02edf199
+    beq x18, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x20, 0x44f4c26f
+    .word 0xc26a5933    #p.bitrev x18, x20, 6, 1
+    li x19, 0x03e60c7c
+    beq x18, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x20, 0x7e6b77d4
+    .word 0xc07a5933    #p.bitrev x18, x20, 7, 0
+    li x19, 0x0057ddac
+    beq x18, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x20, 0x44261e8e
+    .word 0xc43a5933    #p.bitrev x18, x20, 3, 2
+    li x19, 0x23998681
+    beq x18, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x20, 0x015b4f09
+    .word 0xc20a5933    #p.bitrev x18, x20, 0, 1
+    li x19, 0x60f1e540
+    beq x18, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x20, 0xf5f7164d
+    .word 0xc02a5933    #p.bitrev x18, x20, 2, 0
+    li x19, 0x2c9a3beb
+    beq x18, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_general_alu.S
+++ b/cv32/tests/core/custom/pulp_general_alu.S
@@ -1,0 +1,1450 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests all general ALU instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x200
+    li x14, 0x210
+    li x15, 0x0
+    li x16, 0xff7811b4
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0xc356d985
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the p.abs instruction. values loaded in and compared to are expected output values
+#p.abs instruction is of format "p.abs rD, rs1". rD = rs1 < 0 ? -rs1 : rs1
+test1:
+    li x20, 0x12577823
+    p.abs x18, x20
+    li x19, 0x12577823
+    beq x18, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x20, 0x85763245
+    p.abs x18, x20
+    li x19, 0x7a89cdbb
+    beq x18, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x20, 0x69879573
+    p.abs x18, x20
+    li x19, 0x69879573
+    beq x18, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x20, 0x98349834
+    p.abs x18, x20
+    li x19, 0x67cb67cc
+    beq x18, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x20, 0x00000000
+    p.abs x18, x20
+    li x19, 0x00000000
+    beq x18, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x20, 0xffffffff
+    p.abs x18, x20
+    li x19, 0x1
+    beq x18, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the p.slet instruction. values loaded in and compared to are expected output values
+#p.slet instruction is of format "p.slet rD, rs1, rs2". rD = rs1 <= rs2 ? 1 : 0
+#comparison is signed
+test7:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.slet x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.slet x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.slet x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.slet x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.slet x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x20, 0xffffffff
+    li x21, 0xffffffff
+    p.slet x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the p.sletu instruction. values loaded in and compared to are expected output values
+#p.sletu instruction is of format "p.sletu rD, rs1, rs2". rD = rs1 <= rs2 ? 1 : 0
+#comparison is unsigned
+test13:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.sletu x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.sletu x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.sletu x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.sletu x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.sletu x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x20, 0xffffffff
+    li x21, 0xffffffff
+    p.sletu x18, x20, x21
+    li x19, 0x1
+    beq x18, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the p.min instruction. values loaded in and compared to are expected output values
+#p.min instruction is of format "p.min rD, rs1, rs2". rD = rs1 < rs2 ? rs1 : rs2
+#comparison is signed
+test19:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.min x18, x20, x21
+    li x19, 0x82570957
+    beq x18, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.min x18, x20, x21
+    li x19, 0x84029440
+    beq x18, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.min x18, x20, x21
+    li x19, 0x69879573
+    beq x18, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.min x18, x20, x21
+    li x19, 0x98349834
+    beq x18, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.min x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x20, 0xfffffffe
+    li x21, 0xffffffff
+    p.min x18, x20, x21
+    li x19, 0xfffffffe
+    beq x18, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the p.minu instruction. values loaded in and compared to are expected output values
+#p.minu instruction is of format "p.minu rD, rs1, rs2". rD = rs1 < rs2 ? rs1 : rs2
+#comparison is unsigned
+test25:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.minu x18, x20, x21
+    li x19, 0x12577823
+    beq x18, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.minu x18, x20, x21
+    li x19, 0x84029440
+    beq x18, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.minu x18, x20, x21
+    li x19, 0x69879573
+    beq x18, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.minu x18, x20, x21
+    li x19, 0x13525363
+    beq x18, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.minu x18, x20, x21
+    li x19, 0x00000000
+    beq x18, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x20, 0xfffffffe
+    li x21, 0xffffffff
+    p.minu x18, x20, x21
+    li x19, 0xfffffffe
+    beq x18, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the p.max instruction. values loaded in and compared to are expected output values
+#p.max instruction is of format "p.max rD, rs1, rs2". rD = rs1 < rs2 ? rs2 : rs1
+#comparison is signed
+test31:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.max x18, x20, x21
+    li x19, 0x12577823
+    beq x18, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.max x18, x20, x21
+    li x19, 0x85763245
+    beq x18, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.max x18, x20, x21
+    li x19, 0x74014801
+    beq x18, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.max x18, x20, x21
+    li x19, 0x13525363
+    beq x18, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.max x18, x20, x21
+    li x19, 0x00000000
+    beq x18, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x20, 0xffffffff
+    li x21, 0xfffffffe
+    p.max x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the p.maxu instruction. values loaded in and compared to are expected output values
+#p.maxu instruction is of format "p.maxu rD, rs1, rs2". rD = rs1 < rs2 ? rs2 : rs1
+#comparison is unsigned
+test37:
+    li x20, 0x12577823
+    li x21, 0x82570957
+    p.maxu x18, x20, x21
+    li x19, 0x82570957
+    beq x18, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x20, 0x85763245
+    li x21, 0x84029440
+    p.maxu x18, x20, x21
+    li x19, 0x85763245
+    beq x18, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x20, 0x69879573
+    li x21, 0x74014801
+    p.maxu x18, x20, x21
+    li x19, 0x74014801
+    beq x18, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x20, 0x98349834
+    li x21, 0x13525363
+    p.maxu x18, x20, x21
+    li x19, 0x98349834
+    beq x18, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x20, 0x00000000
+    li x21, 0xffffffff
+    p.maxu x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x20, 0xffffffff
+    li x21, 0xfffffffe
+    p.maxu x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the p.exths instruction. values loaded in and compared to are expected output values
+#p.exths instruction is of format "p.exths rD, rs1". rD = Sext(rs1[15:0])
+test43:
+    li x20, 0x12577823
+    p.exths x18, x20
+    li x19, 0x00007823
+    beq x18, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x20, 0x85763245
+    p.exths x18, x20
+    li x19, 0x00003245
+    beq x18, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x20, 0x69879573
+    p.exths x18, x20
+    li x19, 0xffff9573
+    beq x18, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x20, 0x98349834
+    p.exths x18, x20
+    li x19, 0xffff9834
+    beq x18, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x20, 0x00000000
+    p.exths x18, x20
+    li x19, 0x00000000
+    beq x18, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x20, 0xffffffff
+    p.exths x18, x20
+    li x19, 0xffffffff
+    beq x18, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the p.exthz instruction. values loaded in and compared to are expected output values
+#p.exthz instruction is of format "p.exthz rD, rs1". rD = Zext(rs1[15:0])
+test49:
+    li x20, 0x12577823
+    p.exthz x18, x20
+    li x19, 0x00007823
+    beq x18, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x20, 0x85763245
+    p.exthz x18, x20
+    li x19, 0x00003245
+    beq x18, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x20, 0x69879573
+    p.exthz x18, x20
+    li x19, 0x00009573
+    beq x18, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x20, 0x98349834
+    p.exthz x18, x20
+    li x19, 0x00009834
+    beq x18, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x20, 0x00000000
+    p.exthz x18, x20
+    li x19, 0x00000000
+    beq x18, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x20, 0xffffffff
+    p.exthz x18, x20
+    li x19, 0x0000ffff
+    beq x18, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the p.extbs instruction. values loaded in and compared to are expected output values
+#p.extbs instruction is of format "p.extbs rD, rs1". rD = Sext(rs1[7:0])
+test55:
+    li x20, 0x12577823
+    p.extbs x18, x20
+    li x19, 0x00000023
+    beq x18, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x20, 0x857632a5
+    p.extbs x18, x20
+    li x19, 0xffffffa5
+    beq x18, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x20, 0x69879583
+    p.extbs x18, x20
+    li x19, 0xffffff83
+    beq x18, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x20, 0x98349834
+    p.extbs x18, x20
+    li x19, 0x00000034
+    beq x18, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x20, 0x00000000
+    p.extbs x18, x20
+    li x19, 0x00000000
+    beq x18, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x20, 0xffffffff
+    p.extbs x18, x20
+    li x19, 0xffffffff
+    beq x18, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the p.extbz instruction. values loaded in and compared to are expected output values
+#p.extbz instruction is of format "p.extbz rD, rs1". rD = Zext(rs1[7:0])
+test61:
+    li x20, 0x12577823
+    p.extbz x18, x20
+    li x19, 0x00000023
+    beq x18, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x20, 0x85763245
+    p.extbz x18, x20
+    li x19, 0x00000045
+    beq x18, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x20, 0x69879573
+    p.extbz x18, x20
+    li x19, 0x00000073
+    beq x18, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x20, 0x98349834
+    p.extbz x18, x20
+    li x19, 0x00000034
+    beq x18, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x20, 0x00000000
+    p.extbz x18, x20
+    li x19, 0x00000000
+    beq x18, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x20, 0xffffffff
+    p.extbz x18, x20
+    li x19, 0x000000ff
+    beq x18, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the p.clip instruction. values loaded in and compared to are expected output values
+#p.clip instruction is of format "p.clip rD, rs1, ls2". if rs1 <= -2^(ls2-1), rD = -2^(ls2-1)
+#or if rs1 >= 2^(ls2-1), rD = 2^(ls2-1)-1, else rD = rs1
+test67:
+    li x20, 0x12577823
+    p.clip x18, x20, 15
+    li x19, 0x00003fff
+    beq x18, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x20, 0x85763245
+    p.clip x18, x20, 26
+    li x19, 0xfe000000
+    beq x18, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x20, 0x69879573
+    p.clip x18, x20, 31
+    li x19, 0x3fffffff
+    beq x18, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x20, 0x98349834
+    p.clip x18, x20, 31
+    li x19, 0xc0000000
+    beq x18, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x20, 0x00000000
+    p.clip x18, x20, 10
+    li x19, 0x00000000
+    beq x18, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x20, 0xffffffff
+    p.clip x18, x20, 6
+    li x19, 0xffffffff
+    beq x18, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the p.clipr instruction. values loaded in and compared to are expected output values
+#p.clipr instruction is of format "p.clipr rD, rs1, rs2". if rs1 <= -(rs2+1), rD = -(rs2+1)
+#or if rs1 >= rs2, rD = rs2, else rD = rs1
+test73:
+    li x20, 0x12577823
+    li x21, 0x08095074
+    p.clipr x18, x20, x21
+    li x19, 0x08095074
+    beq x18, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x20, 0x85763245
+    li x21, 0x00405809
+    p.clipr x18, x20, x21
+    li x19, 0xffbfa7f6
+    beq x18, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x20, 0x69879573
+    li x21, 0x698f9097
+    p.clipr x18, x20, x21
+    li x19, 0x69879573
+    beq x18, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x20, 0x98349834
+    li x21, 0x7f000000
+    p.clipr x18, x20, x21
+    li x19, 0x98349834
+    beq x18, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x20, 0x00000000
+    li x21, 0x70908094
+    p.clipr x18, x20, x21
+    li x19, 0x00000000
+    beq x18, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x20, 0xffffffff
+    li x21, 0x70988098
+    p.clipr x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the p.clipu instruction. values loaded in and compared to are expected output values
+#p.clipu instruction is of format "p.clipu rD, rs1, ls2". if rs1 <= 0, rD = 0
+#or if rs1 >= 2^(ls2-1), rD = 2^(ls2-1)-1, else rD = rs1
+test79:
+    li x20, 0x12577823
+    p.clipu x18, x20, 15
+    li x19, 0x00003fff
+    beq x18, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x20, 0x85763245
+    p.clipu x18, x20, 26
+    li x19, 0x0
+    beq x18, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x20, 0x69879573
+    p.clipu x18, x20, 31
+    li x19, 0x3fffffff
+    beq x18, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x20, 0x98349834
+    p.clipu x18, x20, 31
+    li x19, 0x0
+    beq x18, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x20, 0x00000000
+    p.clipu x18, x20, 10
+    li x19, 0x00000000
+    beq x18, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x20, 0xffffffff
+    p.clipu x18, x20, 6
+    li x19, 0x0
+    beq x18, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the p.clipur instruction. values loaded in and compared to are expected output values
+#p.clipur instruction is of format "p.clipur rD, rs1, rs2". if rs1 <= -(rs2+1), rD = -(rs2+1)
+#or if rs1 >= rs2, rD = rs2, else rD = rs1
+test85:
+    li x20, 0x12577825
+    li x21, 0x08095074
+    p.clipur x18, x20, x21
+    li x19, 0x08095074
+    beq x18, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x20, 0x85763245
+    li x21, 0x00405809
+    p.clipur x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x20, 0x69879573
+    li x21, 0x698f9097
+    p.clipur x18, x20, x21
+    li x19, 0x69879573
+    beq x18, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x20, 0x98349834
+    li x21, 0x7f000000
+    p.clipur x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x20, 0x00000000
+    li x21, 0x70908094
+    p.clipur x18, x20, x21
+    li x19, 0x00000000
+    beq x18, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x20, 0xffffffff
+    li x21, 0x70988098
+    p.clipur x18, x20, x21
+    li x19, 0x0
+    beq x18, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the p.addN instruction. values loaded in andcompared to are expected output values
+#p.addN instruction is of format "p.addN rD, rs1, rs2, ls3". rD = (rs1 + rs2) >>> ls3
+test91:
+    li x20, 0x72936987
+    li x21, 0x09734009
+    p.addN x18, x20, x21, 4
+    li x19, 0x07c06a99
+    beq x18, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x20, 0x6bac0f09
+    li x21, 0x9f8fae8c
+    p.addN x18, x20, x21, 6
+    li x19, 0x2ceef6
+    beq x18, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x20, 0x42346c3a
+    li x21, 0x5f877f8f
+    p.addN x18, x20, x21, 0xd 
+    li x19, 0xfffd0ddf
+    beq x18, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x20, 0xc3dc9c1f
+    li x21, 0xe396652a
+    p.addN x18, x20, x21, 9
+    li x19, 0xffd3b980
+    beq x18, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x20, 0x44587ccc
+    li x21, 0x452a294f
+    p.addN x18, x20, x21, 0x18
+    li x19, 0xffffff89
+    beq x18, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x20, 0x11c7b074
+    li x21, 0x57e03f4b
+    p.addN x18, x20, x21, 10
+    li x19, 0x001a69fb
+    beq x18, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the p.adduN instruction. values loaded in andcompared to are expected output values
+#p.adduN instruction is of format "p.adduN rD, rs1, rs2, ls3". rD = (rs1 + rs2) >> ls3
+test97:
+    li x20, 0xb2157f04
+    li x21, 0xb5bf1b07
+    p.adduN x18, x20, x21, 0xe
+    li x19, 0x00019f52
+    beq x18, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x20, 0x398f97d9
+    li x21, 0x41f67bbb
+    p.adduN x18, x20, x21, 0xc
+    li x19, 0x0007b861
+    beq x18, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x20, 0x75157c72
+    li x21, 0xe2969e22
+    p.adduN x18, x20, x21, 3
+    li x19, 0x0af58352
+    beq x18, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x20, 0x6b6c6895
+    li x21, 0x08dfc119
+    p.adduN x18, x20, x21, 0xf
+    li x19, 0x0000e898
+    beq x18, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x20, 0xf989a204
+    li x21, 0xe3cc5625
+    p.adduN x18, x20, x21, 6
+    li x19, 0x037557e0
+    beq x18, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x20, 0x4b31472c
+    li x21, 0x782df448
+    p.adduN x18, x20, x21, 0xc
+    li x19, 0x000c35f3
+    beq x18, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the p.addRN instruction. values loaded in andcompared to are expected output values
+#p.addRN instruction is of format "p.addRN rD, rs1, rs2, ls3". rD = (rs1 + rs2 + 2^(ls3-1)) >>> ls3
+test103:
+    li x20, 0xec5864c5
+    li x21, 0xaf202e1f
+    p.addRN x18, x20, x21, 0xe
+    li x19, 0xfffe6de2
+    beq x18, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x20, 0xa117f390
+    li x21, 0x502f1a97
+    p.addRN x18, x20, x21, 0xc
+    li x19, 0xffff1471
+    beq x18, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x20, 0x0e573f8d
+    li x21, 0x53e33b97
+    p.addRN x18, x20, x21, 0x1e
+    li x19, 0xfffffffe
+    beq x18, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x20, 0xd9231dc0
+    li x21, 0xcdefaa4c
+    p.addRN x18, x20, x21, 0xa
+    li x19, 0xffe9c4b2
+    beq x18, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x20, 0x2cddf47b
+    li x21, 0x3ecdc49d
+    p.addRN x18, x20, x21, 4
+    li x19, 0x06babb92
+    beq x18, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x20, 0x5f32c376
+    li x21, 0x1cb579cf
+    p.addRN x18, x20, x21, 0xf
+    li x19, 0x0000f7d0
+    beq x18, x19, test109
+    c.addi x15, 0x1
+#tests109-114 test the p.adduRN instruction. values loaded in andcompared to are expected output values
+#p.adduRN instruction is of format "p.adduRN rD, rs1, rs2, ls3". rD = (rs1 + rs2 + 2^(ls3-1)) >> ls3
+test109:
+    li x20, 0xc5e72ff3
+    li x21, 0x7aedfaa4
+    p.adduRN x18, x20, x21, 0xa
+    li x19, 0x0010354b
+    beq x18, x19, test110
+    c.addi x15, 0x1
+test110:
+    li x20, 0xb819c9fc
+    li x21, 0x9a4797c0
+    p.adduRN x18, x20, x21, 3
+    li x19, 0x0a4c2c38
+    beq x18, x19, test111
+    c.addi x15, 0x1
+test111:
+    li x20, 0x5b1db039
+    li x21, 0xac2fbd67
+    p.adduRN x18, x20, x21, 9
+    li x19, 0x0003a6b7
+    beq x18, x19, test112
+    c.addi x15, 0x1
+test112:
+    li x20, 0x190fe0d1
+    li x21, 0xb26a9865
+    p.adduRN x18, x20, x21, 0xa
+    li x19, 0x0032de9e
+    beq x18, x19, test113
+    c.addi x15, 0x1
+test113:
+    li x20, 0x20d5dd4a
+    li x21, 0x58838351
+    p.adduRN x18, x20, x21, 0xb
+    li x19, 0x000f2b2c
+    beq x18, x19, test114
+    c.addi x15, 0x1
+test114:
+    li x20, 0x6137c87d
+    li x21, 0x5e197fed
+    p.adduRN x18, x20, x21, 0xd
+    li x19, 0x0005fa8a
+    beq x18, x19, test115
+    c.addi x15, 0x1
+#tests115-120 test the p.addNr instruction. values loaded in andcompared to are expected output values
+#p.addNr instruction is of format "p.addNr rD, rs1, rs2". rD = (rD + rs1) >>> rs2[4:0]
+test115:
+    li x18, 0x646f6bd5
+    li x20, 0x2d4ffc3b
+    li x21, 0xed7354c3
+    p.addNr x18, x20, x21
+    li x19, 0xf237ed02
+    beq x18, x19, test116
+    c.addi x15, 0x1
+test116:
+    li x18, 0xb86e922f
+    li x20, 0x5f242322
+    li x21, 0x6e2fe71a
+    p.addNr x18, x20, x21
+    li x19, 0x00000005
+    beq x18, x19, test117
+    c.addi x15, 0x1
+test117:
+    li x18, 0xced663d0
+    li x20, 0xf8fc447c
+    li x21, 0x52c0d7df
+    p.addNr x18, x20, x21
+    li x19, 0xffffffff
+    beq x18, x19, test118
+    c.addi x15, 0x1
+test118:
+    li x18, 0xc1ef74f9
+    li x20, 0xe9ee71b6
+    li x21, 0x219106a7
+    p.addNr x18, x20, x21
+    li x19, 0xff57bbcd
+    beq x18, x19, test119
+    c.addi x15, 0x1
+test119:
+    li x18, 0x3a5c81d2
+    li x20, 0xb09e0fb3
+    li x21, 0xf3251a70
+    p.addNr x18, x20, x21
+    li x19, 0xffffeafa
+    beq x18, x19, test120
+    c.addi x15, 0x1
+test120:
+    li x18, 0xa5b921bf
+    li x20, 0xcead29a4
+    li x21, 0x5dd92029
+    p.addNr x18, x20, x21
+    li x19, 0x003a3325
+    beq x18, x19, test121
+    c.addi x15, 0x1
+#tests121-126 test the p.adduNr instruction. values loaded in andcompared to are expected output values
+#p.adduNr instruction is of format "p.adduNr rD, rs1, rs2". rD = (rD + rs1) >> rs2[4:0]
+test121:
+    li x18, 0x65cef5d7
+    li x20, 0x60e59b8a
+    li x21, 0x9d36df4b
+    p.adduNr x18, x20, x21
+    li x19, 0x0018d692
+    beq x18, x19, test122
+    c.addi x15, 0x1
+test122:
+    li x18, 0xba2a731d
+    li x20, 0x6e9335ba
+    li x21, 0x4b174fd0
+    p.adduNr x18, x20, x21
+    li x19, 0x000028bd
+    beq x18, x19, test123
+    c.addi x15, 0x1
+test123:
+    li x18, 0x9264b71c
+    li x20, 0x7aada0de
+    li x21, 0xaa66eb7c
+    p.adduNr x18, x20, x21
+    li x19, 0x00000000
+    beq x18, x19, test124
+    c.addi x15, 0x1
+test124:
+    li x18, 0xee8a2c3b
+    li x20, 0xc2bfab6b
+    li x21, 0xab36de09
+    p.adduNr x18, x20, x21
+    li x19, 0x0058a4eb
+    beq x18, x19, test125
+    c.addi x15, 0x1
+test125:
+    li x18, 0x8bcaf600
+    li x20, 0x0ea2c360
+    li x21, 0x05984e93
+    p.adduNr x18, x20, x21
+    li x19, 0x0000134d
+    beq x18, x19, test126
+    c.addi x15, 0x1
+test126:
+    li x18, 0x52658344
+    li x20, 0x1f77523b
+    li x21, 0xfacb520d
+    p.adduNr x18, x20, x21
+    li x19, 0x00038ee6
+    beq x18, x19, test127
+    c.addi x15, 0x1
+#tests127-132 test the p.addRNr instruction. values loaded in and compared to are expected output values
+#p.addRNr instruction is of format "p.addRNr rD, rs1, rs2". rD = (rD + rs1 + 2^(rs2[4:0]-1)) >>> rs2[4:0]
+test127:
+    li x18, 0x913c3879
+    li x20, 0x964b68d4
+    li x21, 0x361922fa
+    p.addRNr x18, x20, x21
+    li x19, 0x0000000a
+    beq x18, x19, test128
+    c.addi x15, 0x1
+test128:
+    li x18, 0x03f7a125
+    li x20, 0xa3c9eccd
+    li x21, 0x1be630b7
+    p.addRNr x18, x20, x21
+    li x19, 0xffffff50
+    beq x18, x19, test129
+    c.addi x15, 0x1
+test129:
+    li x18, 0x34b63af5
+    li x20, 0xa5e12c0c
+    li x21, 0xd51e66eb
+    p.addRNr x18, x20, x21
+    li x19, 0xfffb52ed
+    beq x18, x19, test130
+    c.addi x15, 0x1
+test130:
+    li x18, 0xff1aa145
+    li x20, 0xfdf121e1
+    li x21, 0x0b58d4ec
+    p.addRNr x18, x20, x21
+    li x19, 0xffffd0bc
+    beq x18, x19, test131
+    c.addi x15, 0x1
+test131:
+    li x18, 0x97251982
+    li x20, 0x00488629
+    li x21, 0xc5f54aeb
+    p.addRNr x18, x20, x21
+    li x19, 0xfff2edb4
+    beq x18, x19, test132
+    c.addi x15, 0x1
+test132:
+    li x18, 0x3968f2d8
+    li x20, 0x2429ff2f
+    li x21, 0x9819e086
+    p.addRNr x18, x20, x21
+    li x19, 0x01764bc8
+    beq x18, x19, test133
+    c.addi x15, 0x1
+#tests133-138 test the p.adduRNr instruction. values loaded in and compared to are expected output values
+#p.adduRNr instruction is of format "p.adduRNr rD, rs1, rs2". rD = (rD + rs1 + 2^(rs2[4:0]-1)) >> rs2[4:0]
+test133:
+    li x18, 0x456a58c7
+    li x20, 0x41487a7d
+    li x21, 0x106418ac
+    p.adduRNr x18, x20, x21
+    li x19, 0x00086b2d
+    beq x18, x19, test134
+    c.addi x15, 0x1
+test134:
+    li x18, 0x71fa9839
+    li x20, 0x991bcb1d
+    li x21, 0x4de92911
+    p.adduRNr x18, x20, x21
+    li x19, 0x0000058b
+    beq x18, x19, test135
+    c.addi x15, 0x1
+test135:
+    li x18, 0xaa581c17
+    li x20, 0x3943efaf
+    li x21, 0x729929d9
+    p.adduRNr x18, x20, x21
+    li x19, 0x00000072
+    beq x18, x19, test136
+    c.addi x15, 0x1
+test136:
+    li x18, 0x67358b2d
+    li x20, 0xf1f9706f
+    li x21, 0xea5711bf
+    p.adduRNr x18, x20, x21
+    li x19, 0x00000001
+    beq x18, x19, test137
+    c.addi x15, 0x1
+test137:
+    li x18, 0x616d6b1a
+    li x20, 0x675fa4d2
+    li x21, 0x2f7243c9
+    p.adduRNr x18, x20, x21
+    li x19, 0x00646688
+    beq x18, x19, test138
+    c.addi x15, 0x1
+test138:
+    li x18, 0xbfdf721a
+    li x20, 0xd2082e34
+    li x21, 0x640e1c44
+    p.adduRNr x18, x20, x21
+    li x19, 0x091e7a05
+    beq x18, x19, test139
+    c.addi x15, 0x1
+#tests139-144 test the p.subN instruction. values loaded in andcompared to are expected output values
+#p.subN instruction is of format "p.subN rD, rs1, rs2, ls3". rD = (rs1 - rs2) >>> ls3
+test139:
+    li x20, 0x2d221d9b
+    li x21, 0x104bfa70
+    p.subN x18, x20, x21, 8
+    li x19, 0x01cd623
+    beq x18, x19, test140
+    c.addi x15, 0x1
+test140:
+    li x20, 0x7e089f95
+    li x21, 0x449323b6
+    p.subN x18, x20, x21, 5
+    li x19, 0x01cbabde
+    beq x18, x19, test141
+    c.addi x15, 0x1
+test141:
+    li x20, 0xa74931fa
+    li x21, 0x9b7131e3
+    p.subN x18, x20, x21, 7
+    li x19, 0x0017b000
+    beq x18, x19, test142
+    c.addi x15, 0x1
+test142:
+    li x20, 0x1dd4997f
+    li x21, 0x53a6e152
+    p.subN x18, x20, x21, 0xc
+    li x19, 0xfffca2db
+    beq x18, x19, test143
+    c.addi x15, 0x1
+test143:
+    li x20, 0xa17c64d6
+    li x21, 0x313e6061
+    p.subN x18, x20, x21, 0x10
+    li x19, 0x0000703e
+    beq x18, x19, test144
+    c.addi x15, 0x1
+test144:
+    li x20, 0xe081ba5c
+    li x21, 0x0de1ad03
+    p.subN x18, x20, x21, 0x12
+    li x19, 0xfffff4a8
+    beq x18, x19, test145
+    c.addi x15, 0x1
+#tests145-150 test the p.subuN instruction. values loaded in andcompared to are expected output values
+#p.subuN instruction is of format "p.subuN rD, rs1, rs2, ls3". rD = (rs1 - rs2) >> ls3
+test145:
+    li x20, 0xa59ad94e
+    li x21, 0xc473a2ea
+    p.subuN x18, x20, x21, 3
+    li x19, 0x1c24e6cc
+    beq x18, x19, test146
+    c.addi x15, 0x1
+test146:
+    li x20, 0x3208375a
+    li x21, 0x4aef0ff0
+    p.subuN x18, x20, x21, 0xb
+    li x19, 0x001ce324
+    beq x18, x19, test147
+    c.addi x15, 0x1
+test147:
+    li x20, 0xc266172f
+    li x21, 0x326303a7
+    p.subuN x18, x20, x21, 2
+    li x19, 0x2400c4e2
+    beq x18, x19, test148
+    c.addi x15, 0x1
+test148:
+    li x20, 0x430eb2ba
+    li x21, 0xe5639f98
+    p.subuN x18, x20, x21, 0x11
+    li x19, 0x00002ed5
+    beq x18, x19, test149
+    c.addi x15, 0x1
+test149:
+    li x20, 0x7be90b07
+    li x21, 0x46d56a8c
+    p.subuN x18, x20, x21, 9
+    li x19, 0x001a89d0
+    beq x18, x19, test150
+    c.addi x15, 0x1
+test150:
+    li x20, 0x0e16c7cf
+    li x21, 0x9219530c
+    p.subuN x18, x20, x21, 0x12
+    li x19, 0x00001eff
+    beq x18, x19, test151
+    c.addi x15, 0x1
+#tests151-156 test the p.subRN instruction. values loaded in andcompared to are expected output values
+#p.subRN instruction is of format "p.subRN rD, rs1, rs2, ls3". rD = (rs1 - rs2 + 2^(ls3-1)) >>> ls3
+test151:
+    li x20, 0x84ac1cee
+    li x21, 0xd2fb2d2d
+    p.subRN x18, x20, x21, 0x11
+    li x19, 0xffffd8d8
+    beq x18, x19, test152
+    c.addi x15, 0x1
+test152:
+    li x20, 0xe3db1897
+    li x21, 0x04855369
+    p.subRN x18, x20, x21, 0xc
+    li x19, 0xfffdf55c
+    beq x18, x19, test153
+    c.addi x15, 0x1
+test153:
+    li x20, 0xadc655f1
+    li x21, 0x4aafcf57
+    p.subRN x18, x20, x21, 0xb
+    li x19, 0x000c62d1
+    beq x18, x19, test154
+    c.addi x15, 0x1
+test154:
+    li x20, 0x4623ef1d
+    li x21, 0x30f7be5a
+    p.subRN x18, x20, x21, 0x17
+    li x19, 0x0000002a
+    beq x18, x19, test155
+    c.addi x15, 0x1
+test155:
+    li x20, 0xac15aded
+    li x21, 0xe3ec3b7c
+    p.subRN x18, x20, x21, 4
+    li x19, 0xfc829727
+    beq x18, x19, test156
+    c.addi x15, 0x1
+test156:
+    li x20, 0xa6256e0b
+    li x21, 0xd4e8f056
+    p.subRN x18, x20, x21, 0xa
+    li x19, 0xfff44f1f
+    beq x18, x19, test157
+    c.addi x15, 0x1
+#tests157-162 test the p.subuRN instruction. values loaded in andcompared to are expected output values
+#p.subuRN instruction is of format "p.subuRN rD, rs1, rs2, ls3". rD = (rs1 - rs2 + 2^(ls3-1)) >> ls3
+test157:
+    li x20, 0x84ac1cee
+    li x21, 0xd2fb2d2d
+    p.subuRN x18, x20, x21, 0x11
+    li x19, 0x000058d8
+    beq x18, x19, test158
+    c.addi x15, 0x1
+test158:
+    li x20, 0xe3db1897
+    li x21, 0x04855369
+    p.subuRN x18, x20, x21, 0xc
+    li x19, 0x000df55c
+    beq x18, x19, test159
+    c.addi x15, 0x1
+test159:
+    li x20, 0xadc655f1
+    li x21, 0x4aafcf57
+    p.subuRN x18, x20, x21, 0xb
+    li x19, 0x000c62d1
+    beq x18, x19, test160
+    c.addi x15, 0x1
+test160:
+    li x20, 0x4623ef1d
+    li x21, 0x30f7be5a
+    p.subuRN x18, x20, x21, 0x17
+    li x19, 0x0000002a
+    beq x18, x19, test161
+    c.addi x15, 0x1
+test161:
+    li x20, 0xac15aded
+    li x21, 0xe3ec3b7c
+    p.subuRN x18, x20, x21, 4
+    li x19, 0x0c829727
+    beq x18, x19, test162
+    c.addi x15, 0x1
+test162:
+    li x20, 0xa6256e0b
+    li x21, 0xd4e8f056
+    p.subuRN x18, x20, x21, 0xa
+    li x19, 0x00344f1f
+    beq x18, x19, test163
+    c.addi x15, 0x1
+#tests163-168 test the p.subNr instruction. values loaded in andcompared to are expected output values
+#p.subNr instruction is of format "p.subNr rD, rs1, rs2". rD = (rD - rs1) >>> rs2[4:0]
+test163:
+    li x18, 0x8c178e58
+    li x20, 0xbec1d356
+    li x21, 0x35a0de16
+    p.subNr x18, x20, x21
+    li x19, 0xffffff35
+    beq x18, x19, test164
+    c.addi x15, 0x1
+test164:
+    li x18, 0x5a755dcc
+    li x20, 0x42daab66
+    li x21, 0xdfed16a2
+    p.subNr x18, x20, x21
+    li x19, 0x05e6ac99
+    beq x18, x19, test165
+    c.addi x15, 0x1
+test165:
+    li x18, 0x20d46d05
+    li x20, 0x8e2d2a35
+    li x21, 0xcf7c564b
+    p.subNr x18, x20, x21
+    li x19, 0xfff254e8
+    beq x18, x19, test166
+    c.addi x15, 0x1
+test166:
+    li x18, 0x5fc53a5c
+    li x20, 0x0bbe1773
+    li x21, 0x905a118f
+    p.subNr x18, x20, x21
+    li x19, 0x0000a80e
+    beq x18, x19, test167
+    c.addi x15, 0x1
+test167:
+    li x18, 0xe18fe383
+    li x20, 0xea4821e3
+    li x21, 0x1ac9f4f7
+    p.subNr x18, x20, x21
+    li x19, 0xffffffee
+    beq x18, x19, test168
+    c.addi x15, 0x1
+test168:
+    li x18, 0x54596448
+    li x20, 0x44756aa2
+    li x21, 0x22128b2e
+    p.subNr x18, x20, x21
+    li x19, 0x00003f8f
+    beq x18, x19, test169
+    c.addi x15, 0x1
+#tests169-174 test the p.subuNr instruction. values loaded in andcompared to are expected output values
+#p.subuNr instruction is of format "p.subuNr rD, rs1, rs2". rD = (rD - rs1) >> rs2[4:0]
+test169:
+    li x18, 0xcc3fa958
+    li x20, 0xcc9ba04b
+    li x21, 0x683854e2
+    p.subuNr x18, x20, x21
+    li x19, 0x3fe90243
+    beq x18, x19, test170
+    c.addi x15, 0x1
+test170:
+    li x18, 0x6a494b61
+    li x20, 0x30c8745d
+    li x21, 0xbe0eb1a4
+    p.subuNr x18, x20, x21
+    li x19, 0x03980d70
+    beq x18, x19, test171
+    c.addi x15, 0x1
+test171:
+    li x18, 0xd8151a3e
+    li x20, 0x7e6826a7
+    li x21, 0x7c5f1d29
+    p.subuNr x18, x20, x21
+    li x19, 0x002cd679
+    beq x18, x19, test172
+    c.addi x15, 0x1
+test172:
+    li x18, 0x8669f154
+    li x20, 0x5b4183ac
+    li x21, 0x57bd7285
+    p.subuNr x18, x20, x21
+    li x19, 0x159436d
+    beq x18, x19, test173
+    c.addi x15, 0x1
+test173:
+    li x18, 0x523c0d99
+    li x20, 0x3d395a21
+    li x21, 0xd07290bc
+    p.subuNr x18, x20, x21
+    li x19, 0x00000001
+    beq x18, x19, test174
+    c.addi x15, 0x1
+test174:
+    li x18, 0x448a8dd2
+    li x20, 0x0a108d00
+    li x21, 0x660481a2
+    p.subuNr x18, x20, x21
+    li x19, 0x0e9e8034
+    beq x18, x19, test175
+    c.addi x15, 0x1
+#tests175-180 test the p.subRNr instruction. values loaded in and compared to are expected output values
+#p.subRNr instruction is of format "p.subRNr rD, rs1, rs2". rD = (rD - rs1 + 2^(rs2[4:0]-1)) >>> rs2[4:0]
+test175:
+    li x18, 0xb3940dbe
+    li x20, 0x6d94e10e
+    li x21, 0xfc9c1515
+    p.subRNr x18, x20, x21
+    li x19, 0x230
+    beq x18, x19, test176
+    c.addi x15, 0x1
+test176:
+    li x18, 0xe303c6ae
+    li x20, 0x022bbb19
+    li x21, 0xcb889d81
+    p.subRNr x18, x20, x21
+    li x19, 0xf06c05cb
+    beq x18, x19, test177
+    c.addi x15, 0x1
+test177:
+    li x18, 0xb838e0d6
+    li x20, 0xbbc61816
+    li x21, 0x642520d2
+    p.subRNr x18, x20, x21
+    li x19, 0xffffff1d
+    beq x18, x19, test178
+    c.addi x15, 0x1
+test178:
+    li x18, 0x43cb36c9
+    li x20, 0x4307307c
+    li x21, 0xd88202e7
+    p.subRNr x18, x20, x21
+    li x19, 0x0001880d
+    beq x18, x19, test179
+    c.addi x15, 0x1
+test179:
+    li x18, 0x46ccf70f
+    li x20, 0x35be2580
+    li x21, 0x23e1312f
+    p.subRNr x18, x20, x21
+    li x19, 0x0000221e
+    beq x18, x19, test180
+    c.addi x15, 0x1
+test180:
+    li x18, 0xdcfbbbc2
+    li x20, 0xafc4a083
+    li x21, 0xf4b525f8
+    p.subRNr x18, x20, x21
+    li x19, 0x0000002d
+    beq x18, x19, test181
+    c.addi x15, 0x1
+#tests181-186 test the p.subuRNr instruction. values loaded in and compared to are expected output values
+#p.subuRNr instruction is of format "p.subuRNr rD, rs1, rs2". rD = (rD - rs1 + 2^(rs2[4:0]-1)) >> rs2[4:0]
+test181:
+    li x18, 0xb3940dbe
+    li x20, 0x6d94e10e
+    li x21, 0xfc9c1515
+    p.subuRNr x18, x20, x21
+    li x19, 0x00000230
+    beq x18, x19, test182
+    c.addi x15, 0x1
+test182:
+    li x18, 0xe303c6ae
+    li x20, 0x022bbb19
+    li x21, 0xcb889d81
+    p.subuRNr x18, x20, x21
+    li x19, 0x706c05cb
+    beq x18, x19, test183
+    c.addi x15, 0x1
+test183:
+    li x18, 0xb838e0d6
+    li x20, 0xbbc61816
+    li x21, 0x642520d2
+    p.subuRNr x18, x20, x21
+    li x19, 0x00003f1d
+    beq x18, x19, test184
+    c.addi x15, 0x1
+test184:
+    li x18, 0x43cb36c9
+    li x20, 0x4307307c
+    li x21, 0xd88202e7
+    p.subuRNr x18, x20, x21
+    li x19, 0x0001880d
+    beq x18, x19, test185
+    c.addi x15, 0x1
+test185:
+    li x18, 0x46ccf70f
+    li x20, 0x35be2580
+    li x21, 0x23e1312f
+    p.subuRNr x18, x20, x21
+    li x19, 0x0000221e
+    beq x18, x19, test186
+    c.addi x15, 0x1
+test186:
+    li x18, 0xdcfbbbc2
+    li x20, 0xafc4a083
+    li x21, 0xf4b525f8
+    p.subuRNr x18, x20, x21
+    li x19, 0x0000002d
+    beq x18, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_immediate_branching.S
+++ b/cv32/tests/core/custom/pulp_immediate_branching.S
@@ -1,0 +1,162 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests all immediate branching instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the p.beqimm instruction. values loaded in and compared to are expected output values
+#p.beqimm is of form "p.beqimm rs1, Imm5, Imm12". Branches to PC + (Imm12 << 1) if rs1==Imm5.
+#Imm5 is signed for this instruction
+test1:
+    li x17, 0x00000005
+    p.beqimm x17, 0x05, check1
+    c.addi x15, 0x1
+    nop
+    nop
+    nop
+check1:
+    c.addi x16, 0x1
+test2:
+    li x17, -10
+    p.beqimm x17, -10, check2
+    c.addi x15, 0x1
+    nop
+    nop
+check2:
+    c.addi x16, 0x1
+test3:
+    li x17, -3
+    p.beqimm x17, -3, check3
+    c.addi x15, 0x1
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+check3:
+    c.addi x16, 0x1
+test4:
+    li x17, 0x00000007
+    p.beqimm x17, 0x07, check4
+    c.addi x15, 0x1
+check4:
+    c.addi x16, 0x1
+test5:
+    li x17, 0x00000000
+    p.beqimm x17, 0x01, exit
+    c.addi x16, 0x1
+test6:
+    li x17, -7
+    p.beqimm x17, -6, exit
+    c.addi x16, 0x1
+#tests7-12 test the p.bneimm instruction. values loaded in and compared to are expected output values
+#p.bneimm is of form "p.bneimm, rs1, Imm5, Imm 12". Branched to PC + (Imm12 << 1) if rs1==Imm5.
+#Imm5 is signed for this instruction
+test7: #114
+    li x17, 0xffffffff
+    p.bneimm x17, 0xe, check7
+    c.addi x15, 0x1
+    nop
+    nop
+    nop
+check7:
+    c.addi x16, 0x1
+test8:
+    li x17, -10
+    p.bneimm x17, -8, check8
+    c.addi x15, 0x1
+    nop
+    nop
+check8:
+    c.addi x16, 0x1
+test9:
+    li x17, -3
+    p.bneimm x17, 5, check9
+    c.addi x15, 0x1
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+check9:
+    c.addi x16, 0x1
+test10:
+    li x17, 0x00000008
+    p.bneimm x17, 0x06, check10
+    c.addi x15, 0x1
+check10:
+    c.addi x16, 0x1
+test11:
+    li x17, 0x00000000
+    p.bneimm x17, 0x00, exit
+    c.addi x16, 0x1
+test12:
+    li x17, -7
+    p.bneimm x17, -7, exit_check
+    c.addi x16, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_multiply_accumulate.S
+++ b/cv32/tests/core/custom/pulp_multiply_accumulate.S
@@ -1,0 +1,1098 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests all multiply-accumulate instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x200
+    li x14, 0x210
+    li x15, 0x0
+    li x16, 0xff7811b4
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0xc356d985
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the p.mac instruction. values loaded in and compared to are expected output values
+#p.mac instruction is of format "p.mac rD, rs1, rs2". rD = rD + rs1 * rs2
+test1:
+    li x18, 0xe8a5056b
+    li x20, 0x2e05bb8c
+    li x21, 0x9ac17ad0
+    p.mac x18, x20, x21
+    li x19, 0xa53a1f2b
+    beq x18, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x18, 0xf474bbd5
+    li x20, 0xbb06dba8
+    li x21, 0x1331adce
+    p.mac x18, x20, x21
+    li x19, 0x99920505
+    beq x18, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x18, 0xa5fd60b4
+    li x20, 0xe56cc495
+    li x21, 0x26455ded
+    p.mac x18, x20, x21
+    li x19, 0xa9427fa5
+    beq x18, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x18, 0xd3b769ab
+    li x20, 0xa693f8ed
+    li x21, 0x98649434
+    p.mac x18, x20, x21
+    li x19, 0x2a42fdcf
+    beq x18, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x18, 0x79fe6a01
+    li x20, 0xabeae759
+    li x21, 0x37c34582
+    p.mac x18, x20, x21
+    li x19, 0x6f6de233
+    beq x18, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x18, 0xe2cff4bc
+    li x20, 0x698f518e
+    li x21, 0xff0a0a1f
+    p.mac x18, x20, x21
+    li x19, 0xe5e660ee
+    beq x18, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the p.msu instruction. values loaded in and compared to are expected output values
+#p.msu instruction is of format "p.msu rD, rs1, rs2". rD = rD - rs1 * rs2
+test7:
+    li x18, 0x9a213505
+    li x20, 0x91619407
+    li x21, 0xc6ee52b8
+    p.msu x18, x20, x21
+    li x19, 0xd21291fd
+    beq x18, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x18, 0x64a7d13a
+    li x20, 0x568985a7
+    li x21, 0x58c041b1
+    p.msu x18, x20, x21
+    li x19, 0xff6301c3
+    beq x18, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x18, 0x3166c1df
+    li x20, 0xaaa824bc
+    li x21, 0xfbe9e46d
+    p.msu x18, x20, x21
+    li x19, 0x03fbadd3
+    beq x18, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x18, 0x15aca170
+    li x20, 0xceda0bed
+    li x21, 0xbf3be51f
+    p.msu x18, x20, x21
+    li x19, 0x69fb2ebd
+    beq x18, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x18, 0x6316050a
+    li x20, 0x6ea40095
+    li x21, 0x8a5fbb09
+    p.msu x18, x20, x21
+    li x19, 0x299a28cd
+    beq x18, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x18, 0xb3d3cae2
+    li x20, 0x0478637a
+    li x21, 0x2d2dc58f
+    p.msu x18, x20, x21
+    li x19, 0xa19557bc
+    beq x18, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the p.muls instruction. values loaded in and compared to are expected output values
+#p.muls instruction is of format "p.muls rD, rs1, rs2". rD[31:0] = Sext(rs1[15:0]) * Sext(rs2[15:0])
+test13:
+    li x20, 0x1efce4a5
+    li x21, 0xa6529f8c
+    p.muls x18, x20, x21
+    li x19, 0x0a4e853c
+    beq x18, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x20, 0xaf5cbf12
+    li x21, 0x6d2c1168
+    p.muls x18, x20, x21
+    li x19, 0xfb95d150
+    beq x18, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x20, 0x91ef944b
+    li x21, 0x12d44ba4
+    p.muls x18, x20, x21
+    li x19, 0xe02cf90c
+    beq x18, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x20, 0x011349f4
+    li x21, 0x388b7224
+    p.muls x18, x20, x21
+    li x19, 0x20f90e50
+    beq x18, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x20, 0x3f59a8a1
+    li x21, 0xaa5e39a7
+    p.muls x18, x20, x21
+    li x19, 0xec52da07
+    beq x18, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x20, 0x73107229
+    li x21, 0x5e5604cd
+    p.muls x18, x20, x21
+    li x19, 0x02240ed5
+    beq x18, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the p.mulhhs instruction. values loaded in and compared to are expected output values
+#p.mulhhs instruction is of format "p.mulhhs rD, rs1, rs2". rD[31:0] = Sext(rs1[31:15]) * Sext(rs2[31:15])
+test19:
+    li x20, 0x47186154
+    li x21, 0x81300f73
+    p.mulhhs x18, x20, x21
+    li x19, 0xdcc86c80
+    beq x18, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x20, 0x57517955
+    li x21, 0xee33a51c
+    p.mulhhs x18, x20, x21
+    li x19, 0xf9edb323
+    beq x18, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x20, 0x3a30c494
+    li x21, 0x161c6fa5
+    p.mulhhs x18, x20, x21
+    li x19, 0x05067d40
+    beq x18, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x20, 0x73d13103
+    li x21, 0x7c3c4d6f
+    p.mulhhs x18, x20, x21
+    li x19, 0x383460fc
+    beq x18, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x20, 0x8abe0f9f
+    li x21, 0xdf26fe0d
+    p.mulhhs x18, x20, x21
+    li x19, 0x0f0c1a34
+    beq x18, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x20, 0x468bf1d2
+    li x21, 0x0fc23c8b
+    p.mulhhs x18, x20, x21
+    li x19, 0x04579a56
+    beq x18, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the p.mulsN instruction. values loaded in and compared to are expected output values
+#p.mulsN instruction is of format "p.mulsN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[15:0]) * Sext(rs2[15:0])) >>> ls3
+test25:
+    li x20, 0x74331682
+    li x21, 0x0aa1f5a9
+    p.mulsN x18, x20, x21, 7
+    li x19, 0xfffe2e8b
+    beq x18, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x20, 0xde4f9245
+    li x21, 0x1605a4a9
+    p.mulsN x18, x20, x21, 3
+    li x19, 0x04e4d871
+    beq x18, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x20, 0xd91414bd
+    li x21, 0xa3970907
+    p.mulsN x18, x20, x21, 8
+    li x19, 0x0000bb36
+    beq x18, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x20, 0x28d31573
+    li x21, 0x3ae29717
+    p.mulsN x18, x20, x21, 0x19
+    li x19, 0xfffffffb
+    beq x18, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x20, 0x30c868ca
+    li x21, 0x7c404007
+    p.mulsN x18, x20, x21, 0xf
+    li x19, 0x0000346a
+    beq x18, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x20, 0x26d2600c
+    li x21, 0x729daf0f
+    p.mulsN x18, x20, x21, 0xa
+    li x19, 0xfff86875
+    beq x18, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the p.mulhhsN instruction. values loaded in and compared to are expected output values
+#p.mulhhsN instruction is of format "p.mulhhsN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[31:15]) * Sext(rs2[31:15])) >>> ls3
+test31:
+    li x20, 0x47186154
+    li x21, 0x81300f73
+    p.mulhhsN x18, x20, x21, 6
+    li x19, 0xff7321b2
+    beq x18, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x20, 0x57517955
+    li x21, 0xee33a51c
+    p.mulhhsN x18, x20, x21, 9
+    li x19, 0xfffcf6d9
+    beq x18, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x20, 0x3a30c494
+    li x21, 0x161c6fa5
+    p.mulhhsN x18, x20, x21, 0x12
+    li x19, 0x00000141
+    beq x18, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x20, 0x73d13103
+    li x21, 0x7c3c4d6f
+    p.mulhhsN x18, x20, x21, 0x17
+    li x19, 0x00000070
+    beq x18, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x20, 0x8abe0f9f
+    li x21, 0xdf26fe0d
+    p.mulhhsN x18, x20, x21, 2
+    li x19, 0x03c3068d
+    beq x18, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x20, 0x468bf1d2
+    li x21, 0x0fc23c8b
+    p.mulhhsN x18, x20, x21, 9
+    li x19, 0x00022bcd
+    beq x18, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the p.mulsRN instruction. values loaded in and compared to are expected output values
+#p.mulsRN instruction is of format "p.mulsRN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[15:0]) * Sext(rs2[15:0]) + 2^(ls3-1)) >>> ls3
+test37:
+    li x20, 0x645be558
+    li x21, 0x62e5f55c
+    p.mulsRN x18, x20, x21, 2
+    li x19, 0x0046e8e8
+    beq x18, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x20, 0x4635074b
+    li x21, 0xe7c4c350
+    p.mulsRN x18, x20, x21, 6
+    li x19, 0xfff915a2
+    beq x18, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x20, 0xfedb2992
+    li x21, 0x2b9a5f93
+    p.mulsRN x18, x20, x21, 0xf
+    li x19, 0x00001f0a
+    beq x18, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x20, 0xb0f25142
+    li x21, 0xdd3234fa
+    p.mulsRN x18, x20, x21, 8
+    li x19, 0x0010d0c2
+    beq x18, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x20, 0x02790358
+    li x21, 0x6f13c02b
+    p.mulsRN x18, x20, x21, 5
+    li x19, 0xfff9547e
+    beq x18, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x20, 0x2ee3bd6d
+    li x21, 0xa7525b2a
+    p.mulsRN x18, x20, x21, 0xb
+    li x19, 0xfffd095a
+    beq x18, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the p.mulhhsRN instruction. values loaded in and compared to are expected output values
+#p.mulhhsRN instruction is of format "p.mulhhsRN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[31:15]) * Sext(rs2[31:15])) >>> ls3
+test43:
+    li x20, 0xd4d8f1cc
+    li x21, 0x49d48c10
+    p.mulhhsRN x18, x20, x21, 0xc
+    li x19, 0xffff38de
+    beq x18, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x20, 0x04c87470
+    li x21, 0x9c7bc8b5
+    p.mulhhsRN x18, x20, x21, 0x12
+    li x19, 0xffffff89
+    beq x18, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x20, 0xf05e71ec
+    li x21, 0xd842481b
+    p.mulhhsRN x18, x20, x21, 0x10
+    li x19, 0x0000026d
+    beq x18, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x20, 0x71abaa20
+    li x21, 0x6475d3e0
+    p.mulhhsRN x18, x20, x21, 3
+    li x19, 0x059357e5
+    beq x18, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x20, 0xa4f23563
+    li x21, 0xa54cdf55
+    p.mulhhsRN x18, x20, x21, 6
+    li x19, 0x00810bc7
+    beq x18, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x20, 0x3079b2b5
+    li x21, 0xcb198c64
+    p.mulhhsRN x18, x20, x21, 0x14
+    li x19, 0xffffff60
+    beq x18, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the p.mulu instruction. values loaded in and compared to are expected output values
+#p.mulu instruction is of format "p.mulu rD, rs1, rs2". rD[31:0] = Zext(rs1[15:0]) * Zext(rs2[15:0])
+test49:
+    li x20, 0x76166875
+    li x21, 0xdde8888b
+    p.mulu x18, x20, x21
+    li x19, 0x37b6df87
+    beq x18, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x20, 0xd2562f8e
+    li x21, 0xdb29c6c3
+    p.mulu x18, x20, x21
+    li x19, 0x24ec0d2a
+    beq x18, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x20, 0xb24b4bbf
+    li x21, 0x2acef5ae
+    p.mulu x18, x20, x21
+    li x19, 0x48b146d2
+    beq x18, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x20, 0xdfc326dc
+    li x21, 0x42ed13f0
+    p.mulu x18, x20, x21
+    li x19, 0x0306c240
+    beq x18, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x20, 0x48b617d0
+    li x21, 0xe5265d14
+    p.mulu x18, x20, x21
+    li x19, 0x08a86c40
+    beq x18, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x20, 0x9f60f8c5
+    li x21, 0xbac9e541
+    p.mulu x18, x20, x21
+    li x19, 0xdec76305
+    beq x18, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the p.mulhhu instruction. values loaded in and compared to are expected output values
+#p.mulhhu instruction is of format "p.mulhhu rD, rs1, rs2". rD[31:0] = Zext(rs1[31:15]) * Zext(rs2[31:15])
+test55:
+    li x20, 0xc3fb288f
+    li x21, 0x2790adaf
+    p.mulhhu x18, x20, x21
+    li x19, 0x1e497a30
+    beq x18, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x20, 0x663d5315
+    li x21, 0x2d9709f3
+    p.mulhhu x18, x20, x21
+    li x19, 0x123506fb
+    beq x18, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x20, 0x5c7ed832
+    li x21, 0x315bf527
+    p.mulhhu x18, x20, x21
+    li x19, 0x11d4feca
+    beq x18, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x20, 0xb97ecf47
+    li x21, 0xc78d0ed6
+    p.mulhhu x18, x20, x21
+    li x19, 0x90971c66
+    beq x18, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x20, 0x8967cd6d
+    li x21, 0x7d583a7c
+    p.mulhhu x18, x20, x21
+    li x19, 0x43468668
+    beq x18, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x20, 0xa077484b
+    li x21, 0xe729d470
+    p.mulhhu x18, x20, x21
+    li x19, 0x90e5140f
+    beq x18, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the p.muluN instruction. values loaded in and compared to are expected output values
+#p.muluN instruction is of format "p.muluN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[15:0]) * Zext(rs2[15:0])) >> ls3
+test61:
+    li x20, 0x76166875
+    li x21, 0xdde8888b
+    p.muluN x18, x20, x21, 0xe
+    li x19, 0x0000dedb
+    beq x18, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x20, 0xd2562f8e
+    li x21, 0xdb29c6c3
+    p.muluN x18, x20, x21, 3
+    li x19, 0x049d81a5
+    beq x18, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x20, 0xb24b4bbf
+    li x21, 0x2acef5ae
+    p.muluN x18, x20, x21, 9
+    li x19, 0x002458a3
+    beq x18, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x20, 0xdfc326dc
+    li x21, 0x42ed13f0
+    p.muluN x18, x20, x21, 5
+    li x19, 0x00183612
+    beq x18, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x20, 0x48b617d0
+    li x21, 0xe5265d14
+    p.muluN x18, x20, x21, 0x12
+    li x19, 0x0000022a
+    beq x18, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x20, 0x9f60f8c5
+    li x21, 0xbac9e541
+    p.muluN x18, x20, x21, 1
+    li x19, 0x6f63b182
+    beq x18, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the p.mulhhuN instruction. values loaded in and compared to are expected output values
+#p.mulhhuN instruction is of format "p.mulhhuN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[31:15]) * Zext(rs2[31:15])) >> ls3
+test67:
+    li x20, 0xc3fb288f
+    li x21, 0x2790adaf
+    p.mulhhuN x18, x20, x21, 0x1b
+    li x19, 0x00000003
+    beq x18, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x20, 0x663d5315
+    li x21, 0x2d9709f3
+    p.mulhhuN x18, x20, x21, 0xd
+    li x19, 0x000091a8
+    beq x18, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x20, 0x5c7ed832
+    li x21, 0x315bf527
+    p.mulhhuN x18, x20, x21, 7
+    li x19, 0x0023a9fd
+    beq x18, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x20, 0xb97ecf47
+    li x21, 0xc78d0ed6
+    p.mulhhuN x18, x20, x21, 1
+    li x19, 0x484b8e33
+    beq x18, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x20, 0x8967cd6d
+    li x21, 0x7d583a7c
+    p.mulhhuN x18, x20, x21, 5
+    li x19, 0x021a3433
+    beq x18, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x20, 0xa077484b
+    li x21, 0xe729d470
+    p.mulhhuN x18, x20, x21, 0xa
+    li x19, 0x00243945
+    beq x18, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the p.muluRN instruction. values loaded in and compared to are expected output values
+#p.muluRN instruction is of format "p.muluRN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[15:0]) * Zext(rs2[15:0]) + 2^(ls3-1)) >> ls3
+test73:
+    li x20, 0x830e73b0
+    li x21, 0x1eba9c18
+    p.muluRN x18, x20, x21, 0xe
+    li x19, 0x00011a28
+    beq x18, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x20, 0x82345bf4
+    li x21, 0x1b110ff1
+    p.muluRN x18, x20, x21, 6
+    li x19, 0x0016e773
+    beq x18, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x20, 0xb8207aa3
+    li x21, 0xfe75774f
+    p.muluRN x18, x20, x21, 0x11
+    li x19, 0x00001c94
+    beq x18, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x20, 0x863deeb5
+    li x21, 0x0cb19e03
+    p.muluRN x18, x20, x21, 0xb
+    li x19, 0x00126ad0
+    beq x18, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x20, 0xd19fbf93
+    li x21, 0x60c2ad03
+    p.muluRN x18, x20, x21, 3
+    li x19, 0x102f12b7
+    beq x18, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x20, 0x93f10127
+    li x21, 0x553b188d
+    p.muluRN x18, x20, x21, 8
+    li x19, 0x00001c4a
+    beq x18, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the p.mulhhuRN instruction. values loaded in and compared to are expected output values
+#p.mulhhuRN instruction is of format "p.mulhhuRN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[31:15]) * Zext(rs2[31:15])) >> ls3
+test79:
+    li x20, 0xe35855c5
+    li x21, 0x4e4efe65
+    p.mulhhuRN x18, x20, x21, 0xf
+    li x19, 0x00008b14
+    beq x18, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x20, 0x873f255e
+    li x21, 0xfbcde5a9
+    p.mulhhuRN x18, x20, x21, 1
+    li x19, 0x4283893a
+    beq x18, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x20, 0x29498247
+    li x21, 0x6361c24c
+    p.mulhhuRN x18, x20, x21, 0x12
+    li x19, 0x00000402
+    beq x18, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x20, 0x03cd73c5
+    li x21, 0xd9bccd6f
+    p.mulhhuRN x18, x20, x21, 6
+    li x19, 0x000cee3e
+    beq x18, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x20, 0xf8843486
+    li x21, 0xfcfff40d
+    p.mulhhuRN x18, x20, x21, 0xa
+    li x19, 0x003d665f
+    beq x18, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x20, 0x7c03056e
+    li x21, 0x70c49147
+    p.mulhhuRN x18, x20, x21, 0x17
+    li x19, 0x0000006d
+    beq x18, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the p.macsN instruction. values loaded in and compared to are expected output values
+#p.macsN instruction is of format "p.macsN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[15:0]) * Sext(rs2[31:15]) + rD) >>> ls3
+test85:
+    li x18, 0x6a2e7c11
+    li x20, 0x57a8ce44
+    li x21, 0x7c6896e9
+    p.macsN x18, x20, x21, 0xd
+    li x19, 0x0003f4c8
+    beq x18, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x18, 0x6413f818
+    li x20, 0x6c6fb460
+    li x21, 0x4918213a
+    p.macsN x18, x20, x21, 2
+    li x19, 0x1690cd76
+    beq x18, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x18, 0x16f6a68c
+    li x20, 0x1b0dc262
+    li x21, 0xc21daa61
+    p.macsN x18, x20, x21, 7
+    li x19, 0x005724c3
+    beq x18, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x18, 0x2e606155
+    li x20, 0xc269d7ad
+    li x21, 0x9046caf0
+    p.macsN x18, x20, x21, 0x1b
+    li x19, 0x00000006
+    beq x18, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x18, 0x75d70d74
+    li x20, 0xc7d93cc7
+    li x21, 0x7425161d
+    p.macsN x18, x20, x21, 0x13
+    li x19, 0x00000f62
+    beq x18, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x18, 0x2bc1092f
+    li x20, 0x6f43d7f1
+    li x21, 0xce26920a
+    p.macsN x18, x20, x21, 0xa
+    li x19, 0x000f3d7a
+    beq x18, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the p.machhsN instruction. values loaded in and compared to are expected output values
+#p.machhsN instruction is of format "p.machhsN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[31:15]) * Sext(rs2[31:15]) + rD) >>> ls3
+test91:
+    li x18, 0x40fdf1f1
+    li x20, 0x71864767
+    li x21, 0xdf9f65be
+    p.machhsN x18, x20, x21, 9
+    li x19, 0x00195117
+    beq x18, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x18, 0xa6741035
+    li x20, 0x84d3d280
+    li x21, 0x243498ec
+    p.machhsN x18, x20, x21, 0xf
+    li x19, 0xffff2a11
+    beq x18, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x18, 0x7833984e
+    li x20, 0x49838219
+    li x21, 0x9e7cf7d9
+    p.machhsN x18, x20, x21, 6
+    li x19, 0x0170cc37
+    beq x18, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x18, 0x69ce694b
+    li x20, 0xc9d1b683
+    li x21, 0xb60c38de
+    p.machhsN x18, x20, x21, 0xa
+    li x19, 0x001e5d5d
+    beq x18, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x18, 0x209ff130
+    li x20, 0xb780d34f
+    li x21, 0x0c0ba5f7
+    p.machhsN x18, x20, x21, 2
+    li x19, 0x074db4ec
+    beq x18, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x18, 0xc0a6df19
+    li x20, 0xd8156015
+    li x21, 0xb8f77a85
+    p.machhsN x18, x20, x21, 0x16
+    li x19, 0xffffff2e
+    beq x18, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the p.macsRN instruction. values loaded in and compared to are expected output values
+#p.macsRN instruction is of format "p.macsRN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[15:0]) * Sext(rs2[15:0]) + rD + 2^(ls3-1)) >>> ls3
+test97:
+    li x18, 0xb1d75295
+    li x20, 0xb7ff187f
+    li x21, 0xb3b76d7c
+    p.macsRN x18, x20, x21, 0xd
+    li x19, 0xfffde28a
+    beq x18, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x18, 0x6c85dd0d
+    li x20, 0x1aaf3098
+    li x21, 0xe0749583
+    p.macsRN x18, x20, x21, 7
+    li x19, 0x0b09e66
+    beq x18, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x18, 0x829e3220
+    li x20, 0xd6ae528b
+    li x21, 0x6be9b0f7
+    p.macsRN x18, x20, x21, 1
+    li x19, 0x3491331f
+    beq x18, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x18, 0x82ba9f8f
+    li x20, 0xc1da8695
+    li x21, 0x92fa7744
+    p.macsRN x18, x20, x21, 0x12
+    li x19, 0x0000128a
+    beq x18, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x18, 0x15f43032
+    li x20, 0x853095fa
+    li x21, 0x289272cd
+    p.macsRN x18, x20, x21, 0xb
+    li x19, 0xfffccd14
+    beq x18, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x18, 0x807ce4a5
+    li x20, 0x75feee4d
+    li x21, 0x62b00035
+    p.macsRN x18, x20, x21, 0x15
+    li x19, 0xfffffc04
+    beq x18, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the p.machhsRN instruction. values loaded in and compared to are expected output values
+#p.machhsRN instruction is of format "p.machhsRN rD, rs1, rs2, ls3". rD[31:0] = (Sext(rs1[31:15]) * Sext(rs2[31:15]) + rD + 2^(ls3-1)) >>> ls3
+test103:
+    li x18, 0x40fd6367
+    li x20, 0x1621d778
+    li x21, 0x4698c081
+    p.machhsRN x18, x20, x21, 0xf
+    li x19, 0x00008e2f
+    beq x18, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x18, 0x026766d0
+    li x20, 0xeef80b37
+    li x21, 0xd20c6da4
+    p.machhsRN x18, x20, x21, 6
+    li x19, 0x0015d82a
+    beq x18, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x18, 0x809ae8b3
+    li x20, 0xa84ec8c1
+    li x21, 0x8d14df0f
+    p.machhsRN x18, x20, x21, 2
+    li x19, 0xe9fe4133
+    beq x18, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x18, 0xb00ae2f3
+    li x20, 0x4bcdd061
+    li x21, 0x8a482256
+    p.machhsRN x18, x20, x21, 0x12
+    li x19, 0xffffe34c
+    beq x18, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x18, 0xe6238423
+    li x20, 0xccd49e71
+    li x21, 0x4f146a7f
+    p.machhsRN x18, x20, x21, 0x19
+    li x19, 0xffffffeb
+    beq x18, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x18, 0x077d9219
+    li x20, 0xfa8f4efa
+    li x21, 0x1b8ecf5b
+    p.machhsRN x18, x20, x21, 9
+    li x19, 0x000373d1
+    beq x18, x19, test109
+    c.addi x15, 0x1
+#tests109-114 test the p.macuN instruction. values loaded in and compared to are expected output values
+#p.macuN instruction is of format "p.macuN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[15:0]) * Zext(rs2[31:15]) + rD) >> ls3
+test109:
+    li x18, 0x5bca07fb
+    li x20, 0xbcc46afd
+    li x21, 0xd8721ad7
+    p.macuN x18, x20, x21, 8
+    li x19, 0x670194
+    beq x18, x19, test110
+    c.addi x15, 0x1
+test110:
+    li x18, 0x9c521928
+    li x20, 0x82f89100
+    li x21, 0x72103b7a
+    p.macuN x18, x20, x21, 0xc
+    li x19, 0x000be023
+    beq x18, x19, test111
+    c.addi x15, 0x1
+test111:
+    li x18, 0x01d5fc7d
+    li x20, 0xb0c40752
+    li x21, 0x38952318
+    p.macuN x18, x20, x21, 5
+    li x19, 0x0016b711
+    beq x18, x19, test112
+    c.addi x15, 0x1
+test112:
+    li x18, 0x0cb435b5
+    li x20, 0x2575c2ee
+    li x21, 0xc8836a0e
+    p.macuN x18, x20, x21, 0x12
+    li x19, 0x0000175d
+    beq x18, x19, test113
+    c.addi x15, 0x1
+test113:
+    li x18, 0x8d593849
+    li x20, 0x0cd78dc2
+    li x21, 0x688d2e0b
+    p.macuN x18, x20, x21, 3 
+    li x19, 0x14db0573
+    beq x18, x19, test114
+    c.addi x15, 0x1
+test114:
+    li x18, 0x8659af2c
+    li x20, 0xb756fd2b
+    li x21, 0xd4ce16ee
+    p.macuN x18, x20, x21, 0x17
+    li x19, 0x0000013a
+    beq x18, x19, test115
+    c.addi x15, 0x1
+#tests115-120 test the p.machhuN instruction. values loaded in and compared to are expected output values
+#p.machhuN instruction is of format "p.machhuN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[31:15]) * Zext(rs2[31:15]) + rD) >> ls3
+test115:
+    li x18, 0x715ef760
+    li x20, 0xa215e735
+    li x21, 0x02a34d70
+    p.machhuN x18, x20, x21, 0xe
+    li x19, 0x0001cc29
+    beq x18, x19, test116
+    c.addi x15, 0x1
+test116:
+    li x18, 0xebeeede1
+    li x20, 0x7363e8cb
+    li x21, 0xdbaecfe0
+    p.machhuN x18, x20, x21, 2
+    li x19, 0x13bcc30a
+    beq x18, x19, test117
+    c.addi x15, 0x1
+test117:
+    li x18, 0xcee2e5b0
+    li x20, 0x99e14ec0
+    li x21, 0xc1e4b273
+    p.machhuN x18, x20, x21, 7
+    li x19, 0x0086dd26
+    beq x18, x19, test118
+    c.addi x15, 0x1
+test118:
+    li x18, 0x211da244
+    li x20, 0xdb749b50
+    li x21, 0xcc7af2da
+    p.machhuN x18, x20, x21, 0xa
+    li x19, 0x003419a9
+    beq x18, x19, test119
+    c.addi x15, 0x1
+test119:
+    li x18, 0x95b52cc7
+    li x20, 0xb9be6816
+    li x21, 0xeaf964be
+    p.machhuN x18, x20, x21, 0x15
+    li x19, 0x00000201
+    beq x18, x19, test120
+    c.addi x15, 0x1
+test120:
+    li x18, 0xcfc106bd
+    li x20, 0xade1a537
+    li x21, 0x7d456dfb
+    p.machhuN x18, x20, x21, 5
+    li x19, 0x0126b60b
+    beq x18, x19, test121
+    c.addi x15, 0x1
+#tests121-126 test the p.macuRN instruction. values loaded in and compared to are expected output values
+#p.macuRN instruction is of format "p.macuRN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[15:0]) * Zext(rs2[15:0]) + rD + 2^(ls3-1)) >> ls3
+test121:
+    li x18, 0x400a5e9a
+    li x20, 0xd6dbd128
+    li x21, 0xe5a1a96f
+    p.macuRN x18, x20, x21, 0xb
+    li x19, 0x00194f0f
+    beq x18, x19, test122
+    c.addi x15, 0x1
+test122:
+    li x18, 0x6371836d
+    li x20, 0xbc604581
+    li x21, 0x445aeea5
+    p.macuRN x18, x20, x21, 8
+    li x19, 0x00a43c3e
+    beq x18, x19, test123
+    c.addi x15, 0x1
+test123:
+    li x18, 0x469879de
+    li x20, 0x08a5ad4d
+    li x21, 0x642d7edf
+    p.macuRN x18, x20, x21, 3
+    li x19, 0x138f6abe
+    beq x18, x19, test124
+    c.addi x15, 0x1
+test124:
+    li x18, 0xea104bc3
+    li x20, 0xd92e39cc
+    li x21, 0x6474e421
+    p.macuRN x18, x20, x21, 0x15
+    li x19, 0x000000ed
+    beq x18, x19, test125
+    c.addi x15, 0x1
+test125:
+    li x18, 0xe765e24e
+    li x20, 0x4e17470b
+    li x21, 0xc55e9600
+    p.macuRN x18, x20, x21, 0xd
+    li x19, 0x00008833
+    beq x18, x19, test126
+    c.addi x15, 0x1
+test126:
+    li x18, 0x3def16e1
+    li x20, 0x4b5a1d37
+    li x21, 0xb4c52043
+    p.macuRN x18, x20, x21, 0x11
+    li x19, 0x000020cf
+    beq x18, x19, test127
+    c.addi x15, 0x1
+#tests127-132 test the p.machhuRN instruction. values loaded in and compared to are expected output values
+#p.machhuRN instruction is of format "p.machhuRN rD, rs1, rs2, ls3". rD[31:0] = (Zext(rs1[31:15]) * Zext(rs2[31:15]) + rD + 2^(ls3-1)) >> ls3
+test127:
+    li x18, 0x27dac03d
+    li x20, 0xf83d2546
+    li x21, 0xd8eb64fd
+    p.machhuRN x18, x20, x21, 3
+    li x19, 0x1f464308
+    beq x18, x19, test128
+    c.addi x15, 0x1
+test128:
+    li x18, 0xca3923cc
+    li x20, 0x3bad5492
+    li x21, 0x22b9c984
+    p.machhuRN x18, x20, x21, 0x1f
+    li x19, 0x00000000
+    beq x18, x19, test129
+    c.addi x15, 0x1
+test129:
+    li x18, 0xb5dd5975
+    li x20, 0x0b497b58
+    li x21, 0xc98b5324
+    p.machhuRN x18, x20, x21, 0xd
+    li x19, 0x0005f5fe
+    beq x18, x19, test130
+    c.addi x15, 0x1
+test130:
+    li x18, 0x01e2fe68
+    li x20, 0x4881f1b4
+    li x21, 0xf242cebf
+    p.machhuRN x18, x20, x21, 0x5
+    li x19, 0x0233fd0d
+    beq x18, x19, test131
+    c.addi x15, 0x1
+test131:
+    li x18, 0x7ff4ce78
+    li x20, 0x6e91ac4b
+    li x21, 0xf7b7766f
+    p.machhuRN x18, x20, x21, 0x11
+    li x19, 0x00007579
+    beq x18, x19, test132
+    c.addi x15, 0x1
+test132:
+    li x18, 0x5fad7f7e
+    li x20, 0x35c8b6c1
+    li x21, 0x3ff4ab69
+    p.machhuRN x18, x20, x21, 0x16
+    li x19, 0x000001b4
+    beq x18, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_add_sub.S
+++ b/cv32/tests/core/custom/pulp_vectorial_add_sub.S
@@ -1,0 +1,850 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.add.h instruction. values loaded in and compared to are expected output values
+#pv.add.h is of the form "pv.add.h rD, rs1, rs2". rD[31:16] = rs1[31:16]+rs2[31:16], rD[15:0] = rs1[15:0]+rs2[15:0]
+test1:
+    li x17, 0xa42e5f23
+    li x18, 0x03f5b3ae
+    pv.add.h x19, x17, x18
+    li x20, 0xa82312d1
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x923812e3
+    li x18, 0xee2f2fa8
+    pv.add.h x19, x17, x18
+    li x20, 0x8067428b
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x7bd6778c
+    li x18, 0x4ae75eb2
+    pv.add.h x19, x17, x18
+    li x20, 0xc6bdd63e
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x53f30da3
+    li x18, 0xd550292f
+    pv.add.h x19, x17, x18
+    li x20, 0x294336d2
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x7b35a243
+    li x18, 0x21b9f9b3
+    pv.add.h x19, x17, x18
+    li x20, 0x9cee9bf6
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x4deed767
+    li x18, 0xe8baa301
+    pv.add.h x19, x17, x18
+    li x20, 0x36a87a68
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.add.sc.h instruction. values loaded in and compared to are expected output values
+#pv.add.sc.h is of the form "pv.add.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16]+rs2[15:0], rD[15:0] = rs1[15:0]+rs2[15:0]
+test7:
+    li x17, 0x040193eb
+    li x18, 0x655fe439
+    pv.add.sc.h x19, x17, x18
+    li x20, 0xe83a7824
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x24db2f5e
+    li x18, 0x8734e438
+    pv.add.sc.h x19, x17, x18
+    li x20, 0x09131396
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x77ccab0d
+    li x18, 0x05d2692b
+    pv.add.sc.h x19, x17, x18
+    li x20, 0xe0f71438
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xa6cb5330
+    li x18, 0x5e2078a1
+    pv.add.sc.h x19, x17, x18
+    li x20, 0x1f6ccbd1
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xdc856605
+    li x18, 0x0de722a9
+    pv.add.sc.h x19, x17, x18
+    li x20, 0xff2e88ae
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x305d6141
+    li x18, 0x4ae3e9cc
+    pv.add.sc.h x19, x17, x18
+    li x20, 0x1a294b0d
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.add.sci.h instruction. values loaded in and compared to are expected output values
+#pv.add.sci.h is of the form "pv.add.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16]+Sext(Imm6), rD[15:0] = rs1[15:0]+Sext(Imm6)
+test13:
+    li x17, 0x993f35ed
+    pv.add.sci.h x19, x17, 0x0e
+    li x20, 0x994d35fb
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x03ee3d4b
+    pv.add.sci.h x19, x17, 0x04
+    li x20, 0x03f23d4f
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xed29a590
+    pv.add.sci.h x19, x17, 0x1c
+    li x20, 0xed45a5ac
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0xa74684d2
+    pv.add.sci.h x19, x17, 0x08
+    li x20, 0xa74e84da
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x6714ae3f
+    pv.add.sci.h x19, x17, 0x14
+    li x20, 0x6728ae53
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x81899f05
+    pv.add.sci.h x19, x17, 0x1c
+    li x20, 0x81a59f21
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.add.b instruction. values loaded in and compared to are expected output values
+#pv.add.b is of the form "pv.add.b rD, rs1, rs2". rD[31:24] = rs1[31:24]+rs2[31:24]
+#rD[23:16] = rs1[23:16]+rs2[23:16], rD[15:8] = rs1[15:8]+rs2[15:8], rD[7:0] = rs1[7:0]+rs2[7:0]
+test19:
+    li x17, 0x97f73b3e
+    li x18, 0x4cb3e882
+    pv.add.b x19, x17, x18
+    li x20, 0xe3aa23c0
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x819ffec2
+    li x18, 0xeef9e3e9
+    pv.add.b x19, x17, x18
+    li x20, 0x6f98e1ab
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xd3769c0c
+    li x18, 0xf2b49c73
+    pv.add.b x19, x17, x18
+    li x20, 0xc52a387f
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xc6e280fc
+    li x18, 0x4645719c
+    pv.add.b x19, x17, x18
+    li x20, 0x0c27f198
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x4a13436e
+    li x18, 0x2e6560e9
+    pv.add.b x19, x17, x18
+    li x20, 0x7878a357
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x5d1d4055
+    li x18, 0x027aaaf3
+    pv.add.b x19, x17, x18
+    li x20, 0x5f97ea48
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.add.sc.b instruction. values loaded in and compared to are expected output values
+#pv.add.sc.b is of the form "pv.add.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24]+rs2[7:0]
+#rD[23:16] = rs1[23:16]+rs2[7:0], rD[15:8] = rs1[15:8]+rs2[7:0], rD[7:0] = rs1[7:0]+rs2[7:0]
+test25:
+    li x17, 0xfc057499
+    li x18, 0xbac6cac2
+    pv.add.sc.b x19, x17, x18
+    li x20, 0xbec7365b
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x8b91e0d7
+    li x18, 0xb5b54608
+    pv.add.sc.b x19, x17, x18
+    li x20, 0x9399e8df
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x2dfdd9d1
+    li x18, 0xa26efc40
+    pv.add.sc.b x19, x17, x18
+    li x20, 0x6d3d1911
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x19e2b1d4
+    li x18, 0x95260c42
+    pv.add.sc.b x19, x17, x18
+    li x20, 0x5b24f316
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x919df356
+    li x18, 0xf016c712
+    pv.add.sc.b x19, x17, x18
+    li x20, 0xa3af0568
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x7708106a
+    li x18, 0xc6f84497
+    pv.add.sc.b x19, x17, x18
+    li x20, 0x0e9fa701
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.add.sci.b instruction. values loaded in and compared to are expected output values
+#pv.add.sci.b is of the form "pv.add.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24]+Sext(Imm6),
+# rD[23:16] = rs1[23:16]+Sext(Imm6), rD[15:8] = rs1[15:8]+Sext(Imm6), rD[7:0] = rs1[7:0]+Sext(Imm6)
+test31:
+    li x17, 0x3d5951bd
+    pv.add.sci.b x19, x17, 0x1f
+    li x20, 0x5c7870dc
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xb047c2fe
+    pv.add.sci.b x19, x17, 0x08
+    li x20, 0xb84fca06
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0x7dbe6ba0
+    pv.add.sci.b x19, x17, 0x16
+    li x20, 0x93d481b6
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0xed9e0824
+    pv.add.sci.b x19, x17, 0x0c
+    li x20, 0xf9aa1430
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x25c7f6f6
+    pv.add.sci.b x19, x17, 0x0b
+    li x20, 0x30d20101
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x1f63428e
+    pv.add.sci.b x19, x17, 0x13
+    li x20, 0x327655a1
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.add.div2 instruction. values loaded in and compared to are expected output values
+#pv.add.div2 is of the form "pv.add.div2 rD, rs1, rs2". rD[31:16] = (rs1[31:16] + rs2[31:16])>>1
+#rD [15:0] = (rs1[15:0] + rs2[15:0])>>1
+test37:
+    li x17, 0xf14b3729
+    li x18, 0xa6dffa04
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x4c151896
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x615a3814
+    li x18, 0x0b218a1d
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x363d6118
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x899b9daa
+    li x18, 0xc799bf72
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x289a2e8e
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x784a98e3
+    li x18, 0xa5385e64
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x1d827ba3
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0xa80f53e9
+    li x18, 0xe3e07c1e
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x45f77c1f
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x721f17b7
+    li x18, 0xca3256f2
+    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x1e286ea9
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.add.div4 instruction. values loaded in and compared to are expected output values
+#pv.add.div4 is of the form "pv.add.div4 rD, rs1, rs2". rD[31:16] = (rs1[31:16] + rs2[31:16])>>2
+#rD [15:0] = (rs1[15:0] + rs2[15:0])>>2
+test43:
+    li x17, 0xf996c75d
+    li x18, 0x6fcc0d8b
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x1a58353a
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x1ace57a3
+    li x18, 0x5a105f37
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x1d372db6
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xa4a93062
+    li x18, 0x2f1a9732
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x34f031e5
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0x842aeebb
+    li x18, 0xf8ec8340
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x1f451c7e
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xae2beb6d
+    li x18, 0x2881cd1c
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x35ab2e22
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0xe0de49ca
+    li x18, 0xeda89810
+    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    li x20, 0x33a13876
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.add.div8 instruction. values loaded in and compared to are expected output values
+#pv.add.div8 is of the form "pv.add.div8 rD, rs1, rs2". rD[31:16] = (rs1[31:16] + rs2[31:16])>>3
+#rD [15:0] = (rs1[15:0] + rs2[15:0])>>3
+test49:
+    li x17, 0x00f0091b
+    li x18, 0x04868a8f
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x00ae1275
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0x349f1c44
+    li x18, 0xde7a69e0
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x026310c4
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x453011b7
+    li x18, 0x855ce1b1
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x19511e6d
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x4e544def
+    li x18, 0xf63d2d7f
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x08920f6d
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x751ed585
+    li x18, 0xed1fed20
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x0c471854
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x1b1b67d7
+    li x18, 0xf758297f
+    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    li x20, 0x024e122a
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.sub.h instruction. values loaded in and compared to are expected output values
+#pv.sub.h is of the form "pv.sub.h rD, rs1, rs2". rD[31:16] = rs1[31:16]-rs2[31:16], rD[15:0] = rs1[15:0]-rs2[15:0]
+test55:
+    li x17, 0xa5fe61e9
+    li x18, 0x6d2eada6
+    pv.sub.h x19, x17, x18
+    li x20, 0x38d0b443
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0x20518159
+    li x18, 0x47c10ed4
+    pv.sub.h x19, x17, x18
+    li x20, 0xd8907285
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x5e2f82f7
+    li x18, 0xf7cbed64
+    pv.sub.h x19, x17, x18
+    li x20, 0x66649593
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0xee25be40
+    li x18, 0xccbbfaf0
+    pv.sub.h x19, x17, x18
+    li x20, 0x216ac350
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x2151d226
+    li x18, 0x8011f883
+    pv.sub.h x19, x17, x18
+    li x20, 0xa140d9a3
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x80236713
+    li x18, 0xc1a1aa5e
+    pv.sub.h x19, x17, x18
+    li x20, 0xbe82bcb5
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.sub.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sub.sc.h is of the form "pv.sub.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16]+rs2[15:0], rD[15:0] = rs1[15:0]+rs2[15:0]
+test61:
+    li x17, 0xfe8eb60b
+    li x18, 0xb11d10d1
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0xedbda53a
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x9187649a
+    li x18, 0x7c609474
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0xfd13d026
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x649a11cc
+    li x18, 0x790f41cf
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0x22cbcffd
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0x67047842
+    li x18, 0xd54a4072
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0x269237d0
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x455e1a95
+    li x18, 0x2b3e5493
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0xf0cbc602
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x4684179b
+    li x18, 0xe41321d8
+    pv.sub.sc.h x19, x17, x18
+    li x20, 0x24acf5c3
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.sub.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sub.sci.h is of the form "pv.sub.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16]+Sext(Imm6), rD[15:0] = rs1[15:0]+Sext(Imm6)
+test67:
+    li x17, 0x9a8a18dc
+    pv.sub.sci.h x19, x17, 0x1f
+    li x20, 0x9a6b18bd
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x34088d99
+    pv.sub.sci.h x19, x17, 0x01
+    li x20, 0x34078d98
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x6864ab38
+    pv.sub.sci.h x19, x17, 0x04
+    li x20, 0x6860ab34
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x97148fd8
+    pv.sub.sci.h x19, x17, 0x0c
+    li x20, 0x97088fcc
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0xe19b7596
+    pv.sub.sci.h x19, x17, 0x07
+    li x20, 0xe194758f
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x93064ffd
+    pv.sub.sci.h x19, x17, 0x1d
+    li x20, 0x92e94fe0
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.sub.b instruction. values loaded in and compared to are expected output values
+#pv.sub.b is of the form "pv.sub.b rD, rs1, rs2". rD[31:24] = rs1[31:24]+rs2[31:24]
+#rD[23:16] = rs1[23:16]+rs2[23:16], rD[15:8] = rs1[15:8]+rs2[15:8], rD[7:0] = rs1[7:0]+rs2[7:0]
+test73:
+    li x17, 0x18f69b81
+    li x18, 0xb3d5eeba
+    pv.sub.b x19, x17, x18
+    li x20, 0x6521adc7
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0x6b6281ef
+    li x18, 0xc61239c3
+    pv.sub.b x19, x17, x18
+    li x20, 0xa550482c
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0xef63bce7
+    li x18, 0xbe238abf
+    pv.sub.b x19, x17, x18
+    li x20, 0x31403228
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0x2bf0c91d
+    li x18, 0x89db9b85
+    pv.sub.b x19, x17, x18
+    li x20, 0xa2152e98
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0xe7c8f49f
+    li x18, 0x79b65283
+    pv.sub.b x19, x17, x18
+    li x20, 0x6e12a21c
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0x7dc527aa
+    li x18, 0xb6039765
+    pv.sub.b x19, x17, x18
+    li x20, 0xc7c29045
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.sub.sc.b instruction. values loaded in and compared to are expected output values
+#pv.sub.sc.b is of the form "pv.sub.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24]-rs2[7:0]
+#rD[23:16] = rs1[23:16]-rs2[7:0], rD[15:8] = rs1[15:8]-rs2[7:0], rD[7:0] = rs1[7:0]-rs2[7:0]
+test79:
+    li x17, 0xedf1ec44
+    li x18, 0xf8ec82e9
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x0408035b
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x842c8cb3
+    li x18, 0x124ce9f4
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x903898bf
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0xea3a9a7f
+    li x18, 0x141e3ab2
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x3888e8cd
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x189e6733
+    li x18, 0x2fdab0cd
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x4bd19a66
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x97448d7f
+    li x18, 0x704caa6c
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x2bd82113
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0x445a3f73
+    li x18, 0x1da0d110
+    pv.sub.sc.b x19, x17, x18
+    li x20, 0x344a2f63
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.sub.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sub.sci.b is of the form "pv.sub.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24]-Sext(Imm6),
+# rD[23:16] = rs1[23:16]-Sext(Imm6), rD[15:8] = rs1[15:8]-Sext(Imm6), rD[7:0] = rs1[7:0]-Sext(Imm6)
+test85:
+    li x17, 0x436049c4
+    pv.sub.sci.b x19, x17, 0x10
+    li x20, 0x335039b4
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0xa78cafc4
+    pv.sub.sci.b x19, x17, 0x02
+    li x20, 0xa58aadc2
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x5afd71c3
+    pv.sub.sci.b x19, x17, 0x13
+    li x20, 0x47ea5eb0
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0xa7e5eff7
+    pv.sub.sci.b x19, x17, 0x0a
+    li x20, 0x9ddbe5ed
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x79254ad8
+    pv.sub.sci.b x19, x17, 0x08
+    li x20, 0x711d42d0
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0x7a009533
+    pv.sub.sci.b x19, x17, 0x11
+    li x20, 0x69ef8422
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests90-96 test the pv.sub.div2 instruction. values loaded in and compared to are expected output values
+#pv.sub.div2 is of the form "pv.sub.div2 rD, rs1, rs2". rD[31:16] = (rs1[31:16] - rs2[31:16])>>1
+#rD [15:0] = (rs1[15:0] - rs2[15:0])>>1
+test91:
+    li x17, 0xdb0ab431
+    li x18, 0x8c72f00e
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x274c6211
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0xe22e4d2c
+    li x18, 0xd707d030
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x05933e7e
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xd2a0ab24
+    li x18, 0xb7313266
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x0db73c5f
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0x421fcb78
+    li x18, 0x50d96dfb
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x78a32ebe
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x07690ee7
+    li x18, 0x4d704c3f
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x5cfc6154
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0xef6d5d16
+    li x18, 0xa1357fb6
+    .word 0x6528a9d7    #pv.sub.div2 x19, x17, x18
+    li x20, 0x271c6eb0
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.sub.div4 instruction. values loaded in and compared to are expected output values
+#pv.sub.div4 is of the form "pv.sub.div4 rD, rs1, rs2". rD[31:16] = (rs1[31:16] - rs2[31:16])>>2
+#rD [15:0] = (rs1[15:0] - rs2[15:0])>>2
+test97:
+    li x17, 0x9acbbae8
+    li x18, 0x864b1016
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x05202ab4
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0x7d16ce4a
+    li x18, 0x1a39f5ed
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x18b73617
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0x8c067ac4
+    li x18, 0xb45b1be9
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x35ea17b6
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0xc88dc454
+    li x18, 0xfae38066
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x336a10fb
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0x4145fcae
+    li x18, 0x4466b932
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x3f3710df
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0xe8790ad6
+    li x18, 0xeb8fa0c2
+    .word 0x6528c9d7    #pv.sub.div4 x19, x17, x18
+    li x20, 0x3f3a1a85
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.sub.div8 instruction. values loaded in and compared to are expected output values
+#pv.sub.div8 is of the form "pv.sub.div8 rD, rs1, rs2". rD[31:16] = (rs1[31:16] - rs2[31:16])>>3
+#rD [15:0] = (rs1[15:0] - rs2[15:0])>>3
+test103:
+    li x17, 0xd9827dbe
+    li x18, 0xa07767f4
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x072102b9
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0x1c6c1752
+    li x18, 0x1ed81a7e
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x1fb21f9a
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x1ef8926f
+    li x18, 0x5e33d573
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x1818179f
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x2da3a6a8
+    li x18, 0x315abce2
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x1f891d38
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0xdf01e292
+    li x18, 0xfd537fba
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x1c350c5b
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0x4ab407b2
+    li x18, 0xd8cf4e64
+    .word 0x6528e9d7    #pv.sub.div8 x19, x17, x18
+    li x20, 0x0e3c1729
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_avg.S
+++ b/cv32/tests/core/custom/pulp_vectorial_avg.S
@@ -1,0 +1,656 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.avg.h instruction. values loaded in and compared to are expected output values
+#pv.avg.h is of the form "pv.avg.h rD, rs1, rs2". rD[31:16] = (rs1[31:16]+rs2[31:16])>>>1, (rD[15:0] = rs1[15:0]+rs2[15:0])>>>1
+test1:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avg.h x19, x17, x18
+    li x20, 0xd5fa0132
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avg.h x19, x17, x18
+    li x20, 0x16d8de89
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avg.h x19, x17, x18
+    li x20, 0x03dcd19d
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avg.h x19, x17, x18
+    li x20, 0x2c491e0f
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avg.h x19, x17, x18
+    li x20, 0xca36e4cd
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avg.h x19, x17, x18
+    li x20, 0x08e51492
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.avg.sc.h instruction. values loaded in and compared to are expected output values
+#pv.avg.sc.h is of the form "pv.avg.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16]+rs2[15:0])>>>1, (rD[15:0] = rs1[15:0]+rs2[15:0])>>>1
+test7:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0x11380132
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0x3449de89
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0xeb08d19d
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0x2d8e1e0f
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0x22ace4cd
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avg.sc.h x19, x17, x18
+    li x20, 0xebb01492
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.avg.sci.h instruction. values loaded in and compared to are expected output values
+#pv.avg.sci.h is of the form "pv.avg.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16]+Imm6)>>>1, (rD[15:0] = rs1[15:0]+Imm6)>>>1
+test13:
+    li x17, 0x3f93d54c
+    pv.avg.sci.h x19, x17, 0x18
+    li x20, 0x1fd5eab2
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0xa82ba368
+    pv.avg.sci.h x19, x17, 0x09
+    li x20, 0xd41ad1b8
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xa3391d9d
+    pv.avg.sci.h x19, x17, 0x14
+    li x20, 0xd1a60ed8
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x2ceae9ad
+    pv.avg.sci.h x19, x17, 0x01
+    li x20, 0x1675f4d7
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x8efc1970
+    pv.avg.sci.h x19, x17, 0x1f
+    li x20, 0xc78d0cc7
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x8e2f9a75
+    pv.avg.sci.h x19, x17, 0x05
+    li x20, 0xc71acd3d
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.avg.b instruction. values loaded in and compared to are expected output values
+#pv.avg.b is of the form "pv.avg.b rD, rs1, rs2". rD[31:16] = (rs1[31:24]+rs2[31:24])>>>1,
+#rD[23:16] = (rs1[23:16]+rs2[23:16])>>>1, (rD[15:8] = rs1[15:8]+rs2[15:8])>>>1. (rD[7:0] = rs1[7:0]+rs2[7:0])>>>1
+test19:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avg.b x19, x17, x18
+    li x20, 0xd5fa0032
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avg.b x19, x17, x18
+    li x20, 0x16d8de09
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avg.b x19, x17, x18
+    li x20, 0x03dcd11d
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avg.b x19, x17, x18
+    li x20, 0x2cc91d0f
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avg.b x19, x17, x18
+    li x20, 0xca36e4cd
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avg.b x19, x17, x18
+    li x20, 0x08e51412
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.avg.sc.b instruction. values loaded in and compared to are expected output values
+#pv.avg.sc.b is of the form "pv.avg.sc.b rD, rs1, rs2". rD[31:16] = (rs1[31:24]+rs2[7:0])>>>1,
+#rD[23:16] = (rs1[23:16]+rs2[7:106])>>>1, (rD[15:8] = rs1[15:8]+rs2[7:0])>>>1. (rD[7:0] = rs1[7:0]+rs2[7:0])>>>1
+test25:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0xf138e132
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0x33c9dd09
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0xf208d91d
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0xc70e370f
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0x022cc4cd
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avg.sc.b x19, x17, x18
+    li x20, 0xd7300012
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.avg.sci.b instruction. values loaded in and compared to are expected output values
+#pv.avg.sci.b is of the form "pv.avg.sci.b rD, rs1, Imm6". rD[31:16] = (rs1[31:24]+Imm6)>>>1,
+#rD[23:16] = (rs1[23:16]+Imm6)>>>1, (rD[15:8] = rs1[15:8]+Imm6)>>>1. (rD[7:0] = rs1[7:0]+Imm6)>>>1
+test31:
+    li x17, 0x3f93d54c
+    pv.avg.sci.b x19, x17, 0x18
+    li x20, 0x2bd5f632
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xa82ba368
+    pv.avg.sci.b x19, x17, 0x09
+    li x20, 0xd81ad638
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xa3391d9d
+    pv.avg.sci.b x19, x17, 0x14
+    li x20, 0xdb2618d8
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x2ceae9ad
+    pv.avg.sci.b x19, x17, 0x01
+    li x20, 0x16f5f5d7
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x8efc1970
+    pv.avg.sci.b x19, x17, 0x1f
+    li x20, 0xd60d1cc7
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x8e2f9a75
+    pv.avg.sci.b x19, x17, 0x05
+    li x20, 0xc91acf3d
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.avgu.h instruction. values loaded in and compared to are expected output values
+#pv.avgu.h is of the form "pv.avgu.h rD, rs1, rs2". rD[31:16] = (rs1[31:16]+rs2[31:16])>>1, (rD[15:0] = rs1[15:0]+rs2[15:0])>>1
+test37:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avgu.h x19, x17, x18
+    li x20, 0x55fa0132
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avgu.h x19, x17, x18
+    li x20, 0x16d85e89
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avgu.h x19, x17, x18
+    li x20, 0x03dc519d
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avgu.h x19, x17, x18
+    li x20, 0x2c491e0f
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avgu.h x19, x17, x18
+    li x20, 0x4a3664cd
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avgu.h x19, x17, x18
+    li x20, 0x08e51492
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.avgu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.avgu.sc.h is of the form "pv.avgu.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16]+rs2[15:0])>>1, (rD[15:0] = rs1[15:0]+rs2[15:0])>>1
+test43:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x11380132
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x34495e89
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x6b08519d
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x2d8e1e0f
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x22ac64cd
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avgu.sc.h x19, x17, x18
+    li x20, 0x6bb01492
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.avgu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.avgu.sci.h is of the form "pv.avgu.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16]+Imm6)>>1, (rD[15:0] = rs1[15:0]+Imm6)>>1
+test49:
+    li x17, 0x3f93d54c
+    pv.avgu.sci.h x19, x17, 0x18
+    li x20, 0x1fd56ab2
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0xa82ba368
+    pv.avgu.sci.h x19, x17, 0x09
+    li x20, 0x541a51b8
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0xa3391d9d
+    pv.avgu.sci.h x19, x17, 0x14
+    li x20, 0x51a60ed8
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x2ceae9ad
+    pv.avgu.sci.h x19, x17, 0x01
+    li x20, 0x167574d7
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x8efc1970
+    pv.avgu.sci.h x19, x17, 0x1f
+    li x20, 0x478d0cc7
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x8e2f9a75
+    pv.avgu.sci.h x19, x17, 0x05
+    li x20, 0x471a4d3d
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.avgu.b instruction. values loaded in and compared to are expected output values
+#pv.avgu.b is of the form "pv.avgu.b rD, rs1, rs2". rD[31:16] = (rs1[31:24]+rs2[31:24])>>1,
+#rD[23:16] = (rs1[23:16]+rs2[23:16])>>1, (rD[15:8] = rs1[15:8]+rs2[15:8])>>1. (rD[7:0] = rs1[7:0]+rs2[7:0])>>1
+test55:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avgu.b x19, x17, x18
+    li x20, 0x557a0032
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avgu.b x19, x17, x18
+    li x20, 0x16585e09
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avgu.b x19, x17, x18
+    li x20, 0x035c511d
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avgu.b x19, x17, x18
+    li x20, 0x2c491d0f
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avgu.b x19, x17, x18
+    li x20, 0x4a36644d
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avgu.b x19, x17, x18
+    li x20, 0x08651412
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.avgu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.avgu.sc.b is of the form "pv.avgu.sc.b rD, rs1, rs2". rD[31:16] = (rs1[31:24]+rs2[7:0])>>1,
+#rD[23:16] = (rs1[23:16]+rs2[7:106])>>1, (rD[15:8] = rs1[15:8]+rs2[7:0])>>1. (rD[7:0] = rs1[7:0]+rs2[7:0])>>1
+test61:
+    li x17, 0x39c819bc
+    li x18, 0x722ce8a9
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x71386132
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x123d66be
+    li x18, 0x1b745655
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x33495d09
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0xacd77a02
+    li x18, 0x5ae12939
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x7208591d
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xf684d787
+    li x18, 0x620f6498
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x470e370f
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0xf548798a
+    li x18, 0x9f245010
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x022c444d
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x9748e90c
+    li x18, 0x7a834018
+    pv.avgu.sc.b x19, x17, x18
+    li x20, 0x57300012
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.avgu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.avgu.sci.b is of the form "pv.avgu.sci.b rD, rs1, Imm6". rD[31:16] = (rs1[31:24]+Imm6)>>1,
+#rD[23:16] = (rs1[23:16]+Imm6)>>1, (rD[15:8] = rs1[15:8]+Imm6)>>1. (rD[7:0] = rs1[7:0]+Imm6)>>1
+test67:
+    li x17, 0x3f93d54c
+    pv.avgu.sci.b x19, x17, 0x18
+    li x20, 0x2b557632
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0xa82ba368
+    pv.avgu.sci.b x19, x17, 0x09
+    li x20, 0x581a5638
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0xa3391d9d
+    pv.avgu.sci.b x19, x17, 0x14
+    li x20, 0x5b261858
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x2ceae9ad
+    pv.avgu.sci.b x19, x17, 0x01
+    li x20, 0x16757557
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0x8efc1970
+    pv.avgu.sci.b x19, x17, 0x1f
+    li x20, 0x560d1c47
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x8e2f9a75
+    pv.avgu.sci.b x19, x17, 0x05
+    li x20, 0x491a4f3d
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.abs.h instruction. values loaded in and compared to are expected output values
+#pv.abs.h is of the form "pv.abs.h rD, rs1, rs2".
+test73:
+    li x17, 0xccb59b65
+    pv.abs.h x19, x17
+    li x20, 0x334b649b
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0xb6a36d61
+    pv.abs.h x19, x17
+    li x20, 0x495d6d61
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0xd540fa50
+    pv.abs.h x19, x17
+    li x20, 0x2ac005b0
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0x97f2acad
+    pv.abs.h x19, x17
+    li x20, 0x680e5353
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0x84def8bd
+    pv.abs.h x19, x17
+    li x20, 0x7b220743
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0x602a4434
+    pv.abs.h x19, x17
+    li x20, 0x602a4434
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.abs.b instruction. values loaded in and compared to are expected output values
+#pv.abs.b is of the form "pv.abs.b rD, rs1, rs2".
+test79:
+    li x17, 0x9168aff7
+    pv.abs.b x19, x17
+    li x20, 0x6f685109
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x95422b18
+    pv.abs.b x19, x17
+    li x20, 0x6b422b18
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0x786d4744
+    pv.abs.b x19, x17
+    li x20, 0x786d4744
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x4c122684
+    pv.abs.b x19, x17
+    li x20, 0x4c12267c
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x52f42286
+    pv.abs.b x19, x17
+    li x20, 0x520c227a
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0x4682c47d
+    pv.abs.b x19, x17
+    li x20, 0x467e3c7d
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_bit_manip.S
+++ b/cv32/tests/core/custom/pulp_vectorial_bit_manip.S
@@ -1,0 +1,313 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.extract.h instruction. values loaded in and compared to are expected output values
+#pv.extract.h is of the form "pv.extract.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[31:16], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test1:
+    li x17, 0x6e83fe1d
+    pv.extract.h x19, x17, 0x1
+    li x20, 0x00006e83
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0xe0e0ed49
+    pv.extract.h x19, x17, 0x0
+    li x20, 0xffffed49
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x13f8c76b
+    pv.extract.h x19, x17, 0x0
+    li x20, 0xffffc76b
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x54b60c72
+    pv.extract.h x19, x17, 0x1
+    li x20, 0x000054b6
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x7c9f4803
+    pv.extract.h x19, x17, 0x1
+    li x20, 0x00007c9f
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x932d8211
+    pv.extract.h x19, x17, 0x0
+    li x20, 0xffff8211
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.or.extract.b instruction. values loaded in and compared to are expected output values
+#pv.extract.b is of the form "pv.extract.b rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[15:0], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test7:
+    li x17, 0x82c18db2
+    pv.extract.b x19, x17, 0x3
+    li x20, 0xffffff82
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x39596713
+    pv.extract.b x19, x17, 0x2
+    li x20, 0x00000059
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x7c5c722a
+    pv.extract.b x19, x17, 0x1
+    li x20, 0x00000072
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xb2ca6873
+    pv.extract.b x19, x17, 0x1
+    li x20, 0x00000068
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x79683a4d
+    pv.extract.b x19, x17, 0x0
+    li x20, 0x0000004d
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x47d6b3f0
+    pv.extract.b x19, x17, 0x2
+    li x20, 0xffffffd6
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.extractu.h instruction. values loaded in and compared to are expected output values
+#pv.extractu.h is of the form "pv.extractu.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] >> Imm6, rD[15:0] = rs1[15:0] >> Imm6
+test13:
+    li x17, 0x8726dc40
+    pv.extractu.h x19, x17, 0x0
+    li x20, 0x0000dc40
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0xe65f22ef
+    pv.extractu.h x19, x17, 0x0
+    li x20, 0x000022ef
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xec24072b
+    pv.extractu.h x19, x17, 0x0
+    li x20, 0x0000072b
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0xd4565ca5
+    pv.extractu.h x19, x17, 0x1
+    li x20, 0x0000d456
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x2c7607a3
+    pv.extractu.h x19, x17, 0x1
+    li x20, 0x00002c76
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x8f9afbc2
+    pv.extractu.h x19, x17, 0x1
+    li x20, 0x00008f9a
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.extractu.b instruction. values loaded in and compared to are expected output values
+#pv.extractu.b is of the form "pv.extractu.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[31:24],
+#rD[23:16] = rs1[23:16] >> rs2[23:16], rD[15:8] = rs1[15:8] >> rs2[15:8], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test19:
+    li x17, 0x91395f1e
+    pv.extractu.b x19, x17, 0x3
+    li x20, 0x00000091
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0xee565b86
+    pv.extractu.b x19, x17, 0x1
+    li x20, 0x0000005b
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0x7eed2f26
+    pv.extractu.b x19, x17, 0x0
+    li x20, 0x00000026
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x7220a83e
+    pv.extractu.b x19, x17, 0x2
+    li x20, 0x00000020
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xacc718a1
+    pv.extractu.b x19, x17, 0x2
+    li x20, 0x000000c7
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0xffddaaa6
+    pv.extractu.b x19, x17, 0x3
+    li x20, 0x000000ff
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.insert.h instruction. values loaded in and compared to are expected output values
+#pv.insert.h is of the form "pv.insert.h rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[7:0],
+#rD[23:16] = rs1[23:16] >> rs2[7:0], rD[15:8] = rs1[15:8] >> rs2[7:0], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test25:
+    li x20, 0x626ef04f
+    li x17, 0x8ac2523d
+    pv.insert.h x19, x17, 0x1
+    li x20, 0x523df04f
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x20, 0x88fbb7a1
+    li x17, 0xd08380a0
+    pv.insert.h x19, x17, 0x1
+    li x20, 0x80a0b7a1
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x20, 0xbfbacff4
+    li x17, 0xdc33ba16
+    pv.insert.h x19, x17, 0x1
+    li x20, 0xba16cff4
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x20, 0x990fc831
+    li x17, 0x600419c0
+    pv.insert.h x19, x17, 0x0
+    li x20, 0x990f19c0
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x20, 0x044da5f9
+    li x17, 0x2cddf91e
+    pv.insert.h x19, x17, 0x0
+    li x20, 0x044df91e
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x20, 0x5a626f2a
+    li x17, 0xe571bb0d
+    pv.insert.h x19, x17, 0x0 #.word 0xb00889d7
+    li x20, 0x5a62bb0d
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.insert.b instruction. values loaded in and compared to are expected output values
+#pv.insert.b is of the form "pv.insert.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >> Imm6,
+#rD[23:16] = rs1[23:16] >> Imm6, rD[15:8] = rs1[15:8] >> Imm6, rD[7:0] = rs1[7:0] >> Imm6
+test31:
+    li x20, 0xe67cfd8a
+    li x17, 0xb589205f
+    pv.insert.b x19, x17, 0x1
+    li x20, 0xe67c5f8a
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x20, 0xef58b0a8
+    li x17, 0x161409d6
+    pv.insert.b x19, x17, 0x3
+    li x20, 0xd658b0a8
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x20, 0x1d06993b
+    li x17, 0xfde810b0
+    pv.insert.b x19, x17, 0x0
+    li x20, 0x1d06993b
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x20, 0xc536517f
+    li x17, 0x8ffba9b9
+    pv.insert.b x19, x17, 0x2
+    li x20, 0xc5b9517f
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x20, 0xda47d50c
+    li x17, 0x8b13650e
+    pv.insert.b x19, x17, 0x3
+    li x20, 0x0e47d50c
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x20, 0x4724b9d9
+    li x17, 0x8fdfaefe
+    pv.insert.b x19, x17, 0x2 #.word 0xb02899d7
+    li x20, 0x47feb9d9
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_bitwise.S
+++ b/cv32/tests/core/custom/pulp_vectorial_bitwise.S
@@ -1,0 +1,835 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.or.h instruction. values loaded in and compared to are expected output values
+#pv.or.h is of the form "pv.or.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[31:16], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test1:
+    li x17, 0x657bda72
+    li x18, 0x59aa04b1
+    pv.or.h x19, x17, x18
+    li x20, 0x7dfbdef3
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x140a6ff7
+    li x18, 0x0efdd06b
+    pv.or.h x19, x17, x18
+    li x20, 0x1effffff
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x9983f501
+    li x18, 0x16f9d5f0
+    pv.or.h x19, x17, x18
+    li x20, 0x9ffbf5f1
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0xd92d92d6
+    li x18, 0xbba807a1
+    pv.or.h x19, x17, x18
+    li x20, 0xfbad97f7
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xc00e6d89
+    li x18, 0xeed71ddf
+    pv.or.h x19, x17, x18
+    li x20, 0xeedf7ddf
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x1e395fc2
+    li x18, 0xf69ecbd2
+    pv.or.h x19, x17, x18
+    li x20, 0xfebfdfd2
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.or.sc.h instruction. values loaded in and compared to are expected output values
+#pv.or.sc.h is of the form "pv.or.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[15:0], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test7:
+    li x17, 0x3fe3b0fa
+    li x18, 0xb954f88c
+    pv.or.sc.h x19, x17, x18
+    li x20, 0xffeff8fe
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x662374b9
+    li x18, 0xa607b208
+    pv.or.sc.h x19, x17, x18
+    li x20, 0xf62bf6b9
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x58deebb1
+    li x18, 0xd8fc3c47
+    pv.or.sc.h x19, x17, x18
+    li x20, 0x7cdffff7
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xecc73ceb
+    li x18, 0x1412bcc9
+    pv.or.sc.h x19, x17, x18
+    li x20, 0xfccfbceb
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x32580dc8
+    li x18, 0x15072c8c
+    pv.or.sc.h x19, x17, x18
+    li x20, 0x3edc2dcc
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x4d38d066
+    li x18, 0x89eb0164
+    pv.or.sc.h x19, x17, x18
+    li x20, 0x4d7cd166
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.or.sci.h instruction. values loaded in and compared to are expected output values
+#pv.or.sci.h is of the form "pv.or.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] >> Imm6, rD[15:0] = rs1[15:0] >> Imm6
+test13:
+    li x17, 0x2d49a810
+    pv.or.sci.h x19, x17, 0x1f
+    li x20, 0x2d5fa81f
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x45102ecd
+    pv.or.sci.h x19, x17, 0x12
+    li x20, 0x45122edf
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x22c7ba55
+    pv.or.sci.h x19, x17, 0x01
+    li x20, 0x22c7ba55
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0xf573676d
+    pv.or.sci.h x19, x17, 0x0e
+    li x20, 0xf57f676f
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x1c8ca198
+    pv.or.sci.h x19, x17, 0x08
+    li x20, 0x1c8ca198
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x2b71cd21
+    pv.or.sci.h x19, x17, 0x16
+    li x20, 0x2b77cd37
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.or.b instruction. values loaded in and compared to are expected output values
+#pv.or.b is of the form "pv.or.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[31:24],
+#rD[23:16] = rs1[23:16] >> rs2[23:16], rD[15:8] = rs1[15:8] >> rs2[15:8], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test19:
+    li x17, 0xe0460e79
+    li x18, 0xf9cbde58
+    pv.or.b x19, x17, x18
+    li x20, 0xf9cfde79
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0xe1b0d64f
+    li x18, 0x49dc6980
+    pv.or.b x19, x17, x18
+    li x20, 0xe9fcffcf
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xdcbf8a96
+    li x18, 0x3864501b
+    pv.or.b x19, x17, x18
+    li x20, 0xfcffda9f
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x0e7be150
+    li x18, 0x23016c43
+    pv.or.b x19, x17, x18
+    li x20, 0x2f7bed53
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x64da5da8
+    li x18, 0xdc6f702e
+    pv.or.b x19, x17, x18
+    li x20, 0xfcff7dae
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0xbea51598
+    li x18, 0x11ea3b21
+    pv.or.b x19, x17, x18
+    li x20, 0xbfef3fb9
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.or.sc.b instruction. values loaded in and compared to are expected output values
+#pv.or.sc.b is of the form "pv.or.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[7:0],
+#rD[23:16] = rs1[23:16] >> rs2[7:0], rD[15:8] = rs1[15:8] >> rs2[7:0], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test25:
+    li x17, 0x9ecb68ba
+    li x18, 0x92d5cc2f
+    pv.or.sc.b x19, x17, x18
+    li x20, 0xbfef6fbf
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x20f9e89d
+    li x18, 0x5e977c24
+    pv.or.sc.b x19, x17, x18
+    li x20, 0x24fdecbd
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x88e586ca
+    li x18, 0xec9682ab
+    pv.or.sc.b x19, x17, x18
+    li x20, 0xabefafeb
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x770be1de
+    li x18, 0xfc975a74
+    pv.or.sc.b x19, x17, x18
+    li x20, 0x777ff5fe
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x18c52e2c
+    li x18, 0xd9fa93c4
+    pv.or.sc.b x19, x17, x18
+    li x20, 0xdcc5eeec
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0xfdc10da8
+    li x18, 0xea8f828f
+    pv.or.sc.b x19, x17, x18
+    li x20, 0xffcf8faf
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.or.sci.b instruction. values loaded in and compared to are expected output values
+#pv.or.sci.b is of the form "pv.or.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >> Imm6,
+#rD[23:16] = rs1[23:16] >> Imm6, rD[15:8] = rs1[15:8] >> Imm6, rD[7:0] = rs1[7:0] >> Imm6
+test31:
+    li x17, 0x45f2f26f
+    pv.or.sci.b x19, x17, 0x01
+    li x20, 0x45f3f36f
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xef678ffe
+    pv.or.sci.b x19, x17, 0x06
+    li x20, 0xef678ffe
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xa230117b
+    pv.or.sci.b x19, x17, 0x1f
+    li x20, 0xbf3f1f7f
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0xa0de4b63
+    pv.or.sci.b x19, x17, 0x11
+    li x20, 0xb1df5b73
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0xe28220ff
+    pv.or.sci.b x19, x17, 0x1e
+    li x20, 0xfe9e3eff
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x03c56ba9
+    pv.or.sci.b x19, x17, 0x0c
+    li x20, 0x0fcd6fad
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.xor.h instruction. values loaded in and compared to are expected output values
+#pv.xor.h is of the form "pv.xor.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >>> rs2[31:16], rD[15:0] = rs1[15:0] >>> rs2[15:0]
+test37:
+    li x17, 0x8d9067f6
+    li x18, 0x348887b4
+    pv.xor.h x19, x17, x18
+    li x20, 0xb918e042
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x7407dc4e
+    li x18, 0xae5b3cc1
+    pv.xor.h x19, x17, x18
+    li x20, 0xda5ce08f
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x4457727a
+    li x18, 0x1ce7e477
+    pv.xor.h x19, x17, x18
+    li x20, 0x58b0960d
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x5796d5ce
+    li x18, 0xb14e2f52
+    pv.xor.h x19, x17, x18
+    li x20, 0xe6d8fa9c
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x2559bb33
+    li x18, 0x9fb5165e
+    pv.xor.h x19, x17, x18
+    li x20, 0xbaecad6d
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x1a4622f9
+    li x18, 0x1cf98a38
+    pv.xor.h x19, x17, x18
+    li x20, 0x06bfa8c1
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.xor.sc.h instruction. values loaded in and compared to are expected output values
+#pv.xor.sc.h is of the form "pv.xor.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >>> rs2[15:0], rD[15:0] = rs1[15:0] >>> rs2[15:0]
+test43:
+    li x17, 0xcea6c78a
+    li x18, 0x8cedce07
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0x00a1098d
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x7ab9f70d
+    li x18, 0x6aaa0ae2
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0x705bfdef
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0x1b1b150f
+    li x18, 0xa3982de1
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0x36fa38ee
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0x71120818
+    li x18, 0xf43847a5
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0x36b74fbd
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xe4bb9393
+    li x18, 0xc3c8c085
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0x243e5316
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0x0c7367ae
+    li x18, 0x48b8deff
+    pv.xor.sc.h x19, x17, x18
+    li x20, 0xd28cb951
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.xor.sci.h instruction. values loaded in and compared to are expected output values
+#pv.xor.sci.h is of the form "pv.xor.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] >>> Imm6, rD[15:0] = rs1[15:0] >>> Imm6
+test49:
+    li x17, 0xc6a93f9a
+    pv.xor.sci.h x19, x17, 0x0f
+    li x20, 0xc6a63f95
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0xc072435e
+    pv.xor.sci.h x19, x17, 0x14
+    li x20, 0xc066434a
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x3f0de36e
+    pv.xor.sci.h x19, x17, 0x1c
+    li x20, 0x3f11e372
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x82d96782
+    pv.xor.sci.h x19, x17, 0x17
+    li x20, 0x82ce6795
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x602eae54
+    pv.xor.sci.h x19, x17, 0x04
+    li x20, 0x602aae50
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0xeef13cf5
+    pv.xor.sci.h x19, x17, 0x0d
+    li x20, 0xeefc3cf8
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.xor.b instruction. values loaded in and compared to are expected output values
+#pv.xor.b is of the form "pv.xor.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >>> rs2[31:24],
+#rD[23:16] = rs1[23:16] >>> rs2[23:16], rD[15:8] = rs1[15:8] >>> rs2[15:8], rD[7:0] = rs1[7:0] >>> rs2[7:0]
+test55:
+    li x17, 0x9d52faba
+    li x18, 0x0e94d9d0
+    pv.xor.b x19, x17, x18
+    li x20, 0x93c6236a
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xe23099b4
+    li x18, 0xf941d6d5
+    pv.xor.b x19, x17, x18
+    li x20, 0x1b714f61
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x5ecd0570
+    li x18, 0xea32442c
+    pv.xor.b x19, x17, x18
+    li x20, 0xb4ff415c
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x6e041a3f
+    li x18, 0xe50b5b60
+    pv.xor.b x19, x17, x18
+    li x20, 0x8b0f415f
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x2759fc4c
+    li x18, 0xb0e789eb
+    pv.xor.b x19, x17, x18
+    li x20, 0x97be75a7
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x4e17fbca
+    li x18, 0x8c91bc4c
+    pv.xor.b x19, x17, x18
+    li x20, 0xc2864786
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.xor.sc.b instruction. values loaded in and compared to are expected output values
+#pv.xor.sc.b is of the form "pv.xor.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >>> rs2[7:0],
+#rD[23:16] = rs1[23:16] >>> rs2[7:0], rD[15:8] = rs1[15:8] >>> rs2[7:0], rD[7:0] = rs1[7:0] >>> rs2[7:0]
+test61:
+    li x17, 0x9d8cd086
+    li x18, 0x11b6edc7
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0x5a4b1741
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x8656c5da
+    li x18, 0xa0214b3c
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0xba6af9e6
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0xb8647504
+    li x18, 0x931f58ee
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0x568a9bea
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xa4f892a6
+    li x18, 0xfeb834fd
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0x59056f5b
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x483d6346
+    li x18, 0xfbcd9b8f
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0xc7b2ecc9
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x8ed5e422
+    li x18, 0x9897d69d
+    pv.xor.sc.b x19, x17, x18
+    li x20, 0x134879bf
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.xor.sci.b instruction. values loaded in and compared to are expected output values
+#pv.xor.sci.b is of the form "pv.xor.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >>> Imm6,
+#rD[23:16] = rs1[23:16] >>> Imm6, rD[15:8] = rs1[15:8] >>> Imm6, rD[7:0] = rs1[7:0] >>> Imm6
+test67:
+    li x17, 0x9e7e2c08
+    pv.xor.sci.b x19, x17, 0x0c
+    li x20, 0x92722004
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x70f016c4
+    pv.xor.sci.b x19, x17, 0x0f
+    li x20, 0x7fff19cb
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x31b52ee7
+    pv.xor.sci.b x19, x17, 0x10
+    li x20, 0x21a53ef7
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0xfdac3e79
+    pv.xor.sci.b x19, x17, 0x11
+    li x20, 0xecbd2f68
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0xe4f56f6b
+    pv.xor.sci.b x19, x17, 0x07
+    li x20, 0xe3f2686c
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x385f4c51
+    pv.xor.sci.b x19, x17, 0x19
+    li x20, 0x21465548
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.and.h instruction. values loaded in and compared to are expected output values
+#pv.and.h is of the form "pv.and.h rD, rs1, rs2". rD[31:16] = rs1[31:16] << rs2[31:16], rD[15:0] = rs1[15:0] << rs2[15:0]
+test73:
+    li x17, 0x579f4304
+    li x18, 0xe1c62010
+    pv.and.h x19, x17, x18
+    li x20, 0x41860000
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0x9690792b
+    li x18, 0x88ec0a3f
+    pv.and.h x19, x17, x18
+    li x20, 0x8080082b
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0x0b628f04
+    li x18, 0xdfb558a2
+    pv.and.h x19, x17, x18
+    li x20, 0x0b200800
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0xdf5fb37d
+    li x18, 0xa251556f
+    pv.and.h x19, x17, x18
+    li x20, 0x8251116d
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0x9dc1792b
+    li x18, 0x93e4705f
+    pv.and.h x19, x17, x18
+    li x20, 0x91c0700b
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0xe30d8661
+    li x18, 0x4b2737b3
+    pv.and.h x19, x17, x18
+    li x20, 0x43050621
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.and.sc.h instruction. values loaded in and compared to are expected output values
+#pv.and.sc.h is of the form "pv.and.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] << rs2[15:0], rD[15:0] = rs1[15:0] << rs2[15:0]
+test79:
+    li x17, 0x272c6cee
+    li x18, 0xab0fe7df
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x270c64ce
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x686af499
+    li x18, 0x1d488f2d
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x08288409
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0x10d98c7f
+    li x18, 0x8dfa6d66
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x00400c66
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0xde5ac9d8
+    li x18, 0x6fe15777
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x56524150
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x6d5497ab
+    li x18, 0x3695a0fb
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x205080ab
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0x57db7990
+    li x18, 0xe35c3a98
+    pv.and.sc.h x19, x17, x18
+    li x20, 0x12983890
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.and.sci.h instruction. values loaded in and compared to are expected output values
+#pv.and.sci.h is of the form "pv.and.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] << Imm6, rD[15:0] = rs1[15:0] << Imm6
+test85:
+    li x17, 0x6b5a90ee
+    pv.and.sci.h x19, x17, 0x1c
+    li x20, 0x0018000c
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0x4eed2f8c
+    pv.and.sci.h x19, x17, 0x1f
+    li x20, 0x000d000c
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x2d79a92b
+    pv.and.sci.h x19, x17, 0x04
+    li x20, 0x00000000
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0x6dfdffe1
+    pv.and.sci.h x19, x17, 0x05
+    li x20, 0x00050001
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x9219e929
+    pv.and.sci.h x19, x17, 0x12
+    li x20, 0x00100000
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0x4995fb0a
+    pv.and.sci.h x19, x17, 0x0f
+    li x20, 0x0005000a
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.and.b instruction. values loaded in and compared to are expected output values
+#pv.and.b is of the form "pv.and.b rD, rs1, rs2". rD[31:24] = rs1[31:24] << rs2[31:24],
+#rD[23:16] = rs1[23:16] << rs2[23:16], rD[15:8] = rs1[15:8] << rs2[15:8], rD[7:0] = rs1[7:0] << rs2[7:0]
+test91:
+    li x17, 0x457241b2
+    li x18, 0x5b9c16cc
+    pv.and.b x19, x17, x18
+    li x20, 0x41100080
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0xe15f82cb
+    li x18, 0x8c82489e
+    pv.and.b x19, x17, x18
+    li x20, 0x8002008a
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0x7e41586d
+    li x18, 0xf63a7d04
+    pv.and.b x19, x17, x18
+    li x20, 0x76005804
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0xb00fc96c
+    li x18, 0x551491bb
+    pv.and.b x19, x17, x18
+    li x20, 0x10048128
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x70e0222e
+    li x18, 0xcf057cfe
+    pv.and.b x19, x17, x18
+    li x20, 0x4000202e
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0x85f019a2
+    li x18, 0xbe5330d7
+    pv.and.b x19, x17, x18
+    li x20, 0x84501082
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.and.sc.b instruction. values loaded in and compared to are expected output values
+#pv.and.sc.b is of the form "pv.and.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] << rs2[7:0],
+#rD[23:16] = rs1[23:16] << rs2[7:0], rD[15:8] = rs1[15:8] << rs2[7:0], rD[7:0] = rs1[7:0] << rs2[7:0]
+test97:
+    li x17, 0x33e0da01
+    li x18, 0x36639341
+    pv.and.sc.b x19, x17, x18
+    li x20, 0x01404001
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0x51ae5970
+    li x18, 0x956799ea
+    pv.and.sc.b x19, x17, x18
+    li x20, 0x40aa4860
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0xa2dd188a
+    li x18, 0x3713bafc
+    pv.and.sc.b x19, x17, x18
+    li x20, 0xa0dc1888
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0x134052e1
+    li x18, 0x9dfe3aaa
+    pv.and.sc.b x19, x17, x18
+    li x20, 0x020002a0
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0xdfcf294a
+    li x18, 0x12d2eba3
+    pv.and.sc.b x19, x17, x18
+    li x20, 0x83832102
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0x01c863a2
+    li x18, 0x9ccd2e91
+    pv.and.sc.b x19, x17, x18
+    li x20, 0x01800180
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.and.sci.b instruction. values loaded in and compared to are expected output values
+#pv.and.sci.b is of the form "pv.and.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] << Imm6,
+#rD[23:16] = rs1[23:16] << Imm6, rD[15:8] = rs1[15:8] << Imm6, rD[7:0] = rs1[7:0] << Imm6
+test103:
+    li x17, 0x72c32832
+    pv.and.sci.b x19, x17, 0x0a
+    li x20, 0x02020802
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0x31ee72ee
+    pv.and.sci.b x19, x17, 0x1e
+    li x20, 0x100e120e
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x524e2d03
+    pv.and.sci.b x19, x17, 0x16
+    li x20, 0x12060402
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x8689d89c
+    pv.and.sci.b x19, x17, 0x0f
+    li x20, 0x609080c
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0x89c2bfb1
+    pv.and.sci.b x19, x17, 0x14
+    li x20, 0x00001410
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0x5c2e4685
+    pv.and.sci.b x19, x17, 0x1f
+    li x20, 0x1c0e0605
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_comparison_1.S
+++ b/cv32/tests/core/custom/pulp_vectorial_comparison_1.S
@@ -1,0 +1,826 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.cmpeq.h instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.h is of the form "pv.cmpeq.h rD, rs1, rs2".
+test1:
+    li x17, 0x1d2a938d
+    li x18, 0xaa03938d
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x6da6b594
+    li x18, 0x6da60ac2
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x4d419302
+    li x18, 0xe6223401
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x09100c36
+    li x18, 0x09100c36
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xdf4e73e7
+    li x18, 0x051fb62f
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0xd6d3feb8
+    li x18, 0xd6d3feb8
+    pv.cmpeq.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.cmpeq.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.sc.h is of the form "pv.cmpeq.sc.h rD, rs1, rs2".
+test7:
+    li x17, 0xa2d86f51
+    li x18, 0x15b7a2d8
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x00050005
+    li x18, 0xc7590005
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0xb47fb60d
+    li x18, 0xa5c2c65a
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x7633579b
+    li x18, 0xea56579b
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xb2b390f1
+    li x18, 0xbaa750e2
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0xbef9bef9
+    li x18, 0x338fbef9
+    pv.cmpeq.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.cmpeq.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.sci.h is of the form "pv.cmpeq.sci.h rD, rs1, Imm6".
+test13:
+    li x17, 0x001f001f
+    pv.cmpeq.sci.h x19, x17, 0x1f
+    li x20, 0xffffffff
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x8f58bb58
+    pv.cmpeq.sci.h x19, x17, 0x6
+    li x20, 0x00000000
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xb844000c
+    pv.cmpeq.sci.h x19, x17, 0xc
+    li x20, 0x0000ffff
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x0013c0f3
+    pv.cmpeq.sci.h x19, x17, 0x13
+    li x20, 0xffff0000
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x94342983
+    pv.cmpeq.sci.h x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x001a001a
+    pv.cmpeq.sci.h x19, x17, 0x1a
+    li x20, 0xffffffff
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.cmpeq.b instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.b is of the form "pv.cmpeq.b rD, rs1, rs2".
+test19:
+    li x17, 0xfee6cd15
+    li x18, 0xc9f2cdb9
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x43fb42ed
+    li x18, 0x43b04296
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xd2b683d5
+    li x18, 0xcbb6c3d5
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xb5b28f18
+    li x18, 0x2c0bdfd3
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x1a7d74c4
+    li x18, 0x1a7d74c4
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x2035e686
+    li x18, 0x3f060e86
+    pv.cmpeq.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.cmpeq.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.sc.b is of the form "pv.cmpeq.sc.b rD, rs1, rs2".
+test25:
+    li x17, 0xa28b3ea7
+    li x18, 0x51b2f630
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x5cdd3e28
+    li x18, 0xd2fb313e
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0xf5f52966
+    li x18, 0xd4d9f3f5
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0xbe0fe6f9
+    li x18, 0x044266f9
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0xcc31c821
+    li x18, 0xa9901831
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0xc9fa59f5
+    li x18, 0x15763ead
+    pv.cmpeq.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.cmpeq.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpeq.sci.b is of the form "pv.cmpeq.sci.b rD, rs1, Imm6".
+test31:
+    li x17, 0xed12fe15
+    pv.cmpeq.sci.b x19, x17, 0x12
+    li x20, 0x00ff0000
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0x0cda0cf8
+    pv.cmpeq.sci.b x19, x17, 0xc
+    li x20, 0xff00ff00
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0x7ce82910
+    pv.cmpeq.sci.b x19, x17, 0x10
+    li x20, 0x000000ff
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x1369a5dd
+    pv.cmpeq.sci.b x19, x17, 0x13
+    li x20, 0xff000000
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x589d054c
+    pv.cmpeq.sci.b x19, x17, 0x5
+    li x20, 0x0000ff00
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0xe91d13f0
+    pv.cmpeq.sci.b x19, x17, 0x1d
+    li x20, 0x00ff0000
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.cmpne.h instruction. values loaded in and compared to are expected output values
+#pv.cmpne.h is of the form "pv.cmpne.h rD, rs1, rs2".
+test37:
+    li x17, 0xccb9afed
+    li x18, 0x8a3aafed
+    pv.cmpne.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0xf3c8ea33
+    li x18, 0x0d6b2784
+    pv.cmpne.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x6787bc36
+    li x18, 0x6787c2d3
+    pv.cmpne.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x9846ba87
+    li x18, 0x9846ba87
+    pv.cmpne.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x498ebcca
+    li x18, 0x421f637d
+    pv.cmpne.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0xc71757b2
+    li x18, 0xfd1757b2
+    pv.cmpne.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.cmpne.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpne.sc.h is of the form "pv.cmpne.sc.h rD, rs1, rs2".
+test43:
+    li x17, 0x74cd74cd
+    li x18, 0xe55374cd
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0xaa223487
+    li x18, 0x58dc1fa0
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0x23a4a348
+    li x18, 0xba86a348
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xf67abc9b
+    li x18, 0x3328f67a
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0x89123bce
+    li x18, 0x46cd2f98
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0xa4293948
+    li x18, 0x9c8fa429
+    pv.cmpne.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.cmpne.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpne.sci.h is of the form "pv.cmpne.sci.h rD, rs1, Imm6".
+test49:
+    li x17, 0x000dd435
+    pv.cmpne.sci.h x19, x17, 0xd
+    li x20, 0x0000ffff
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0xb8b00007
+    pv.cmpne.sci.h x19, x17, 0x7
+    li x20, 0xffff0000
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x00020002
+    pv.cmpne.sci.h x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0xeddec921
+    pv.cmpne.sci.h x19, x17, 0x1c
+    li x20, 0xffffffff
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x6ec839dc
+    pv.cmpne.sci.h x19, x17, 0x10
+    li x20, 0xffffffff
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x0000bb4d
+    pv.cmpne.sci.h x19, x17, 0x0
+    li x20, 0x0000ffff
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.cmpne.b instruction. values loaded in and compared to are expected output values
+#pv.cmpne.b is of the form "pv.cmpne.b rD, rs1, rs2".
+test55:
+    li x17, 0xdd169b17
+    li x18, 0xe516aa17
+    pv.cmpne.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xcb8b9b20
+    li x18, 0x68f03c20
+    pv.cmpne.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0xbc7cc2d8
+    li x18, 0xbcebc2b2
+    pv.cmpne.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0xc7cb9312
+    li x18, 0xc37660fe
+    pv.cmpne.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x4dd1a689
+    li x18, 0x2ed19c56
+    pv.cmpne.b x19, x17, x18
+    li x20, 0xff00ffff
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0xfbe84fba
+    li x18, 0xfbe84fba
+    pv.cmpne.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.cmpne.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpne.sc.b is of the form "pv.cmpne.sc.b rD, rs1, rs2".
+test61:
+    li x17, 0x5ed61df5
+    li x18, 0xc5e8bf27
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x8a5df68a
+    li x18, 0xfb21de8a
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0x00ffff00
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x9f735394
+    li x18, 0x7d19d373
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0xff00ffff
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xeeeeeeee
+    li x18, 0x05fb8dee
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0xa4b80b27
+    li x18, 0x689cb3a4
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0xc55fcd80
+    li x18, 0x6d059863
+    pv.cmpne.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.cmpne.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpne.sci.b is of the form "pv.cmpne.sci.b rD, rs1, Imm6".
+test67:
+    li x17, 0x0a38ff0a
+    pv.cmpne.sci.b x19, x17, 0xa
+    li x20, 0x00ffff00
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x188ca729
+    pv.cmpne.sci.b x19, x17, 0x18
+    li x20, 0x00ffffff
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0xb41e26b8
+    pv.cmpne.sci.b x19, x17, 0x1e
+    li x20, 0xff00ffff
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x36fe4c86
+    pv.cmpne.sci.b x19, x17, 0x05
+    li x20, 0xffffffff
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0xa8cf1414
+    pv.cmpne.sci.b x19, x17, 0x14
+    li x20, 0xffff0000
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0xf897437e
+    pv.cmpne.sci.b x19, x17, 0x8
+    li x20, 0xffffffff
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.cmpgt.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.h is of the form "pv.cmpgt.h rD, rs1, rs2".
+test73:
+    li x17, 0x40fc86fa
+    li x18, 0xf486b68f
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0xeda80242
+    li x18, 0x20cbcb80
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0xbe0668b4
+    li x18, 0xce3c764e
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0xe2958a37
+    li x18, 0x2b944692
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0xeaa9d9ca
+    li x18, 0x7d98411e
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0x724566f4
+    li x18, 0x3e90dbe6
+    pv.cmpgt.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.cmpgt.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.sc.h is of the form "pv.cmpgt.sc.h rD, rs1, rs2".
+test79:
+    li x17, 0x3e998a14
+    li x18, 0xd8c9e031
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x568d1d04
+    li x18, 0xebacff17
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0xb27b96f5
+    li x18, 0x21d49a39
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x9c251041
+    li x18, 0x03432a7a
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x20a4d96c
+    li x18, 0x5f3fd12b
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0xbd6234c6
+    li x18, 0x354a2d37
+    pv.cmpgt.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.cmpgt.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.sci.h is of the form "pv.cmpgt.sci.h rD, rs1, Imm6".
+test85:
+    li x17, 0x57dbe7cb
+    pv.cmpgt.sci.h x19, x17, 0x1d
+    li x20, 0xffff0000
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0x86fe7a69
+    pv.cmpgt.sci.h x19, x17, 0x1
+    li x20, 0x0000ffff
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x2d417975
+    pv.cmpgt.sci.h x19, x17, 0x5
+    li x20, 0xffffffff
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0xc586f391
+    pv.cmpgt.sci.h x19, x17, 0x18
+    li x20, 0x00000000
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x38ccf127
+    pv.cmpgt.sci.h x19, x17, 0x09
+    li x20, 0xffff0000
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0xba393def
+    pv.cmpgt.sci.h x19, x17, 0x1f
+    li x20, 0x0000ffff
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.cmpgt.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.b is of the form "pv.cmpgt.b rD, rs1, rs2".
+test91:
+    li x17, 0x60af9b4c
+    li x18, 0x14e66ee2
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0xff0000ff
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0xca6b0531
+    li x18, 0xca160400
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xb10797a0
+    li x18, 0xad45142d
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0xff000000
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0x606d888a
+    li x18, 0x41fe0c9b
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0xbd53fe09
+    li x18, 0x1a57ec32
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0x73d9119a
+    li x18, 0x9fb04c88
+    pv.cmpgt.b x19, x17, x18
+    li x20, 0xffff00ff
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.cmpgt.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.sc.b is of the form "pv.cmpgt.sc.b rD, rs1, rs2".
+test97:
+    li x17, 0xc276014e
+    li x18, 0x71ccf7ed
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0x1abed23a
+    li x18, 0x05dccdb7
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0x23af7d6b
+    li x18, 0xb833437d
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0x6f15f401
+    li x18, 0x174b810c
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0xb714168f
+    li x18, 0x4b278418
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0x4be75c36
+    li x18, 0xc4011682
+    pv.cmpgt.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.cmpgt.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgt.sci.b is of the form "pv.cmpgt.sci.b rD, rs1, Imm6".
+test103:
+    li x17, 0x2da42ff0
+    pv.cmpgt.sci.b x19, x17, 0x12
+    li x20, 0xff00ff00
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0x6dfaabd3
+    pv.cmpgt.sci.b x19, x17, 0x4
+    li x20, 0xff000000
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0xd51caa3b
+    pv.cmpgt.sci.b x19, x17, 0x1c
+    li x20, 0x000000ff
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x8d812c93
+    pv.cmpgt.sci.b x19, x17, 0x9
+    li x20, 0x0000ff00
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0x1fa82884
+    pv.cmpgt.sci.b x19, x17, 0xf
+    li x20, 0xff00ff00
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0x7abd8b42
+    pv.cmpgt.sci.b x19, x17, 0x1d
+    li x20, 0xff0000ff
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_comparison_2.S
+++ b/cv32/tests/core/custom/pulp_vectorial_comparison_2.S
@@ -1,0 +1,826 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.cmpge.h instruction. values loaded in and compared to are expected output values
+#pv.cmpge.h is of the form "pv.cmpge.h rD, rs1, rs2".
+test1:
+    li x17, 0x5d04e2ac
+    li x18, 0x8fdfd1f9
+    pv.cmpge.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0xed38536c
+    li x18, 0xf10b7400
+    pv.cmpge.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0xaec58c96
+    li x18, 0xcc367abe
+    pv.cmpge.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0xfa41584b
+    li x18, 0x799ae39e
+    pv.cmpge.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xb50d78e7
+    li x18, 0xb50d280e
+    pv.cmpge.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x6a946ccc
+    li x18, 0x5b5c65f7
+    pv.cmpge.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.cmpge.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpge.sc.h is of the form "pv.cmpge.sc.h rD, rs1, rs2".
+test7:
+    li x17, 0xe65f6c5d
+    li x18, 0x76a8c85c
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x395338f8
+    li x18, 0xd385fd25
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x05ac90ed
+    li x18, 0x9a887b36
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x65530174
+    li x18, 0x82014c03
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x91e84198
+    li x18, 0xa37791e8
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0xfafd58b0
+    li x18, 0xfe134f98
+    pv.cmpge.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.cmpge.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpge.sci.h is of the form "pv.cmpge.sci.h rD, rs1, Imm6".
+test13:
+    li x17, 0xd1c14ae8
+    pv.cmpge.sci.h x19, x17, 0xa
+    li x20, 0x0000ffff
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0xb153bb98
+    pv.cmpge.sci.h x19, x17, 0x0
+    li x20, 0x00000000
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x802c4c59
+    pv.cmpge.sci.h x19, x17, 0x3
+    li x20, 0x0000ffff
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x36c40b3e
+    pv.cmpge.sci.h x19, x17, 0x5
+    li x20, 0xffffffff
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x6732bf8b
+    pv.cmpge.sci.h x19, x17, 0xf
+    li x20, 0xffff0000
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x5c4f0002
+    pv.cmpge.sci.h x19, x17, 0x2
+    li x20, 0xffffffff
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.cmpge.b instruction. values loaded in and compared to are expected output values
+#pv.cmpge.b is of the form "pv.cmpge.b rD, rs1, rs2".
+test19:
+    li x17, 0x0237e535
+    li x18, 0xb1b6109e
+    pv.cmpge.b x19, x17, x18
+    li x20, 0xffff00ff
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0xb498bfa6
+    li x18, 0x21464685
+    pv.cmpge.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0x5685debb
+    li x18, 0xd08564dd
+    pv.cmpge.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xf976f74a
+    li x18, 0x5b0a5851
+    pv.cmpge.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x862d1de4
+    li x18, 0xf6dbbb7f
+    pv.cmpge.b x19, x17, x18
+    li x20, 0x00ffff00
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x10cf603d
+    li x18, 0xd60cbf90
+    pv.cmpge.b x19, x17, x18
+    li x20, 0xff00ffff
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.cmpge.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpge.sc.b is of the form "pv.cmpge.sc.b rD, rs1, rs2".
+test25:
+    li x17, 0x12a1418e
+    li x18, 0x14377da7
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x2f51b27f
+    li x18, 0x75a5668a
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x11ba732f
+    li x18, 0x8a8aa473
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x8b9b83df
+    li x18, 0x50eb2209
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0xc953927f
+    li x18, 0xd1a482f0
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x8c3d1013
+    li x18, 0x0e77cd20
+    pv.cmpge.sc.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.cmpge.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpge.sci.b is of the form "pv.cmpge.sci.b rD, rs1, Imm6".
+test31:
+    li x17, 0x36c82041
+    pv.cmpge.sci.b x19, x17, 0x9
+    li x20, 0xff00ffff
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xa3fdbe1d
+    pv.cmpge.sci.b x19, x17, 0x5
+    li x20, 0x000000ff
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xa5fc0eae
+    pv.cmpge.sci.b x19, x17, 0xe
+    li x20, 0x0000ff00
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x2f051a47
+    pv.cmpge.sci.b x19, x17, 0x6
+    li x20, 0xff00ffff
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x6a9ea4f7
+    pv.cmpge.sci.b x19, x17, 0xb
+    li x20, 0xff000000
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x082e6381
+    pv.cmpge.sci.b x19, x17, 0x8
+    li x20, 0xffffff00
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.cmplt.h instruction. values loaded in and compared to are expected output values
+#pv.cmplt.h is of the form "pv.cmplt.h rD, rs1, rs2".
+test37:
+    li x17, 0x209aee74
+    li x18, 0xe74c4470
+    pv.cmplt.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x7c57f474
+    li x18, 0xb0fbf474
+    pv.cmplt.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0xc7bb3f49
+    li x18, 0x151a4688
+    pv.cmplt.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x4aee84bc
+    li x18, 0x2cb52f31
+    pv.cmplt.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x20d120b7
+    li x18, 0x970a3f72
+    pv.cmplt.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x55de301a
+    li x18, 0x37335977
+    pv.cmplt.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.cmplt.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmplt.sc.h is of the form "pv.cmplt.sc.h rD, rs1, rs2".
+test43:
+    li x17, 0x02fea8b4
+    li x18, 0x8c836759
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0xa0121a95
+    li x18, 0xd8d276f2
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xf57828b3
+    li x18, 0xf0e5eabc
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xcd8c70c0
+    li x18, 0x180d6dd0
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0x566494d3
+    li x18, 0x56a15664
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0xf59e6750
+    li x18, 0x55608171
+    pv.cmplt.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.cmplt.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmplt.sci.h is of the form "pv.cmplt.sci.h rD, rs1, Imm6".
+test49:
+    li x17, 0xe3bb71e0
+    pv.cmplt.sci.h x19, x17, 0x1
+    li x20, 0xffff0000
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0x18bd3d5e
+    pv.cmplt.sci.h x19, x17, 0x5
+    li x20, 0x00000000
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0xb5dba974
+    pv.cmplt.sci.h x19, x17, 0xe
+    li x20, 0xffffffff
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0xfe1f5fea
+    pv.cmplt.sci.h x19, x17, 0x0
+    li x20, 0xffff0000
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0xb617000f
+    pv.cmplt.sci.h x19, x17, 0xf
+    li x20, 0xffff0000
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0xcd1c3b5d
+    pv.cmplt.sci.h x19, x17, 0xb
+    li x20, 0xffff0000
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.cmplt.b instruction. values loaded in and compared to are expected output values
+#pv.cmplt.b is of the form "pv.cmplt.b rD, rs1, rs2".
+test55:
+    li x17, 0x55860b34
+    li x18, 0x9e62710f
+    pv.cmplt.b x19, x17, x18
+    li x20, 0x00ffff00
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0x25816a9b
+    li x18, 0x389e40a6
+    pv.cmplt.b x19, x17, x18
+    li x20, 0xffff00ff
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x7f116e8d
+    li x18, 0x035e6e6a
+    pv.cmplt.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x8607692a
+    li x18, 0x02bb9691
+    pv.cmplt.b x19, x17, x18
+    li x20, 0xff000000
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x0274fd96
+    li x18, 0x3b1a5796
+    pv.cmplt.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0xc7b81e1d
+    li x18, 0xbb90c083
+    pv.cmplt.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.cmplt.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmplt.sc.b is of the form "pv.cmplt.sc.b rD, rs1, rs2".
+test61:
+    li x17, 0x9b21bee4
+    li x18, 0x6a840351
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0xbe78d503
+    li x18, 0xf566036f
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0xff00ffff
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x1df6174c
+    li x18, 0xcd4e480f
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xc7f92f5c
+    li x18, 0x2dc395c7
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0xd09a1ad6
+    li x18, 0x154996f7
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0xffff00ff
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x9780e2e1
+    li x18, 0x7c942c83
+    pv.cmplt.sc.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.cmplt.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmplt.sci.b is of the form "pv.cmplt.sci.b rD, rs1, Imm6".
+test67:
+    li x17, 0x66984600
+    pv.cmplt.sci.b x19, x17, 0x0
+    li x20, 0x00ff0000
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x29ba7f23
+    pv.cmplt.sci.b x19, x17, 0x3
+    li x20, 0x00ff0000
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x93ab8222
+    pv.cmplt.sci.b x19, x17, 0xa
+    li x20, 0xffffff00
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x6576ff07
+    pv.cmplt.sci.b x19, x17, 0x8
+    li x20, 0x0000ffff
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0xb6702fc3
+    pv.cmplt.sci.b x19, x17, 0x7
+    li x20, 0xff0000ff
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x2ff37bf7
+    pv.cmplt.sci.b x19, x17, 0xf
+    li x20, 0x00ff00ff
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.cmple.h instruction. values loaded in and compared to are expected output values
+#pv.cmple.h is of the form "pv.cmple.h rD, rs1, rs2".
+test73:
+    li x17, 0x003bfd58
+    li x18, 0x640e2058
+    pv.cmple.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0x6d220310
+    li x18, 0xf6e052f6
+    pv.cmple.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0x8e1319b6
+    li x18, 0x1009037d
+    pv.cmple.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0x67cd3e5b
+    li x18, 0x9a11e8d0
+    pv.cmple.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0x87ef53ca
+    li x18, 0x87efda70
+    pv.cmple.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0xad4a994c
+    li x18, 0xbd8a6c9f
+    pv.cmple.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.cmple.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmple.sc.h is of the form "pv.cmple.sc.h rD, rs1, rs2".
+test79:
+    li x17, 0xb0153c6a
+    li x18, 0x17517676
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x5f2707ee
+    li x18, 0x8164df16
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0x1c449936
+    li x18, 0x26f9059b
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x82408f8b
+    li x18, 0x786cc6e2
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0xaa7a3d5e
+    li x18, 0xd11a1b76
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0xe1a3fa81
+    li x18, 0x4332e1a3
+    pv.cmple.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.cmple.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmple.sci.h is of the form "pv.cmple.sci.h rD, rs1, Imm6".
+test85:
+    li x17, 0x35b84a12
+    pv.cmple.sci.h x19, x17, 0xd
+    li x20, 0x00000000
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0x209d000c
+    pv.cmple.sci.h x19, x17, 0xc
+    li x20, 0x0000ffff
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x0004bf7b
+    pv.cmple.sci.h x19, x17, 0x4
+    li x20, 0xffffffff
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0x8726fec2
+    pv.cmple.sci.h x19, x17, 0xf
+    li x20, 0xffffffff
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x407ab95e
+    pv.cmple.sci.h x19, x17, 0x8
+    li x20, 0x0000ffff
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0xa05e6fe2
+    pv.cmple.sci.h x19, x17, 0xa
+    li x20, 0xffff0000
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.cmple.b instruction. values loaded in and compared to are expected output values
+#pv.cmple.b is of the form "pv.cmple.b rD, rs1, rs2".
+test91:
+    li x17, 0x92b4c136
+    li x18, 0xa6b4282c
+    pv.cmple.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0x029ec3d0
+    li x18, 0xab0341e5
+    pv.cmple.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xdec66ef7
+    li x18, 0x1c914d93
+    pv.cmple.b x19, x17, x18
+    li x20, 0xff000000
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0xc2c21e78
+    li x18, 0x6addfa51
+    pv.cmple.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x58fa4b8c
+    li x18, 0xc0c59646
+    pv.cmple.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0xcc7cf13a
+    li x18, 0x4ce50a42
+    pv.cmple.b x19, x17, x18
+    li x20, 0xff00ffff
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.cmple.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmple.sc.b is of the form "pv.cmple.sc.b rD, rs1, rs2".
+test97:
+    li x17, 0x0504db6f
+    li x18, 0x698c684f
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0x09238516
+    li x18, 0xde85a2d3
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0xd0a51442
+    li x18, 0xa72181d0
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0x80f06357
+    li x18, 0xd3b54968
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0x697390f0
+    li x18, 0x0d4163d9
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0xa89d9f78
+    li x18, 0xa2005459
+    pv.cmple.sc.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.cmple.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmple.sci.b is of the form "pv.cmple.sci.b rD, rs1, Imm6".
+test103:
+    li x17, 0xcde20efa
+    pv.cmple.sci.b x19, x17, 0xe
+    li x20, 0xffffffff
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0xc65d0bb6
+    pv.cmple.sci.b x19, x17, 0xc
+    li x20, 0xff00ffff
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x25177826
+    pv.cmple.sci.b x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x5021f615
+    pv.cmple.sci.b x19, x17, 0x7
+    li x20, 0x0000ff00
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0xbf701751
+    pv.cmple.sci.b x19, x17, 0x4
+    li x20, 0xff000000
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0x6693f223
+    pv.cmple.sci.b x19, x17, 0x0
+    li x20, 0x00ffff00
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_comparison_3.S
+++ b/cv32/tests/core/custom/pulp_vectorial_comparison_3.S
@@ -1,0 +1,1078 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.cmpgtu.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.h is of the form "pv.cmpgtu.h rD, rs1, rs2".
+test1:
+    li x17, 0x6013caa4
+    li x18, 0xb14037d4
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0xb0fd8577
+    li x18, 0x3671504c
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0xea7b84d3
+    li x18, 0x8153fdc1
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x9dc46f0c
+    li x18, 0x15fe331b
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xf1d0377c
+    li x18, 0xf7c5457c
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0xc36186a9
+    li x18, 0xb14c86a9
+    pv.cmpgtu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.cmpgtu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.sc.h is of the form "pv.cmpgtu.sc.h rD, rs1, rs2".
+test7:
+    li x17, 0x00e7de9f
+    li x18, 0x09e6feef
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x69491061
+    li x18, 0xc83201bc
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x00ac6630
+    li x18, 0xcf0f0463
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x44b6d853
+    li x18, 0x07a42247
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xef1972e7
+    li x18, 0xea98ed5f
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x9f8cdd18
+    li x18, 0xa7cf51c7
+    pv.cmpgtu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.cmpgtu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.sci.h is of the form "pv.cmpgtu.sci.h rD, rs1, Imm6".
+test13:
+    li x17, 0xcb843416
+    pv.cmpgtu.sci.h x19, x17, 0x2
+    li x20, 0xffffffff
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x0008483b
+    pv.cmpgtu.sci.h x19, x17, 0x8
+    li x20, 0x0000ffff
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x2c99000e
+    pv.cmpgtu.sci.h x19, x17, 0xf
+    li x20, 0xffff0000
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0xe871c0f9
+    pv.cmpgtu.sci.h x19, x17, 0x5
+    li x20, 0xffffffff
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x031b0c7b
+    pv.cmpgtu.sci.h x19, x17, 0x0
+    li x20, 0xffffffff
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x00000001
+    pv.cmpgtu.sci.h x19, x17, 0x8
+    li x20, 0x00000000
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.cmpgtu.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.b is of the form "pv.cmpgtu.b rD, rs1, rs2".
+test19:
+    li x17, 0xf32d8965
+    li x18, 0x467b9233
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0xff0000ff
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x99646fbb
+    li x18, 0x3b1a545f
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xb4da0e27
+    li x18, 0xe9950e0a
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x2dbb65f6
+    li x18, 0x7e87737e
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xa5f2c84c
+    li x18, 0x8f7686be
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x27888653
+    li x18, 0x99b500df
+    pv.cmpgtu.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.cmpgtu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.sc.b is of the form "pv.cmpgtu.sc.b rD, rs1, rs2".
+test25:
+    li x17, 0xfbc50434
+    li x18, 0xc34df4ec
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0xff000000
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x782cba40
+    li x18, 0xde6e3cba
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x48404297
+    li x18, 0xfe1d2742
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0xff0000ff
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x7250b4b8
+    li x18, 0x20e7680c
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x732d7316
+    li x18, 0x9e09e7b8
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x3a835a5f
+    li x18, 0x34b2f75b
+    pv.cmpgtu.sc.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.cmpgtu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgtu.sci.b is of the form "pv.cmpgtu.sci.b rD, rs1, Imm6".
+test31:
+    li x17, 0xeffe076f
+    pv.cmpgtu.sci.b x19, x17, 0x7
+    li x20, 0xffff00ff
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0x689e057b
+    pv.cmpgtu.sci.b x19, x17, 0x8
+    li x20, 0xffff00ff
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0x2ca79f2d
+    pv.cmpgtu.sci.b x19, x17, 0xa
+    li x20, 0xffffffff
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0xf5189ed5
+    pv.cmpgtu.sci.b x19, x17, 0x2
+    li x20, 0xffffffff
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x19ed73b1
+    pv.cmpgtu.sci.b x19, x17, 0xf
+    li x20, 0xffffffff
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x9617f9de
+    pv.cmpgtu.sci.b x19, x17, 0x5
+    li x20, 0xffffffff
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.cmpgeu.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.h is of the form "pv.cmpgeu.h rD, rs1, rs2".
+test37:
+    li x17, 0x4e8e5ede
+    li x18, 0xf270491c
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0xe0f0c81d
+    li x18, 0x033e973c
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x59d559f4
+    li x18, 0xb53559f4
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x821b12b6
+    li x18, 0x783dce4b
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x75d9ce25
+    li x18, 0x86004200
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x8aa5ca19
+    li x18, 0x4ca3f661
+    pv.cmpgeu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.cmpgeu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.sc.h is of the form "pv.cmpgeu.sc.h rD, rs1, rs2".
+test43:
+    li x17, 0x74cd038c
+    li x18, 0xf98d9c81
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x9af6df85
+    li x18, 0xafa4251a
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xf4bd11e7
+    li x18, 0x85ded011
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xfc8f3b8b
+    li x18, 0x9cf9fc8f
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0x89fa6f08
+    li x18, 0x76a22964
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0x767b9f82
+    li x18, 0x3cb5863f
+    pv.cmpgeu.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.cmpgeu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.sci.h is of the form "pv.cmpgeu.sci.h rD, rs1, Imm6".
+test49:
+    li x17, 0x0004429d
+    pv.cmpgeu.sci.h x19, x17, 0x5
+    li x20, 0x0000ffff
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0x52985b2e
+    pv.cmpgeu.sci.h x19, x17, 0x0
+    li x20, 0xffffffff
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x79a34cf9
+    pv.cmpgeu.sci.h x19, x17, 0x3
+    li x20, 0xffffffff
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x4ada0001
+    pv.cmpgeu.sci.h x19, x17, 0xd
+    li x20, 0xffff0000
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x5490c2f6
+    pv.cmpgeu.sci.h x19, x17, 0x8
+    li x20, 0xffffffff
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0xc40682b2
+    pv.cmpgeu.sci.h x19, x17, 0x2
+    li x20, 0xffffffff
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.cmpgeu.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.b is of the form "pv.cmpgeu.b rD, rs1, rs2".
+test55:
+    li x17, 0xd72fb6a6
+    li x18, 0xbb2f3bcc
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xd8bc2481
+    li x18, 0x7ddedccf
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0xff000000
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0xe3297a2f
+    li x18, 0xe0d00ffd
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x5f3aac83
+    li x18, 0xd2bfcb78
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x6aaeb3b9
+    li x18, 0x16ea1ecd
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0xd0cfaeb9
+    li x18, 0xdd9aa444
+    pv.cmpgeu.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.cmpgeu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.sc.b is of the form "pv.cmpgeu.sc.b rD, rs1, rs2".
+test61:
+    li x17, 0x3f51997e
+    li x18, 0xfb9218a4
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x04134e9b
+    li x18, 0x70865b05
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0x00ffffff
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0xcfa73661
+    li x18, 0x8be8dca7
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0x5c8ef9dd
+    li x18, 0x307d5327
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x275d8c36
+    li x18, 0x69fa33df
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x7d9f572a
+    li x18, 0x38e79e9e
+    pv.cmpgeu.sc.b x19, x17, x18
+    li x20, 0x00ff0000
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.cmpgeu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpgeu.sci.b is of the form "pv.cmpgeu.sci.b rD, rs1, Imm6".
+test67:
+    li x17, 0x50082a23
+    pv.cmpgeu.sci.b x19, x17, 0xc
+    li x20, 0xff00ffff
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0xa1495c0f
+    pv.cmpgeu.sci.b x19, x17, 0xf
+    li x20, 0xffffffff
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x6a2d9791
+    pv.cmpgeu.sci.b x19, x17, 0x7
+    li x20, 0xffffffff
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x91cc0098
+    pv.cmpgeu.sci.b x19, x17, 0x1
+    li x20, 0xffff00ff
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0x94429491
+    pv.cmpgeu.sci.b x19, x17, 0x4
+    li x20, 0xffffffff
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x8e4b041c
+    pv.cmpgeu.sci.b x19, x17, 0xa
+    li x20, 0xffff00ff
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.cmpltu.h instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.h is of the form "pv.cmpltu.h rD, rs1, rs2".
+test73:
+    li x17, 0x6d362f93
+    li x18, 0x6a0e3bdc
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0x011afdcf
+    li x18, 0x750856f3
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0x3a5d7e42
+    li x18, 0xa7054756
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0x5c324cdf
+    li x18, 0xd0d5021d
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0x8d47f02a
+    li x18, 0x419e1060
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0x810913b1
+    li x18, 0x8c22678e
+    pv.cmpltu.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.cmpltu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.sc.h is of the form "pv.cmpltu.sc.h rD, rs1, rs2".
+test79:
+    li x17, 0x840378a0
+    li x18, 0x84031cf1
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x5a143639
+    li x18, 0x1d7cf65e
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0x9035f996
+    li x18, 0xe2321917
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x472212ef
+    li x18, 0x074d6855
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x2766c214
+    li x18, 0x27d4c4a5
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0x293c9e5b
+    li x18, 0xf854a192
+    pv.cmpltu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.cmpltu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.sci.h is of the form "pv.cmpltu.sci.h rD, rs1, Imm6".
+test85:
+    li x17, 0x47882da2
+    pv.cmpltu.sci.h x19, x17, 0x0
+    li x20, 0x00000000
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0x50710007
+    pv.cmpltu.sci.h x19, x17, 0x8
+    li x20, 0x0000ffff
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x00014925
+    pv.cmpltu.sci.h x19, x17, 0x4
+    li x20, 0xffff0000
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0xedf9f32a
+    pv.cmpltu.sci.h x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x00060002
+    pv.cmpltu.sci.h x19, x17, 0x9
+    li x20, 0xffffffff
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0x8307d78b
+    pv.cmpltu.sci.h x19, x17, 0xc
+    li x20, 0x00000000
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.cmpltu.b instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.b is of the form "pv.cmpltu.b rD, rs1, rs2".
+test91:
+    li x17, 0x9cbc6cec
+    li x18, 0xa404e17f
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0x3565128b
+    li x18, 0x4c32a248
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0xff00ff00
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xd684fdbe
+    li x18, 0x27706aa1
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0xf0f72813
+    li x18, 0x0c122859
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x971b89fc
+    li x18, 0xf73da7fd
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0x543d0cda
+    li x18, 0x7e3eb612
+    pv.cmpltu.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.cmpltu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.sc.b is of the form "pv.cmpltu.sc.b rD, rs1, rs2".
+test97:
+    li x17, 0xfcf54290
+    li x18, 0xbc31f858
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0xc8419963
+    li x18, 0xcf960f32
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0xca0857c9
+    li x18, 0x8cb4cb62
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0x00ffff00
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0x45000095
+    li x18, 0x1500b74d
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0x4bc43321
+    li x18, 0x3c6ec6e9
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0xd560a84a
+    li x18, 0x87ffefa8
+    pv.cmpltu.sc.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.cmpltu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpltu.sci.b is of the form "pv.cmpltu.sci.b rD, rs1, Imm6".
+test103:
+    li x17, 0x66ed230a
+    pv.cmpltu.sci.b x19, x17, 0xa
+    li x20, 0x00000000
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0xc70baab8
+    pv.cmpltu.sci.b x19, x17, 0xc
+    li x20, 0x00ff0000
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x4381c243
+    pv.cmpltu.sci.b x19, x17, 0xb
+    li x20, 0x00000000
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x01020304
+    pv.cmpltu.sci.b x19, x17, 0x4
+    li x20, 0xffffff00
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0x29cfb5ca
+    pv.cmpltu.sci.b x19, x17, 0x9
+    li x20, 0x00000000
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0xf68378aa
+    pv.cmpltu.sci.b x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test109
+    c.addi x15, 0x1
+#tests109-114 test the pv.cmpleu.h instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.h is of the form "pv.cmpleu.h rD, rs1, rs2".
+test109:
+    li x17, 0xc7bd326f
+    li x18, 0x7cb7bb41
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test110
+    c.addi x15, 0x1
+test110:
+    li x17, 0xc9724571
+    li x18, 0x0a882c3c
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test111
+    c.addi x15, 0x1
+test111:
+    li x17, 0x620810a7
+    li x18, 0x162b10a7
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test112
+    c.addi x15, 0x1
+test112:
+    li x17, 0x24bcacf5
+    li x18, 0x51d0d881
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test113
+    c.addi x15, 0x1
+test113:
+    li x17, 0x7ad769ff
+    li x18, 0x1d85c249
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test114
+    c.addi x15, 0x1
+test114:
+    li x17, 0xf95b86db
+    li x18, 0xa0ad37c1
+    pv.cmpleu.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test115
+    c.addi x15, 0x1
+#tests115-120 test the pv.cmpleu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.sc.h is of the form "pv.cmpleu.sc.h rD, rs1, rs2".
+test115:
+    li x17, 0x46b0e3ad
+    li x18, 0x3722189b
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test116
+    c.addi x15, 0x1
+test116:
+    li x17, 0x119c9fc3
+    li x18, 0x3a6a119c
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test117
+    c.addi x15, 0x1
+test117:
+    li x17, 0xf42b80dd
+    li x18, 0xb6f2f147
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test118
+    c.addi x15, 0x1
+test118:
+    li x17, 0xa2118935
+    li x18, 0x8105d093
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test119
+    c.addi x15, 0x1
+test119:
+    li x17, 0xc9d50ecd
+    li x18, 0x4c4b0488
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test120
+    c.addi x15, 0x1
+test120:
+    li x17, 0x416b44a1
+    li x18, 0xab40256e
+    pv.cmpleu.sc.h x19, x17, x18
+    li x20, 0x00000000
+    beq x20, x19, test121
+    c.addi x15, 0x1
+#tests121-126 test the pv.cmpleu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.sci.h is of the form "pv.cmpleu.sci.h rD, rs1, Imm6".
+test121:
+    li x17, 0x000b7df0
+    pv.cmpleu.sci.h x19, x17, 0xc
+    li x20, 0xffff0000
+    beq x20, x19, test122
+    c.addi x15, 0x1
+test122:
+    li x17, 0xff73c470
+    pv.cmpleu.sci.h x19, x17, 0x3
+    li x20, 0x00000000
+    beq x20, x19, test123
+    c.addi x15, 0x1
+test123:
+    li x17, 0x0003000c
+    pv.cmpleu.sci.h x19, x17, 0xe
+    li x20, 0xffffffff
+    beq x20, x19, test124
+    c.addi x15, 0x1
+test124:
+    li x17, 0xe028b943
+    pv.cmpleu.sci.h x19, x17, 0x6
+    li x20, 0x00000000
+    beq x20, x19, test125
+    c.addi x15, 0x1
+test125:
+    li x17, 0x62d37357
+    pv.cmpleu.sci.h x19, x17, 0x2
+    li x20, 0x00000000
+    beq x20, x19, test126
+    c.addi x15, 0x1
+test126:
+    li x17, 0x57ac0007
+    pv.cmpleu.sci.h x19, x17, 0x8
+    li x20, 0x0000ffff
+    beq x20, x19, test127
+    c.addi x15, 0x1
+#tests127-132 test the pv.cmpleu.b instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.b is of the form "pv.cmpleu.b rD, rs1, rs2".
+test127:
+    li x17, 0xdf0b0723
+    li x18, 0xf61fa987
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test128
+    c.addi x15, 0x1
+test128:
+    li x17, 0x40592630
+    li x18, 0xa6ce9028
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test129
+    c.addi x15, 0x1
+test129:
+    li x17, 0x47b64c62
+    li x18, 0x1f94d351
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0x0000ff00
+    beq x20, x19, test130
+    c.addi x15, 0x1
+test130:
+    li x17, 0xf2d4ec55
+    li x18, 0xf51236ec
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0xff0000ff
+    beq x20, x19, test131
+    c.addi x15, 0x1
+test131:
+    li x17, 0xfde2d521
+    li x18, 0x73dd9821
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0x000000ff
+    beq x20, x19, test132
+    c.addi x15, 0x1
+test132:
+    li x17, 0x659f8ad6
+    li x18, 0x0bdf09f2
+    pv.cmpleu.b x19, x17, x18
+    li x20, 0x00ff00ff
+    beq x20, x19, test133
+    c.addi x15, 0x1
+#tests133-138 test the pv.cmpleu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.sc.b is of the form "pv.cmpleu.sc.b rD, rs1, rs2".
+test133:
+    li x17, 0x8d4458a6
+    li x18, 0xa64e68ff
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test134
+    c.addi x15, 0x1
+test134:
+    li x17, 0x94a65e59
+    li x18, 0xd2cff673
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test135
+    c.addi x15, 0x1
+test135:
+    li x17, 0x73c213c3
+    li x18, 0x61d4dcc2
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0xffffff00
+    beq x20, x19, test136
+    c.addi x15, 0x1
+test136:
+    li x17, 0x513de5e5
+    li x18, 0xa0c0e7b4
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0xffff0000
+    beq x20, x19, test137
+    c.addi x15, 0x1
+test137:
+    li x17, 0xac520936
+    li x18, 0x284c69f1
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0xffffffff
+    beq x20, x19, test138
+    c.addi x15, 0x1
+test138:
+    li x17, 0xe1e01123
+    li x18, 0x28e067d8
+    pv.cmpleu.sc.b x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test139
+    c.addi x15, 0x1
+#tests139-144 test the pv.cmpleu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.cmpleu.sci.b is of the form "pv.cmpleu.sci.b rD, rs1, Imm6".
+test139:
+    li x17, 0x43c87702
+    pv.cmpleu.sci.b x19, x17, 0x9
+    li x20, 0x000000ff
+    beq x20, x19, test140
+    c.addi x15, 0x1
+test140:
+    li x17, 0x02f755a9
+    pv.cmpleu.sci.b x19, x17, 0x2
+    li x20, 0xff000000
+    beq x20, x19, test141
+    c.addi x15, 0x1
+test141:
+    li x17, 0x0bb3103a
+    pv.cmpleu.sci.b x19, x17, 0xc
+    li x20, 0xff000000
+    beq x20, x19, test142
+    c.addi x15, 0x1
+test142:
+    li x17, 0x050e693e
+    pv.cmpleu.sci.b x19, x17, 0xf
+    li x20, 0xffff0000
+    beq x20, x19, test143
+    c.addi x15, 0x1
+test143:
+    li x17, 0x445ee72f
+    pv.cmpleu.sci.b x19, x17, 0x3
+    li x20, 0x00000000
+    beq x20, x19, test144
+    c.addi x15, 0x1
+test144:
+    li x17, 0x0f841e08
+    pv.cmpleu.sci.b x19, x17, 0x8
+    li x20, 0x000000ff
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_complex.S
+++ b/cv32/tests/core/custom/pulp_vectorial_complex.S
@@ -1,0 +1,688 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5911efde
+    li x4, 0x40001104
+#tests1-6 test the pv.subrotmj instruction. values loaded in and compared to are expected output values
+#pv.subrotmj is of the form "pv.subrotmj rD, rs1, rs2". rD[15:0] = rs1[31:16]-rs2[31:16],
+#rD[31:16] = rs2[15:0]-rs1[15:0]
+test1:
+    li x17, 0xaf2d2f97
+    li x18, 0x6dc18787
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0x57f0416c
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x109bf3c5
+    li x18, 0x1acfd8f6
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0xe531f5cc
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x24e9d2ae
+    li x18, 0x304f5001
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0x7d53f49a
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0xa0ffa6e4
+    li x18, 0x02d8668b
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0xbfa79e27
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x6b3808fe
+    li x18, 0x73ce484a
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0x3f4cf76a
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x054c2c63
+    li x18, 0x2f2e30c2
+    .word 0x6d2889d7    #pv.subrotmj x19, x17, x18
+    li x20, 0x045fd61e
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.subrotmj.div2 instruction. values loaded in and compared to are expected output values
+#pv.subrotmj.div2 is of the form "pv.subrotmj.div2 rD, rs1, rs2". rD[15:0] = (rs1[31:16]-rs2[31:16])>>1,
+#rD[31:16] = (rs2[15:0]-rs1[15:0])>>1
+test7:
+    li x17, 0xf630bfb4
+    li x18, 0xcffa4336
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0xc1c1131b
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x3f433b1e
+    li x18, 0x809492e2
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0x2be2df57
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0xbe812610
+    li x18, 0x8eae076d
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0xf0ae17e9
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x8893401d
+    li x18, 0x0a586318
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0x117d3f1d
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x6fb8bcd2
+    li x18, 0x24070fca
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0x297c25d8
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x4c43c1f4
+    li x18, 0x66d3202f
+    .word 0x6d28a9d7    #pv.subrotmj.div2 x19, x17, x18
+    li x20, 0x2f1df2b8
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.subrotmj.div4 instruction. values loaded in and compared to are expected output values
+#pv.subrotmj.div4 is of the form "pv.subrotmj.div4 rD, rs1, rs2". rD[15:0] = (rs1[31:16]-rs2[31:16])>>2,
+#rD[31:16] = (rs2[15:0]-rs1[15:0])>>2
+test13:
+    li x17, 0x1bff7f6e
+    li x18, 0x38092ba1
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0xeb0cf8fd
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0xd85d23e9
+    li x18, 0xcf4da1d1
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0x1f7a0244
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xdb922fd6
+    li x18, 0x101ecbe1
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0xe702f2dd
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x412fc401
+    li x18, 0x3f26c504
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0x00400082
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x54cdba63
+    li x18, 0x62a71824
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0x1770fc89
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0xe35cadaa
+    li x18, 0xbd884bda
+    .word 0x6d28c9d7    #pv.subrotmj.div4 x19, x17, x18
+    li x20, 0xe78c0975
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.subrotmj.div8 instruction. values loaded in and compared to are expected output values
+#pv.subrotmj.div8 is of the form "pv.subrotmj.div8 rD, rs1, rs2". rD[15:0] = (rs1[31:16]-rs2[31:16])>>3,
+#rD[31:16] = (rs2[15:0]-rs1[15:0])>>3
+test19:
+    li x17, 0xb75b6f5c
+    li x18, 0x7ee6e76d
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0x0f02070e
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x41d543eb
+    li x18, 0x5790d5de
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0xf23efd48
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0x03b28e4e
+    li x18, 0x157426c4
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0xf30efdc7
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xcc07813c
+    li x18, 0x1e911df9
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0xf397f5ae
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xfbab5801
+    li x18, 0xe8a2bbd0
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0x0c790261
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x2e098dc4
+    li x18, 0xeaf898b2
+    .word 0x6d28e9d7    #pv.subrotmj.div8 x19, x17, x18
+    li x20, 0x015d0862
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.cplxconj instruction. values loaded in and compared to are expected output values
+#pv.cplxconj is of the form "pv.cplxconj rD, rs1".
+test25:
+    li x17, 0x8442ad8e
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0x7bbead8e
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x66cd7991
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0x99337991
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x49849965
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0xb67c9965
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x21367b6b
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0xdeca7b6b
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x1477100a
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0xeb89100a
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0xa615f8ce
+    .word 0x5c0889d7    #pv.cplxconj x19, x17
+    li x20, 0x59ebf8ce
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.cplxmul.r instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.r is of the form "pv.cplxmul.r rD, rs1, rs2".
+test31:
+    li x19, 0xe093a374
+    li x17, 0x68c48474
+    li x18, 0xb5a735b7
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0xe0930901
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x19, 0xbb90ae84
+    li x17, 0x3862897a
+    li x18, 0xae76a3dc
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0xbb90793c
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x19, 0x25cc94b3
+    li x17, 0xb7cbb7dc
+    li x18, 0x71df311a
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0x25cc2490
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x19, 0x4b0b9796
+    li x17, 0xee3c5a30
+    li x18, 0x9629081b
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0x4b0bf705
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x19, 0x0e7c05a1
+    li x17, 0xfa556505
+    li x18, 0x1e1e9e99
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0x0e7cb476
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x19, 0x0c50fd6d
+    li x17, 0x1c198900
+    li x18, 0x16a779a5
+    .word 0x572889d7    #pv.cplxmul.r x19, x17, x18
+    li x20, 0x0c5089ef
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.cplxmul.r.div2 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.r.div2 is of the form "pv.cplxmul.r.div2 rD, rs1, rs2".
+test37:
+    li x19, 0xf2d306f0
+    li x17, 0xb188c359
+    li x18, 0x58ba54ab
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0xf2d30722
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x19, 0x7c9674fd
+    li x17, 0xa1441f2b
+    li x18, 0xad8ac34a
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0x7c96da17
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x19, 0x2d033231
+    li x17, 0x5480e56e
+    li x18, 0x829107fb
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0x2d032893
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x19, 0xec097a26
+    li x17, 0x7737ce12
+    li x18, 0x5af57d71
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0xec09bd2d
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x19, 0x68ef850a
+    li x17, 0x7e7caf49
+    li x18, 0x48b48c84
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0x68ef007d
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x19, 0x2e16d229
+    li x17, 0x09f38f2a
+    li x18, 0x67e4f120
+    .word 0x5728a9d7    #pv.cplxmul.r.div2 x19, x17, x18
+    li x20, 0x2e160284
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.cplxmul.r.div4 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.r.div4 is of the form "pv.cplxmul.r.div4 rD, rs1, rs2".
+test43:
+    li x19, 0x68dc4d8d
+    li x17, 0xd81aa079
+    li x18, 0x1b333d39
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0x68dc01eb
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x19, 0xcaac8fcb
+    li x17, 0xb7062e88
+    li x18, 0x804905e9
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0xcaac097a
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x19, 0x1301e0bb
+    li x17, 0xa54d96d4
+    li x18, 0x327ac09b
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0x130115f6
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x19, 0xf8bda6a1
+    li x17, 0xad3b3d23
+    li x18, 0xf388c2ac
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0xf8bdf6a9
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x19, 0x1b17aad1
+    li x17, 0x02cda197
+    li x18, 0xc953f6b1
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0x1b17
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x19, 0x7dad1aac
+    li x17, 0xeb187f17
+    li x18, 0xfc758e75
+    .word 0x5728c9d7    #pv.cplxmul.r.div4 x19, x17, x18
+    li x20, 0x7dad
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.cplxmul.r.div8 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.r.div8 is of the form "pv.cplxmul.r.div8 rD, rs1, rs2".
+test49:
+    li x19, 0x52271eb6
+    li x17, 0xec34072f
+    li x18, 0xe05ad5c9
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0x5227
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x19, 0xa25b2a08
+    li x17, 0x4a0eed30
+    li x18, 0x641bea8e
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0xa25b
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x19, 0x83407d59
+    li x17, 0x3a940235
+    li x18, 0x8fcc3806
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0x8340
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x19, 0x23a5a7b8
+    li x17, 0xe447bb1a
+    li x18, 0xcec233e9
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0x23a5
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x19, 0x9f032bb7
+    li x17, 0x4c06d0db
+    li x18, 0x49c9231d
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0x9f03
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x19, 0xb03076a9
+    li x17, 0x5b349c89
+    li x18, 0x16d3f8c5
+    .word 0x5728e9d7    #pv.cplxmul.r.div8 x19, x17, x18
+    li x20, 0xb030
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.cplxmul.i instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.i is of the form "pv.cplxmul.i.div2 rD, rs1, rs2".
+test55:
+    li x19, 0x74f95d16
+    li x17, 0x13c99767
+    li x18, 0x49fdbc20
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0xb90c5d16
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x19, 0x89b50197
+    li x17, 0xc8de8cef
+    li x18, 0xb46b8232
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0x7a210197
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x19, 0xd927e9de
+    li x17, 0x0dd4ce08
+    li x18, 0xf258bdea
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0xfe31e9de
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x19, 0x9e9eb3ef
+    li x17, 0x6d97b987
+    li x18, 0x1bf24f6e
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0x349eb3ef
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x19, 0x1630bd14
+    li x17, 0x158ea724
+    li x18, 0x7ea93025
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0xb02dbd14
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x19, 0xc43932b4
+    li x17, 0xf67d173b
+    li x18, 0x8c470b5b
+    .word 0x552889d7    #pv.cplxmul.i x19, x17, x18
+    li x20, 0xea2732b4
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.cplxmul.i.div2 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.i.div2 is of the form "pv.cplxmul.i.div2 rD, rs1, rs2".
+test61:
+    li x19, 0x93da3581
+    li x17, 0xf58e6a19
+    li x18, 0xbd76f586
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0xead93581
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x19, 0x2feac4d4
+    li x17, 0xb7d1d296
+    li x18, 0xe603c7b5
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0x147bc4d4
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x19, 0x2c645321
+    li x17, 0xea6727f5
+    li x18, 0x2394b319
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0x0c0a5321
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x19, 0xc4b99188
+    li x17, 0xb62f1e31
+    li x18, 0x3af596fa
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0x253c9188
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x19, 0x0ec2cba9
+    li x17, 0xc3fb0f53
+    li x18, 0x984b363b
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0xed13cba9
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x19, 0xd212d156
+    li x17, 0x9e5dfeb9
+    li x18, 0x5f95a943
+    .word 0x5528a9d7    #pv.cplxmul.i.div2 x19, x17, x18
+    li x20, 0x209ad156
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.cplxmul.i.div4 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.i.div4 is of the form "pv.cplxmul.i.div4 rD, rs1, rs2".
+test67:
+    li x19, 0x3d497610
+    li x17, 0xe61d23c5
+    li x18, 0x07764e8c
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0xfc8c7610
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x19, 0xb15f4484
+    li x17, 0xd11f623c
+    li x18, 0xcb030d7d
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0xf4994484
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x19, 0x1a3c19f8
+    li x17, 0x746bbe56
+    li x18, 0x86370b92
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0x0f9e19f8
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x19, 0xbbaf71d3
+    li x17, 0x88547464
+    li x18, 0x5c5c8b42
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0x304871d3
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x19, 0x68960022
+    li x17, 0xbb7a7372
+    li x18, 0x3447029e
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0x0b6f0022
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x19, 0xd1af248d
+    li x17, 0x95c7029d
+    li x18, 0x0457e346
+    .word 0x5528c9d7    #pv.cplxmul.i.div4 x19, x17, x18
+    li x20, 0x05fb248d
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.cplxmul.i.div8 instruction. values loaded in and compared to are expected output values
+#pv.cplxmul.i.div8 is of the form "pv.cplxmul.i.div8 rD, rs1, rs2".
+test73:
+    li x19, 0x9dd06f4f
+    li x17, 0x80356c34
+    li x18, 0x4dcf2b10
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0x02d96f4f
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x19, 0x8bb89d46
+    li x17, 0x2bd857cb
+    li x18, 0xdfb54df1
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0x00919d46
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x19, 0xee4604ec
+    li x17, 0xc7b2c6ec
+    li x18, 0x9f2505fb
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0x051104ec
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x19, 0x68619b42
+    li x17, 0xa102a05e
+    li x18, 0x604a0eb0
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0xf5a59b42
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x19, 0x52d8aa89
+    li x17, 0xea6ac15d
+    li x18, 0x707ad99d
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0xf9edaa89
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x19, 0xf6489edd
+    li x17, 0x0b5fab1d
+    li x18, 0xe22b4542
+    .word 0x5528e9d7    #pv.cplxmul.i.div8 x19, x17, x18
+    li x20, 0x033d9edd
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_dot_product_1.S
+++ b/cv32/tests/core/custom/pulp_vectorial_dot_product_1.S
@@ -1,0 +1,826 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.dotup.h instruction. values loaded in and compared to are expected output values
+#pv.dotup.h is of the form "pv.dotup.h rD, rs1, rs2"
+test1:
+    li x17, 0x8d7fd0d4
+    li x18, 0xfc7b09b2
+    pv.dotup.h x19, x17, x18
+    li x20, 0x9375a76d
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x30794165
+    li x18, 0x746b2820
+    pv.dotup.h x19, x17, x18
+    li x20, 0x204b0b33
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0xd3b7e82c
+    li x18, 0x095ccaf7
+    pv.dotup.h x19, x17, x18
+    li x20, 0xbfd03f38
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x8147d144
+    li x18, 0x6f633d3a
+    pv.dotup.h x19, x17, x18
+    li x20, 0x6a4c64dd
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0xd264baa9
+    li x18, 0x40f0b913
+    pv.dotup.h x19, x17, x18
+    li x20, 0xbc50394b
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x9e2d2f27
+    li x18, 0xa14bf1a7
+    pv.dotup.h x19, x17, x18
+    li x20, 0x902b1da0
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.dotup.sc.h instruction. values loaded in and compared to are expected output values
+#pv.dotup.sc.h is of the form "pv.dotup.sc.h rD, rs1, rs2"
+test7:
+    li x17, 0x7850ff4b
+    li x18, 0xf74314d0
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0x1e8949f0
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0xeed2cf26
+    li x18, 0x4e449958
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0x0b228540
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x99c5cb0c
+    li x18, 0x602feda7
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0x4b3e4157
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x76f60132
+    li x18, 0xfb3365f7
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0x2fdbb698
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x9f2bae05
+    li x18, 0xe194c218
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0xfc9d9c80
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0xa1e360b5
+    li x18, 0xbd1db2ec
+    pv.dotup.sc.h x19, x17, x18
+    li x20, 0xb4bc1420
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.dotup.sci.h instruction. values loaded in and compared to are expected output values
+#pv.dotup.sci.h is of the form "pv.dotup.sci.h rD, rs1, Imm6"
+test13:
+    li x17, 0xc30a2b68
+    pv.dotup.sci.h x19, x17, 0x1f
+    li x20, 0x001cdfce
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x96437fa8
+    pv.dotup.sci.h x19, x17, 0x04
+    li x20, 0x000457ac
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x0eba82f5
+    pv.dotup.sci.h x19, x17, 0x1d
+    li x20, 0x001080d3
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0xf8069c7d
+    pv.dotup.sci.h x19, x17, 0x08
+    li x20, 0x000ca418
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x8dff2c6d
+    pv.dotup.sci.h x19, x17, 0x0b
+    li x20, 0x000802a4
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x70ea0687
+    pv.dotup.sci.h x19, x17, 0x15
+    li x20, 0x0009cc45
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.dotup.b instruction. values loaded in and compared to are expected output values
+#pv.dotup.b is of the form "pv.dotup.b rD, rs1, rs2"
+test19:
+    li x17, 0xc71e0ac8
+    li x18, 0x04ae1745
+    pv.dotup.b x19, x17, x18
+    li x20, 0x00004e4e
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x155abaf5
+    li x18, 0x13fe66b2
+    pv.dotup.b x19, x17, x18
+    li x20, 0x00014f51
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0x9d63534a
+    li x18, 0xcde8e371
+    pv.dotup.b x19, x17, x18
+    li x20, 0x000141b4
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x508b2b5d
+    li x18, 0x51f8078f
+    pv.dotup.b x19, x17, x18
+    li x20, 0x0000d518
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x0777091d
+    li x18, 0xa1ac9cf4
+    pv.dotup.b x19, x17, x18
+    li x20, 0x0000757b
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0xadc46b3f
+    li x18, 0x50cadfb3
+    pv.dotup.b x19, x17, x18
+    li x20, 0x000159fa
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.dotup.sc.b instruction. values loaded in and compared to are expected output values
+#pv.or.sc.b is of the form "pv.dotup.sc.b rD, rs1, rs2"
+test25:
+    li x17, 0x723a555c
+    li x18, 0xc58efe52
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x00006fca
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0xad02556e
+    li x18, 0xb8cce704
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x00005c8
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x25b8d3e3
+    li x18, 0x6cf178db
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x000233c1
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0xdab28669
+    li x18, 0x3ec976e3
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x00023311
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0xb8f9ec8f
+    li x18, 0x50ca6bb5
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x00023e1c
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0xbe578060
+    li x18, 0x0b332fdd
+    pv.dotup.sc.b x19, x17, x18
+    li x20, 0x0001b081
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.dotup.sci.b instruction. values loaded in and compared to are expected output values
+#pv.dotup.sci.b is of the form "pv.dotup.sci.b rD, rs1, Imm6"
+test31:
+    li x17, 0x375cf3e1
+    pv.dotup.sci.b x19, x17, 0x0a
+    li x20, 0x00001806
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0x741ff4fd
+    pv.dotup.sci.b x19, x17, 0x02
+    li x20, 0x00000508
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0x64379371
+    pv.dotup.sci.b x19, x17, 0x1c
+    li x20, 0x00002d64
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x70095e27
+    pv.dotup.sci.b x19, x17, 0x04
+    li x20, 0x000003f8
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0xed23b04c
+    pv.dotup.sci.b x19, x17, 0x08
+    li x20, 0x00001060
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0xb73e73df
+    pv.dotup.sci.b x19, x17, 0x0e
+    li x20, 0x00001fe2
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.dotusp.h instruction. values loaded in and compared to are expected output values
+#pv.dotusp.h is of the form "pv.dotusp.h rD, rs1, rs2"
+test37:
+    li x17, 0xc2b4bab2
+    li x18, 0x28efdc3e
+    pv.dotusp.h x19, x17, x18
+    li x20, 0x050e1528
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x361d7b9d
+    li x18, 0xf44d555f
+    pv.dotusp.h x19, x17, x18
+    li x20, 0x26bfeafc
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x8bcd51a1
+    li x18, 0xe6af416e
+    pv.dotusp.h x19, x17, x18
+    li x20, 0x0709b351
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x10ca59e2
+    li x18, 0x3d1144be
+    pv.dotusp.h x19, x17, x18
+    li x20, 0x1c23fd26
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0xbc490bca
+    li x18, 0xb659cf99
+    pv.dotusp.h x19, x17, x18
+    li x20, 0xc799bd1b
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0xda832e89
+    li x18, 0xa406e8ce
+    pv.dotusp.h x19, x17, x18
+    li x20, 0xad46a550
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.dotusp.sc.h instruction. values loaded in and compared to are expected output values
+#pv.dotusp.sc.h is of the form "pv.dotusp.sc.h rD, rs1, rs2"
+test43:
+    li x17, 0x75d8c786
+    li x18, 0x073d4040
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0x4fa6d780
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0xc9de6255
+    li x18, 0x4a01ff57
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0xff39d255
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xc5a6c38b
+    li x18, 0xf78a072c
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0x0b03eb6c
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0x007bee13
+    li x18, 0x3a930631
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0x05c4fd2e
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xc18ca673
+    li x18, 0x1d4c393f
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0x50805ec1
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0xd1931c9c
+    li x18, 0xc652343d
+    pv.dotusp.sc.h x19, x17, x18
+    li x20, 0x309a4d33
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.dotusp.sci.h instruction. values loaded in and compared to are expected output values
+#pv.dotusp.sci.h is of the form "pv.dotusp.sci.h rD, rs1, Imm6"
+test49:
+    li x17, 0x9898f9da
+    pv.dotusp.sci.h x19, x17, 0x0f
+    li x20, 0x001794ae
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0x3906a14c
+    pv.dotusp.sci.h x19, x17, 0x1f
+    li x20, 0x001a6fee
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x68b23822
+    pv.dotusp.sci.h x19, x17, 0x05
+    li x20, 0x00032424
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x3f9fc689
+    pv.dotusp.sci.h x19, x17, 0x14
+    li x20, 0x00147b20
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x2cbd4d4d
+    pv.dotusp.sci.h x19, x17, 0x0d
+    li x20, 0x00063282
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x767f1301
+    pv.dotusp.sci.h x19, x17, 0x05
+    li x20, 0x0002af80
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.dotusp.b instruction. values loaded in and compared to are expected output values
+#pv.dotusp.b is of the form "pv.dotusp.b rD, rs1, rs2"
+test55:
+    li x17, 0x78b948eb
+    li x18, 0xa10db278
+    pv.dotusp.b x19, x17, x18
+    li x20, 0x00003515
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0x8a0044d4
+    li x18, 0x956ca42c
+    pv.dotusp.b x19, x17, x18
+    li x20, 0xffffd252
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x1f438bc2
+    li x18, 0xa2878bc4
+    pv.dotusp.b x19, x17, x18
+    li x20, 0xffff67f4
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x441ff178
+    li x18, 0x7b692489
+    pv.dotusp.b x19, x17, x18
+    li x20, 0x0000177f
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0xb2283b1a
+    li x18, 0x70cf688f
+    pv.dotusp.b x19, x17, x18
+    li x20, 0x000052b6
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x54cfaa4d
+    li x18, 0xc917967e
+    pv.dotusp.b x19, x17, x18
+    li x20, 0xffffe00f
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.dotusp.sc.b instruction. values loaded in and compared to are expected output values
+#pv.dotusp.sc.b is of the form "pv.dotusp.sc.b rD, rs1, rs2"
+test61:
+    li x17, 0x3288c6b0
+    li x18, 0x0bc36aea
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0xffffcfe0
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x2cd847f0
+    li x18, 0x12d2fdbc
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0xffff6854
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0xfca71bac
+    li x18, 0x5fae1422
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0x00005214
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0x8869ea62
+    li x18, 0xafe8b45b
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0x0000cbaf
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x5c517c0b
+    li x18, 0xe895d795
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0xffff7f44
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0xeb055bef
+    li x18, 0xe96cfb9b
+    pv.dotusp.sc.b x19, x17, x18
+    li x20, 0xffff1f1e
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.dotusp.sci.b instruction. values loaded in and compared to are expected output values
+#pv.dotusp.sci.b is of the form "pv.dotusp.sci.b rD, rs1, Imm6"
+test67:
+    li x17, 0xa222991a
+    pv.dotusp.sci.b x19, x17, 0x10
+    li x20, 0x00001770
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x7d071124
+    pv.dotusp.sci.b x19, x17, 0x1d
+    li x20, 0x000014f5
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0xcd97df91
+    pv.dotusp.sci.b x19, x17, 0x0c
+    li x20, 0x000021f0
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x3276e2da
+    pv.dotusp.sci.b x19, x17, 0x0d
+    li x20, 0x00001f14
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0xa4548d4c
+    pv.dotusp.sci.b x19, x17, 0x07
+    li x20, 0x00000cb7
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0xde5c08dd
+    pv.dotusp.sci.b x19, x17, 0x06
+    li x20, 0x00000cba
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.dotsp.h instruction. values loaded in and compared to are expected output values
+#pv.dotsp.h is of the form "pv.dotsp.h rD, rs1, rs2"
+test73:
+    li x17, 0x32617430
+    li x18, 0xf6237fd6
+    pv.dotsp.h x19, x17, x18
+    li x20, 0x38140963
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0x45670453
+    li x18, 0x1c9fe38c
+    pv.dotsp.h x19, x17, x18
+    li x20, 0x0747555d
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0x1b9d05f3
+    li x18, 0x466033ff
+    pv.dotsp.h x19, x17, x18
+    li x20, 0x08cc9eed
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0x62b680f5
+    li x18, 0xd035b500
+    pv.dotsp.h x19, x17, x18
+    li x20, 0x12ca88ae
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0x3950ad4e
+    li x18, 0x9f1fd488
+    pv.dotsp.h x19, x17, x18
+    li x20, 0xf85a4a20
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0xe6f68033
+    li x18, 0x08f643ba
+    pv.dotsp.h x19, x17, x18
+    li x20, 0xdd501e72
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.dotsp.sc.h instruction. values loaded in and compared to are expected output values
+#pv.dotsp.sc.h is of the form "pv.dotsp.sc.h rD, rs1, rs2"
+test79:
+    li x17, 0x5f534237
+    li x18, 0xe5f45f7a
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0x3c3f31c4
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0xcc81894c
+    li x18, 0x611b6e10
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0xb6d372d0
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0xe4176d99
+    li x18, 0x86264b2a
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0x17fbf6e0
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0x1c248f32
+    li x18, 0xdbf46889
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0xdd6da106
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0x01dd1d61
+    li x18, 0x801c5e19
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0x0b7bd10e
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0xb203ff4e
+    li x18, 0x4abc4ca3
+    pv.dotsp.sc.h x19, x17, x18
+    li x20, 0xe871f293
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.dotsp.sci.h instruction. values loaded in and compared to are expected output values
+#pv.dotsp.sci.h is of the form "pv.dotsp.sci.h rD, rs1, Imm6"
+test85:
+    li x17, 0xa0bf6c6c
+    pv.dotsp.sci.h x19, x17, 0x0e
+    li x20, 0x0000b85a
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0x11917e9e
+    pv.dotsp.sci.h x19, x17, 0x1c
+    li x20, 0x000fc524
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x21d2135d
+    pv.dotsp.sci.h x19, x17, 0x12
+    li x20, 0x0003bd4e
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0xbf947e2a
+    pv.dotsp.sci.h x19, x17, 0x1b
+    li x20, 0x0006830a
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0x97068b1a
+    pv.dotsp.sci.h x19, x17, 0x03
+    li x20, 0xfffd6660
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0x44db3c7b
+    pv.dotsp.sci.h x19, x17, 0x0d
+    li x20, 0x0006915e
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.dotsp.b instruction. values loaded in and compared to are expected output values
+#pv.dotsp.b is of the form "pv.dotsp.b rD, rs1, rs2"
+test91:
+    li x17, 0x02fb75bc
+    li x18, 0xd152ff76
+    pv.dotsp.b x19, x17, x18
+    li x20, 0xffffde3b
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0xb7336a6c
+    li x18, 0xf24fbc1a
+    pv.dotsp.b x19, x17, x18
+    li x20, 0x0000028b
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xaa3d6c3f
+    li x18, 0x578240e4
+    pv.dotsp.b x19, x17, x18
+    li x20, 0xffffd8dc
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0xbebd393e
+    li x18, 0x3720913c
+    pv.dotsp.b x19, x17, x18
+    li x20, 0xffffdf43
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x8a6bc6b7
+    li x18, 0x0e996134
+    pv.dotsp.b x19, x17, x18
+    li x20, 0xffffa9b1
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0x35eec174
+    li x18, 0x5049b31c
+    pv.dotsp.b x19, x17, x18
+    li x20, 0x00002b11
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.dotsp.sc.b instruction. values loaded in and compared to are expected output values
+#pv.dotsp.sc.b is of the form "pv.dotsp.sc.b rD, rs1, rs2"
+test97:
+    li x17, 0x1db6da34
+    li x18, 0x1b3a7736
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0xfffff976
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0x02c6d241
+    li x18, 0x0af8642e
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0xfffff95a
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0x5da3634e
+    li x18, 0x072c9c19
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0x00001149
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0x3c0d1c41
+    li x18, 0x5cf64a54
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0x00003678
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0x9b8c5402
+    li x18, 0x1b5c9218
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0xfffff3b8
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0x60aeb8a3
+    li x18, 0x58050242
+    pv.dotsp.sc.b x19, x17, x18
+    li x20, 0xffffd912
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.dotsp.sci.b instruction. values loaded in and compared to are expected output values
+#pv.dotsp.sci.b is of the form "pv.dotsp.sci.b rD, rs1, Imm6"
+test103:
+    li x17, 0x46e895d9
+    pv.dotsp.sci.b x19, x17, 0x05
+    li x20, 0xfffffe0c
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0x28846a49
+    pv.dotsp.sci.b x19, x17, 0x01
+    li x20, 0x0000005f
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x8f4ffd41
+    pv.dotsp.sci.b x19, x17, 0x12
+    li x20, 0x000001f8
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x547d9f3a
+    pv.dotsp.sci.b x19, x17, 0x18
+    li x20, 0x00000ff0
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0xa83cc2f9
+    pv.dotsp.sci.b x19, x17, 0x04
+    li x20, 0xfffffe7c
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0xc97c4baf
+    pv.dotsp.sci.b x19, x17, 0x10
+    li x20, 0x000003f0
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_dot_product_2.S
+++ b/cv32/tests/core/custom/pulp_vectorial_dot_product_2.S
@@ -1,0 +1,934 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.sdotup.h instruction. values loaded in and compared to are expected output values
+#pv.sdotup.h is of the form "pv.sdotup.h rD, rs1, rs2"
+test1:
+    li x19, 0xa02c2a67
+    li x17, 0x8d7fd0d4
+    li x18, 0xfc7b09b2
+    pv.sdotup.h x19, x17, x18
+    li x20, 0x33a1d1d4
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x19, 0xe203b60c
+    li x17, 0x30794165
+    li x18, 0x746b2820
+    pv.sdotup.h x19, x17, x18
+    li x20, 0x024ec13f
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x19, 0x73a09426
+    li x17, 0xd3b7e82c
+    li x18, 0x095ccaf7
+    pv.sdotup.h x19, x17, x18
+    li x20, 0x3370d35e
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x19, 0x2fa589c2
+    li x17, 0x8147d144
+    li x18, 0x6f633d3a
+    pv.sdotup.h x19, x17, x18
+    li x20, 0x99f1ee9f
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x19, 0xe713a432
+    li x17, 0xd264baa9
+    li x18, 0x40f0b913
+    pv.sdotup.h x19, x17, x18
+    li x20, 0xa363dd7d
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x19, 0xc676189d
+    li x17, 0x9e2d2f27
+    li x18, 0xa14bf1a7
+    pv.sdotup.h x19, x17, x18
+    li x20, 0x56a1363d
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.sdotup.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sdotup.sc.h is of the form "pv.sdotup.sc.h rD, rs1, rs2"
+test7:
+    li x19, 0x1b197fca
+    li x17, 0x7850ff4b
+    li x18, 0xf74314d0
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0x39a2c9ba
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x19, 0xa2a2c0ee
+    li x17, 0xeed2cf26
+    li x18, 0x4e449958
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0xadc5462e
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x19, 0xe4f67358
+    li x17, 0x99c5cb0c
+    li x18, 0x602feda7
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0x3034b4af
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x19, 0xec17ce6e
+    li x17, 0x76f60132
+    li x18, 0xfb3365f7
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0x1bf38506
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x19, 0xdf3cee3a
+    li x17, 0x9f2bae05
+    li x18, 0xe194c218
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0xdbda8aba
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x19, 0xa6839365
+    li x17, 0xa1e360b5
+    li x18, 0xbd1db2ec
+    pv.sdotup.sc.h x19, x17, x18
+    li x20, 0x5b3fa785
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.sdotup.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sdotup.sci.h is of the form "pv.sdotup.sci.h rD, rs1, Imm6"
+test13:
+    li x19, 0x545fff15
+    li x17, 0xc30a2b68
+    pv.sdotup.sci.h x19, x17, 0x1f
+    li x20, 0x547cdee3
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x19, 0xf65ec051
+    li x17, 0x96437fa8
+    pv.sdotup.sci.h x19, x17, 0x04
+    li x20, 0xf66317fd
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x19, 0x455a3d6f
+    li x17, 0x0eba82f5
+    pv.sdotup.sci.h x19, x17, 0x1d
+    li x20, 0x456abe42
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x19, 0xbdb2196a
+    li x17, 0xf8069c7d
+    pv.sdotup.sci.h x19, x17, 0x08
+    li x20, 0xbdbebd82
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x19, 0xc81e285e
+    li x17, 0x8dff2c6d
+    pv.sdotup.sci.h x19, x17, 0x0b
+    li x20, 0xc8262b02
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x19, 0x02ac2919
+    li x17, 0x70ea0687
+    pv.sdotup.sci.h x19, x17, 0x15
+    li x20, 0x02b5f55e
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.sdotup.b instruction. values loaded in and compared to are expected output values
+#pv.sdotup.b is of the form "pv.sdotup.b rD, rs1, rs2"
+test19:
+    li x19, 0x12ef7631
+    li x17, 0xc71e0ac8
+    li x18, 0x04ae1745
+    pv.sdotup.b x19, x17, x18
+    li x20, 0x12efc47f
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x19, 0x7c5ec5c9
+    li x17, 0x155abaf5
+    li x18, 0x13fe66b2
+    pv.sdotup.b x19, x17, x18
+    li x20, 0x7c60151a
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x19, 0x2b9998e3
+    li x17, 0x9d63534a
+    li x18, 0xcde8e371
+    pv.sdotup.b x19, x17, x18
+    li x20, 0x2b9ada97
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x19, 0x289b0378
+    li x17, 0x508b2b5d
+    li x18, 0x51f8078f
+    pv.sdotup.b x19, x17, x18
+    li x20, 0x289bd890
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x19, 0x836f94ce
+    li x17, 0x0777091d
+    li x18, 0xa1ac9cf4
+    pv.sdotup.b x19, x17, x18
+    li x20, 0x83700a49
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x19, 0xfe85aa49
+    li x17, 0xadc46b3f
+    li x18, 0x50cadfb3
+    pv.sdotup.b x19, x17, x18
+    li x20, 0xfe870443
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.sdotup.sc.b instruction. values loaded in and compared to are expected output values
+#pv.or.sc.b is of the form "pv.sdotup.sc.b rD, rs1, rs2"
+test25:
+    li x19, 0x716c4d86
+    li x17, 0x723a555c
+    li x18, 0xc58efe52
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0x716cbd50
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x19, 0xe2442067
+    li x17, 0xad02556e
+    li x18, 0xb8cce704
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0xe244262f
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x19, 0x5a8e7cc2
+    li x17, 0x25b8d3e3
+    li x18, 0x6cf178db
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0x5a90b083
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x19, 0xa6b443ee
+    li x17, 0xdab28669
+    li x18, 0x3ec976e3
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0xa6b676ff
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x19, 0x2fc3f0b9
+    li x17, 0xb8f9ec8f
+    li x18, 0x50ca6bb5
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0x2fc62ed5
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x19, 0xe4763281
+    li x17, 0xbe578060
+    li x18, 0x0b332fdd
+    pv.sdotup.sc.b x19, x17, x18
+    li x20, 0xe477e302
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.sdotup.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sdotup.sci.b is of the form "pv.sdotup.sci.b rD, rs1, Imm6"
+test31:
+    li x19, 0x162fbd9a
+    li x17, 0x375cf3e1
+    pv.sdotup.sci.b x19, x17, 0x0a
+    li x20, 0x162fd5a0
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x19, 0x46cee932
+    li x17, 0x741ff4fd
+    pv.sdotup.sci.b x19, x17, 0x02
+    li x20, 0x46ceee3a
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x19, 0x66ffbaf5
+    li x17, 0x64379371
+    pv.sdotup.sci.b x19, x17, 0x1c
+    li x20, 0x66ffe859
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x19, 0x9220ebce
+    li x17, 0x70095e27
+    pv.sdotup.sci.b x19, x17, 0x04
+    li x20, 0x9220efc6
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x19, 0x29e4b1bf
+    li x17, 0xed23b04c
+    pv.sdotup.sci.b x19, x17, 0x08
+    li x20, 0x29e4c21f
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x19, 0x481efa13
+    li x17, 0xb73e73df
+    pv.sdotup.sci.b x19, x17, 0x0e
+    li x20, 0x481f19f5
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.sdotusp.h instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.h is of the form "pv.sdotusp.h rD, rs1, rs2"
+test37:
+    li x19, 0x10b8147a
+    li x17, 0xc2b4bab2
+    li x18, 0x28efdc3e
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0x15c629a2
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x19, 0xb9f31792
+    li x17, 0x361d7b9d
+    li x18, 0xf44d555f
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0xe0b3028e
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x19, 0x495ffc6b
+    li x17, 0x8bcd51a1
+    li x18, 0xe6af416e
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0x5069afbc
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x19, 0x38bf90b1
+    li x17, 0x10ca59e2
+    li x18, 0x3d1144be
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0x54e38dd7
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x19, 0xb9a73cef
+    li x17, 0xbc490bca
+    li x18, 0xb659cf99
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0x8140fa0a
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x19, 0xcd913e6e
+    li x17, 0xda832e89
+    li x18, 0xa406e8ce
+    pv.sdotusp.h x19, x17, x18
+    li x20, 0x7ad7e3be
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.sdotusp.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.sc.h is of the form "pv.sdotusp.sc.h rD, rs1, rs2"
+test43:
+    li x19, 0xa4fac58c
+    li x17, 0x75d8c786
+    li x18, 0x073d4040
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0xf4a19d0c
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x19, 0x197172aa
+    li x17, 0xc9de6255
+    li x18, 0x4a01ff57
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0x18ab44ff
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x19, 0xc390e5ca
+    li x17, 0xc5a6c38b
+    li x18, 0xf78a072c
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0xce94d136
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x19, 0x913d4bd1
+    li x17, 0x007bee13
+    li x18, 0x3a930631
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0x970248ff
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x19, 0x9dd4ddd6
+    li x17, 0xc18ca673
+    li x18, 0x1d4c393f
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0xee553c97
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x19, 0x0d1ae27d
+    li x17, 0xd1931c9c
+    li x18, 0xc652343d
+    pv.sdotusp.sc.h x19, x17, x18
+    li x20, 0x3db52fb0
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.sdotusp.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.sci.h is of the form "pv.sdotusp.sci.h rD, rs1, Imm6"
+test49:
+    li x19, 0xa372f233
+    li x17, 0x9898f9da
+    pv.sdotusp.sci.h x19, x17, 0x0f
+    li x20, 0xa38a86e1
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x19, 0xa5bef506
+    li x17, 0x3906a14c
+    pv.sdotusp.sci.h x19, x17, 0x1f
+    li x20, 0xa5d964f4
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x19, 0x22a6fe4f
+    li x17, 0x68b23822
+    pv.sdotusp.sci.h x19, x17, 0x05
+    li x20, 0x22aa2273
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x19, 0x78ae7867
+    li x17, 0x3f9fc689
+    pv.sdotusp.sci.h x19, x17, 0x14
+    li x20, 0x78c2f387
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x19, 0x90e93731
+    li x17, 0x2cbd4d4d
+    pv.sdotusp.sci.h x19, x17, 0x0d
+    li x20, 0x90ef69b3
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x19, 0xc18ec5d2
+    li x17, 0x767f1301
+    pv.sdotusp.sci.h x19, x17, 0x05
+    li x20, 0xc1917552
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.sdotusp.b instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.b is of the form "pv.sdotusp.b rD, rs1, rs2"
+test55:
+    li x19, 0xa6f55edb
+    li x17, 0x78b948eb
+    li x18, 0xa10db278
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0xa6f593f0
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x19, 0xa6f7a2c8
+    li x17, 0x8a0044d4
+    li x18, 0x956ca42c
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0xa6f7751a
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x19, 0x33f4f487
+    li x17, 0x1f438bc2
+    li x18, 0xa2878bc4
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0x33f45c7b
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x19, 0xd4095822
+    li x17, 0x441ff178
+    li x18, 0x7b692489
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0xd4096fa1
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x19, 0x095b9429
+    li x17, 0xb2283b1a
+    li x18, 0x70cf688f
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0x095be6df
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x19, 0xce188cd0
+    li x17, 0x54cfaa4d
+    li x18, 0xc917967e
+    pv.sdotusp.b x19, x17, x18
+    li x20, 0xce186cdf
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.sdotusp.sc.b instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.sc.b is of the form "pv.sdotusp.sc.b rD, rs1, rs2"
+test61:
+    li x19, 0xe148067f
+    li x17, 0x3288c6b0
+    li x18, 0x0bc36aea
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0xe147d65f
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x19, 0x3664e60b
+    li x17, 0x2cd847f0
+    li x18, 0x12d2fdbc
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0x36644e5f
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x19, 0x6b3163ff
+    li x17, 0xfca71bac
+    li x18, 0x5fae1422
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0x6b31b613
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x19, 0x2dcdd299
+    li x17, 0x8869ea62
+    li x18, 0xafe8b45b
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0x2dce9e48
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x19, 0x4aaf236b
+    li x17, 0x5c517c0b
+    li x18, 0xe895d795
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0x4aaea2af
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x19, 0x76fb9587
+    li x17, 0xeb055bef
+    li x18, 0xe96cfb9b
+    pv.sdotusp.sc.b x19, x17, x18
+    li x20, 0x76fab4a5
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.sdotusp.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sdotusp.sci.b is of the form "pv.sdotusp.sci.b rD, rs1, Imm6"
+test67:
+    li x19, 0x50588517
+    li x17, 0xa222991a
+    pv.sdotusp.sci.b x19, x17, 0x10
+    li x20, 0x50589c87
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x19, 0x47c672af
+    li x17, 0x7d071124
+    pv.sdotusp.sci.b x19, x17, 0x1d
+    li x20, 0x47c687a4
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x19, 0x21b018e9
+    li x17, 0xcd97df91
+    pv.sdotusp.sci.b x19, x17, 0x0c
+    li x20, 0x21b03ad9
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x19, 0x145940ed
+    li x17, 0x3276e2da
+    pv.sdotusp.sci.b x19, x17, 0x0d
+    li x20, 0x14596001
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x19, 0x3eb4ebf3
+    li x17, 0xa4548d4c
+    pv.sdotusp.sci.b x19, x17, 0x07
+    li x20, 0x3eb4f8aa
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x19, 0x05d39623
+    li x17, 0xde5c08dd
+    pv.sdotusp.sci.b x19, x17, 0x06
+    li x20, 0x05d3a2dd
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.sdotsp.h instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.h is of the form "pv.sdotsp.h rD, rs1, rs2"
+test73:
+    li x19, 0xc13fcb61
+    li x17, 0x32617430
+    li x18, 0xf6237fd6
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0xf953d4c4
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x19, 0x392f2cab
+    li x17, 0x45670453
+    li x18, 0x1c9fe38c
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0x40768208
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x19, 0x167c58cc
+    li x17, 0x1b9d05f3
+    li x18, 0x466033ff
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0x1f48f7b9
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x19, 0xfbb9b14f
+    li x17, 0x62b680f5
+    li x18, 0xd035b500
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0x0e8439fd
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x19, 0xefd58612
+    li x17, 0x3950ad4e
+    li x18, 0x9f1fd488
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0xe82fd032
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x19, 0x671b63ed
+    li x17, 0xe6f68033
+    li x18, 0x08f643ba
+    pv.sdotsp.h x19, x17, x18
+    li x20, 0x446b825f
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.sdotsp.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.sc.h is of the form "pv.sdotsp.sc.h rD, rs1, rs2"
+test79:
+    li x19, 0x5cd3f582
+    li x17, 0x5f534237
+    li x18, 0xe5f45f7a
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0x99132746
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x19, 0xaa3caa98
+    li x17, 0xcc81894c
+    li x18, 0x611b6e10
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0x61101d68
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x19, 0x5a7ae574
+    li x17, 0xe4176d99
+    li x18, 0x86264b2a
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0x7276dc54
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x19, 0x904c0fae
+    li x17, 0x1c248f32
+    li x18, 0xdbf46889
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0x6db9b0b4
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x19, 0x9b444707
+    li x17, 0x01dd1d61
+    li x18, 0x801c5e19
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0xa6c01815
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x19, 0x20343ec8
+    li x17, 0xb203ff4e
+    li x18, 0x4abc4ca3
+    pv.sdotsp.sc.h x19, x17, x18
+    li x20, 0x08a6315b
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.sdotsp.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.sci.h is of the form "pv.sdotsp.sci.h rD, rs1, Imm6"
+test85:
+    li x19, 0xaf9f2d53
+    li x17, 0xa0bf6c6c
+    pv.sdotsp.sci.h x19, x17, 0x0e
+    li x20, 0xaf9fe5ad
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x19, 0xf451c0dd
+    li x17, 0x11917e9e
+    pv.sdotsp.sci.h x19, x17, 0x1c
+    li x20, 0xf4618601
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x19, 0x44e772f7
+    li x17, 0x21d2135d
+    pv.sdotsp.sci.h x19, x17, 0x12
+    li x20, 0x44eb3045
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x19, 0x79f4eac9
+    li x17, 0xbf947e2a
+    pv.sdotsp.sci.h x19, x17, 0x1b
+    li x20, 0x79fb6dd3
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x19, 0x54f94a8c
+    li x17, 0x97068b1a
+    pv.sdotsp.sci.h x19, x17, 0x03
+    li x20, 0x54f6b0ec
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x19, 0x57cd79c2
+    li x17, 0x44db3c7b
+    pv.sdotsp.sci.h x19, x17, 0x0d
+    li x20, 0x57d40b20
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.sdotsp.b instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.b is of the form "pv.sdotsp.b rD, rs1, rs2"
+test91:
+    li x19, 0x3cbbce34
+    li x17, 0x02fb75bc
+    li x18, 0xd152ff76
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0x3cbbac6f
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x19, 0x3ea348d8
+    li x17, 0xb7336a6c
+    li x18, 0xf24fbc1a
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0x3ea34b63
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x19, 0x7c6b5bad
+    li x17, 0xaa3d6c3f
+    li x18, 0x578240e4
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0x7c6b3489
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x19, 0xd75f4bf1
+    li x17, 0xbebd393e
+    li x18, 0x3720913c
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0xd75f2b34
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x19, 0x9ca2df54
+    li x17, 0x8a6bc6b7
+    li x18, 0x0e996134
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0x9ca28905
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x19, 0x1f437786
+    li x17, 0x35eec174
+    li x18, 0x5049b31c
+    pv.sdotsp.b x19, x17, x18
+    li x20, 0x1f43a297
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.sdotsp.sc.b instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.sc.b is of the form "pv.sdotsp.sc.b rD, rs1, rs2"
+test97:
+    li x19, 0x36e5da3f
+    li x17, 0x1db6da34
+    li x18, 0x1b3a7736
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0x36e5d3b5
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x19, 0x1850a15f
+    li x17, 0x02c6d241
+    li x18, 0x0af8642e
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0x18509ab9
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x19, 0x5515b670
+    li x17, 0x5da3634e
+    li x18, 0x072c9c19
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0x5515c7b9
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x19, 0xcbe7832a
+    li x17, 0x3c0d1c41
+    li x18, 0x5cf64a54
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0xcbe7b9a2
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x19, 0x84eaf32e
+    li x17, 0x9b8c5402
+    li x18, 0x1b5c9218
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0x84eae6e6
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x19, 0x8dea1b9a
+    li x17, 0x60aeb8a3
+    li x18, 0x58050242
+    pv.sdotsp.sc.b x19, x17, x18
+    li x20, 0x8de9f4ac
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.sdotsp.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sdotsp.sci.b is of the form "pv.sdotsp.sci.b rD, rs1, Imm6"
+test103:
+    li x19, 0x1e5fdb51
+    li x17, 0x46e895d9
+    pv.sdotsp.sci.b x19, x17, 0x05
+    li x20, 0x1e5fd95d
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x19, 0x98debfb8
+    li x17, 0x28846a49
+    pv.sdotsp.sci.b x19, x17, 0x01
+    li x20, 0x98dec017
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x19, 0x59d396ef
+    li x17, 0x8f4ffd41
+    pv.sdotsp.sci.b x19, x17, 0x12
+    li x20, 0x59d398e7
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x19, 0x38574f45
+    li x17, 0x547d9f3a
+    pv.sdotsp.sci.b x19, x17, 0x18
+    li x20, 0x38575f35
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x19, 0xca3bb03a
+    li x17, 0xa83cc2f9
+    pv.sdotsp.sci.b x19, x17, 0x04
+    li x20, 0xca3baeb6
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x19, 0x2185911a
+    li x17, 0xc97c4baf
+    pv.sdotsp.sci.b x19, x17, 0x10
+    li x20, 0x2185950a
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_max.S
+++ b/cv32/tests/core/custom/pulp_vectorial_max.S
@@ -1,0 +1,604 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.max.h instruction. values loaded in and compared to are expected output values
+#pv.max.h is of the form "pv.max.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[31:16]) ? rs1[31:16] : rs2[31:16]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is signed
+test1:
+    li x17, 0xa5bdf218
+    li x18, 0x9b1f75fd
+    pv.max.h x19, x17, x18
+    li x20, 0xa5bd75fd
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x485e8614
+    li x18, 0x20e7e312
+    pv.max.h x19, x17, x18
+    li x20, 0x485ee312
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x8c5b6b5c
+    li x18, 0x1cef5501
+    pv.max.h x19, x17, x18
+    li x20, 0x1cef6b5c
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x5111dc0e
+    li x18, 0xf9be2fc4
+    pv.max.h x19, x17, x18
+    li x20, 0x51112fc4
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x0665f815
+    li x18, 0xf3af5859
+    pv.max.h x19, x17, x18
+    li x20, 0x06655859
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x008be78e
+    li x18, 0x2461aa6b
+    pv.max.h x19, x17, x18
+    li x20, 0x2461e78e
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.max.sc.h instruction. values loaded in and compared to are expected output values
+#pv.max.sc.h is of the form "pv.max.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[15:0]) ? rs1[31:16] : rs2[15:0]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is signed
+test7:
+    li x17, 0x0e61cdd1
+    li x18, 0xca577cbe
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x7cbe7cbe
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x05c70c67
+    li x18, 0x5bae2205
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x22052205
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0xa4bb5388
+    li x18, 0x451a3a51
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x3a515388
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x6a80a0bf
+    li x18, 0x6fb32d2c
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x6a802d2c
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x06af9f11
+    li x18, 0xd6b2d71e
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x06afd71e
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x23976964
+    li x18, 0xa6e6c709
+    pv.max.sc.h x19, x17, x18
+    li x20, 0x23976964
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.max.sci.h instruction. values loaded in and compared to are expected output values
+#pv.max.sci.h is of the form "pv.max.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16] < Imm6) ? rs1[31:16] : Imm6
+#rD[15:0] = (rs1[15:0] < Imm6) ? rs1[15:0] : Imm6
+#Note: this operation is signed
+test13:
+    li x17, 0x68f98d40
+    pv.max.sci.h x19, x17, -31
+    li x20, 0x68f9ffe1
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x632ccde0
+    pv.max.sci.h x19, x17, 4
+    li x20, 0x632c0004
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xe388c3c2
+    pv.max.sci.h x19, x17, 12
+    li x20, 0x000c000c
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x5e5e4cc1
+    pv.max.sci.h x19, x17, -8
+    li x20, 0x5e5e4cc1
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x1a9e4b0b
+    pv.max.sci.h x19, x17, 25
+    li x20, 0x1a9e4b0b
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0xeb583e8e
+    pv.max.sci.h x19, x17, -20
+    li x20, 0xffec3e8e
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.max.b instruction. values loaded in and compared to are expected output values
+#pv.max.b is of the form "pv.max.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[31:24]) ? rs1[31:24] : rs2[31:24],
+#rD[23:16] = (rs1[23:16] < rs2[23:16]) ? rs1[23:16] : rs2[23:16], rD[15:8] = (rs1[15:8] < rs2[15:8]) ? rs1[15:8] : rs2[15:8]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is signed
+test19:
+    li x17, 0x57d5ba10
+    li x18, 0xb8fb99fe
+    pv.max.b x19, x17, x18
+    li x20, 0x57fbba10
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x53643b08
+    li x18, 0x45ddde21
+    pv.max.b x19, x17, x18
+    li x20, 0x53643b21
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0x74f545ab
+    li x18, 0x5c6001ef
+    pv.max.b x19, x17, x18
+    li x20, 0x746045ef
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x1d4130e4
+    li x18, 0x291c785d
+    pv.max.b x19, x17, x18
+    li x20, 0x2941785d
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xa1f3d698
+    li x18, 0x5ec7e5bf
+    pv.max.b x19, x17, x18
+    li x20, 0x5ef3e5bf
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0xffd13622
+    li x18, 0x6583ae84
+    pv.max.b x19, x17, x18
+    li x20, 0x65d13622
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.max.sc.b instruction. values loaded in and compared to are expected output values
+#pv.max.sc.b is of the form "pv.max.sc.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[7:0]) ? rs1[31:24] : rs2[7:0],
+#rD[23:16] = (rs1[23:16] < rs2[7:0]) ? rs1[23:16] : rs2[7:0], rD[15:8] = (rs1[15:8] < rs2[7:0]) ? rs1[15:8] : rs2[7:0]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is signed
+test25:
+    li x17, 0xe8e06d5e
+    li x18, 0xd2a78b47
+    pv.max.sc.b x19, x17, x18
+    li x20, 0x47476d5e
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x8b61d990
+    li x18, 0x1130c5c2
+    pv.max.sc.b x19, x17, x18
+    li x20, 0xc261d9c2
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0xb7e54cfd
+    li x18, 0x34db4908
+    pv.max.sc.b x19, x17, x18
+    li x20, 0x08084c08
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0xbeae9182
+    li x18, 0xc6b8a0e5
+    pv.max.sc.b x19, x17, x18
+    li x20, 0xe5e5e5e5
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x4ae0d93b
+    li x18, 0x07161363
+    pv.max.sc.b x19, x17, x18
+    li x20, 0x63636363
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x8d712b11
+    li x18, 0x4a119ae2
+    pv.max.sc.b x19, x17, x18
+    li x20, 0xe2712b11
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.max.sci.b instruction. values loaded in and compared to are expected output values
+#pv.max.sci.b is of the form "pv.max.sci.b rD, rs1, Imm6". rD[31:24] = (rs1[31:24] < Imm6) ? rs1[31:24] : Imm6,
+#rD[23:16] = (rs1[23:16] < Imm6) ? rs1[23:16] : Imm6, rD[15:8] = (rs1[15:8] < Imm6) ? rs1[15:8] : Imm6
+#rD[7:0] = (rs1[7:0] < Imm6) ? rs1[7:0] : Imm6
+#Note: this operation is signed
+test31:
+    li x17, 0x5d500f41
+    pv.max.sci.b x19, x17, 31
+    li x20, 0x5d501f41
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0x47cb1a44
+    pv.max.sci.b x19, x17, -28
+    li x20, 0x47e41a44
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0x4c1de3f0
+    pv.max.sci.b x19, x17, 7
+    li x20, 0x4c1d0707
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x23673031
+    pv.max.sci.b x19, x17, -15
+    li x20, 0x23673031
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x5e7210ca
+    pv.max.sci.b x19, x17, 3
+    li x20, 0x5e721003
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0xb96e9513
+    pv.max.sci.b x19, x17, -5
+    li x20, 0xfb6efb13
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.maxu.h instruction. values loaded in and compared to are expected output values
+#pv.maxu.h is of the form "pv.maxu.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[31:16]) ? rs1[31:16] : rs2[31:16]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is unsigned
+test37:
+    li x17, 0x137e84de
+    li x18, 0xf6570ec4
+    pv.maxu.h x19, x17, x18
+    li x20, 0xf65784de
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x2fd5e84d
+    li x18, 0x48b8a287
+    pv.maxu.h x19, x17, x18
+    li x20, 0x48b8e84d
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0xb797125b
+    li x18, 0x1da8fe26
+    pv.maxu.h x19, x17, x18
+    li x20, 0xb797fe26
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x04237026
+    li x18, 0x6a3c8d9b
+    pv.maxu.h x19, x17, x18
+    li x20, 0x6a3c8d9b
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0xd751f4c9
+    li x18, 0x954ca8c3
+    pv.maxu.h x19, x17, x18
+    li x20, 0xd751f4c9
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x7748fe61
+    li x18, 0x81d7be34
+    pv.maxu.h x19, x17, x18
+    li x20, 0x81d7fe61
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.maxu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.maxu.sc.h is of the form "pv.maxu.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[15:0]) ? rs1[31:16] : rs2[15:0]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is unsigned
+test43:
+    li x17, 0xc6475aaa
+    li x18, 0xf4e3e76c
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0xe76ce76c
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x494897ed
+    li x18, 0x55817edb
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0x7edb97ed
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xe41f4be2
+    li x18, 0x57c005fd
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0xe41f4be2
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xbc3a28b5
+    li x18, 0xd1d80561
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0xbc3a28b5
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xec7d6ec5
+    li x18, 0x1a85cbf1
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0xec7dcbf1
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0x2a76bb1a
+    li x18, 0xd2081774
+    pv.maxu.sc.h x19, x17, x18
+    li x20, 0x2a76bb1a
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.maxu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.maxu.sci.h is of the form "pv.maxu.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16] < Imm6) ? rs1[31:16] : Imm6
+#rD[15:0] = (rs1[15:0] < Imm6) ? rs1[15:0] : Imm6
+#Note: this operation is unsigned
+test49:
+    li x17, 0xa8df8a3f
+    pv.maxu.sci.h x19, x17, 7
+    li x20, 0xa8df8a3f
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0xa5a3805a
+    pv.maxu.sci.h x19, x17, 25
+    li x20, 0xa5a3805a
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x0408f5de
+    pv.maxu.sci.h x19, x17, 63
+    li x20, 0x0408f5de
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x487d0383
+    pv.maxu.sci.h x19, x17, 13
+    li x20, 0x487d0383
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x426e0022
+    pv.maxu.sci.h x19, x17, 48
+    li x20, 0x426e0030
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x6e958c26
+    pv.maxu.sci.h x19, x17, 37
+    li x20, 0x6e958c26
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.maxu.b instruction. values loaded in and compared to are expected output values
+#pv.maxu.b is of the form "pv.maxu.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[31:24]) ? rs1[31:24] : rs2[31:24],
+#rD[23:16] = (rs1[23:16] < rs2[23:16]) ? rs1[23:16] : rs2[23:16], rD[15:8] = (rs1[15:8] < rs2[15:8]) ? rs1[15:8] : rs2[15:8]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is unsigned
+test55:
+    li x17, 0x0a9c9e0f
+    li x18, 0xca1fa63f
+    pv.maxu.b x19, x17, x18
+    li x20, 0xca9ca63f
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xfa8225cc
+    li x18, 0xe6653139
+    pv.maxu.b x19, x17, x18
+    li x20, 0xfa8231cc
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x4905989c
+    li x18, 0x330a6231
+    pv.maxu.b x19, x17, x18
+    li x20, 0x490a989c
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0xefa420af
+    li x18, 0x216abca5
+    pv.maxu.b x19, x17, x18
+    li x20, 0xefa4bcaf
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x52446d60
+    li x18, 0x64e53210
+    pv.maxu.b x19, x17, x18
+    li x20, 0x64e56d60
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x6667f26c
+    li x18, 0xd225475c
+    pv.maxu.b x19, x17, x18
+    li x20, 0xd267f26c
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.maxu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.maxu.sc.b is of the form "pv.maxu.sc.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[7:0]) ? rs1[31:24] : rs2[7:0],
+#rD[23:16] = (rs1[23:16] < rs2[7:0]) ? rs1[23:16] : rs2[7:0], rD[15:8] = (rs1[15:8] < rs2[7:0]) ? rs1[15:8] : rs2[7:0]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is unsigned
+test61:
+    li x17, 0xa2ef7541
+    li x18, 0xefc3e173
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0xa2ef7573
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x01129349
+    li x18, 0x30fe7d05
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0x05129349
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x695f33e5
+    li x18, 0x94cf9a4d
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0x695f4de5
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0x1824569e
+    li x18, 0xa44a5129
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0x2929569e
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x13603783
+    li x18, 0xbaffa7b8
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0xb8b8b8b8
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x823f183d
+    li x18, 0xddabb51e
+    pv.maxu.sc.b x19, x17, x18
+    li x20, 0x823f1e3d
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.maxu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.maxu.sci.b is of the form "pv.maxu.sci.b rD, rs1, Imm6". rD[31:24] = (rs1[31:24] < Imm6) ? rs1[31:24] : Imm6,
+#rD[23:16] = (rs1[23:16] < Imm6) ? rs1[23:16] : Imm6, rD[15:8] = (rs1[15:8] < Imm6) ? rs1[15:8] : Imm6
+#rD[7:0] = (rs1[7:0] < Imm6) ? rs1[7:0] : Imm6
+#Note: this operation is unsigned
+test67:
+    li x17, 0xe127d500
+    pv.maxu.sci.b x19, x17, 8
+    li x20, 0xe127d508
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0xb2555556
+    pv.maxu.sci.b x19, x17, 25
+    li x20, 0xb2555556
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x50ef49de
+    pv.maxu.sci.b x19, x17, 37
+    li x20, 0x50ef49de
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x386221dd
+    pv.maxu.sci.b x19, x17, 54
+    li x20, 0x386236dd
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0x9c24b7e7
+    pv.maxu.sci.b x19, x17, 63
+    li x20, 0x9c3fb7e7
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x809e5f46
+    pv.maxu.sci.b x19, x17, 12
+    li x20, 0x809e5f46
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_min.S
+++ b/cv32/tests/core/custom/pulp_vectorial_min.S
@@ -1,0 +1,604 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.min.h instruction. values loaded in and compared to are expected output values
+#pv.min.h is of the form "pv.min.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[31:16]) ? rs1[31:16] : rs2[31:16]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is signed
+test1:
+    li x17, 0x50d528e5
+    li x18, 0xd2cf7173
+    pv.min.h x19, x17, x18
+    li x20, 0xd2cf28e5
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0xa3c77bc1
+    li x18, 0xb3d90cf0
+    pv.min.h x19, x17, x18
+    li x20, 0xa3c70cf0
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0xb86f7dae
+    li x18, 0x8c185ca0
+    pv.min.h x19, x17, x18
+    li x20, 0x8c185ca0
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x48ffc231
+    li x18, 0x1f1d5987
+    pv.min.h x19, x17, x18
+    li x20, 0x1f1dc231
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x8777da38
+    li x18, 0x3040219e
+    pv.min.h x19, x17, x18
+    li x20, 0x8777da38
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x0a0202d8
+    li x18, 0x5f83ca63
+    pv.min.h x19, x17, x18
+    li x20, 0x0a02ca63
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.min.sc.h instruction. values loaded in and compared to are expected output values
+#pv.min.sc.h is of the form "pv.min.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[15:0]) ? rs1[31:16] : rs2[15:0]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is signed
+test7:
+    li x17, 0xe4c71d90
+    li x18, 0x2c90fe3f
+    pv.min.sc.h x19, x17, x18
+    li x20, 0xe4c7fe3f
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0xd9f43272
+    li x18, 0x74cbad98
+    pv.min.sc.h x19, x17, x18
+    li x20, 0xad98ad98
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x2930b92c
+    li x18, 0xc4282e63
+    pv.min.sc.h x19, x17, x18
+    li x20, 0x2930b92c
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0x5b3b8e29
+    li x18, 0xff8d069e
+    pv.min.sc.h x19, x17, x18
+    li x20, 0x069e8e29
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0x0e946b49
+    li x18, 0x86b1c07d
+    pv.min.sc.h x19, x17, x18
+    li x20, 0xc07dc07d
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x4f75555c
+    li x18, 0xd5a1db0d
+    pv.min.sc.h x19, x17, x18
+    li x20, 0xdb0ddb0d
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.min.sci.h instruction. values loaded in and compared to are expected output values
+#pv.min.sci.h is of the form "pv.min.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16] < Imm6) ? rs1[31:16] : Imm6
+#rD[15:0] = (rs1[15:0] < Imm6) ? rs1[15:0] : Imm6
+#Note: this operation is signed
+test13:
+    li x17, 0xb6dcd8fd
+    pv.min.sci.h x19, x17, -10
+    li x20, 0xb6dcd8fd
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0xf5102b91
+    pv.min.sci.h x19, x17, 31
+    li x20, 0xf510001f
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x837c1963
+    pv.min.sci.h x19, x17, -1
+    li x20, 0x837cffff
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x311e6bac
+    pv.min.sci.h x19, x17, 6
+    li x20, 0x00060006
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x49c63a96
+    pv.min.sci.h x19, x17, 18
+    li x20, 0x00120012
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x4701d5c0
+    pv.min.sci.h x19, x17, -27
+    li x20, 0xffe5d5c0
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.min.b instruction. values loaded in and compared to are expected output values
+#pv.min.b is of the form "pv.min.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[31:24]) ? rs1[31:24] : rs2[31:24],
+#rD[23:16] = (rs1[23:16] < rs2[23:16]) ? rs1[23:16] : rs2[23:16], rD[15:8] = (rs1[15:8] < rs2[15:8]) ? rs1[15:8] : rs2[15:8]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is signed
+test19:
+    li x17, 0xab5477c6
+    li x18, 0x70948c7a
+    pv.min.b x19, x17, x18
+    li x20, 0xab948cc6
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x223b89be
+    li x18, 0xe26ed5c8
+    pv.min.b x19, x17, x18
+    li x20, 0xe23b89be
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xfc41fbe7
+    li x18, 0xeeff784e
+    pv.min.b x19, x17, x18
+    li x20, 0xeefffbe7
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xf0eb7ef6
+    li x18, 0x5308253a
+    pv.min.b x19, x17, x18
+    li x20, 0xf0eb25f6
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x0c1d7592
+    li x18, 0x4000d0f7
+    pv.min.b x19, x17, x18
+    li x20, 0x0c00d092
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x535ee5af
+    li x18, 0xe9c4024b
+    pv.min.b x19, x17, x18
+    li x20, 0xe9c4e5af
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.min.sc.b instruction. values loaded in and compared to are expected output values
+#pv.min.sc.b is of the form "pv.min.sc.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[7:0]) ? rs1[31:24] : rs2[7:0],
+#rD[23:16] = (rs1[23:16] < rs2[7:0]) ? rs1[23:16] : rs2[7:0], rD[15:8] = (rs1[15:8] < rs2[7:0]) ? rs1[15:8] : rs2[7:0]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is signed
+test25:
+    li x17, 0xb1ebd4aa
+    li x18, 0xdf539b90
+    pv.min.sc.b x19, x17, x18
+    li x20, 0x90909090
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x8ae451b4
+    li x18, 0x3392d130
+    pv.min.sc.b x19, x17, x18
+    li x20, 0x8ae430b4
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x95cc319d
+    li x18, 0x302de29a
+    pv.min.sc.b x19, x17, x18
+    li x20, 0x959a9a9a
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0xc7573c19
+    li x18, 0x750b8b12
+    pv.min.sc.b x19, x17, x18
+    li x20, 0xc7121212
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x79176d77
+    li x18, 0x4d898d50
+    pv.min.sc.b x19, x17, x18
+    li x20, 0x50175050
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x3be8009b
+    li x18, 0xf93d44d7
+    pv.min.sc.b x19, x17, x18
+    li x20, 0xd7d7d79b
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.min.sci.b instruction. values loaded in and compared to are expected output values
+#pv.min.sci.b is of the form "pv.min.sci.b rD, rs1, Imm6". rD[31:24] = (rs1[31:24] < Imm6) ? rs1[31:24] : Imm6,
+#rD[23:16] = (rs1[23:16] < Imm6) ? rs1[23:16] : Imm6, rD[15:8] = (rs1[15:8] < Imm6) ? rs1[15:8] : Imm6
+#rD[7:0] = (rs1[7:0] < Imm6) ? rs1[7:0] : Imm6
+#Note: this operation is signed
+test31:
+    li x17, 0x8aa0713b
+    pv.min.sci.b x19, x17, 5
+    li x20, 0x8aa00505
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xb85b2cb2
+    pv.min.sci.b x19, x17, 31
+    li x20, 0xb81f1fb2
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xbd4d4004
+    pv.min.sci.b x19, x17, -12
+    li x20, 0xbdf4f4f4
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0x0b057a9c
+    pv.min.sci.b x19, x17, -25
+    li x20, 0xe7e7e79c
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x4bec8e74
+    pv.min.sci.b x19, x17, 14
+    li x20, 0x0eec8e0e
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0x88ace027
+    pv.min.sci.b x19, x17, -2
+    li x20, 0x88ace0fe
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.minu.h instruction. values loaded in and compared to are expected output values
+#pv.minu.h is of the form "pv.minu.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[31:16]) ? rs1[31:16] : rs2[31:16]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is unsigned
+test37:
+    li x17, 0x5ab31690
+    li x18, 0xaa6f43e1
+    pv.minu.h x19, x17, x18
+    li x20, 0x5ab31690
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0xbb3bc8d0
+    li x18, 0xe864027d
+    pv.minu.h x19, x17, x18
+    li x20, 0xbb3b027d
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x3bd680c4
+    li x18, 0xdd981fdc
+    pv.minu.h x19, x17, x18
+    li x20, 0x3bd61fdc
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0xceaa0cfa
+    li x18, 0xa6363714
+    pv.minu.h x19, x17, x18
+    li x20, 0xa6360cfa
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x5270bdd6
+    li x18, 0xa7685441
+    pv.minu.h x19, x17, x18
+    li x20, 0x52705441
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0xd1477429
+    li x18, 0x3ed73daa
+    pv.minu.h x19, x17, x18
+    li x20, 0x3ed73daa
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.minu.sc.h instruction. values loaded in and compared to are expected output values
+#pv.minu.sc.h is of the form "pv.minu.sc.h rD, rs1, rs2". rD[31:16] = (rs1[31:16] < rs2[15:0]) ? rs1[31:16] : rs2[15:0]
+#rD[15:0] = (rs1[15:0] < rs2[15:0]) ? rs1[15:0] : rs2[15:0]
+#Note: this operation is unsigned
+test43:
+    li x17, 0xe4397d37
+    li x18, 0x443e0dec
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x0dec0dec
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0xfe046649
+    li x18, 0x501378e4
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x78e46649
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xedc3e359
+    li x18, 0x6bd34e43
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x4e434e43
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0x78a1e965
+    li x18, 0x2da36eb5
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x6eb56eb5
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xb47d65b9
+    li x18, 0x0299555f
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x555f555f
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0x094fd1af
+    li x18, 0xdb51eeff
+    pv.minu.sc.h x19, x17, x18
+    li x20, 0x094fd1af
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.minu.sci.h instruction. values loaded in and compared to are expected output values
+#pv.minu.sci.h is of the form "pv.minu.sci.h rD, rs1, Imm6". rD[31:16] = (rs1[31:16] < Imm6) ? rs1[31:16] : Imm6
+#rD[15:0] = (rs1[15:0] < Imm6) ? rs1[15:0] : Imm6
+#Note: this operation is unsigned
+test49:
+    li x17, 0x36275f43
+    pv.minu.sci.h x19, x17, 7
+    li x20, 0x00070007
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0x5078d9e5
+    pv.minu.sci.h x19, x17, 61
+    li x20, 0x003d003d
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0xc6af7dff
+    pv.minu.sci.h x19, x17, 46
+    li x20, 0x002e002e
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0x8be32eec
+    pv.minu.sci.h x19, x17, 19
+    li x20, 0x00130013
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x00280c67
+    pv.minu.sci.h x19, x17, 63
+    li x20, 0x0028003f
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0xbb81dd79
+    pv.minu.sci.h x19, x17, 31
+    li x20, 0x001f001f
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.minu.b instruction. values loaded in and compared to are expected output values
+#pv.minu.b is of the form "pv.minu.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[31:24]) ? rs1[31:24] : rs2[31:24],
+#rD[23:16] = (rs1[23:16] < rs2[23:16]) ? rs1[23:16] : rs2[23:16], rD[15:8] = (rs1[15:8] < rs2[15:8]) ? rs1[15:8] : rs2[15:8]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is unsigned
+test55:
+    li x17, 0xabcc4035
+    li x18, 0xff2bf8e2
+    pv.minu.b x19, x17, x18
+    li x20, 0xab2b4035
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xfacb134c
+    li x18, 0x6c57317d
+    pv.minu.b x19, x17, x18
+    li x20, 0x6c57134c
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0x8ca1e2c2
+    li x18, 0x14521a15
+    pv.minu.b x19, x17, x18
+    li x20, 0x14521a15
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x50a23469
+    li x18, 0xa3e1c74b
+    pv.minu.b x19, x17, x18
+    li x20, 0x50a2344b
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0xca8fe2cf
+    li x18, 0x2b0d54d7
+    pv.minu.b x19, x17, x18
+    li x20, 0x2b0d54cf
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0xb20af4dc
+    li x18, 0x0f883d09
+    pv.minu.b x19, x17, x18
+    li x20, 0x0f0a3d09
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.minu.sc.b instruction. values loaded in and compared to are expected output values
+#pv.minu.sc.b is of the form "pv.minu.sc.b rD, rs1, rs2". rD[31:24] = (rs1[31:24] < rs2[7:0]) ? rs1[31:24] : rs2[7:0],
+#rD[23:16] = (rs1[23:16] < rs2[7:0]) ? rs1[23:16] : rs2[7:0], rD[15:8] = (rs1[15:8] < rs2[7:0]) ? rs1[15:8] : rs2[7:0]
+#rD[7:0] = (rs1[7:0] < rs2[7:0]) ? rs1[7:0] : rs2[7:0]
+#Note: this operation is unsigned
+test61:
+    li x17, 0xe0c626a5
+    li x18, 0x0bfc86bc
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0xbcbc26a5
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x559d8487
+    li x18, 0x834e39c2
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0x559d8487
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x05c1fd2a
+    li x18, 0xb87766b9
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0x05b9b92a
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xced7df83
+    li x18, 0x7a2b0046
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0x46464646
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0xa7902b23
+    li x18, 0x0250f5bc
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0xa7902b23
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0xa997e80f
+    li x18, 0x6441727b
+    pv.minu.sc.b x19, x17, x18
+    li x20, 0x7b7b7b0f
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.minu.sci.b instruction. values loaded in and compared to are expected output values
+#pv.minu.sci.b is of the form "pv.minu.sci.b rD, rs1, Imm6". rD[31:24] = (rs1[31:24] < Imm6) ? rs1[31:24] : Imm6,
+#rD[23:16] = (rs1[23:16] < Imm6) ? rs1[23:16] : Imm6, rD[15:8] = (rs1[15:8] < Imm6) ? rs1[15:8] : Imm6
+#rD[7:0] = (rs1[7:0] < Imm6) ? rs1[7:0] : Imm6
+#Note: this operation is unsigned
+test67:
+    li x17, 0xdc285752
+    pv.minu.sci.b x19, x17, 45
+    li x20, 0x2d282d2d
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0xdf0278d8
+    pv.minu.sci.b x19, x17, 8
+    li x20, 0x08020808
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0x32b8fc31
+    pv.minu.sci.b x19, x17, 63
+    li x20, 0x323f3f31
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x35b3cb9e
+    pv.minu.sci.b x19, x17, 15
+    li x20, 0x0f0f0f0f
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0x2b81c895
+    pv.minu.sci.b x19, x17, 28
+    li x20, 0x1c1c1c1c
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0x2451b6da
+    pv.minu.sci.b x19, x17, 41
+    li x20, 0x24292929
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_shift.S
+++ b/cv32/tests/core/custom/pulp_vectorial_shift.S
@@ -1,0 +1,835 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.srl.h instruction. values loaded in and compared to are expected output values
+#pv.srl.h is of the form "pv.srl.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[31:16], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test1:
+    li x17, 0xe127d500
+    li x18, 0x000a0003
+    pv.srl.h x19, x17, x18
+    li x20, 0x00381aa0
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x50ef49de
+    li x18, 0x000e000b
+    pv.srl.h x19, x17, x18
+    li x20, 0x00010009
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x9c24b7e7
+    li x18, 0x0002000c
+    pv.srl.h x19, x17, x18
+    li x20, 0x2709000b
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x9f21bbd4
+    li x18, 0x0003000b
+    pv.srl.h x19, x17, x18
+    li x20, 0x13e40017
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x28e2b8f4
+    li x18, 0x000e0005
+    pv.srl.h x19, x17, x18
+    li x20, 0x000005c7
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x859f9138
+    li x18, 0x000f0001
+    pv.srl.h x19, x17, x18
+    li x20, 0x0001489c
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.srl.sc.h instruction. values loaded in and compared to are expected output values
+#pv.srl.sc.h is of the form "pv.srl.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >> rs2[15:0], rD[15:0] = rs1[15:0] >> rs2[15:0]
+test7:
+    li x17, 0xb2555556
+    li x18, 0x18040003
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x164a0aaa
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0x386221dd
+    li x18, 0x160e000c
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x00030002
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x809e5f46
+    li x18, 0xf20c0006
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x0202017d
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xaa5ca38a
+    li x18, 0xc684000f
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x00010001
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xd65e1061
+    li x18, 0xc981000b
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x001a0002
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x9a4bb8e6
+    li x18, 0x3e470001
+    pv.srl.sc.h x19, x17, x18
+    li x20, 0x4d255c73
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.srl.sci.h instruction. values loaded in and compared to are expected output values
+#pv.srl.sci.h is of the form "pv.srl.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] >> Imm6, rD[15:0] = rs1[15:0] >> Imm6
+test13:
+    li x17, 0xcec0bdb9
+    pv.srl.sci.h x19, x17, 0x5
+    li x20, 0x067605ed
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x3f62b493
+    pv.srl.sci.h x19, x17, 0x2
+    li x20, 0x0fd82d24
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0xd4b564d6
+    pv.srl.sci.h x19, x17, 0x8
+    li x20, 0x00d40064
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x4a83c696
+    pv.srl.sci.h x19, x17, 0x4
+    li x20, 0x04a80c69
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x9c823245
+    pv.srl.sci.h x19, x17, 0x5
+    li x20, 0x04e40192
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0x7315d811
+    pv.srl.sci.h x19, x17, 0x1
+    li x20, 0x398a6c08
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.srl.b instruction. values loaded in and compared to are expected output values
+#pv.srl.b is of the form "pv.srl.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[31:24],
+#rD[23:16] = rs1[23:16] >> rs2[23:16], rD[15:8] = rs1[15:8] >> rs2[15:8], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test19:
+    li x17, 0xcb831d7c
+    li x18, 0x01060104
+    pv.srl.b x19, x17, x18
+    li x20, 0x65020e07
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x4a7ff967
+    li x18, 0x02060507
+    pv.srl.b x19, x17, x18
+    li x20, 0x12010700
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xaab480fe
+    li x18, 0x05050703
+    pv.srl.b x19, x17, x18
+    li x20, 0x0505011f
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0x64f68a08
+    li x18, 0x01000507
+    pv.srl.b x19, x17, x18
+    li x20, 0x32f60400
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0xa71763f2
+    li x18, 0x02050301
+    pv.srl.b x19, x17, x18
+    li x20, 0x29000c79
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0xce4ce609
+    li x18, 0x00040001
+    pv.srl.b x19, x17, x18
+    li x20, 0xce04e604
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.srl.sc.b instruction. values loaded in and compared to are expected output values
+#pv.srl.sc.b is of the form "pv.srl.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[7:0],
+#rD[23:16] = rs1[23:16] >> rs2[7:0], rD[15:8] = rs1[15:8] >> rs2[7:0], rD[7:0] = rs1[7:0] >> rs2[7:0]
+test25:
+    li x17, 0x0e62b9ac
+    li x18, 0x42d80203
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x010c1715
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0x1e8be092
+    li x18, 0xbe676f07
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x00010101
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0xf0e9ab5a
+    li x18, 0x881ac505
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x07070502
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x3704ae00
+    li x18, 0xad4d9f01
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x1b025700
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x111237e9
+    li x18, 0xe5232d06
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x00000003
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x85bd0af6
+    li x18, 0x730b0506
+    pv.srl.sc.b x19, x17, x18
+    li x20, 0x02020003
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.srl.sci.b instruction. values loaded in and compared to are expected output values
+#pv.srl.sci.b is of the form "pv.srl.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >> Imm6,
+#rD[23:16] = rs1[23:16] >> Imm6, rD[15:8] = rs1[15:8] >> Imm6, rD[7:0] = rs1[7:0] >> Imm6
+test31:
+    li x17, 0x829e30a9
+    pv.srl.sci.b x19, x17, 0x1
+    li x20, 0x414f1854
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0x92338f86
+    pv.srl.sci.b x19, x17, 0x5
+    li x20, 0x04010404
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xc03229a6
+    pv.srl.sci.b x19, x17, 0x6
+    li x20, 0x03000002
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0xf87ef97a
+    pv.srl.sci.b x19, x17, 0x4
+    li x20, 0x0f070f07
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x6873a284
+    pv.srl.sci.b x19, x17, 0x7
+    li x20, 0x00000101
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0xbe151d06
+    pv.srl.sci.b x19, x17, 0x2
+    li x20, 0x2f050701
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.sra.h instruction. values loaded in and compared to are expected output values
+#pv.sra.h is of the form "pv.sra.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >>> rs2[31:16], rD[15:0] = rs1[15:0] >>> rs2[15:0]
+test37:
+    li x17, 0x6cc801e8
+    li x18, 0x000f0005
+    pv.sra.h x19, x17, x18
+    li x20, 0x0000000f
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0xf984409a
+    li x18, 0x00050004
+    pv.sra.h x19, x17, x18
+    li x20, 0xffcc0409
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x8b7b2815
+    li x18, 0x00060003
+    pv.sra.h x19, x17, x18
+    li x20, 0xfe2d0502
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x6a2c3d33
+    li x18, 0x000b000c
+    pv.sra.h x19, x17, x18
+    li x20, 0x000d0003
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x3e5e4ccd
+    li x18, 0x00090001
+    pv.sra.h x19, x17, x18
+    li x20, 0x001f2666
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x79a7027f
+    li x18, 0x0007000d
+    pv.sra.h x19, x17, x18
+    li x20, 0x00f30000
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.sra.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sra.sc.h is of the form "pv.sra.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] >>> rs2[15:0], rD[15:0] = rs1[15:0] >>> rs2[15:0]
+test43:
+    li x17, 0x8d34283b
+    li x18, 0x6796000c
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0xfff80002
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x17, 0x112fe766
+    li x18, 0x8b27000d
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0x0000ffff
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x17, 0xe0887dc1
+    li x18, 0x347c000b
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0xfffc000f
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x17, 0xb3b07b10
+    li x18, 0x347c0006
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0xfece01ec
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x17, 0xe7f042b4
+    li x18, 0x592b0007
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0xffcf0085
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x17, 0xc234a4b1
+    li x18, 0xe80f0004
+    pv.sra.sc.h x19, x17, x18
+    li x20, 0xfc23fa4b
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.sra.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sra.sci.h is of the form "pv.sra.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] >>> Imm6, rD[15:0] = rs1[15:0] >>> Imm6
+test49:
+    li x17, 0x4af9a865
+    pv.sra.sci.h x19, x17, 0x0
+    li x20, 0x4af9a865
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x17, 0xe9370e0e
+    pv.sra.sci.h x19, x17, 0xe
+    li x20, 0xffff0000
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x17, 0x586aeefb
+    pv.sra.sci.h x19, x17, 0x4
+    li x20, 0x0586feef
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x17, 0xa5aa7ed3
+    pv.sra.sci.h x19, x17, 0xa
+    li x20, 0xffe9001f
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x17, 0x39423068
+    pv.sra.sci.h x19, x17, 0x3
+    li x20, 0x0728060d
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x17, 0x1c371395
+    pv.sra.sci.h x19, x17, 0x9
+    li x20, 0x000e0009
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.sra.b instruction. values loaded in and compared to are expected output values
+#pv.sra.b is of the form "pv.sra.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >>> rs2[31:24],
+#rD[23:16] = rs1[23:16] >>> rs2[23:16], rD[15:8] = rs1[15:8] >>> rs2[15:8], rD[7:0] = rs1[7:0] >>> rs2[7:0]
+test55:
+    li x17, 0x8cbe613d
+    li x18, 0x00040706
+    pv.sra.b x19, x17, x18
+    li x20, 0x8cfb0000
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xae2831ce
+    li x18, 0x02000104
+    pv.sra.b x19, x17, x18
+    li x20, 0xeb2818fc
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0xa49d1848
+    li x18, 0x02070305
+    pv.sra.b x19, x17, x18
+    li x20, 0xe9ff0302
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0xf738b790
+    li x18, 0x03000407
+    pv.sra.b x19, x17, x18
+    li x20, 0xfe38fbff
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0x5e99bd85
+    li x18, 0x02060405
+    pv.sra.b x19, x17, x18
+    li x20, 0x17fefbfc
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0xcdbca023
+    li x18, 0x02060504
+    pv.sra.b x19, x17, x18
+    li x20, 0xf3fefd02
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.sra.sc.b instruction. values loaded in and compared to are expected output values
+#pv.sra.sc.b is of the form "pv.sra.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] >>> rs2[7:0],
+#rD[23:16] = rs1[23:16] >>> rs2[7:0], rD[15:8] = rs1[15:8] >>> rs2[7:0], rD[7:0] = rs1[7:0] >>> rs2[7:0]
+test61:
+    li x17, 0xad972df0
+    li x18, 0x05040006
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0xfefe00ff
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0xfd535dbe
+    li x18, 0x06030401
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0xfe292edf
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x81e96979
+    li x18, 0x06030704
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0xf8fe0607
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xa54e5e43
+    li x18, 0x03040502
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0xe9131710
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0xcbf79c3b
+    li x18, 0x04030106
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0xfffffe00
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x4e96f377
+    li x18, 0x02070006
+    pv.sra.sc.b x19, x17, x18
+    li x20, 0x01feff01
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.sra.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sra.sci.b is of the form "pv.sra.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >>> Imm6,
+#rD[23:16] = rs1[23:16] >>> Imm6, rD[15:8] = rs1[15:8] >>> Imm6, rD[7:0] = rs1[7:0] >>> Imm6
+test67:
+    li x17, 0x42ba88d1
+    pv.sra.sci.b x19, x17, 0x3
+    li x20, 0x08f7f1fa
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x17, 0x3f70269e
+    pv.sra.sci.b x19, x17, 0x2
+    li x20, 0x0f1c09e7
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x17, 0xdd2e40ac
+    pv.sra.sci.b x19, x17, 0x4
+    li x20, 0xfd0204fa
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x17, 0x68a0e6c0
+    pv.sra.sci.b x19, x17, 0x7
+    li x20, 0x00ffffff
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x17, 0x5b1cb2b7
+    pv.sra.sci.b x19, x17, 0x0
+    li x20, 0x5b1cb2b7
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x17, 0xaf4da78a
+    pv.sra.sci.b x19, x17, 0x6
+    li x20, 0xfe01fefe
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.sll.h instruction. values loaded in and compared to are expected output values
+#pv.sll.h is of the form "pv.sll.h rD, rs1, rs2". rD[31:16] = rs1[31:16] << rs2[31:16], rD[15:0] = rs1[15:0] << rs2[15:0]
+test73:
+    li x17, 0x10a74307
+    li x18, 0x00010008
+    pv.sll.h x19, x17, x18
+    li x20, 0x214e0700
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x17, 0xbba83884
+    li x18, 0x000d0005
+    pv.sll.h x19, x17, x18
+    li x20, 0x00001080
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x17, 0x6e812011
+    li x18, 0x000f000b
+    pv.sll.h x19, x17, x18
+    li x20, 0x80008800
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x17, 0xbdf5de4a
+    li x18, 0x00050001
+    pv.sll.h x19, x17, x18
+    li x20, 0xbea0bc94
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x17, 0xc8c71be7
+    li x18, 0x000c000c
+    pv.sll.h x19, x17, x18
+    li x20, 0x70007000
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x17, 0x0ef5fbe8
+    li x18, 0x00010000
+    pv.sll.h x19, x17, x18
+    li x20, 0x1deafbe8
+    beq x20, x19, test79
+    c.addi x15, 0x1
+#tests79-84 test the pv.sll.sc.h instruction. values loaded in and compared to are expected output values
+#pv.sll.sc.h is of the form "pv.sll.sc.h rD, rs1, rs2". rD[31:16] = rs1[31:16] << rs2[15:0], rD[15:0] = rs1[15:0] << rs2[15:0]
+test79:
+    li x17, 0xea4b73f2
+    li x18, 0xfc000003
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0x52589f90
+    beq x20, x19, test80
+    c.addi x15, 0x1
+test80:
+    li x17, 0x50bae067
+    li x18, 0x56d70009
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0x7400ce00
+    beq x20, x19, test81
+    c.addi x15, 0x1
+test81:
+    li x17, 0x3a1f90a1
+    li x18, 0x2671000b
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0xf8000800
+    beq x20, x19, test82
+    c.addi x15, 0x1
+test82:
+    li x17, 0xb5580729
+    li x18, 0x3c9f000c
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0x80009000
+    beq x20, x19, test83
+    c.addi x15, 0x1
+test83:
+    li x17, 0xdf1cae90
+    li x18, 0x468c0006
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0xc700a400
+    beq x20, x19, test84
+    c.addi x15, 0x1
+test84:
+    li x17, 0x12550e34
+    li x18, 0x57900008
+    pv.sll.sc.h x19, x17, x18
+    li x20, 0x55003400
+    beq x20, x19, test85
+    c.addi x15, 0x1
+#tests85-90 test the pv.sll.sci.h instruction. values loaded in and compared to are expected output values
+#pv.sll.sci.h is of the form "pv.sll.sci.h rD, rs1, Imm6". rD[31:16] = rs1[31:16] << Imm6, rD[15:0] = rs1[15:0] << Imm6
+test85:
+    li x17, 0xf896c991
+    pv.sll.sci.h x19, x17, 0x7
+    li x20, 0x4b00c880
+    beq x20, x19, test86
+    c.addi x15, 0x1
+test86:
+    li x17, 0xfac5bd85
+    pv.sll.sci.h x19, x17, 0x9
+    li x20, 0x8a000a00
+    beq x20, x19, test87
+    c.addi x15, 0x1
+test87:
+    li x17, 0x61812809
+    pv.sll.sci.h x19, x17, 0x0
+    li x20, 0x61812809
+    beq x20, x19, test88
+    c.addi x15, 0x1
+test88:
+    li x17, 0xab1f59ab
+    pv.sll.sci.h x19, x17, 0xb
+    li x20, 0xf8005800
+    beq x20, x19, test89
+    c.addi x15, 0x1
+test89:
+    li x17, 0xf3b53fd6
+    pv.sll.sci.h x19, x17, 0x4
+    li x20, 0x3b50fd60
+    beq x20, x19, test90
+    c.addi x15, 0x1
+test90:
+    li x17, 0x2bb960ef
+    pv.sll.sci.h x19, x17, 0xc
+    li x20, 0x9000f000
+    beq x20, x19, test91
+    c.addi x15, 0x1
+#tests91-96 test the pv.sll.b instruction. values loaded in and compared to are expected output values
+#pv.sll.b is of the form "pv.sll.b rD, rs1, rs2". rD[31:24] = rs1[31:24] << rs2[31:24],
+#rD[23:16] = rs1[23:16] << rs2[23:16], rD[15:8] = rs1[15:8] << rs2[15:8], rD[7:0] = rs1[7:0] << rs2[7:0]
+test91:
+    li x17, 0x6d288d59
+    li x18, 0x02030501
+    pv.sll.b x19, x17, x18
+    li x20, 0xb440a0b2
+    beq x20, x19, test92
+    c.addi x15, 0x1
+test92:
+    li x17, 0x33714b3c
+    li x18, 0x06000303
+    pv.sll.b x19, x17, x18
+    li x20, 0xc07158e0
+    beq x20, x19, test93
+    c.addi x15, 0x1
+test93:
+    li x17, 0xd555d6d6
+    li x18, 0x07060400
+    pv.sll.b x19, x17, x18
+    li x20, 0x804060d6
+    beq x20, x19, test94
+    c.addi x15, 0x1
+test94:
+    li x17, 0x486a2333
+    li x18, 0x03040205
+    pv.sll.b x19, x17, x18
+    li x20, 0x40a08c60
+    beq x20, x19, test95
+    c.addi x15, 0x1
+test95:
+    li x17, 0x32a8546f
+    li x18, 0x04060302
+    pv.sll.b x19, x17, x18
+    li x20, 0x2000a0bc
+    beq x20, x19, test96
+    c.addi x15, 0x1
+test96:
+    li x17, 0x4884d67f
+    li x18, 0x07010105
+    pv.sll.b x19, x17, x18
+    li x20, 0x0008ace0
+    beq x20, x19, test97
+    c.addi x15, 0x1
+#tests97-102 test the pv.sll.sc.b instruction. values loaded in and compared to are expected output values
+#pv.sll.sc.b is of the form "pv.sll.sc.b rD, rs1, rs2". rD[31:24] = rs1[31:24] << rs2[7:0],
+#rD[23:16] = rs1[23:16] << rs2[7:0], rD[15:8] = rs1[15:8] << rs2[7:0], rD[7:0] = rs1[7:0] << rs2[7:0]
+test97:
+    li x17, 0x00f117bc
+    li x18, 0xad83d903
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0x0088b8e0
+    beq x20, x19, test98
+    c.addi x15, 0x1
+test98:
+    li x17, 0xa10f69e0
+    li x18, 0x2451e707
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0x80808000
+    beq x20, x19, test99
+    c.addi x15, 0x1
+test99:
+    li x17, 0xfda54148
+    li x18, 0xa82a0f06
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0x40404000
+    beq x20, x19, test100
+    c.addi x15, 0x1
+test100:
+    li x17, 0xfa148144
+    li x18, 0x67205504
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0xa0401040
+    beq x20, x19, test101
+    c.addi x15, 0x1
+test101:
+    li x17, 0x0423ea84
+    li x18, 0x73156305
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0x80604080
+    beq x20, x19, test102
+    c.addi x15, 0x1
+test102:
+    li x17, 0x509b57b0
+    li x18, 0x4de56401
+    pv.sll.sc.b x19, x17, x18
+    li x20, 0xa036ae60
+    beq x20, x19, test103
+    c.addi x15, 0x1
+#tests103-108 test the pv.sll.sci.b instruction. values loaded in and compared to are expected output values
+#pv.sll.sci.b is of the form "pv.sll.sci.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] << Imm6,
+#rD[23:16] = rs1[23:16] << Imm6, rD[15:8] = rs1[15:8] << Imm6, rD[7:0] = rs1[7:0] << Imm6
+test103:
+    li x17, 0x99de05f3
+    pv.sll.sci.b x19, x17, 0x7
+    li x20, 0x80008080
+    beq x20, x19, test104
+    c.addi x15, 0x1
+test104:
+    li x17, 0xac20afb7
+    pv.sll.sci.b x19, x17, 0x5
+    li x20, 0x8000e0e0
+    beq x20, x19, test105
+    c.addi x15, 0x1
+test105:
+    li x17, 0x252a0327
+    pv.sll.sci.b x19, x17, 0x4
+    li x20, 0x50a03070
+    beq x20, x19, test106
+    c.addi x15, 0x1
+test106:
+    li x17, 0x4dddd53d
+    pv.sll.sci.b x19, x17, 0x0
+    li x20, 0x4dddd53d
+    beq x20, x19, test107
+    c.addi x15, 0x1
+test107:
+    li x17, 0xca054618
+    pv.sll.sci.b x19, x17, 0x1
+    li x20, 0x940a8c30
+    beq x20, x19, test108
+    c.addi x15, 0x1
+test108:
+    li x17, 0x3088abde
+    pv.sll.sci.b x19, x17, 0x3
+    li x20, 0x804058f0
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32/tests/core/custom/pulp_vectorial_shuffle_pack.S
+++ b/cv32/tests/core/custom/pulp_vectorial_shuffle_pack.S
@@ -1,0 +1,636 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests some vectorial/SIMD instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+    li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+#tests1-6 test the pv.shuffle.h instruction. values loaded in and compared to are expected output values
+#pv.shuffle.h is of the form "pv.shuffle.h rD, rs1, rs2".
+test1:
+    li x17, 0xeb3d8bec
+    li x18, 0xdd2cd85f
+    pv.shuffle.h x19, x17, x18
+    li x20, 0x8beceb3d
+    beq x20, x19, test2
+    c.addi x15, 0x1
+test2:
+    li x17, 0x98c7e168
+    li x18, 0xad2df825
+    pv.shuffle.h x19, x17, x18
+    li x20, 0x98c798c7
+    beq x20, x19, test3
+    c.addi x15, 0x1
+test3:
+    li x17, 0x8c1ad07e
+    li x18, 0xbf62d942
+    pv.shuffle.h x19, x17, x18
+    li x20, 0xd07ed07e
+    beq x20, x19, test4
+    c.addi x15, 0x1
+test4:
+    li x17, 0x2f661389
+    li x18, 0xdd07991d
+    pv.shuffle.h x19, x17, x18
+    li x20, 0x2f662f66
+    beq x20, x19, test5
+    c.addi x15, 0x1
+test5:
+    li x17, 0x1934aee5
+    li x18, 0x82ef3f3a
+    pv.shuffle.h x19, x17, x18
+    li x20, 0x1934aee5
+    beq x20, x19, test6
+    c.addi x15, 0x1
+test6:
+    li x17, 0x54580572
+    li x18, 0x3c6e07f4
+    pv.shuffle.h x19, x17, x18
+    li x20, 0x05720572
+    beq x20, x19, test7
+    c.addi x15, 0x1
+#tests7-12 test the pv.shuffle.sci.h instruction. values loaded in and compared to are expected output values
+#pv.shuffle.sci.h is of the form "pv.shuffle.sci.h rD, rs1, Imm6".
+test7:
+    li x17, 0x65611a7f
+    pv.shuffle.sci.h x19, x17, 0xb
+    li x20, 0x65616561
+    beq x20, x19, test8
+    c.addi x15, 0x1
+test8:
+    li x17, 0xb03ec1e9
+    pv.shuffle.sci.h x19, x17, 0x5
+    li x20, 0xc1e9b03e
+    beq x20, x19, test9
+    c.addi x15, 0x1
+test9:
+    li x17, 0x656b1acf
+    pv.shuffle.sci.h x19, x17, 0x7
+    li x20, 0x656b656b
+    beq x20, x19, test10
+    c.addi x15, 0x1
+test10:
+    li x17, 0xc8440911
+    pv.shuffle.sci.h x19, x17, 0xc
+    li x20, 0x09110911
+    beq x20, x19, test11
+    c.addi x15, 0x1
+test11:
+    li x17, 0xaf077cef
+    pv.shuffle.sci.h x19, x17, 0xe
+    li x20, 0xaf077cef
+    beq x20, x19, test12
+    c.addi x15, 0x1
+test12:
+    li x17, 0x374e3a34
+    pv.shuffle.sci.h x19, x17, 0x1
+    li x20, 0x3a34374e
+    beq x20, x19, test13
+    c.addi x15, 0x1
+#tests13-18 test the pv.shuffle.b instruction. values loaded in and compared to are expected output values
+#pv.shuffle.b is of the form "pv.shuffle.b rD, rs1, rs2".
+test13:
+    li x17, 0x442e57db
+    li x18, 0x847478f0
+    pv.shuffle.b x19, x17, x18
+    li x20, 0xdbdbdbdb
+    beq x20, x19, test14
+    c.addi x15, 0x1
+test14:
+    li x17, 0x6d0febb3
+    li x18, 0x5c9476e3
+    pv.shuffle.b x19, x17, x18
+    li x20, 0xb3b30f6d
+    beq x20, x19, test15
+    c.addi x15, 0x1
+test15:
+    li x17, 0x2afa56b0
+    li x18, 0x9e5657fd
+    pv.shuffle.b x19, x17, x18
+    li x20, 0xfafa2a56
+    beq x20, x19, test16
+    c.addi x15, 0x1
+test16:
+    li x17, 0x0cf589bc
+    li x18, 0xbe2bc2b8
+    pv.shuffle.b x19, x17, x18
+    li x20, 0xf50cf5bc
+    beq x20, x19, test17
+    c.addi x15, 0x1
+test17:
+    li x17, 0x36347756
+    li x18, 0x4e66d17a
+    pv.shuffle.b x19, x17, x18
+    li x20, 0x34347734
+    beq x20, x19, test18
+    c.addi x15, 0x1
+test18:
+    li x17, 0xe3a6da52
+    li x18, 0x135c2125
+    pv.shuffle.b x19, x17, x18
+    li x20, 0xe352dada
+    beq x20, x19, test19
+    c.addi x15, 0x1
+#tests19-24 test the pv.shuffleI0.sci.b instruction. values loaded in and compared to are expected output values
+#pv.shuffleI0.sci.b is of the form "pv.shuffleI0.sci.b rD, rs1, Imm6".
+test19:
+    li x17, 0x46caee88
+    pv.shuffleI0.sci.b x19, x17, 50
+    li x20, 0x884688ca
+    beq x20, x19, test20
+    c.addi x15, 0x1
+test20:
+    li x17, 0x958f6050
+    pv.shuffleI0.sci.b x19, x17, 12
+    li x20, 0x50509550
+    beq x20, x19, test21
+    c.addi x15, 0x1
+test21:
+    li x17, 0xf03ee7d0
+    pv.shuffleI0.sci.b x19, x17, 2
+    li x20, 0xd0d0d03e
+    beq x20, x19, test22
+    c.addi x15, 0x1
+test22:
+    li x17, 0xaeaa31e2
+    pv.shuffleI0.sci.b x19, x17, 46
+    li x20, 0xe2aaaeaa
+    beq x20, x19, test23
+    c.addi x15, 0x1
+test23:
+    li x17, 0x8271df42
+    pv.shuffleI0.sci.b x19, x17, 34
+    li x20, 0x42714271
+    beq x20, x19, test24
+    c.addi x15, 0x1
+test24:
+    li x17, 0x8f7084d6
+    pv.shuffleI0.sci.b x19, x17, 22
+    li x20, 0xd6848470
+    beq x20, x19, test25
+    c.addi x15, 0x1
+#tests25-30 test the pv.shuffleI1.sci.b instruction. values loaded in and compared to are expected output values
+#pv.shuffleI1.sci.b is of the form "pv.shuffleI1.sci.b rD, rs1, Imm6".
+test25:
+    li x17, 0x817e3e19
+    pv.shuffleI1.sci.b x19, x17, 16
+    li x20, 0x3e3e1919
+    beq x20, x19, test26
+    c.addi x15, 0x1
+test26:
+    li x17, 0xb5a8378f
+    pv.shuffleI1.sci.b x19, x17, 46
+    li x20, 0x37a8b5a8
+    beq x20, x19, test27
+    c.addi x15, 0x1
+test27:
+    li x17, 0x039d72d9
+    pv.shuffleI1.sci.b x19, x17, 28
+    li x20, 0x727203d9
+    beq x20, x19, test28
+    c.addi x15, 0x1
+test28:
+    li x17, 0x120c3083
+    pv.shuffleI1.sci.b x19, x17, 3
+    li x20, 0x30838312
+    beq x20, x19, test29
+    c.addi x15, 0x1
+test29:
+    li x17, 0x734e8f95
+    pv.shuffleI1.sci.b x19, x17, 13
+    li x20, 0x8f95738f
+    beq x20, x19, test30
+    c.addi x15, 0x1
+test30:
+    li x17, 0x63782b7f
+    pv.shuffleI1.sci.b x19, x17, 31
+    li x20, 0x2b2b6363
+    beq x20, x19, test31
+    c.addi x15, 0x1
+#tests31-36 test the pv.shuffleI2.sci.b instruction. values loaded in and compared to are expected output values
+#pv.shuffleI2.sci.b is of the form "pv.shuffleI2.sci.b rD, rs1, Imm6".
+test31:
+    li x17, 0xac800f82
+    pv.shuffleI2.sci.b x19, x17, 41
+    li x20, 0x8080800f
+    beq x20, x19, test32
+    c.addi x15, 0x1
+test32:
+    li x17, 0xe5f83eef
+    pv.shuffleI2.sci.b x19, x17, 18
+    li x20, 0xf83eeff8
+    beq x20, x19, test33
+    c.addi x15, 0x1
+test33:
+    li x17, 0xcf04e07a
+    pv.shuffleI2.sci.b x19, x17, 32
+    li x20, 0x04047a7a
+    beq x20, x19, test34
+    c.addi x15, 0x1
+test34:
+    li x17, 0xde8e49ec
+    pv.shuffleI2.sci.b x19, x17, 5
+    li x20, 0x8eec4949
+    beq x20, x19, test35
+    c.addi x15, 0x1
+test35:
+    li x17, 0x01a6fcfb
+    pv.shuffleI2.sci.b x19, x17, 37
+    li x20, 0xa6a6fcfc
+    beq x20, x19, test36
+    c.addi x15, 0x1
+test36:
+    li x17, 0xa8092856
+    pv.shuffleI2.sci.b x19, x17, 4
+    li x20, 0x09562856
+    beq x20, x19, test37
+    c.addi x15, 0x1
+#tests37-42 test the pv.shuffleI3.sci.b instruction. values loaded in and compared to are expected output values
+#pv.shuffleI3.sci.b is of the form "pv.shuffleI3.sci.b rD, rs1, Imm6".
+test37:
+    li x17, 0x1e53472c
+    pv.shuffleI3.sci.b x19, x17, 14
+    li x20, 0x1e2c1e53
+    beq x20, x19, test38
+    c.addi x15, 0x1
+test38:
+    li x17, 0x8b09bdff
+    pv.shuffleI3.sci.b x19, x17, 53
+    li x20, 0x8b8bbdbd
+    beq x20, x19, test39
+    c.addi x15, 0x1
+test39:
+    li x17, 0x2300a758
+    pv.shuffleI3.sci.b x19, x17, 26
+    li x20, 0x23a70000
+    beq x20, x19, test40
+    c.addi x15, 0x1
+test40:
+    li x17, 0x6c6b9079
+    pv.shuffleI3.sci.b x19, x17, 37
+    li x20, 0x6c6b9090
+    beq x20, x19, test41
+    c.addi x15, 0x1
+test41:
+    li x17, 0x51d0126b
+    pv.shuffleI3.sci.b x19, x17, 19
+    li x20, 0x51126b51
+    beq x20, x19, test42
+    c.addi x15, 0x1
+test42:
+    li x17, 0x52dc2310
+    pv.shuffleI3.sci.b x19, x17, 34
+    li x20, 0x52dc10dc
+    beq x20, x19, test43
+    c.addi x15, 0x1
+#tests43-48 test the pv.shuffle2.h instruction. values loaded in and compared to are expected output values
+#pv.shuffle2.h is of the form "pv.shuffle2.h rD, rs1, rs2".
+test43:
+    li x19, 0x0b83e7f5
+    li x17, 0xb4af2179
+    li x18, 0x8b3540e7
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0x0b83b4af
+    beq x20, x19, test44
+    c.addi x15, 0x1
+test44:
+    li x19, 0x51d53e8b
+    li x17, 0xcb38f5fa
+    li x18, 0xa81a2f04
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0xf5fa3e8b
+    beq x20, x19, test45
+    c.addi x15, 0x1
+test45:
+    li x19, 0xf8ef994a
+    li x17, 0xd3bc7138
+    li x18, 0x28d1d162
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0xf8ef7138
+    beq x20, x19, test46
+    c.addi x15, 0x1
+test46:
+    li x19, 0xbf137992
+    li x17, 0x3b91dc38
+    li x18, 0x6af5562d
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0xbf13bf13
+    beq x20, x19, test47
+    c.addi x15, 0x1
+test47:
+    li x19, 0x0efea2f4
+    li x17, 0x3123bc4b
+    li x18, 0xc62ec5c8
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0xbc4ba2f4
+    beq x20, x19, test48
+    c.addi x15, 0x1
+test48:
+    li x19, 0x9601ba9d
+    li x17, 0x2e6cbc1c
+    li x18, 0xd94c2e91
+    pv.shuffle2.h x19, x17, x18
+    li x20, 0xba9d9601
+    beq x20, x19, test49
+    c.addi x15, 0x1
+#tests49-54 test the pv.shuffle2.b instruction. values loaded in and compared to are expected output values
+#pv.shuffle2.b is of the form "pv.shuffle2.b rD, rs1, rs2".
+test49:
+    li x19, 0x9d7c9732
+    li x17, 0x2e088505
+    li x18, 0x31a1f55b
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0x9797859d
+    beq x20, x19, test50
+    c.addi x15, 0x1
+test50:
+    li x19, 0x425401e8
+    li x17, 0x6ca51c69
+    li x18, 0x98733f07
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0xe8426c6c
+    beq x20, x19, test51
+    c.addi x15, 0x1
+test51:
+    li x19, 0x5e2f2887
+    li x17, 0x6c397eb0
+    li x18, 0x09f51ade
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0x287e2f39
+    beq x20, x19, test52
+    c.addi x15, 0x1
+test52:
+    li x19, 0xe24c00ae
+    li x17, 0x7f0c37fe
+    li x18, 0xfd4d2913
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0x373700e2
+    beq x20, x19, test53
+    c.addi x15, 0x1
+test53:
+    li x19, 0x873cf3a7
+    li x17, 0x6941a151
+    li x18, 0x34e3e584
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0x5187a151
+    beq x20, x19, test54
+    c.addi x15, 0x1
+test54:
+    li x19, 0xab6e9899
+    li x17, 0x91ac6945
+    li x18, 0x4fe339fe
+    pv.shuffle2.b x19, x17, x18
+    li x20, 0x91ab98ac
+    beq x20, x19, test55
+    c.addi x15, 0x1
+#tests55-60 test the pv.pack instruction. values loaded in and compared to are expected output values
+#pv.pack is of the form "pv.pack rD, rs1, rs2".
+test55:
+    li x17, 0xe9ee2e5f
+    li x18, 0xad8637dc
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0x2e5f37dc
+    beq x20, x19, test56
+    c.addi x15, 0x1
+test56:
+    li x17, 0xafcc2cde
+    li x18, 0x7851d370
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0x2cded370
+    beq x20, x19, test57
+    c.addi x15, 0x1
+test57:
+    li x17, 0xd7686bd6
+    li x18, 0x06b0edf1
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0x6bd6edf1
+    beq x20, x19, test58
+    c.addi x15, 0x1
+test58:
+    li x17, 0x5d71c849
+    li x18, 0x0bad7dbc
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0xc8497dbc
+    beq x20, x19, test59
+    c.addi x15, 0x1
+test59:
+    li x17, 0xc997af18
+    li x18, 0x7a5eb90a
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0xaf18b90a
+    beq x20, x19, test60
+    c.addi x15, 0x1
+test60:
+    li x17, 0x80689e7c
+    li x18, 0x795874bc
+    .word(0xd12889d7)    #pv.pack x19, x17, x18
+    li x20, 0x9e7c74bc
+    beq x20, x19, test61
+    c.addi x15, 0x1
+#tests61-66 test the pv.pack.h instruction. values loaded in and compared to are expected output values
+#pv.pack.h is of the form "pv.pack.h rD, rs1, rs2".
+test61:
+    li x17, 0xffc16020
+    li x18, 0x35374e9a
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0xffc13537
+    beq x20, x19, test62
+    c.addi x15, 0x1
+test62:
+    li x17, 0x932ecc38
+    li x18, 0x1ae6c08b
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0x932e1ae6
+    beq x20, x19, test63
+    c.addi x15, 0x1
+test63:
+    li x17, 0x14c1d05f
+    li x18, 0x59a6e2e8
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0x14c159a6
+    beq x20, x19, test64
+    c.addi x15, 0x1
+test64:
+    li x17, 0xceed5661
+    li x18, 0xb66ae4c4
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0xceedb66a
+    beq x20, x19, test65
+    c.addi x15, 0x1
+test65:
+    li x17, 0x8ddc12c1
+    li x18, 0x7b15b740
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0x8ddc7b15
+    beq x20, x19, test66
+    c.addi x15, 0x1
+test66:
+    li x17, 0x61c756e4
+    li x18, 0x74e224e9
+    .word(0xd32889d7)    #pv.pack.h x19, x17, x18
+    li x20, 0x61c774e2
+    beq x20, x19, test67
+    c.addi x15, 0x1
+#tests67-72 test the pv.packhi.b instruction. values loaded in and compared to are expected output values
+#pv.packhi.b is of the form "pv.packhi.b rD, rs1, rs2".
+test67:
+    li x19, 0xbe89360e
+    li x17, 0xb2a0cdb8
+    li x18, 0x69296b12
+    pv.packhi.b x19, x17, x18
+    li x20, 0xb812360e
+    beq x20, x19, test68
+    c.addi x15, 0x1
+test68:
+    li x19, 0x43fbb89c
+    li x17, 0x7a5dc8fd
+    li x18, 0x95c4c385
+    pv.packhi.b x19, x17, x18
+    li x20, 0xfd85b89c
+    beq x20, x19, test69
+    c.addi x15, 0x1
+test69:
+    li x19, 0x44ce42c2
+    li x17, 0x9fe7387b
+    li x18, 0x7cec73c2
+    pv.packhi.b x19, x17, x18
+    li x20, 0x7bc242c2
+    beq x20, x19, test70
+    c.addi x15, 0x1
+test70:
+    li x19, 0x8d6f2721
+    li x17, 0x3b68bac0
+    li x18, 0x18ccf3ea
+    pv.packhi.b x19, x17, x18
+    li x20, 0xc0ea2721
+    beq x20, x19, test71
+    c.addi x15, 0x1
+test71:
+    li x19, 0x46ab14fa
+    li x17, 0x4c6abd63
+    li x18, 0xd790a6fe
+    pv.packhi.b x19, x17, x18
+    li x20, 0x63fe14fa
+    beq x20, x19, test72
+    c.addi x15, 0x1
+test72:
+    li x19, 0x5c40f45b
+    li x17, 0x29b0f7e5
+    li x18, 0x061253a0
+    pv.packhi.b x19, x17, x18
+    li x20, 0xe5a0f45b
+    beq x20, x19, test73
+    c.addi x15, 0x1
+#tests73-78 test the pv.packlo.b instruction. values loaded in and compared to are expected output values
+#pv.packlo.b is of the form "pv.packlo.b rD, rs1, rs2".
+test73:
+    li x19, 0xa12f98e7
+    li x17, 0x15fb2adb
+    li x18, 0x1bca2b4c
+    pv.packlo.b x19, x17, x18
+    li x20, 0xa12fdb4c
+    beq x20, x19, test74
+    c.addi x15, 0x1
+test74:
+    li x19, 0xe1401313
+    li x17, 0x01bec6dd
+    li x18, 0x3f9f4a72
+    pv.packlo.b x19, x17, x18
+    li x20, 0xe140dd72
+    beq x20, x19, test75
+    c.addi x15, 0x1
+test75:
+    li x19, 0xe572684c
+    li x17, 0x6433a202
+    li x18, 0x296e2d47
+    pv.packlo.b x19, x17, x18
+    li x20, 0xe5720247
+    beq x20, x19, test76
+    c.addi x15, 0x1
+test76:
+    li x19, 0x2fd584b4
+    li x17, 0x9909ae84
+    li x18, 0x76d02d46
+    pv.packlo.b x19, x17, x18
+    li x20, 0x2fd58446
+    beq x20, x19, test77
+    c.addi x15, 0x1
+test77:
+    li x19, 0x6875cc28
+    li x17, 0x5a2a5938
+    li x18, 0x3ce2177c
+    pv.packlo.b x19, x17, x18
+    li x20, 0x6875387c
+    beq x20, x19, test78
+    c.addi x15, 0x1
+test78:
+    li x19, 0xdd50e6c1
+    li x17, 0x1ba9d08d
+    li x18, 0x5f2a0e4b
+    pv.packlo.b x19, x17, x18
+    li x20, 0xdd508d4b
+    beq x20, x19, exit_check
+    c.addi x15, 0x1
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi


### PR DESCRIPTION
Added 18 tests for Xpulp instruction set. Two additional tests left out of this pull request due to test failures due to unknown causes. Of the 18 tests that were added, 3 fail due to issues in either rtl or the toolchain. Test pulp_vectorial_bit_manip fails due to toolchain issues with the pv.insert.(b/h) instructions. Test pulp_vectorial_add_sub fails due to toolchain issues with pv.add.(div2/div4/div8) and pv.sub.(div2/div4/div8). Test pulp_vectorial_complex fails due to rtl issue reported at https://github.com/openhwgroup/cv32e40p/issues/407. 

These tests add limited coverage for all Xpulp instructions with the exception of hardware looping and post-increment load/store instructions (the two tests that were not added to this pull request).

The additions to cv32/sim/Common.mk change the compiler flags when compiling a custom test whose name starts with "pulp_". The new compiler flags allow for compilation with Xpulp enabled and should not effect the default compiler flags in any other circumstances.