### PR TITLE
WorkAround for Riviera-PRO, incompatible array assign

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_iss_wrap.sv
@@ -55,9 +55,7 @@ module uvmt_cv32_iss_wrap
 
    assign b1.Clk = clknrst_if.clk;
    assign step_compare_if.ovp_cpu_PCr = cpu.PCr;
-`ifndef DSIM
-   assign step_compare_if.ovp_cpu_GPR = cpu.GPR;
- `else
+`ifdef DSIM
    assign step_compare_if.ovp_cpu_GPR[31] = cpu.GPR[31];
    assign step_compare_if.ovp_cpu_GPR[30] = cpu.GPR[30];
    assign step_compare_if.ovp_cpu_GPR[29] = cpu.GPR[29];
@@ -90,7 +88,42 @@ module uvmt_cv32_iss_wrap
    assign step_compare_if.ovp_cpu_GPR[2]  = cpu.GPR[2];
    assign step_compare_if.ovp_cpu_GPR[1]  = cpu.GPR[1];
    assign step_compare_if.ovp_cpu_GPR[0]  = cpu.GPR[0];
- `endif  // DSIM
+ `elsif _VCP
+   assign step_compare_if.ovp_cpu_GPR[31] = cpu.GPR[31];
+   assign step_compare_if.ovp_cpu_GPR[30] = cpu.GPR[30];
+   assign step_compare_if.ovp_cpu_GPR[29] = cpu.GPR[29];
+   assign step_compare_if.ovp_cpu_GPR[28] = cpu.GPR[28];
+   assign step_compare_if.ovp_cpu_GPR[27] = cpu.GPR[27];
+   assign step_compare_if.ovp_cpu_GPR[26] = cpu.GPR[26];
+   assign step_compare_if.ovp_cpu_GPR[25] = cpu.GPR[25];
+   assign step_compare_if.ovp_cpu_GPR[24] = cpu.GPR[24];
+   assign step_compare_if.ovp_cpu_GPR[23] = cpu.GPR[23];
+   assign step_compare_if.ovp_cpu_GPR[22] = cpu.GPR[22];
+   assign step_compare_if.ovp_cpu_GPR[21] = cpu.GPR[21];
+   assign step_compare_if.ovp_cpu_GPR[20] = cpu.GPR[20];
+   assign step_compare_if.ovp_cpu_GPR[19] = cpu.GPR[19];
+   assign step_compare_if.ovp_cpu_GPR[18] = cpu.GPR[18];
+   assign step_compare_if.ovp_cpu_GPR[17] = cpu.GPR[17];
+   assign step_compare_if.ovp_cpu_GPR[16] = cpu.GPR[16];
+   assign step_compare_if.ovp_cpu_GPR[15] = cpu.GPR[15];
+   assign step_compare_if.ovp_cpu_GPR[14] = cpu.GPR[14];
+   assign step_compare_if.ovp_cpu_GPR[13] = cpu.GPR[13];
+   assign step_compare_if.ovp_cpu_GPR[12] = cpu.GPR[12];
+   assign step_compare_if.ovp_cpu_GPR[11] = cpu.GPR[11];
+   assign step_compare_if.ovp_cpu_GPR[10] = cpu.GPR[10];
+   assign step_compare_if.ovp_cpu_GPR[9]  = cpu.GPR[9];
+   assign step_compare_if.ovp_cpu_GPR[8]  = cpu.GPR[8];
+   assign step_compare_if.ovp_cpu_GPR[7]  = cpu.GPR[7];
+   assign step_compare_if.ovp_cpu_GPR[6]  = cpu.GPR[6];
+   assign step_compare_if.ovp_cpu_GPR[5]  = cpu.GPR[5];
+   assign step_compare_if.ovp_cpu_GPR[4]  = cpu.GPR[4];
+   assign step_compare_if.ovp_cpu_GPR[3]  = cpu.GPR[3];
+   assign step_compare_if.ovp_cpu_GPR[2]  = cpu.GPR[2];
+   assign step_compare_if.ovp_cpu_GPR[1]  = cpu.GPR[1];
+   assign step_compare_if.ovp_cpu_GPR[0]  = cpu.GPR[0];
+ `else
+   assign step_compare_if.ovp_cpu_GPR = cpu.GPR;
+ `endif  // DSIM & DSIM
    always @(step_compare_if.ovp_b1_Step) b1.Step = step_compare_if.ovp_b1_Step;
    assign b1.Stepping = step_compare_if.ovp_b1_Stepping;
 


### PR DESCRIPTION
Hey!
I added WA for Riviera-PRO, this WA is copy from ifdef for `DSIM`