### PR TITLE
Add sdfirm bench support

### DIFF
--- a/cv32/sim/core/Makefile
+++ b/cv32/sim/core/Makefile
@@ -146,6 +146,8 @@ FPNEW_PKG            := $(CV32E40P_PKG)/rtl/fpnew
 CV32E40P_MANIFEST    := $(CV32E40P_PKG)/cv32e40p_manifest.flist
 export DESIGN_RTL_DIR = $(CV32E40P_PKG)/rtl
 
+SDFIRM_PKG   := $(PROJ_ROOT_DIR)/cv32/tests/core/sdfirm
+
 # Shorthand rules for convience
 cv32e40p_pkg: $(CV32E40P_PKG)
 
@@ -471,6 +473,12 @@ custom: verilate $(VERI_CUSTOM)/$(CUSTOM_PROG).hex
 		"+firmware=$(VERI_CUSTOM)/$(CUSTOM_PROG).hex" \
 		| tee $(VERI_LOG_DIR)/$(CUSTOM_PROG).log
 
+sdfirm: verilate $(SDFIRM)/sdfirm.hex
+	mkdir -p $(VERI_LOG_DIR)
+	./testbench_verilator $(VERI_FLAGS) \
+		"+firmware=$(SDFIRM)/sdfirm.hex" \
+		| tee $(VERI_LOG_DIR)/sdfirm.log
+
 cv32-riscv-tests: verilate ../../tests/core/cv32_riscv_tests_firmware/cv32_riscv_tests_firmware.hex
 	mkdir -p $(VERI_LOG_DIR)
 	./testbench_verilator $(VERI_FLAGS) \
@@ -570,6 +578,12 @@ $(CV32E40P_PKG):
 	$(CLONE_CV32E40P_CMD)
 	$(CLONE_FPNEW_CMD)
 
+###############################################################################
+# SDFIRM program dependencies
+
+clone_sdfirm_prog:
+	$(CLONE_SDFIRM_CMD)
+
 
 ###############################################################################
 # general targets
@@ -585,10 +599,10 @@ tc-clean:
 	find $(CORE_TEST_DIR) -name *.map     -exec rm {} \;
 
 .PHONY: clean clean_all distclean
-clean: questa-clean tc-clean verilate-clean vcs-clean firmware-clean custom-clean dsim-clean xrun-clean vcs-clean
+clean: questa-clean tc-clean verilate-clean vcs-clean firmware-clean sdfirm-clean custom-clean dsim-clean xrun-clean vcs-clean
 
 distclean: clean
-	rm -rf riscv-fesvr riscv-isa-sim $(CV32E40P_PKG) work
+	rm -rf riscv-fesvr riscv-isa-sim $(CV32E40P_PKG) $(SDFIRM_PKG) work
 
 clean_all: distclean
 #endend


### PR DESCRIPTION
sdfirm is a riscv core verification platform that supports various
simulation environments and real chips. It's basically a combo of
sbi and linux, support IRQs, MMU (SV39, SV48) and SMP, can run
tests/benchmarks with multi-core enabled.

After completing core-v-verif basic support, this patch adds git
HASH of sdfirm in core-v-verif. After typing "make sdfirm", the
following shows up:
./testbench_verilator  \
        "+firmware=/home/zetalog/workspace/openhwgroup/core-v-verif/cv32/sim/core/../../../cv32/tests/core/sdfirm/sdfirm.hex" \
        | tee cobj_dir/logs/sdfirm.log
  scopesDump:
    SCOPE 0x7fffe8194318: TOP.tb_top_verilator.riscv_wrapper_i.ram_i
    SCOPE 0x7fffe8194340: TOP.tb_top_verilator.riscv_wrapper_i.ram_i.dp_ram_i
       DPI-EXPORT 0x7fbfb74226c0: read_byte
       DPI-EXPORT 0x7fbfb74226e0: write_byte
    SCOPE 0x7fffe8194368: TOP.tb_top_verilator.riscv_wrapper_i.ram_i.read_mux

[CORE] Core settings: PULP_SECURE =           0, N_PMP_ENTRIES =          16, N_PMP_CFG           4
finished dumping memory

OpenHW Group - CV32E40P Verification
4.4.0-18362-Microsoft - 1.0.0.0
   _____ _____  ______ _____ _____  __  __
  / ____|  __ \|  ____|_   _|  __ \|  \/  |
 | (___ | |  | | |__    | | | |__) | \  / |
  \___ \| |  | |  __|   | | |  _  /| |\/| |
  ____) | |__| | |     _| |_| | \ \| |  | |
 |_____/|_____/|_|    |_____|_|  \_\_|  |_|

EXIT SUCCESS
- /home/zetalog/workspace/openhwgroup/core-v-verif/cv32/sim/core/../../../cv32/tb/core/tb_top_verilator.sv:83: Verilog $finish

Signed-off-by: Lv Zheng <zhenglv@hotmail.com>