### PR TITLE
add explicit weak handlers for all external interrupts in cv32e40p

### DIFF
--- a/cv32/bsp/README.md
+++ b/cv32/bsp/README.md
@@ -45,7 +45,7 @@ exception code `0`, they jump to the same location as exceptions, therefore the
 user software interrupt handler must also handle exceptions.
 
 The vector table is defined in `vectors.S` and may jump to one of the
-following three interrupt request handlers in `handlers.S`:
+following interrupt request handlers in `handlers.S`:
   * `u_sw_irq_handler` - handles user software interrupts and all exceptions.
   Saves all caller saved registers then checks `mcause` and jumps to the
   appropriate handler as follows:

--- a/cv32/bsp/README.md
+++ b/cv32/bsp/README.md
@@ -46,18 +46,54 @@ user software interrupt handler must also handle exceptions.
 
 The vector table is defined in `vectors.S` and may jump to one of the
 following three interrupt request handlers in `handlers.S`:
-  * `sw_irq_handler` - handles user software interrupts and all exceptions.
+  * `u_sw_irq_handler` - handles user software interrupts and all exceptions.
   Saves all caller saved registers then checks `mcause` and jumps to the
   appropriate handler as follows:
     - Breakpoint: jump to `handle_ebreak`.
     - Illegal instruction: jump to `handle_illegal`.
     - Environment call from M-mode: jump to `handle_ecall`.
     - Any other exception or user software interrupt: jump to `handle_unknown`.
-  * `verification_irq_handler` - calls `mret`. Usage of this interrupt is
-  still under discussion.
+  * `m_software_irq_handler` - handles machine-mode software interrupts
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_timer_irq_handler` - handles machine-mode timer interrupts
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_external_irq_handler` - handles machine-mode external interrupts
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast0_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)  
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast1_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast2_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast3_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast4_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast5_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast6_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast7_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast8_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast9_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast10_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast11_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast12_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast13_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast14_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
+  * `m_fast15_irq_handler` - handles machine-mode fast external interrupts (platform extension for CV32)
+    - Currently jumps to `__no_irq_handler`.  Behavior to be defined in future commit.
   * `__no_irq_handler` - loops printing "no exception handler installed".
 
-The following exception handlers may be called from `sw_irq_handler`:
+The following exception handlers may be called from `u_sw_irq_handler`:
   * `handle_ecall` - calls `handle_syscall` which checks the syscall number and
   calls the corresponding syscall function.
   * `handle_ebreak` - currently just prints "ebreak exception handler entered"
@@ -67,7 +103,7 @@ The following exception handlers may be called from `sw_irq_handler`:
   exception. This is the only case where `mepc` is not incremented, because we
   do not know the appropiate action to take.
 
-Returning from the `sw_irq_handler`. All handlers called by `sw_irq_handler`
+Returning from the `u_sw_irq_handler`. All handlers called by `u_sw_irq_handler`
 increment `mepc` before calling `mret`, except for `unknown_handler`. Handlers
 that require `mepc` to be incremented jump to `end_handler_incr_mepc` otherwise
 they jump to `end_handler_ret`. All caller saved registers are restored before

--- a/cv32/bsp/handlers.S
+++ b/cv32/bsp/handlers.S
@@ -21,47 +21,46 @@
 
 .section .text.handlers
 .global __no_irq_handler
-.global sw_irq_handler
-.global verification_irq_handler
-.global software_irq_handler
-.global timer_irq_handler
-.global external_irq_handler
-.global fast0_irq_handler
-.global fast1_irq_handler
-.global fast2_irq_handler
-.global fast3_irq_handler
-.global fast4_irq_handler
-.global fast5_irq_handler
-.global fast6_irq_handler
-.global fast7_irq_handler
-.global fast8_irq_handler
-.global fast9_irq_handler
-.global fast10_irq_handler
-.global fast11_irq_handler
-.global fast12_irq_handler
-.global fast13_irq_handler
-.global fast14_irq_handler
-.global fast15_irq_handler
+.global u_sw_irq_handler
+.global m_software_irq_handler
+.global m_timer_irq_handler
+.global m_external_irq_handler
+.global m_fast0_irq_handler
+.global m_fast1_irq_handler
+.global m_fast2_irq_handler
+.global m_fast3_irq_handler
+.global m_fast4_irq_handler
+.global m_fast5_irq_handler
+.global m_fast6_irq_handler
+.global m_fast7_irq_handler
+.global m_fast8_irq_handler
+.global m_fast9_irq_handler
+.global m_fast10_irq_handler
+.global m_fast11_irq_handler
+.global m_fast12_irq_handler
+.global m_fast13_irq_handler
+.global m_fast14_irq_handler
+.global m_fast15_irq_handler
 
-.weak software_irq_handler
-.weak timer_irq_handler
-.weak external_irq_handler
-.weak fast0_irq_handler
-.weak fast1_irq_handler
-.weak fast2_irq_handler
-.weak fast3_irq_handler
-.weak fast4_irq_handler
-.weak fast5_irq_handler
-.weak fast6_irq_handler
-.weak fast7_irq_handler
-.weak fast8_irq_handler
-.weak fast9_irq_handler
-.weak fast10_irq_handler
-.weak fast11_irq_handler
-.weak fast12_irq_handler
-.weak fast13_irq_handler
-.weak fast14_irq_handler
-.weak fast15_irq_handler
+.weak m_software_irq_handler
+.weak m_timer_irq_handler
+.weak m_external_irq_handler
+.weak m_fast0_irq_handler
+.weak m_fast1_irq_handler
+.weak m_fast2_irq_handler
+.weak m_fast3_irq_handler
+.weak m_fast4_irq_handler
+.weak m_fast5_irq_handler
+.weak m_fast6_irq_handler
+.weak m_fast7_irq_handler
+.weak m_fast8_irq_handler
+.weak m_fast9_irq_handler
+.weak m_fast10_irq_handler
+.weak m_fast11_irq_handler
+.weak m_fast12_irq_handler
+.weak m_fast13_irq_handler
+.weak m_fast14_irq_handler
+.weak m_fast15_irq_handler
 
 
 /* exception handling */
@@ -70,64 +69,64 @@ __no_irq_handler:
 	jal ra, puts
 	j __no_irq_handler
 
-software_irq_handler:
+m_software_irq_handler:
 	j __no_irq_handler
 
-timer_irq_handler:
+m_timer_irq_handler:
 	j __no_irq_handler
 
-external_irq_handler:
+m_external_irq_handler:
 	j __no_irq_handler
 
-fast0_irq_handler:
+m_fast0_irq_handler:
 	j __no_irq_handler
 
-fast1_irq_handler:
+m_fast1_irq_handler:
 	j __no_irq_handler
 
-fast2_irq_handler:
+m_fast2_irq_handler:
 	j __no_irq_handler
 
-fast3_irq_handler:
+m_fast3_irq_handler:
 	j __no_irq_handler
 
-fast4_irq_handler:
+m_fast4_irq_handler:
 	j __no_irq_handler
 
-fast5_irq_handler:
+m_fast5_irq_handler:
 	j __no_irq_handler
 
-fast6_irq_handler:
+m_fast6_irq_handler:
 	j __no_irq_handler
 
-fast7_irq_handler:
+m_fast7_irq_handler:
 	j __no_irq_handler
 
-fast8_irq_handler:
+m_fast8_irq_handler:
 	j __no_irq_handler
 
-fast9_irq_handler:
+m_fast9_irq_handler:
 	j __no_irq_handler
 
-fast10_irq_handler:
+m_fast10_irq_handler:
 	j __no_irq_handler
 
-fast11_irq_handler:
+m_fast11_irq_handler:
 	j __no_irq_handler
 
-fast12_irq_handler:
+m_fast12_irq_handler:
 	j __no_irq_handler
 
-fast13_irq_handler:
+m_fast13_irq_handler:
 	j __no_irq_handler
 
-fast14_irq_handler:
+m_fast14_irq_handler:
 	j __no_irq_handler
 
-fast15_irq_handler:
+m_fast15_irq_handler:
 	j __no_irq_handler
 
-sw_irq_handler:
+u_sw_irq_handler:
 	/* While we are still using puts in handlers, save all caller saved
 	   regs.  Eventually, some of these saves could be deferred.  */
 	addi sp,sp,-64
@@ -208,10 +207,6 @@ end_handler_ret:
 	lw t5, 56(sp)
 	lw t6, 60(sp)
 	addi sp,sp,64
-	mret
-/* this interrupt can be generated for verification purposes, random or when the
-   PC is equal to a given value*/
-verification_irq_handler:
 	mret
 
 .section .rodata

--- a/cv32/bsp/handlers.S
+++ b/cv32/bsp/handlers.S
@@ -23,11 +23,108 @@
 .global __no_irq_handler
 .global sw_irq_handler
 .global verification_irq_handler
+.global software_irq_handler
+.global timer_irq_handler
+.global external_irq_handler
+.global fast0_irq_handler
+.global fast1_irq_handler
+.global fast2_irq_handler
+.global fast3_irq_handler
+.global fast4_irq_handler
+.global fast5_irq_handler
+.global fast6_irq_handler
+.global fast7_irq_handler
+.global fast8_irq_handler
+.global fast9_irq_handler
+.global fast10_irq_handler
+.global fast11_irq_handler
+.global fast12_irq_handler
+.global fast13_irq_handler
+.global fast14_irq_handler
+.global fast15_irq_handler
+
+.weak software_irq_handler
+.weak timer_irq_handler
+.weak external_irq_handler
+.weak fast0_irq_handler
+.weak fast1_irq_handler
+.weak fast2_irq_handler
+.weak fast3_irq_handler
+.weak fast4_irq_handler
+.weak fast5_irq_handler
+.weak fast6_irq_handler
+.weak fast7_irq_handler
+.weak fast8_irq_handler
+.weak fast9_irq_handler
+.weak fast10_irq_handler
+.weak fast11_irq_handler
+.weak fast12_irq_handler
+.weak fast13_irq_handler
+.weak fast14_irq_handler
+.weak fast15_irq_handler
+
 
 /* exception handling */
 __no_irq_handler:
 	la a0, no_exception_handler_msg
 	jal ra, puts
+	j __no_irq_handler
+
+software_irq_handler:
+	j __no_irq_handler
+
+timer_irq_handler:
+	j __no_irq_handler
+
+external_irq_handler:
+	j __no_irq_handler
+
+fast0_irq_handler:
+	j __no_irq_handler
+
+fast1_irq_handler:
+	j __no_irq_handler
+
+fast2_irq_handler:
+	j __no_irq_handler
+
+fast3_irq_handler:
+	j __no_irq_handler
+
+fast4_irq_handler:
+	j __no_irq_handler
+
+fast5_irq_handler:
+	j __no_irq_handler
+
+fast6_irq_handler:
+	j __no_irq_handler
+
+fast7_irq_handler:
+	j __no_irq_handler
+
+fast8_irq_handler:
+	j __no_irq_handler
+
+fast9_irq_handler:
+	j __no_irq_handler
+
+fast10_irq_handler:
+	j __no_irq_handler
+
+fast11_irq_handler:
+	j __no_irq_handler
+
+fast12_irq_handler:
+	j __no_irq_handler
+
+fast13_irq_handler:
+	j __no_irq_handler
+
+fast14_irq_handler:
+	j __no_irq_handler
+
+fast15_irq_handler:
 	j __no_irq_handler
 
 sw_irq_handler:

--- a/cv32/bsp/vectors.S
+++ b/cv32/bsp/vectors.S
@@ -22,32 +22,33 @@ vector_table:
 	j sw_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
+	j software_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j timer_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j external_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j verification_irq_handler
+	j fast0_irq_handler
+	j fast1_irq_handler
+	j fast2_irq_handler
+	j fast3_irq_handler
+	j fast4_irq_handler
+	j fast5_irq_handler
+	j fast6_irq_handler
+	j fast7_irq_handler
+	j fast8_irq_handler
+	j fast9_irq_handler
+	j fast10_irq_handler
+	j fast11_irq_handler
+	j fast12_irq_handler
+	j fast13_irq_handler
+	j fast14_irq_handler
+	j fast15_irq_handler
+

--- a/cv32/bsp/vectors.S
+++ b/cv32/bsp/vectors.S
@@ -19,36 +19,36 @@
 .global vector_table
 
 vector_table:
-	j sw_irq_handler
+	j u_sw_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
-	j software_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j __no_irq_handler
-	j timer_irq_handler
+	j m_software_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
-	j external_irq_handler
+	j m_timer_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j __no_irq_handler
+	j m_external_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
 	j __no_irq_handler
-	j fast0_irq_handler
-	j fast1_irq_handler
-	j fast2_irq_handler
-	j fast3_irq_handler
-	j fast4_irq_handler
-	j fast5_irq_handler
-	j fast6_irq_handler
-	j fast7_irq_handler
-	j fast8_irq_handler
-	j fast9_irq_handler
-	j fast10_irq_handler
-	j fast11_irq_handler
-	j fast12_irq_handler
-	j fast13_irq_handler
-	j fast14_irq_handler
-	j fast15_irq_handler
+	j m_fast0_irq_handler
+	j m_fast1_irq_handler
+	j m_fast2_irq_handler
+	j m_fast3_irq_handler
+	j m_fast4_irq_handler
+	j m_fast5_irq_handler
+	j m_fast6_irq_handler
+	j m_fast7_irq_handler
+	j m_fast8_irq_handler
+	j m_fast9_irq_handler
+	j m_fast10_irq_handler
+	j m_fast11_irq_handler
+	j m_fast12_irq_handler
+	j m_fast13_irq_handler
+	j m_fast14_irq_handler
+	j m_fast15_irq_handler
 


### PR DESCRIPTION
Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>

Proposed additional irq handlers for the mtvec table in the BSP
Please review and give any comments or suggested changes
