### PR TITLE
initial cv_regress release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ metrics.db
 metrics_history.db
 xrun_results
 vsim_results
+__pycache__
 *.swp
 /.cproject
 /.project

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,103 @@
+Core-V-Verif Utilities
+==================================
+
+This directory contains various utilities for running tests and performing various verification-related 
+activities in the core-v-verif repository.
+
+Unless otherwise noted all utilities in this directory should be agnostic to $CWD.  Therefore a user
+should be able to run the utilities via a PATH from any directory.  The utilities will be able to 
+determine their own directory based on the implementation langugage hooks available.
+
+For example from a bash-type shell:
+export PATH=./core-v-verif/bin:$PATH
+
+Utility Documentation
+==================================
+
+Documentation for each of the utilities are included below.  Each utility should also support a help option
+on the command line for describing options and arguments available.
+
+==================================
+
+## makecv32
+This is a simple wrapper around the main simulation Makefile located in:<br>
+
+cv32/sim/uvmt_cv32
+
+This should enable simulations to be executed regardess of current shell directory.  All common make flags
+and conventions should be passed to the underlying Makefile directory.
+
+*Examples:*
+> % makecv32 sanity WAVES=1 SIMUALTOR=vsim<br>
+% makecv32 corev-dv corev_rand_instr_test_0`
+
+## ci_check
+
+Continuous integration checker script.  This script runs a quick sanity regression on the requested 
+simulator for the purposes of ensuring a pull-request can be safely made.  Note that *ci_check* should now
+be able to be executed in any directory where previously it required the user to *cd* to ci/.  Please 
+refer to *ci_check*'s help utility for more details on options
+
+*Examples:*
+> \# Run CI sanity regression on Xcelium<br>
+% ci_check -s xrun<br>
+> \# Get help of all available options<br>
+% ci_check --help
+
+## cv_regress
+
+Regression script generator utility.  *cv_regress* will read in one or more regressions defined in a specific
+YAML format into an output format suitable for the specified regression platform or utlity.  The currently supported
+output platforms are:<br>
+- Metrics JSON (--metrics)
+- Shell Script (--sh)
+
+The format of the YAML testlist file is given below.  All YAML regression testslists should go in the following directory:
+> core-v-verif/\<project>/regress<br>
+
+where *\<project>* is either cv32 (default) or cv64.
+
+Note that the utility has the ability to combine multiple testlists to build larger regressions.  Therefore the --file 
+option may be specified multiple times.
+
+Please refer to the help utility of *cv_regress* for more details on the utility.
+
+*Examples:*
+> \# Read in *cv32_ci_check* testlist with Questa and emit an executable shell script<br>
+% cv_regress --file=cv32_ci_check.yaml --simulator=vsim --outfile=vsim_ci_check.sh
+
+### Regression YAML Format
+
+The following describes the YAML format for regression testlists.  
+
+><*Required*: the name of the testlist><br>
+name: \<string\><br>
+<*Required*: human-readable description to specify the intent of the testlist><br>
+description: \<string><br>
+<br>
+\# List of builds, this can include SystemVerilog compiles and riscv-dv compiles<br>
+\# Multiple builds may be defined<br>
+builds:<br>
+&nbsp;&nbsp;build_name0:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: make command for the build><br>
+&nbsp;&nbsp;&nbsp;&nbsp;cmd: make comp<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: make directory for the build><br>
+&nbsp;&nbsp;&nbsp;&nbsp;dir: cv32/sim/uvmt_cv32<br>
+<br>
+\# List of tests<br>
+\# Multiple tests can be defined<br>
+tests:<br>
+&nbsp;&nbsp;test_name0:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: build dependecies, can be a list of single build_name><br>
+&nbsp;&nbsp;&nbsp;&nbsp;build: \<string><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: human-readable test description><br>
+&nbsp;&nbsp;&nbsp;&nbsp;description: \<string><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: make directory for the test><br>
+&nbsp;&nbsp;&nbsp;&nbsp;dir: \<string><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Optional*: A make command to run before running the test(s).  This could be used for gen_* makes for corev-dv<br>
+&nbsp;&nbsp;&nbsp;&nbsp;precmd: \<string><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Required*: make directory for the test><br>
+&nbsp;&nbsp;&nbsp;&nbsp;cmd: \<string><br>
+&nbsp;&nbsp;&nbsp;&nbsp;<*Optional*: The number of test iterations to run.  Note that all runs will receive a random seed><br>
+&nbsp;&nbsp;&nbsp;&nbsp;num: \<number>
+

--- a/bin/README.md
+++ b/bin/README.md
@@ -8,8 +8,8 @@ Unless otherwise noted all utilities in this directory should be agnostic to $CW
 should be able to run the utilities via a PATH from any directory.  The utilities will be able to 
 determine their own directory based on the implementation langugage hooks available.
 
-For example from a bash-type shell:
-export PATH=./core-v-verif/bin:$PATH
+For example from a bash-type shell:<br>
+> % export PATH=./core-v-verif/bin:$PATH
 
 Utility Documentation
 ==================================

--- a/bin/README.md
+++ b/bin/README.md
@@ -70,11 +70,11 @@ Please refer to the help utility of *cv_regress* for more details on the utility
 
 The following describes the YAML format for regression testlists.  
 
-><*Required*: the name of the testlist><br>
+>\<*Required*: the name of the testlist><br>
 name: \<string\><br>
-<*Required*: human-readable description to specify the intent of the testlist><br>
+\<*Required*: human-readable description to specify the intent of the testlist><br>
 description: \<string><br>
-<br>
+><br>
 \# List of builds, this can include SystemVerilog compiles and riscv-dv compiles<br>
 \# Multiple builds may be defined<br>
 builds:<br>
@@ -83,7 +83,7 @@ builds:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;cmd: make comp<br>
 &nbsp;&nbsp;&nbsp;&nbsp;<*Required*: make directory for the build><br>
 &nbsp;&nbsp;&nbsp;&nbsp;dir: cv32/sim/uvmt_cv32<br>
-<br>
+><br>
 \# List of tests<br>
 \# Multiple tests can be defined<br>
 tests:<br>
@@ -100,4 +100,5 @@ tests:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;cmd: \<string><br>
 &nbsp;&nbsp;&nbsp;&nbsp;<*Optional*: The number of test iterations to run.  Note that all runs will receive a random seed><br>
 &nbsp;&nbsp;&nbsp;&nbsp;num: \<number>
+
 

--- a/bin/ci_check
+++ b/bin/ci_check
@@ -1,0 +1,1 @@
+../ci/ci_check

--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+#
+# cv32_regress: python script to generate a tool-specific regression based
+#               upon YAML specifications of regressions
+#
+# Author: Steve Richmond
+#  email: steve.richmond@silabs.com
+#
+# Written with Python 3.5.1 on RHEL 7.7.  Your python mileage may vary.
+#
+# Restriction:
+#     - Needs to be launched from the ci directory.
+#     - Blindly uses .metrics.json wih no ability for user over-ride.
+#
+# TODO:
+################################################################################
+
+import argparse
+import yaml
+import logging
+import sys
+import os
+import jinja2
+import pprint
+from collections import OrderedDict
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
+
+import cv_regression
+
+logger = logging.getLogger(__name__)
+
+if (sys.version_info < (3,0,0)):
+    print ('Requires python 3')
+    exit(1)
+
+def get_regress_path(project):
+    '''Fetch regression path using project'''
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', project, 'regress'))
+
+def read_file(args, file):
+    '''Read a YAML definition filelist'''
+    full_regress_file = os.path.join(get_regress_path(args.project), file)
+    stream = open(full_regress_file, 'r')
+    logger.info('Reading regression: {}'.format(full_regress_file))
+    testlist = yaml.load(stream)
+    stream.close()
+
+    pp = pprint.PrettyPrinter()
+    logger.debug('Read YAML:')
+    logger.debug(pp.pformat(testlist))
+
+    # Basic validation
+    assert 'name' in testlist, 'Must specify a testlist name in YAML header'
+    assert 'description' in testlist, 'Must specify a testlist description in YAML header'
+    assert 'tests' in testlist, 'A test section with at least one test must be defined'
+    for b, d in testlist['builds'].items():
+        assert 'cmd' in d, 'cmd must be specified in test: ' + b
+        assert 'dir' in d, 'dir must be specified in test: ' + b        
+    for t, d in testlist['tests'].items():
+        assert 'build' in d, 'build must be specified in test: ' + t
+        assert 'description' in d, 'description must be specified in test: ' + t
+        assert 'cmd' in d, 'cmd must be specified in test: ' + t
+        assert 'dir' in d, 'dir must be specified in test: ' + t
+        
+    # Construct a proper regression object
+    regression = cv_regression.Regression(name=testlist['name'],
+                                          description=testlist['description'])
+    for k in testlist['builds']:
+        b = testlist['builds'][k]    
+        build = cv_regression.Build(name=k, simulator=args.simulator, **b)
+        regression.add_build(build)
+
+    for k in testlist['tests']:
+        t = testlist['tests'][k]
+        
+        try:
+            if args.simulator in t['skip_sim']:
+                continue
+        except KeyError:
+            pass
+        test = cv_regression.Test(name=k, simulator=args.simulator, **t)
+        regression.add_test(test)
+
+    return regression
+
+# Start of script
+VALID_SIMULATORS = ('dsim', 'vsim', 'vcs', 'xrun')
+DEFAULT_SIMULATOR = 'dsim'
+VALID_PROJECTS = ('cv32', 'cv64')
+DEFAULT_PROJECT = 'cv32'
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('-f', '--file', action='append', help='One or more input regression YAML lists to read')
+parser.add_argument('-p', '--project', default=DEFAULT_PROJECT, choices=VALID_PROJECTS, help='Select CV32 for regression')
+parser.add_argument('-o', '--outfile', default='regress.out', help='Output file')
+parser.add_argument('-d', '--debug', help='Emit debug messages from logger', action='store_true')
+parser.add_argument('-m', '--metrics', help='Select Metrics waves output', action='store_true')
+parser.add_argument('--sh', help='Select bash shell script output', action='store_true')
+parser.add_argument('-s', '--simulator', help='Select simulator', choices=VALID_SIMULATORS, default=DEFAULT_SIMULATOR)
+
+args = parser.parse_args()
+
+if args.debug:
+    logger.setLevel(logging.DEBUG)
+
+if not args.file:
+    logger.fatal('Must specify a regression definition YAML file with -f or --f')
+    os.sys.exit(2)
+
+regressions = []
+unique_builds = OrderedDict()
+for f in args.file:
+    r = read_file(args, f)
+    regressions.append(r)
+    for b in r.builds.values():
+        if not b.name in unique_builds:
+            unique_builds[b.name] = b
+    
+# Generate output product
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__),                                                         
+                                                        'templates')), trim_blocks=True)
+
+# Output generation
+if args.sh: 
+    # Generate shell script (--script)
+    template = env.get_template('regress_sh.j2')
+    logger.info('Rendering template: regress_sh.j2 into: {}'.format(args.outfile))
+    out_fh = open(args.outfile, 'w')
+    out_fh.write(template.render(regressions=regressions,
+                                 unique_builds=unique_builds))
+    out_fh.close()
+    os.chmod(args.outfile, 0o775)
+elif args.metrics:
+    # Generate a metrics-compatible JSON file (--metrics)
+    template = env.get_template('metrics.json.j2')
+    logger.info('Rendering template: metrics.json.j2 into: {}'.format(args.outfile))
+    out_fh = open(args.outfile, 'w')
+    out_fh.write(template.render(regressions=regressions,
+                                 unique_builds=unique_builds))
+    out_fh.close()
+    os.chmod(args.outfile, 0o775)
+

--- a/bin/lib/README.md
+++ b/bin/lib/README.md
@@ -1,0 +1,6 @@
+Core-V-Verif Library Modules
+==================================
+
+General library modules may be placed in this directory.  Current Python modules are included here.
+
+- cv_regression.py - Python class implementations for *cv_regress* utility

--- a/bin/lib/cv_regression.py
+++ b/bin/lib/cv_regression.py
@@ -1,0 +1,84 @@
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+
+import os
+import sys
+import logging
+from collections import OrderedDict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ISS = 'YES'
+DEFAULT_SIMULATION_PASSED = 'SIMULATION PASSED'
+DEFAULT_SKIP_SIM = []
+
+class Build:
+    '''A regression build object'''
+    def __init__(self, **kwargs):
+
+        # Create defaults    
+        self.iss = DEFAULT_ISS
+
+        for k, v in kwargs.items():            
+            setattr(self, k, v)
+
+    def __str__(self):
+        return '{} {} {}'.format(self.name, self.cmd, self.dir)
+
+class Test:
+    '''A regression test object'''
+    def __init__(self, **kwargs):
+        '''Create a test object'''
+
+        # Set defaults
+        self.skip_sim = DEFAULT_SKIP_SIM
+        self.simulation_passed = DEFAULT_SIMULATION_PASSED
+        self.iss = DEFAULT_ISS
+        self.num = 1
+
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+class Regression:
+    '''A full regression object'''
+    def __init__(self, **kwargs):
+        '''Constructor'''
+        self.builds = OrderedDict()
+        self.tests = OrderedDict()
+
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def add_build(self, build):
+        '''Add a new build object to this regression'''
+        if build.name in self.builds.keys():
+            logger.fatal('Build: {} was defined multiple times'.format(build['name']))
+            os.sys.exit(2)
+
+        self.builds[build.name] = build
+    
+    def add_test(self, test):
+        '''Add a new test object to this regression'''
+        if test.name in self.tests.keys():
+            logger.fatal('Test: {} was defined multiple times'.format(test['name']))
+            os.sys.exit(2)
+
+        self.tests[test.name]  = test
+    

--- a/bin/makecv32
+++ b/bin/makecv32
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+CV32_MAKE=$(dirname $0)/../cv32/sim/uvmt_cv32
+echo ${CV32_MAKE}
+
+cd ${CV32_MAKE} && make "$@"

--- a/bin/templates/README.md
+++ b/bin/templates/README.md
@@ -1,0 +1,7 @@
+Core-V-Verif Templates
+==================================
+
+Templates for core-v-verif utilities are here.  To render templates your Python installation should include the Jinja2 module.  It can be installed via pip using:
+
+> pip install jinja2
+

--- a/bin/templates/metrics.json.j2
+++ b/bin/templates/metrics.json.j2
@@ -1,0 +1,72 @@
+{#
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+# metrics.json.j2: Jinja2 template for rendering metrics.json files for cv_regress
+
+#}
+
+{% import 'regress_macros.j2' as regress_macros %}
+
+{
+    "variables": {
+        "RISCV": "/mux-flow/tools/riscv",
+        "LM_LICENSE_FILE": "2700@license-1",
+        "IMPERAS_QUEUE_LICENSE" : "1"
+    },
+    "builds": {
+        "list:" [
+{% for b in unique_builds.values() %}
+            {
+                "name":     "{{b.name}}",
+                "image":    "cv32-simulation-tools:20200316.10.0",
+                "cmd":      "cd {{b.dir}}; {{b.cmd}} SIMULATOR={{b.simulator}} DSIM_WORK=/mux-flow/build/repo/dsim_work",
+                "wavesCmd": "cd {{b.dir}}; {{b.cmd}} SIMULATOR={{b.simulator}} DSIM_WORK=/mux-flow/build/repo/dsim_work WAVES=1",
+            }
+{% endfor %}
+        ],
+    }
+    "regressions": [
+{% for r in regressions %}
+        {
+            "name": "{{r.name}}",
+            "description": "{{r.description}}",
+            "verbose" : "true",
+            "tests": {
+                "resultsDir": "/mux-flow/build/results",
+                "builds": "[ {% for b in r.builds.values() %}"{{b.name}}",{% endfor %} ]",
+                "list": [
+                    { 
+{% for t in r.tests.values() %}
+                        "name": "{{t.name}}" ,
+                        "build": "{{t.build}}",
+                        "cmd": "cd {{t.dir}}; {{t.cmd}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.ss)}}",
+                        "wavesCmd": "cd {{t.dir}}; {{t.cmd}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.ss)}} WAVES=1",
+                        "metricsFile": "{{t.name}}/metrics.db",
+                        "wavesFile": "{{t.name}}/{{t.name}}.vcd",
+                        "isPass": "{{t.simulation_passed}}",
+                    },                
+{% endfor %}
+                ],
+            },
+        },
+{% endfor %}
+    ]
+}
+

--- a/bin/templates/regress_macros.j2
+++ b/bin/templates/regress_macros.j2
@@ -1,0 +1,3 @@
+{%- macro yesorno(val) -%}
+{%- if val -%}YES{%- else -%}NO{%- endif -%}
+{%- endmacro -%}

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -1,0 +1,100 @@
+{#
+
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+
+#}
+{% import 'regress_macros.j2' as regress_macros -%}
+
+#!/bin/bash
+
+# --------------------------------------------------------------------------------------
+# Variables
+# --------------------------------------------------------------------------------------
+pass_count=0
+fail_count=0
+
+# --------------------------------------------------------------------------------------
+# Functions
+# --------------------------------------------------------------------------------------
+check_log () {
+    log=$1
+    simulation_passed="$2"
+    test_name=$3
+    run_index=$4
+
+    if grep -q "${simulation_passed}" ${log}; then
+        echo "script: Test PASSED: ${test_name}_${run_index} Log: ${log}"
+        ((pass_count+=1))
+    else
+        echo "script: Test FAILED: ${test_name}_${run_index} Log: ${log}"
+        ((fail_count+=1))
+    fi
+}
+
+# --------------------------------------------------------------------------------------
+# Builds
+# --------------------------------------------------------------------------------------
+
+{% for b in unique_builds.values() %}
+# Build:{{b.name}} {{b.description}}
+echo "script: Running build: [cd {{b.dir}} && {{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{b.iss}}]"
+pushd {{b.dir}} > /dev/null
+{{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{b.iss}} >& /dev/null;
+popd > /dev/null
+
+{% endfor -%}
+
+# --------------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------------
+
+{% for r in regressions %}
+{% for t in r.tests.values() %}
+#  Test: {{t.name}} {{t.description}}
+{% if t.precmd %}
+#  Test (Precommand): {{t.name}} {{t.description}}
+echo "script: Running precmd: [cd {{t.dir}} && {{t.precmd}} SIMULATOR={{t.simulator}} SEED=random NUM_TESTS={{t.num}}]"
+pushd {{t.dir}} > /dev/null
+{{t.precmd}} SIMULATOR={{t.simulator}} SEED=random NUM_TESTS={{t.num}} >& /dev/null;
+popd > /dev/null
+
+{% endif %}
+{% for run_index in range(t.num|int) %}
+#  Test (Index: {{run_index}}): {{t.name}} {{t.description}}
+echo "script: Running test [cd {{t.dir}} && {{t.cmd}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RUN_INDEX={{run_index}} SEED=random]"
+pushd {{t.dir}} > /dev/null
+{{t.cmd}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RUN_INDEX={{run_index}} SEED=random >& /dev/null;
+popd > /dev/null
+log={{t.dir}}/{{t.simulator}}_results/{{t.name}}/{{t.simulator}}-{{t.name}}.log
+check_log ${log} "{{t.simulation_passed}}" {{t.name}} {{t.run_index}}
+
+{% endfor %}
+
+{% endfor %}
+{% endfor %}
+
+echo "script: Passing tests: ${pass_count}"
+echo "script: Failing tests: ${fail_count}"
+
+if [ ${fail_count} -ne 0 ]; then
+    exit 1
+fi
+exit 0

--- a/ci/ci_check
+++ b/ci/ci_check
@@ -59,7 +59,8 @@ if (sys.version_info < (3,0,0)):
 name_of_ci_check_regression = 'cv32_ci_check_regression' # must match the name of one regression list in .metrics.json
 # This script is run from the "ci" directory, but the paths used by simulator
 # commands assume we are at the root of the repo.
-topdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+topdir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
+print('ci_check: topdir  : {}'.format(topdir))
 
 ################################################################################
 # Methods....
@@ -67,9 +68,9 @@ topdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 # Check results and print something useful
 # TODO: fix this! (its so ugly I'm embarassed to check it in)
 def check_uvm_results():
-    fail_count = 0;
-    expct_fail = 0;
-    pass_count = 0;
+    fail_count = 0
+    expct_fail = 0
+    pass_count = 0
 
     fails = subprocess.Popen('grep "SIMULATION FAILED" `find ../cv32/sim/uvmt_cv32/{}_results -name "*.log" -print`'.format(args.simulator),
                               stdout=subprocess.PIPE,
@@ -212,8 +213,8 @@ os.chdir(topdir)
 # Step 1: Run the User Regression for the UVM verification environment.
 #
 # .metrics.json is the CI regression config used by Metrics CI tools.
-if (uvm):
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '.metrics.json')) as f:
+if (uvm):    
+    with open(os.path.join(topdir, '.metrics.json')) as f:
       metrics_dict = json.load(f)
 
     # Get the build command
@@ -303,7 +304,7 @@ if  (veril):
     print ('Running Verilator tests on CORE testbench...')
     if (debug):
         print('cv32/sim/core')
-    os.chdir(ps.path.join(topdir,'cv32/sim/core'))
+    os.chdir(os.path.join(topdir,'cv32/sim/core'))
 
     if (prcmd or debug):
         print('make')

--- a/ci/ci_check
+++ b/ci/ci_check
@@ -57,6 +57,9 @@ if (sys.version_info < (3,0,0)):
 ################################################################################
 # Gobals....
 name_of_ci_check_regression = 'cv32_ci_check_regression' # must match the name of one regression list in .metrics.json
+# This script is run from the "ci" directory, but the paths used by simulator
+# commands assume we are at the root of the repo.
+topdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 ################################################################################
 # Methods....
@@ -68,11 +71,11 @@ def check_uvm_results():
     expct_fail = 0;
     pass_count = 0;
 
-    fails = subprocess.Popen('grep "SIMULATION FAILED" `find ../cv32/sim/uvmt_cv32 -name "*.log" -print`',
+    fails = subprocess.Popen('grep "SIMULATION FAILED" `find ../cv32/sim/uvmt_cv32/{}_results -name "*.log" -print`'.format(args.simulator),
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               shell="TRUE")
-    passes = subprocess.Popen('grep "SIMULATION PASSED" `find ../cv32/sim/uvmt_cv32 -name "*.log" -print`',
+    passes = subprocess.Popen('grep "SIMULATION PASSED" `find ../cv32/sim/uvmt_cv32/{}_results -name "*.log" -print`'.format(args.simulator),
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT,
                               shell="TRUE")
@@ -191,11 +194,11 @@ if not (prcmd):
     else:
         print ('This will delete your previously cloned RTL repo plus all previously generated files')
         ask_user()
-        os.chdir('../cv32/sim/uvmt_cv32')
+        os.chdir(os.path.join(topdir, 'cv32/sim/uvmt_cv32'))
         os.system('make clean_all')
-        os.chdir('../core')
+        os.chdir(os.path.join(topdir, 'cv32/sim/core'))
         os.system('make clean_all')
-        os.chdir('../../../ci')
+        os.chdir(os.path.join(topdir, 'ci'))
 
 
 ################################################################################
@@ -203,15 +206,14 @@ if not (prcmd):
 
 # This script is run from the "ci" directory, but the paths used by simulator
 # commands assume we are at the root of the repo.
-os.chdir('../')
-topdir = os.getcwd()
+os.chdir(topdir)
 
 #
 # Step 1: Run the User Regression for the UVM verification environment.
 #
 # .metrics.json is the CI regression config used by Metrics CI tools.
 if (uvm):
-    with open('.metrics.json') as f:
+    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '.metrics.json')) as f:
       metrics_dict = json.load(f)
 
     # Get the build command
@@ -301,7 +303,7 @@ if  (veril):
     print ('Running Verilator tests on CORE testbench...')
     if (debug):
         print('cv32/sim/core')
-    os.chdir('cv32/sim/core')
+    os.chdir(ps.path.join(topdir,'cv32/sim/core'))
 
     if (prcmd or debug):
         print('make')

--- a/cv32/regress/cv32_ci_check.yaml
+++ b/cv32/regress/cv32_ci_check.yaml
@@ -1,0 +1,50 @@
+# YAML file to specify a regression testlist
+---
+# Header
+name: cv32_ci_check
+description: Commit sanity for the cv32
+
+# List of builds
+builds:
+  corev-dv:
+    # required: Make the corev-dv infrastructure    
+    cmd: make corev-dv
+    dir: cv32/sim/uvmt_cv32
+  uvmt_cv32:
+    # required: the make command to create the build
+    cmd: make comp
+    dir: cv32/sim/uvmt_cv32
+
+# List of tests
+tests:
+  hello-world:
+    build: uvmt_cv32
+    description: UVM Hello World Test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make hello-world
+    
+  riscv_ebreak_test_0:
+    build: uvmt_cv32
+    description: Static riscv-dv ebreak test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make custom CUSTOM_PROG=riscv_ebreak_test_0
+
+  illegal:
+    build: uvmt_cv32
+    description: Illegal instruction RISCV test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make custom CUSTOM_PROG=illegal
+
+  interrupt_test:
+    build: uvmt_cv32
+    description: Interrupt directed test
+    dir: cv32/sim/uvmt_cv32
+    iss: no
+    cmd: make interrupt_test
+    skip_sim: [xrun, vsim]
+
+  riscv_arithmetic_basic_test_0:
+    build: uvmt_cv32
+    description: riscv-dv basic math test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make custom CUSTOM_PROG=riscv_arithmetic_basic_test_0

--- a/cv32/regress/cv32_full.yaml
+++ b/cv32/regress/cv32_full.yaml
@@ -1,0 +1,30 @@
+name: cv32_full_regression
+description: Full regression (all tests) for CV32
+
+builds: 
+  corev-dv:
+    cmd: make corev-dv
+    dir: cv32/sim/uvmt_cv32
+  uvmt_cv32:
+    cmd: make comp
+    dir: cv32/sim/uvmt_cv32
+    
+tests:
+  hello-world:
+    build: uvmt_cv32
+    description: UVM hello world test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make hello-world
+
+  modeled_csr_por:
+    build: uvmt_cv32
+    description: Modeled CSR PoR test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make custom CUSTOM_PROG=modeled_csr_por
+
+  riscv_ebreak_test_0:
+    build: uvmt_cv32
+    description: Static riscv-dv ebreak test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make custom CUSTOM_PROG=riscv_ebreak_test_0
+

--- a/cv32/regress/cv32_interrupt.yaml
+++ b/cv32/regress/cv32_interrupt.yaml
@@ -1,0 +1,33 @@
+# YAML file to specify a regression testlist
+---
+# Header
+name: cv32_interrupt
+description: Directed and random interrupt tests for CV32E40P
+
+# List of builds
+builds:
+  corev-dv:
+    # required: Make the corev-dv infrastructure    
+    cmd: make corev-dv
+    dir: cv32/sim/uvmt_cv32
+  uvmt_cv32:
+    # required: the make command to create the build
+    cmd: make comp
+    dir: cv32/sim/uvmt_cv32
+
+# List of tests
+tests:
+  interrupt:
+    build: uvmt_cv32
+    description: Interrupt directed test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make interrupt
+    
+  corev_rand_instr_test_0:
+    build: uvmt_cv32
+    description: Static riscv-dv ebreak test
+    dir: cv32/sim/uvmt_cv32
+    precmd: make gen_corev_rand_instr_test
+    cmd: make custom CUSTOM_PROG=corev_rand_instr_test_0
+    num: 10
+


### PR DESCRIPTION
@MikeOpenHWGroup  We will want to have a call over this particular pull request.  I'm sure all of this is non-controversial. :-)

- Introduces CWD portability (i.e. add wrappers and make sure scripts can be run from any directory)
-- Made slight changes to ci_check for directory robustness, but no functional change
-- regression testlist YAML NOT applied to ci_check yet
- First cut of the cv_regress script which generates various output regression products (metrics json, shell, other regression tools...) from common YAML regression lists
- Initial yaml regression lists for cv32
- Introduce bin/ directory for common utilities in core-v-verif
- README markdowns provided in all new bin and template directories for utility and YAML documentation

All changes should still be backwards compatible

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>