### PR TITLE
update debug_test to test stepie fix

### DIFF
--- a/cv32/tests/core/debug_test/debugger.S
+++ b/cv32/tests/core/debug_test/debugger.S
@@ -184,8 +184,16 @@ _debugger_single_step:
     beq t0, t1, _debugger_single_step_trig_setup
     li t1, 5
     beq t0, t1, _debugger_single_step_stepie_enable
+    li t1, 6
+    beq t0, t1, _debugger_single_step_stepie_disable
     j _debugger_fail
 
+_debugger_single_step_stepie_disable:
+    // enable stepi
+    li t0, 4<<28 | 1<<15 | 1<<2 | 0<<11
+    csrw dcsr, t0
+
+    j _debugger_single_step_end
 _debugger_single_step_stepie_enable:
     // enable stepi
     li t0, 4<<28 | 1<<15 | 1<<2 | 1<<11
@@ -252,6 +260,8 @@ _debugger_single_step_end:
     li t1, 3
     beq t0, t1, _debugger_end
     li t1, 5
+    beq t0, t1, _debugger_end
+    li t1, 6
     beq t0, t1, _debugger_end
     li t1, 0
     sw t1, 0(a1)

--- a/cv32/tests/core/debug_test/single_step.S
+++ b/cv32/tests/core/debug_test/single_step.S
@@ -118,14 +118,6 @@ _irq_wait_loop:
 
     //-----------------
     // Stepping with interrupt, stepie=0
-    addi t0, t0,2 // debug code moves dpc to here
-    li t1, 2
-    // If trigger was correct, debug code skips
-    // loading of t0 to 1, and t0 should be of value 2
-    bne t0, t1, _single_step_fail
-
-
-    // Stepping with interrupt, stepie=1
     la a1, glb_step_info
     li t0, 6
     sw t0, 0(a1)

--- a/cv32/tests/core/debug_test/single_step.S
+++ b/cv32/tests/core/debug_test/single_step.S
@@ -91,10 +91,8 @@ _step_trig_exit:
     bne t0, t1, _single_step_fail
 
 
+    //-----------------
     // Stepping with interrupt, stepie=1
-    // TODO: Stepie is currently not implemented
-    // Extend test to check both stepie=0
-    // and stepie=1 when rtl supports it.
     la a1, glb_step_info
     li t0, 5
     sw t0, 0(a1)
@@ -112,14 +110,51 @@ _step_trig_exit:
     li t0, 2
     sw t0, 0(a1)
 
-// Loop to wait for interrupt to be handled
-// TODO: If stepie=0, add timeout to below loop 
 _irq_wait_loop:
     la a1, glb_expect_irq_entry
     lw t0, 0(a1);
     bne t0, x0, _irq_wait_loop
-    
-    
+
+
+    //-----------------
+    // Stepping with interrupt, stepie=0
+    addi t0, t0,2 // debug code moves dpc to here
+    li t1, 2
+    // If trigger was correct, debug code skips
+    // loading of t0 to 1, and t0 should be of value 2
+    bne t0, t1, _single_step_fail
+
+
+    // Stepping with interrupt, stepie=1
+    la a1, glb_step_info
+    li t0, 6
+    sw t0, 0(a1)
+
+    // Assert irq
+    li a1, 0x15000000
+    li t0, 0x40000000
+    sw t0, 0(a1)
+    li a1, 0x15000004
+    li t0, 2
+    sw t0, 0(a1)
+
+    // Wait out some instructions to give IRQ a chance
+    // Report an ERROR if IRQ taken as we did not set glb_expect_irq_entry flag
+    nop
+    nop
+    nop
+    nop
+
+    // De-Assert irq
+    li a1, 0x15000000
+    li t0, 0x00000000
+    sw t0, 0(a1)
+    li a1, 0x15000004
+    li t0, 1
+    sw t0, 0(a1)
+
+    nop
+    nop
 
     // Cause 2, disable single stepping
     la a1, glb_step_info


### PR DESCRIPTION
Updates the debug_test by writing DCSR.STEPIE and checking if interrupts are blocked or not during single step execution.

This PR should be merged after the RTL fix is merged:
https://github.com/openhwgroup/cv32e40p/pull/494

Signed-off-by: Paul Zavalney <paul.zavalney@silabs.com>