### PR TITLE
ensure uvm_macros.svh is always sourced first in Xcelium

### DIFF
--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -125,6 +125,10 @@ endif
 
 ################################################################################
 
+# File to `include "uvm_macros.svh" since Xcelium automatic UVM compilation
+# does not source the macros file. 
+XRUN_UVM_MACROS_INC_FILE = $(DV_UVMT_CV32_PATH)/uvmt_cv32_uvm_macros_inc.sv
+
 XRUN_FILE_LIST ?= -f $(DV_UVMT_CV32_PATH)/uvmt_cv32.flist
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
     XRUN_FILE_LIST += -f $(DV_UVMT_CV32_PATH)/imperas_iss.flist
@@ -165,6 +169,7 @@ XRUN_COMP = $(XRUN_COMP_FLAGS) \
 		$(XRUN_USER_COMPILE_ARGS) \
 		+incdir+$(DV_UVME_CV32_PATH) \
 		+incdir+$(DV_UVMT_CV32_PATH) \
+		$(XRUN_UVM_MACROS_INC_FILE) \
 		-f $(CV32E40P_MANIFEST) \
 		$(XRUN_FILE_LIST) \
 		$(UVM_PLUSARGS)

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_uvm_macros_inc.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_uvm_macros_inc.sv
@@ -1,0 +1,30 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+
+`ifndef __UVMT_CV32_UVM_MACROS_INC_SV__
+`define __UVMT_CV32_UVM_MACROS_INC_SV__
+
+// Simple inclusion of the uvm_macros.svh file into compilation scope.
+// This should only be used in Xcelium where automatic load of UVM does not
+// include the macros definition file.
+// use of this include file "first" in the simulator compilation filelist
+// ensures all macros are properly defined for usage
+
+`include "uvm_macros.svh"
+
+`endif 


### PR DESCRIPTION
Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>