### PR TITLE
Strichmo/riscv dv irq config

### DIFF
--- a/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
+++ b/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
@@ -35,7 +35,7 @@ class corev_asm_program_gen extends riscv_asm_program_gen;
     instr_stream.push_back(".include \"user_define.h\"");
     instr_stream.push_back(".section .text.start");
     instr_stream.push_back(".globl _start");
-    instr_stream.push_back(".section .text");
+    instr_stream.push_back(".section .init");
     if (cfg.disable_compressed_instr) begin
       instr_stream.push_back(".option norvc;");
     end

--- a/vendor_lib/google/corev-dv/corev_instr_base_test.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_base_test.sv
@@ -36,7 +36,22 @@ class corev_instr_base_test extends riscv_instr_base_test;
   endfunction
 
   virtual function void build_phase(uvm_phase phase);
+    apply_gen_config();
+    apply_privil_reg();
+
     super.build_phase(phase);
+  endfunction
+
+  virtual function void apply_gen_config();
+    `uvm_info("COREVTEST", "I be here", UVM_NONE);
+    uvm_factory::get().set_type_override_by_type(riscv_instr_gen_config::get_type(),
+                                                 corev_instr_gen_config::get_type());
+  endfunction
+
+  virtual function void apply_privil_reg();
+    `uvm_info("COREVTEST", "I be here", UVM_NONE);
+    uvm_factory::get().set_type_override_by_type(riscv_privil_reg::get_type(),
+                                                 corev_privil_reg::get_type());
   endfunction
 
   virtual function void apply_directed_instr();

--- a/vendor_lib/google/corev-dv/corev_instr_base_test.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_base_test.sv
@@ -19,7 +19,9 @@
 // CORE-V instruction generator base test:
 //     - extension of the RISC-V instruction generator base test.
 //
-// Uses the factory to replace riscv_asm_program_gen with corev_asm_program_gen.
+// - Uses the factory to replace riscv_asm_program_gen with corev_asm_program_gen.
+// - Uses the factory to replace riscv_privil_reg with corev_privil_reg which
+//        adds platform-specific fields
 //------------------------------------------------------------------------------
 
 class corev_instr_base_test extends riscv_instr_base_test;
@@ -36,20 +38,18 @@ class corev_instr_base_test extends riscv_instr_base_test;
   endfunction
 
   virtual function void build_phase(uvm_phase phase);
-    apply_gen_config();
-    apply_privil_reg();
+    override_gen_config();
+    override_privil_reg();
 
     super.build_phase(phase);
   endfunction
 
-  virtual function void apply_gen_config();
-    `uvm_info("COREVTEST", "I be here", UVM_NONE);
+  virtual function void override_gen_config();    
     uvm_factory::get().set_type_override_by_type(riscv_instr_gen_config::get_type(),
                                                  corev_instr_gen_config::get_type());
   endfunction
 
-  virtual function void apply_privil_reg();
-    `uvm_info("COREVTEST", "I be here", UVM_NONE);
+  virtual function void override_privil_reg();    
     uvm_factory::get().set_type_override_by_type(riscv_privil_reg::get_type(),
                                                  corev_privil_reg::get_type());
   endfunction

--- a/vendor_lib/google/corev-dv/corev_instr_gen_config.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_gen_config.sv
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google LLC
+ * Copyright 2020 OpenHW Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//------------------------------------------------------------------------------
+// CORE-V instruction generator configuration class:
+//     - extension of the RISC-V instruction generator base test.
+//
+// The base test Uses the factory to replace riscv_instr_gen_config with corev_instr_gen_config
+//------------------------------------------------------------------------------
+
+class corev_instr_gen_config extends riscv_instr_gen_config;
+
+  // CV32E40P requires the MTVEC table to be aligned to 256KB boundaries
+  constraint mtvec_c {
+    //tvec_alignment inside {[9:9]};
+    tvec_alignment == 8;
+  }
+
+  `uvm_object_utils(corev_instr_gen_config)
+
+  function new(string name="");
+    super.new(name);
+  endfunction
+
+endclass

--- a/vendor_lib/google/corev-dv/corev_instr_gen_config.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_gen_config.sv
@@ -25,8 +25,7 @@
 class corev_instr_gen_config extends riscv_instr_gen_config;
 
   // CV32E40P requires the MTVEC table to be aligned to 256KB boundaries
-  constraint mtvec_c {
-    //tvec_alignment inside {[9:9]};
+  constraint mtvec_c {    
     tvec_alignment == 8;
   }
 

--- a/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
@@ -20,6 +20,8 @@ package corev_instr_test_pkg;
   import riscv_instr_pkg::*;
   import riscv_instr_test_pkg::*;
 
+  `include "corev_privil_reg.sv"
+  `include "corev_instr_gen_config.sv"
   `include "corev_asm_program_gen.sv"
   `include "corev_instr_base_test.sv"
 

--- a/vendor_lib/google/corev-dv/corev_privil_reg.sv
+++ b/vendor_lib/google/corev-dv/corev_privil_reg.sv
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Google LLC
+ * Copyright 2020 OpenHW Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//------------------------------------------------------------------------------
+// CORE-V privileged register class
+//     Extends privilege registers for CORE-V core platform extensions
+//
+// The base test Uses the factory to replace riscv_privil_reg with corev_privil_reg
+//------------------------------------------------------------------------------
+
+class corev_privil_reg extends riscv_privil_reg;
+
+  `uvm_object_utils(corev_privil_reg);
+
+  function new(string name="");
+    super.new(name);
+  endfunction
+
+  // Add fields in privileged registers
+  function void init_reg(REG_T reg_name);
+    super.init_reg(reg_name);
+    
+    case(reg_name) inside 
+      // Machine interrupt-enable register
+      MIE: begin
+        fld.delete();
+
+        add_field("USIE",   1,  WARL);
+        add_field("SSIE",   1,  WARL);
+        add_field("WPRI0",  1,  WPRI);
+        add_field("MSIE",   1,  WARL);
+        add_field("UTIE",   1,  WARL);
+        add_field("STIE",   1,  WARL);
+        add_field("WPRI1",  1,  WPRI);
+        add_field("MTIE",   1,  WARL);
+        add_field("UEIE",   1,  WARL);
+        add_field("SEIE",   1,  WARL);
+        add_field("WPRI2",  1,  WPRI);
+        add_field("MEIE",   1,  WARL);
+        add_field("WPRI3",  4,  WPRI);
+        for (int i = 0; i < 16; i++) begin
+          add_field($sformatf("FIE%0d", i), 1, WARL);
+        end
+      end
+      MIP: begin
+        fld.delete();
+
+        add_field("USIP",   1,  WARL);
+        add_field("SSIP",   1,  WARL);
+        add_field("WPRI0",  1,  WPRI);
+        add_field("MSIP",   1,  WARL);
+        add_field("UTIP",   1,  WARL);
+        add_field("STIP",   1,  WARL);
+        add_field("WPRI1",  1,  WPRI);
+        add_field("MTIP",   1,  WARL);
+        add_field("UEIP",   1,  WARL);
+        add_field("SEIP",   1,  WARL);
+        add_field("WPRI2",  1,  WPRI);
+        add_field("MEIP",   1,  WARL);
+        add_field("WPRI3",  4,  WPRI);
+        for (int i = 0; i < 16; i++) begin
+          add_field($sformatf("FIP%0d", i), 1, WARL);
+        end
+      end
+    endcase
+  endfunction : init_reg
+
+endclass : corev_privil_reg
+

--- a/vendor_lib/google/corev-dv/target/cv32e40p/riscv_core_setting.sv
+++ b/vendor_lib/google/corev-dv/target/cv32e40p/riscv_core_setting.sv
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------
+// Processor feature configuration
+//-----------------------------------------------------------------------------
+// XLEN
+parameter int XLEN = 32;
+
+// Parameter for SATP mode, set to BARE if address translation is not supported
+parameter satp_mode_t SATP_MODE = BARE;
+
+// Supported Privileged mode
+privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
+
+// Unsupported instructions
+riscv_instr_name_t unsupported_instr[];
+
+// ISA supported by the processor
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C};
+
+// Interrupt mode support
+mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+
+// The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
+// supported
+int max_interrupt_vector_num = 32;
+
+// Physical memory protection support
+bit support_pmp = 0;
+
+// Debug mode support
+bit support_debug_mode = 0;
+
+// Support delegate trap to user mode
+bit support_umode_trap = 0;
+
+// Support sfence.vma instruction
+bit support_sfence = 0;
+
+// Support unaligned load/store
+bit support_unaligned_load_store = 1'b1;
+
+// GPR setting
+parameter int NUM_FLOAT_GPR = 32;
+parameter int NUM_GPR = 32;
+parameter int NUM_VEC_GPR = 32;
+
+// ----------------------------------------------------------------------------
+// Vector extension configuration
+// ----------------------------------------------------------------------------
+
+// Parameter for vector extension
+parameter int VECTOR_EXTENSION_ENABLE = 0;
+
+parameter int VLEN = 512;
+
+// Maximum size of a single vector element
+parameter int ELEN = 32;
+
+// Minimum size of a sub-element, which must be at most 8-bits.
+parameter int SELEN = 8;
+
+// Maximum size of a single vector element (encoded in vsew format)
+parameter int VELEN = int'($ln(ELEN)/$ln(2)) - 3;
+
+// Maxium LMUL supported by the core
+parameter int MAX_LMUL = 8;
+
+// ----------------------------------------------------------------------------
+// Multi-harts configuration
+// ----------------------------------------------------------------------------
+
+// Number of harts
+parameter int NUM_HARTS = 1;
+
+// ----------------------------------------------------------------------------
+// Previleged CSR implementation
+// ----------------------------------------------------------------------------
+
+// Implemented previlieged CSR list
+`ifdef DSIM
+privileged_reg_t implemented_csr[] = {
+`else
+const privileged_reg_t implemented_csr[] = {
+`endif
+    // Machine mode mode CSR
+    MVENDORID,  // Vendor ID
+    MARCHID,    // Architecture ID
+    MIMPID,     // Implementation ID
+    MHARTID,    // Hardware thread ID
+    MSTATUS,    // Machine status
+    MISA,       // ISA and extensions
+    MIE,        // Machine interrupt-enable register
+    MTVEC,      // Machine trap-handler base address
+    MCOUNTEREN, // Machine counter enable
+    MSCRATCH,   // Scratch register for machine trap handlers
+    MEPC,       // Machine exception program counter
+    MCAUSE,     // Machine trap cause
+    MTVAL,      // Machine bad address or instruction
+    MIP         // Machine interrupt pending
+};
+
+// ----------------------------------------------------------------------------
+// Supported interrupt/exception setting, used for functional coverage
+// ----------------------------------------------------------------------------
+
+`ifdef DSIM
+interrupt_cause_t implemented_interrupt[] = {
+`else
+const interrupt_cause_t implemented_interrupt[] = {
+`endif
+    M_SOFTWARE_INTR,
+    M_TIMER_INTR,
+    M_EXTERNAL_INTR
+};
+
+`ifdef DSIM
+exception_cause_t implemented_exception[] = {
+`else
+const exception_cause_t implemented_exception[] = {
+`endif
+    INSTRUCTION_ACCESS_FAULT,
+    ILLEGAL_INSTRUCTION,
+    BREAKPOINT,
+    LOAD_ADDRESS_MISALIGNED,
+    LOAD_ACCESS_FAULT,
+    ECALL_MMODE
+};


### PR DESCRIPTION
riscv-dv reconfiguration to support interrupts to prepare for random interrupt testing
all changes are in corev-dv and use factory to avoid riscv-dv code changes
added a new corev-dv target specifically for the cv32e40p
