### PR TITLE
rework clknrst_if clock and reset init behavior to match async reset strategy

### DIFF
--- a/cv32/env/uvme_cv32/vseq/uvme_cv32_reset_vseq.sv
+++ b/cv32/env/uvme_cv32/vseq/uvme_cv32_reset_vseq.sv
@@ -68,19 +68,10 @@ task uvme_cv32_reset_vseq_c::body();
    uvma_clknrst_seq_item_c  clk_start_req;
    uvma_clknrst_seq_item_c  reset_assrt_req;
 
-   `uvm_info("RST_VSEQ", $sformatf("Starting clock with period of %0t", (cfg.sys_clk_period * 1ps)), UVM_LOW)
-   `uvm_do_on_with(clk_start_req, p_sequencer.clknrst_sequencer, {
-      action        == UVMA_CLKNRST_SEQ_ITEM_ACTION_START_CLK;
-      initial_value == UVMA_CLKNRST_SEQ_ITEM_INITIAL_VALUE_0;
-      //clk_period    == local::cfg.sys_clk_period;
-      clk_period    == cfg.sys_clk_period;
-      //clk_period    == uvme_cv32_sys_default_clk_period;
-   })
-
-   `uvm_info("RST_VSEQ", $sformatf("waiting %0d clock cycles before issuing reset pulse", num_clk_before_reset), UVM_LOW)
-   repeat (num_clk_before_reset) begin
-      wait (cntxt.clknrst_cntxt.vif.clk === 1);
-   end
+   // Define the clock before applying reset
+   #1;
+   cntxt.clknrst_cntxt.vif.clk = 0;
+   #1;
 
    `uvm_info("RST_VSEQ", $sformatf("Asserting reset for %0t", (rst_deassert_period * 1ps)), UVM_LOW)
    `uvm_do_on_with(reset_assrt_req, p_sequencer.clknrst_sequencer, {
@@ -91,6 +82,15 @@ task uvme_cv32_reset_vseq_c::body();
 
    `uvm_info("RST_VSEQ", $sformatf("Done reset, waiting %0t for DUT to stabilize", (post_rst_wait * 1ps)), UVM_LOW)
    #(post_rst_wait * 1ps);
+
+   `uvm_info("RST_VSEQ", $sformatf("Starting clock with period of %0t", (cfg.sys_clk_period * 1ps)), UVM_LOW)
+   `uvm_do_on_with(clk_start_req, p_sequencer.clknrst_sequencer, {
+      action        == UVMA_CLKNRST_SEQ_ITEM_ACTION_START_CLK;
+      initial_value == UVMA_CLKNRST_SEQ_ITEM_INITIAL_VALUE_0;
+      //clk_period    == local::cfg.sys_clk_period;
+      clk_period    == cfg.sys_clk_period;
+      //clk_period    == uvme_cv32_sys_default_clk_period;
+   })
    
 endtask : body
 

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
@@ -131,7 +131,10 @@ module uvmt_cv32_iss_wrap
    end
 
    initial begin
+     clknrst_if.clk = 1'b0;
       #1;  // time for clknrst_if_dut to set the clk_period
+      wait (clk_period != 0.0);
+      `uvm_info("ISSWRAP", "Starting ISS clock", UVM_LOW)
       clknrst_if.set_period(clk_period);
       clknrst_if.start_clk();
    end

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
@@ -241,8 +241,10 @@ module uvmt_cv32_step_compare
    // Then wait for the next compare event and start the clocks again
    initial begin
       static integer instruction_count = 0;
-      @(negedge clknrst_if.reset_n) ;// To allow uvmt_cv32_base_test_c::reset_phase to execute and set clk_period
-      clknrst_if.start_clk();
+      // Asynchronous reset design, allow the uvmt_cv32_base_test_c::reset_phase to execute a full reset cycle first
+      wait (clknrst_if.reset_n === 1'b0);
+      wait (clknrst_if.reset_n === 1'b1);
+      wait (clknrst_if.clk_active === 1'b1);
       forever begin
          @(step_compare_if.riscv_retire);
          clknrst_if.stop_clk();

--- a/lib/uvm_agents/uvma_clknrst/uvma_clknrst_if.sv
+++ b/lib/uvm_agents/uvma_clknrst/uvma_clknrst_if.sv
@@ -54,6 +54,10 @@ interface uvma_clknrst_if ();
       end
    end
    
+   always @* begin
+      if (clk_active && clk_period == 0.0) 
+         `uvm_fatal("CLKNRSTIF", $sformatf("%m: Clock is active with 0 period"))
+   end
    /**
     * Sets clk_period
     */


### PR DESCRIPTION
avoid clock == x overlap with reset assertion
do not ring clocks until a stable reset cycle (1->0->1) is completed
