### PR TITLE
move functional coverage of the ISA from iss_wrap to uvm component in…

### DIFF
--- a/cv32/env/uvme_cv32/cov/uvme_cv32_cov_model.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_cv32_cov_model.sv
@@ -35,7 +35,8 @@ class uvme_cv32_cov_model_c extends uvm_component;
    // TODO Add Input TLM to uvme_cv32_cov_model_c
    //      Ex: uvm_analysis_port    #(uvma_debug_mon_trn_c)  debug_export;
    //          uvm_tlm_analysis_fifo#(uvma_debug_mon_trn_c)  debug_fifo;
-   
+
+   uvme_rv32isa_covg isa_covg;   
    
    `uvm_component_utils_begin(uvme_cv32_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -120,6 +121,9 @@ function void uvme_cv32_cov_model_c::build_phase(uvm_phase phase);
    if (!cntxt) begin
       `uvm_fatal("CNTXT", "Context handle is null")
    end
+
+   isa_covg = uvme_rv32isa_covg::type_id::create("isa_covg", this);
+   uvm_config_db#(uvme_cv32_cntxt_c)::set(this, "isa_covg", "cntxt", cntxt);
    
    // TODO Build Input TLM
    //      Ex: debug_export = new("debug_export", this);

--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -36,7 +36,8 @@
 
 class uvme_rv32isa_covg extends uvm_component;
 
-    
+    uvme_cv32_cntxt_c cntxt;
+
 // The following CSR ABI names are not currently included:
 // fp, pc
     function gpr_name_t get_gpr_name (string s, r, asm);
@@ -1336,9 +1337,11 @@ class uvme_rv32isa_covg extends uvm_component;
         }
     endgroup
 
+    `uvm_component_utils(uvme_rv32isa_covg)
+
 // TODO : review by 20-July-2020
     function new(string name="rv32isa_covg", uvm_component parent=null);
-        super.new("parent", parent);
+        super.new(name, parent);
         add_cg        = new();
         addi_cg       = new();
         and_cg        = new();
@@ -1415,7 +1418,7 @@ class uvme_rv32isa_covg extends uvm_component;
     function void build_phase(uvm_phase phase);
         super.build_phase(phase);
 
-        void'(uvm_config_db#(uvme_cv32_cntxt_c)::get(this, "", "cntxt", cntxt);
+        void'(uvm_config_db#(uvme_cv32_cntxt_c)::get(this, "", "cntxt", cntxt));
         if (cntxt == null) begin
             `uvm_fatal("RV32ISACOVG", "No cntxt object passed to model");
         end
@@ -1423,6 +1426,13 @@ class uvme_rv32isa_covg extends uvm_component;
 
     task run_phase(uvm_phase phase);
         super.run_phase(phase);
+
+        `uvm_info("rv32isa_covg", "The RV32ISA coverage model is running", UVM_LOW);
+
+        while (1) begin
+           @(cntxt.isa_covg_vif.ins_valid);
+           sample(cntxt.isa_covg_vif.ins);
+        end
     endtask
 
     function void check_compressed(input ins_t ins);
@@ -1636,4 +1646,4 @@ class uvme_rv32isa_covg extends uvm_component;
     endfunction: sample
 
 
-endclass : riscv_32isa_coverage
+endclass : uvme_rv32isa_covg

--- a/cv32/env/uvme_cv32/uvme_cv32_cfg.sv
+++ b/cv32/env/uvme_cv32/uvme_cv32_cfg.sv
@@ -67,7 +67,7 @@ class uvme_cv32_cfg_c extends uvm_object;
       soft enabled                == 0;
       soft is_active              == UVM_PASSIVE;
       soft scoreboarding_enabled  == 1;
-      soft cov_model_enabled      == 0;
+      soft cov_model_enabled      == 1;
       soft trn_log_enabled        == 1;
       soft sys_clk_period       == uvme_cv32_sys_default_clk_period; // see uvme_cv32_constants.sv
       //soft debug_clk_period       == uvme_cv32_debug_default_clk_period;

--- a/cv32/env/uvme_cv32/uvme_cv32_cntxt.sv
+++ b/cv32/env/uvme_cv32/uvme_cv32_cntxt.sv
@@ -23,7 +23,10 @@
  * (uvme_cv32_env_c) components.
  */
 class uvme_cv32_cntxt_c extends uvm_object;
-   
+
+   // Virtual interface for ISA coverage
+   virtual uvmt_cv32_isa_covg_if isa_covg_vif;
+
    // Agent context handles
    uvma_clknrst_cntxt_c  clknrst_cntxt;
    //uvma_debug_cntxt_c    debug_cntxt;

--- a/cv32/env/uvme_cv32/uvme_cv32_env.sv
+++ b/cv32/env/uvme_cv32/uvme_cv32_env.sv
@@ -42,7 +42,6 @@ class uvme_cv32_env_c extends uvm_env;
    uvma_clknrst_agent_c  clknrst_agent;
    //uvma_debug_agent_c  debug_agent;
    
-   
    `uvm_component_utils_begin(uvme_cv32_env_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
       `uvm_field_object(cntxt, UVM_DEFAULT)
@@ -250,11 +249,13 @@ function void uvme_cv32_env_c::create_vsequencer();
    
 endfunction: create_vsequencer
 
-
 function void uvme_cv32_env_c::create_cov_model();
    
    cov_model = uvme_cv32_cov_model_c::type_id::create("cov_model", this);
-   
+   void'(uvm_config_db#(virtual uvmt_cv32_isa_covg_if)::get(this, "", "isa_covg_vif", cntxt.isa_covg_vif));
+   if (cntxt.isa_covg_vif == null) begin
+      `uvm_fatal("CNTXT", $sformatf("No uvmt_cv32_isa_covg_if found in config database"))
+   end
 endfunction: create_cov_model
 
 

--- a/cv32/env/uvme_cv32/uvme_cv32_pkg.sv
+++ b/cv32/env/uvme_cv32/uvme_cv32_pkg.sv
@@ -53,6 +53,7 @@ package uvme_cv32_pkg;
    `include "uvme_cv32_prd.sv"
    
    // Environment components
+   `include "uvme_rv32isa_covg.sv"
    `include "uvme_cv32_cov_model.sv"
    `include "uvme_cv32_sb.sv"
    `include "uvme_cv32_vsqr.sv"

--- a/cv32/env/uvme_cv32/uvme_cv32_tdefs.sv
+++ b/cv32/env/uvme_cv32/uvme_cv32_tdefs.sv
@@ -17,6 +17,70 @@
 `ifndef __UVME_CV32_TDEFS_SV__
 `define __UVME_CV32_TDEFS_SV__
 
+// The following pseudo-instructions have been removed:
+// BEQZ, BGEZ, BGT,BGTU,BGTZ, BLE,BLEU,BLEZ,BLTZ, BNEZ, ILLEGAL
+// J, JR, MV, NOT, NEG, NEGW, RET, SEQZ, SGTZ, SLTZ, SNEZ
+// The following compressed instructions have not been added:
+// C_FLWSP,C_FLDSP,C_FSWSP,C_FSDSP,C_FLW,C_FLD,C_FSW,C_FSD,
+// C_J,C_JR,C_BEQZ,C_BNEZ,C_MV,C_SLLI64,C_SRLI64,C_SRAI64
+// The following instructions have been added:
+// FENCE
+typedef enum {
+    ADD,ADDI,AND,ANDI,AUIPC,BEQ,BGE,BGEU
+    ,BLTU,BNE,BLT, FENCE, EBREAK,ECALL
+    ,J,JAL,JALR,LB,LBU,LH,LHU
+    ,LUI,LW,NOP,OR
+    ,ORI, SB, SH,SLL,SLLI
+    ,SLT,SLTI,SLTIU,SLTU,SRA,SRAI
+    ,SRL,SRLI,SUB,SW,XOR,XORI
+    ,MUL,MULH,MULHU,MULHSU
+    ,DIV,REM,DIVU,REMU
+    ,C_LWSP,C_SWSP,C_LW,C_SW
+    ,C_JAL,C_JALR,C_LI,C_LUI
+    ,C_ADDI,C_ADDI16SP,C_ADDI4SPN
+    ,C_SLLI,C_SRLI,C_SRAI,C_ANDI,C_ADD
+    ,C_AND,C_OR,C_XOR,C_SUB,C_NOP,C_EBREAK
+} instr_name_t; // assembler
+
+
+// The following CSR ABI names are not currently included:
+// fp, pc
+//"gpr_none" CSR ABI name added for JALR instruction check:
+typedef enum {
+    zero,ra,sp,gp,tp,t0,t1,t2,s0
+    ,s1,a0,a1,a2,a3,a4,a5,a6
+    ,a7,s2,s3,s4,s5,s6,s7,s8
+    ,s9,s10,s11,t3,t4,t5,t6
+    ,gpr_none
+} gpr_name_t; // ABI name
+
+// The following CSRs are not currently included:
+// mstatush, mtinst, mtval2, mhpmcounter3, ..., mhpmcounter31,
+// mhpmcounter3h, ..., mhpmcounter31h,
+//The following CSRs have been removed:
+// satp (supervisor-mode address translation and protection)
+typedef enum {
+    marchid,mcause,mcounteren,mcountinhibit,mcycle,mcycleh,medeleg,mepc,mhartid
+    ,mhpmevent10,mhpmevent11,mhpmevent12,mhpmevent13,mhpmevent14,mhpmevent15,mhpmevent16,mhpmevent17
+    ,mhpmevent18,mhpmevent19,mhpmevent20,mhpmevent21,mhpmevent22,mhpmevent23,mhpmevent24,mhpmevent25
+    ,mhpmevent26,mhpmevent27,mhpmevent28,mhpmevent29,mhpmevent3,mhpmevent30,mhpmevent31,mhpmevent4
+    ,mhpmevent5,mhpmevent6,mhpmevent7,mhpmevent8,mhpmevent9,mideleg,mie,mimpid
+    ,minstret,minstreth,mip,misa,mscratch,mstatus,mtval,mtvec
+    ,mvendorid,pmpaddr0,pmpaddr1,pmpaddr10,pmpaddr11,pmpaddr12,pmpaddr13,pmpaddr14
+    ,pmpaddr15,pmpaddr2,pmpaddr3,pmpaddr4,pmpaddr5,pmpaddr6,pmpaddr7,pmpaddr8
+    ,pmpaddr9,pmpcfg0,pmpcfg1,pmpcfg2,pmpcfg3
+} csr_name_t;
+
+typedef struct {
+    string key;
+    string val;
+} ops_t;
+
+typedef struct {
+    string ins_str;
+    instr_name_t asm;
+    ops_t ops[4];
+} ins_t;
 
 // TODO Add scoreboard specializations
 //      Ex: typedef uvml_sb_cntxt_c#(

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
@@ -15,9 +15,6 @@
 //
 //
 
-
-`include "uvmt_rv32isa_covg.sv"
-
 `ifndef __UVMT_CV32_ISS_WRAP_SV__
 `define __UVMT_CV32_ISS_WRAP_SV__
 
@@ -39,7 +36,8 @@ module uvmt_cv32_iss_wrap
    (
     input realtime      clk_period,
     uvma_clknrst_if clknrst_if,
-    uvmt_cv32_step_compare_if step_compare_if
+    uvmt_cv32_step_compare_if step_compare_if,
+    uvmt_cv32_isa_covg_if     isa_covg_if
 //    input bit           Step,
 //    input bit           Stepping,
 //    output logic [31:0] PCr
@@ -99,12 +97,6 @@ module uvmt_cv32_iss_wrap
    always @(step_compare_if.ovp_cpu_busWait) cpu.busWait();
    always @(cpu.Retire) -> step_compare_if.ovp_cpu_retire;
 
-    //coverage cov1;
-    riscv_32isa_coverage cov1;
-    initial begin
-        cov1 = new();
-    end
-
     function void split(input string in_s, output string s1, s2);
         automatic int i;
         for (i=0; i<in_s.len(); i++) begin
@@ -119,20 +111,19 @@ module uvmt_cv32_iss_wrap
          s2 = in_s.substr(i+1,in_s.len()-1);
     endfunction
 
-
     function automatic void sample();
-        string decode = uvmt_cv32_tb.iss_wrap.cpu.Decode;
+        string decode = cpu.Decode;
         string ins_str, op[4], key, val;
         int i;
-        ins_t ins;
+
         int num = $sscanf (decode, "%s %s %s %s %s", ins_str, op[0], op[1], op[2], op[3]);
-        ins.ins_str = ins_str;
+        isa_covg_if.ins.ins_str = ins_str;
         for (i=0; i<num-1; i++) begin
             split(op[i], key, val);
-            ins.ops[i].key=key;
-            ins.ops[i].val=val;
+            isa_covg_if.ins.ops[i].key=key;
+            isa_covg_if.ins.ops[i].val=val;
         end
-        cov1.sample (ins);
+        ->isa_covg_if.ins_valid;
     endfunction
 
    always @(cpu.Retire) begin

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_pkg.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_pkg.sv
@@ -26,8 +26,6 @@
 `include "uvml_logs_macros.sv"
 `include "uvmt_cv32_macros.sv"
 
-// All Interfaces used by the CV32 TB are here
-`include "uvmt_cv32_tb_ifs.sv"
 
 
 /**
@@ -66,5 +64,7 @@ package uvmt_cv32_pkg;
 
 endpackage : uvmt_cv32_pkg
 
+// All Interfaces used by the CV32 TB are here
+`include "uvmt_cv32_tb_ifs.sv"
 
 `endif // __UVMT_CV32_PKG_SV__

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -49,7 +49,8 @@ module uvmt_cv32_tb;
 
    // Step and compare interface
    uvmt_cv32_step_compare_if step_compare_if();
-    
+   uvmt_cv32_isa_covg_if     isa_covg_if();
+
   /**
    * DUT WRAPPER instance:
    * This is an update of the riscv_wrapper.sv from PULP-Platform RI5CY project with
@@ -72,7 +73,8 @@ module uvmt_cv32_tb;
                            )
                            iss_wrap ( .clk_period(clknrst_if.clk_period),
                                       .clknrst_if(clknrst_if_iss),
-                                      .step_compare_if(step_compare_if)
+                                      .step_compare_if(step_compare_if),
+                                      .isa_covg_if(isa_covg_if)
                              );
      /**
       * Step-and-Compare logic 
@@ -100,6 +102,7 @@ module uvmt_cv32_tb;
      uvm_config_db#(virtual uvmt_cv32_core_status_if    )::set(.cntxt(null), .inst_name("*"), .field_name("core_status_vif"),     .value(core_status_if)    );
      uvm_config_db#(virtual uvmt_cv32_core_interrupts_if)::set(.cntxt(null), .inst_name("*"), .field_name("core_interrupts_vif"), .value(core_interrupts_if));
      uvm_config_db#(virtual uvmt_cv32_step_compare_if   )::set(.cntxt(null), .inst_name("*"), .field_name("step_compare_vif"),    .value(step_compare_if));
+     uvm_config_db#(virtual uvmt_cv32_isa_covg_if       )::set(.cntxt(null), .inst_name("*"), .field_name("isa_covg_vif"),        .value(isa_covg_if));
       
      // Make the DUT Wrapper Virtual Peripheral's status outputs available to the base_test
      uvm_config_db#(bit      )::set(.cntxt(null), .inst_name("*"), .field_name("tp"),     .value(1'b0)        );

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -249,6 +249,20 @@ interface uvmt_cv32_core_status_if (
 endinterface : uvmt_cv32_core_status_if
 
 /**
+ * ISA coverage interface
+ * ISS wrapper will fill in ins (instruction) and fire ins_valid event
+ */
+interface uvmt_cv32_isa_covg_if;
+
+  import uvm_pkg::*;
+  import uvme_cv32_pkg::*;
+
+  event ins_valid;
+  ins_t ins;
+
+endinterface : uvmt_cv32_isa_covg_if
+
+/**
  * Step and compare interface
  * Xcelium does not support event types in the module port list
  */


### PR DESCRIPTION
…side uvme_cv32_cov_model

enumerated types for coverage moved into the uvme_cv32_pkg
iss_wrap still supplies the coverage instruction via interaface uvmt_cv32_isa_covg_if

Did not add analysis port yet
Move class definition from uvmt pkg to uvme pkg
Tested coverage via single test in Xcelium and Questa
