### PR TITLE
Overrides for marchid

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -1142,16 +1142,6 @@
             "seed":        1
           },
           {
-            "name":        "cv32-riscv-compliance-tests",
-            "build":       "uvmt_cv32",
-            "cmd":         "cd cv32/sim/uvmt_cv32; make cv32-riscv-compliance-tests SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
-            "wavesCmd":    "cd cv32/sim/uvmt_cv32; make cv32-riscv-compliance-tests SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1 DSIM_DMP_FILE=cv32-riscv-compliance-tests.vcd",
-            "metricsFile": "cv32-riscv-compliance-tests/metrics.db",
-            "wavesFile" :  "cv32-riscv-compliance-tests/cv32-riscv-compliance-tests.vcd",
-            "isPass":      "SIMULATION PASSED",
-            "seed":        1
-          },
-          {
             "name":        "illegal-riscv-tests",
             "build":       "uvmt_cv32",
             "cmd":         "cd cv32/sim/uvmt_cv32; make test TEST=illegal SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -81,6 +81,7 @@ export DV_UVML_TRN_PATH       = $(PROJ_ROOT_DIR)/lib/uvm_libs/uvml_trn
 export DV_UVML_LOGS_PATH      = $(PROJ_ROOT_DIR)/lib/uvm_libs/uvml_logs
 export DV_UVML_SB_PATH        = $(PROJ_ROOT_DIR)/lib/uvm_libs/uvml_sb
   
+export IMPERAS_TOOLS          = $(PROJ_ROOT_DIR)/vendor_lib/imperas/cv32e40p.ic
 export DV_OVPM_HOME           = $(PROJ_ROOT_DIR)/vendor_lib/imperas
 export DV_OVPM_MODEL          = $(DV_OVPM_HOME)/riscv_CV32E40P_OVPsim
 export DV_OVPM_DESIGN         = $(DV_OVPM_HOME)/verilog/design

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
@@ -129,6 +129,7 @@ module uvmt_cv32_step_compare
            ignore = 0;
            csr_val = 0;
            case (index)
+             "marchid"       : csr_val = `CV32E40P_CORE.cs_registers_i.MARCHID; // warning!  defined in cv32e40p_pkg
              "minstret"      : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][31:0];
              "minstreth"     : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][63:32];
              "mcycle"        : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][31:0];

--- a/cv32/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
+++ b/cv32/tests/programs/custom/modeled_csr_por/modeled_csr_por.c
@@ -433,8 +433,8 @@ int main(int argc, char *argv[])
     ++err_cnt;
   }
 
-  if (marchid_rval != 0x0) {
-    printf("ERROR: CSR MARCHID not zero!\n\n");
+  if (marchid_rval != 0x4) {
+    printf("ERROR: CSR MARCHID not 0x4!\n\n");
     ++err_cnt;
   }
 
@@ -494,7 +494,7 @@ int main(int argc, char *argv[])
   printf("\tmhpmcounterh3 = 0x%0x\n", mhpmcounterh[3]);
   printf("\tmhpmcounterh31= 0x%0x\n", mhpmcounterh[31]);
   printf("\tmvendorid     = 0x%0x\n", mvendorid_rval);
-  printf("\tmmarchid      = 0x%0x\n", marchid_rval);
+  printf("\tmarchid       = 0x%0x\n", marchid_rval);
   printf("\tmimpid        = 0x%0x\n", mimpid_rval);
   printf("\tmhartid       = 0x%0x\n", mhartid_rval);
 	printf("\n\n");

--- a/vendor_lib/imperas/cv32e40p.ic
+++ b/vendor_lib/imperas/cv32e40p.ic
@@ -1,0 +1,2 @@
+#-showoverrides
+--override root/cpu0/marchid=4


### PR DESCRIPTION
Hi @strichmo, I'm picking on you to review this one since it adds a `cv32e40p.ic` config file for the Imperas RM and exports a shell variable to point to it.   Its my understanding you are considering something similar, so you can either suggest a different/better way to do this, or add your RM config updates to `cv32e40p.ic`.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>