### PR TITLE
corev-dv interrupt streams and fixes

### DIFF
--- a/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
+++ b/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
@@ -55,6 +55,7 @@ class corev_asm_program_gen extends riscv_asm_program_gen;
     instr_stream.push_back("");
     instr_stream.push_back("#Start: Extracted from riscv_compliance_tests/riscv_test.h");
     instr_stream.push_back("test_done:");
+    instr_stream.push_back("                  csrrci x0,mstatus,0x8 # Clear MSTATUS.MIE to avoid interrupts during test_done");
     instr_stream.push_back("                  lui a0,print_port>>12");
     instr_stream.push_back("                  addi a1,zero,'\\n'");
     instr_stream.push_back("                  sw a1,0(a0)");

--- a/vendor_lib/google/corev-dv/corev_instr_base_test.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_base_test.sv
@@ -31,10 +31,15 @@ class corev_instr_base_test extends riscv_instr_base_test;
   string                  asm_file_name;
   corev_asm_program_gen   asm_gen;
 
+  corev_report_server     rs;
+
   `uvm_component_utils(corev_instr_base_test)
 
   function new(string name="", uvm_component parent=null);
     super.new(name, parent);
+
+    rs = new("rs");
+    uvm_report_server::set_server(rs);
   endfunction
 
   virtual function void build_phase(uvm_phase phase);

--- a/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
@@ -20,9 +20,13 @@ package corev_instr_test_pkg;
   import riscv_instr_pkg::*;
   import riscv_instr_test_pkg::*;
 
+  // Instruction streams
+  `include "corev_interrupt_csr_instr_lib.sv"
+
   `include "corev_privil_reg.sv"
   `include "corev_instr_gen_config.sv"
   `include "corev_asm_program_gen.sv"
+  `include "corev_report_server.sv"
   `include "corev_instr_base_test.sv"
 
 endpackage

--- a/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
+++ b/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
@@ -1,0 +1,49 @@
+class corev_interrupt_csr_instr_stream extends riscv_rand_instr_stream;
+
+  `uvm_object_utils(corev_interrupt_csr_instr_stream)
+  `uvm_object_new
+
+  function void post_randomize();
+    `uvm_info("CVINTRRUPTCSRINSTR", "I am here", UVM_LOW)
+    initialize_instr_list(1);
+    allowed_instr = {CSRRW, CSRRS, CSRRC};
+
+    foreach (instr_list[i]) begin
+      randomize_instr(instr_list[i]);
+      randcase
+        1: generate_mie_write();
+        1: generate_mstatus_mie_write();
+      endcase
+    end
+
+  endfunction
+
+  function void generate_mie_write();
+    // Create a single MIE that can write, clear or set random bits unconstrained
+    `uvm_info("CVINTRCSRINSTR", "Generate MIE", UVM_LOW)
+    initialize_instr_list(.instr_cnt(1));
+
+    instr_list[0] = riscv_instr::get_rand_instr(.include_instr({CSRRW, CSRRS, CSRRC}));
+    instr_list[0].csr_c.constraint_mode(0);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(instr_list[0],
+      csr == MIE;,
+      "Cannot randomize MIE CSR instruction"
+    )    
+  endfunction
+
+  function void generate_mstatus_mie_write();
+    // Randomly set or clear bit 3 (MIE) in MSTATUS    
+    `uvm_info("CVINTRCSRINSTR", "Generate MSTATUS_MIE", UVM_LOW)
+    
+    initialize_instr_list(.instr_cnt(1));
+    instr_list[0] = riscv_instr::get_rand_instr(.include_instr({CSRRWI, CSRRSI, CSRRCI}));
+    instr_list[0].csr_c.constraint_mode(0);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(instr_list[0],
+      rd == ZERO;
+      csr == MSTATUS;
+      imm inside {'h4, 'h0};,
+      "Cannot randomize MSTATUS_MIE CSR instruction"
+    )
+  endfunction
+
+endclass : corev_interrupt_csr_instr_stream

--- a/vendor_lib/google/corev-dv/corev_report_server.sv
+++ b/vendor_lib/google/corev-dv/corev_report_server.sv
@@ -1,0 +1,93 @@
+class corev_report_server extends uvm_default_report_server;
+   
+   extern function new(string name="corev_report_server");
+      
+   extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name="");   
+   extern virtual function void report_summarize(UVM_FILE file=0);
+endclass : corev_report_server
+
+function corev_report_server::new(string name = "corev_report_server");
+   super.new(name);
+endfunction : new
+
+
+function string corev_report_server::compose_report_message(uvm_report_message report_message, string report_object_name="");
+   
+   string sev_string;
+   uvm_severity l_severity;
+   uvm_verbosity l_verbosity;
+   string reduced_filename;
+   string filename_line_string;
+   string time_str;
+   string line_str;
+   string context_str;
+   string verbosity_str;
+   string terminator_str;
+   string msg_body_str;
+   uvm_report_message_element_container el_container;
+   string prefix;
+   uvm_report_handler l_report_handler;
+   
+   l_severity = report_message.get_severity();
+   sev_string = l_severity.name();
+   
+   if (report_message.get_filename() != "") begin
+      reduced_filename = report_message.get_filename();
+      for (int unsigned ii=(reduced_filename.len()-1); ii>0; ii--) begin
+         if (reduced_filename.getc(ii) == "/") begin
+            reduced_filename = reduced_filename.substr(ii+1, (reduced_filename.len()-1));
+            break;
+         end
+      end
+      line_str.itoa(report_message.get_line());
+      filename_line_string = {reduced_filename, "(", line_str, ")"};
+   end
+   
+   // Make definable in terms of units.
+   $swrite(time_str, "%0t", $realtime);
+   
+   if (report_message.get_context() != "") begin
+      context_str = {"@@", report_message.get_context()};
+   end
+   
+   if (show_verbosity) begin
+      if ($cast(l_verbosity, report_message.get_verbosity()))
+         verbosity_str = l_verbosity.name();
+      else
+         verbosity_str.itoa(report_message.get_verbosity());
+      verbosity_str = {"(", verbosity_str, ")"};
+   end
+   
+   if (show_terminator) begin
+      terminator_str = {" -",sev_string};
+   end
+   
+   el_container = report_message.get_element_container();
+   if (el_container.size() == 0) begin
+      msg_body_str = report_message.get_message();
+   end
+   else begin
+      prefix = uvm_default_printer.knobs.prefix;
+      uvm_default_printer.knobs.prefix = " +";
+      msg_body_str = {report_message.get_message(), "\n", el_container.sprint()};
+      uvm_default_printer.knobs.prefix = prefix;
+   end
+   
+   if (report_object_name == "") begin
+      l_report_handler = report_message.get_report_handler();
+      report_object_name = l_report_handler.get_full_name();
+   end
+   
+   compose_report_message = {sev_string, verbosity_str, " @ ", time_str, " : ", filename_line_string
+    , " ", report_object_name, context_str,
+     " [", report_message.get_id(), "] ", msg_body_str, terminator_str};
+   
+endfunction : compose_report_message
+
+
+function void corev_report_server::report_summarize(UVM_FILE file=0);
+   
+   super.report_summarize(file);
+  
+endfunction : report_summarize
+


### PR DESCRIPTION
Fix issue of taking interrupt as test_done is entered and corrupting kernel stack
add the custom report server to riscv-dv to get more readable uvm_info messages
add CSR interrupt write streams into random instruction generator