### PR TITLE
fix latching of exit value from virtual peripheral

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -138,7 +138,7 @@ module uvmt_cv32_tb;
        end
        if (vp_status_if.exit_valid) begin
          evalue <= vp_status_if.exit_value;
-         uvm_config_db#(bit[31:0])::set(.cntxt(null), .inst_name("*"), .field_name("evalue"), .value(evalue));
+         uvm_config_db#(bit[31:0])::set(.cntxt(null), .inst_name("*"), .field_name("evalue"), .value(vp_status_if.exit_value));
        end
      end
    end

--- a/cv32/tests/uvmt_cv32/base-tests/uvmt_cv32_base_test.sv
+++ b/cv32/tests/uvmt_cv32/base-tests/uvmt_cv32_base_test.sv
@@ -315,34 +315,25 @@ function void uvmt_cv32_base_test_c::phase_ended(uvm_phase phase);
      if(!(uvm_config_db#(bit      )::get(null, "*", "evalid", evalid))) `uvm_error("END_OF_TEST", "Cannot get valid from config_db.")
      if(!(uvm_config_db#(bit[31:0])::get(null, "*", "evalue", evalue))) `uvm_error("END_OF_TEST", "Cannot get evalue from config_db.")
 
-     // Use the DUT Wrapper Virtual Peripheral's status outputs to update report server status.
-     if (!tp) `uvm_warning("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to flag test passed.")
+     // Use the DUT Wrapper Virtual Peripheral's status outputs to update report server status.   
      if (tf)  `uvm_error  ("END_OF_TEST", "DUT WRAPPER virtual peripheral flagged test failure.")
+     
+     // Check exit code if a valid exit code was written to Virtual Peripheral
      if (evalid) begin
-       // TODO: handle exit_value properly
-       `uvm_info("END_OF_TEST", $sformatf("DUT WRAPPER virtual peripheral signaled exit_value=%0h.", evalue), UVM_NONE)
+       if (evalue != 0) begin
+          `uvm_error("END_OF_TEST", $sformatf("DUT WRAPPER virtual peripheral signaled exit_value=%0h.", evalue))
+       end 
+       else begin
+         `uvm_info("END_OF_TEST", $sformatf("DUT WRAPPER virtual peripheral signaled exit_value=%0h.", evalue), UVM_NONE)
+       end
      end
-     else begin
-       `uvm_warning("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to exit properly.")
-     end
-     //
 
-      // Report on number of ISS step and compare checks if the ISS is used
-      `ifdef ISS step_compare_vif.report_step_compare(); `endif
+     // Catch hanging tests.  If no exit code nor test pass/test fail status was ever written to Virtual Peripheral
+     // then mark test as failed
+     if (!tp && !evalid && !tf) `uvm_error("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to flag test passed and failed to signal exit value.")   
 
-     /* This does not work because the vp_status signals are all pulses.
-     * TODO: add logic to latch pulses and used the latched values here.
-     // Use the DUT Wrapper Virtual Peripheral's status outputs to update report server status.
-     if (!vp_status_vif.tests_passed) `uvm_warning("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to flag test passed.")
-     if (vp_status_vif.tests_failed)  `uvm_error  ("END_OF_TEST", "DUT WRAPPER virtual peripheral flagged test failure.")
-     if (vp_status_vif.exit_valid) begin
-       // TODO: handle exit_value properly
-       `uvm_info("END_OF_TEST", $sformatf("DUT WRAPPER virtual peripheral signaled exit_value=%0h.", vp_status_vif.exit_value), UVM_NONE)
-     end
-     else begin
-       `uvm_warning("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to exit properly.")
-     end
-     */
+     // Report on number of ISS step and compare checks if the ISS is used
+     `ifdef ISS step_compare_vif.report_step_compare(); `endif
 
      print_banner("test finished");
    end


### PR DESCRIPTION
rewrite test pass fail logic for both riscv and directed tests

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>