### PR TITLE
add build configuration specifications

### DIFF
--- a/bin/cfgyaml2make
+++ b/bin/cfgyaml2make
@@ -21,7 +21,8 @@
 # 
 ################################################################################
 #
-# test_yaml
+# cfgyaml2make
+#   Converts a build configuration YAML to make variables
 #
 # Author: Steve Richmond
 #  email: steve.richmond@silabs.com
@@ -45,67 +46,57 @@ logger.setLevel(logging.INFO)
 
 TOPDIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
 
-VALID_YAMLS = ('corev-dv.yaml', 'test.yaml')
-REQUIRED_KEYS = ('name', 'uvm_test', 'description',)
-CFG_PATH = (
+REQUIRED_KEYS = ('name', 'description',)
+CFG_PATHS = (
             'cv32/tests/cfg',
-            )
-TEST_PATHS = (
-              'cv32/tests/programs/corev-dv/',
-              'cv32/tests/programs/custom',
-              )
+             )
               
 if (sys.version_info < (3,0,0)):
     print ('Requires python 3')
     exit(1)
 
-def read_file(test, type, run_index):
-    '''Read a YAML test specification'''
+def read_file(file):
+    '''Read a YAML build specification'''
 
-    matches = [os.path.join(TOPDIR, p, test, type) for p in TEST_PATHS 
-                if os.path.exists(os.path.join(TOPDIR, p, test, type))]
+    matches = [os.path.join(TOPDIR, p, file) for p in CFG_PATHS 
+                if os.path.exists(os.path.join(TOPDIR, p, file))]
 
     # It is a fatal error to find less than 1 or more than 1 match
     if len(matches) == 0:
-        logger.fatal('Could not find {} in any directories:')
-        for p in TEST_PATHS:
-            logger.fatal(os.path.join(TOPDIR, p, test, type)) 
+        logger.fatal('Could not find {} in any cfg directories:'.format(file))
+        for p in CFG_PATHS:
+            logger.fatal(os.path.join(TOPDIR, p, file)) 
         os.sys.exit(2)
 
     if len(matches) >1 :
-        logger.fatal('Found multiple matches for {}:{} in directories:'.format(test, type))
-        for p in TEST_PATHS:
-            logger.fatal(os.path.join(TOPDIR, p, test, type)) 
+        logger.fatal('Found multiple matches for {} in directories:'.format(yaml))
+        for p in CFG_PATHS:
+            logger.fatal(os.path.join(TOPDIR, p, file))
         os.sys.exit(2)
 
     stream = open(matches[0], 'r')
-    logger.debug('Reading test specification: {}'.format(matches[0]))
-    test_spec = yaml.load(stream)
+    logger.debug('Reading cfg specification: {}'.format(matches[0]))
+    cfg_spec = yaml.load(stream)
     stream.close()
-    test_spec['test_dir'] = os.path.dirname(matches[0])
-
-    # Substitute <RUN_INDEX>
-    for k in test_spec:
-        test_spec[k] = re.sub('<RUN_INDEX>', run_index, test_spec[k])
 
     # Validation
     for k in REQUIRED_KEYS:        
-        if not k in test_spec:
-            logger.fatal('Key [{}] was not found in test specification YAML:'.format(k))
+        if not k in cfg_spec:
+            logger.fatal('Key [{}] was not found in cfg specification YAML:'.format(k))
             logger.fatal('-> : {}'.format(matches[0]))
             os.sys.exit(2)
 
     # Debug the YAML parsing
     pp = pprint.PrettyPrinter()
     logger.debug('Read YAML:')
-    logger.debug(pp.pformat(test_spec))
+    logger.debug(pp.pformat(cfg_spec))
 
-    return test_spec
+    return cfg_spec
 
-def emit_make(test_spec, prefix):
+def emit_make(cfg_spec, prefix):
     '''Emit a hash from the YAML test specification into a makefile that can be included'''
     fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
-    for k,v in sorted(test_spec.items()):
+    for k,v in sorted(cfg_spec.items()):
         fh.write('{}{}={}\n'.format('' if not prefix else prefix.upper() + '_', k.upper(), v.rstrip()))
     fh.close()
 
@@ -115,11 +106,9 @@ def emit_make(test_spec, prefix):
 # Command-line arguments
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-t', '--test', help='Test to look for')
 parser.add_argument('-d', '--debug', action='store_true', help='Display debug messages')
-parser.add_argument('--yaml', choices=VALID_YAMLS, help='Name of YAML test specification to find')
+parser.add_argument('--yaml', help='Name of YAML build specification to find')
 parser.add_argument('--prefix', help='Prefix to add to make variables generated')
-parser.add_argument('--run-index', default='0', help='Add a run index to append to test specifications')
 args = parser.parse_args()
 
 if args.debug:
@@ -127,16 +116,11 @@ if args.debug:
 
 # Validate 
 if not args.yaml:
-    logger.fatal('Must specify the YAML type with --yaml')
-    logger.fatal('Valid choices: {}'.format(VALID_YAMLS))
+    logger.fatal('Must specify the YAML build specification with --yaml')
     os.sys.exit(2)
 
-if not args.test:
-    logger.fatal('Must specify a test with -t or --test')
-    os.sys.exit(2)
-
-test_spec = read_file(test=args.test, type=args.yaml, run_index=args.run_index)
-temp_file = emit_make(test_spec=test_spec, prefix=args.prefix)
+cfg_spec = read_file(file=args.yaml)
+temp_file = emit_make(cfg_spec=cfg_spec, prefix=args.prefix)
 
 logger.debug('File written to {}'.format(temp_file))
 print(temp_file)

--- a/bin/cfgyaml2make
+++ b/bin/cfgyaml2make
@@ -97,7 +97,12 @@ def emit_make(cfg_spec, prefix):
     '''Emit a hash from the YAML test specification into a makefile that can be included'''
     fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
     for k,v in sorted(cfg_spec.items()):
-        fh.write('{}{}={}\n'.format('' if not prefix else prefix.upper() + '_', k.upper(), v.rstrip()))
+        # Handle empty value (allowed)
+        try:
+            v_rstrip = v.rstrip()
+        except AttributeError:
+            v_rstrip = ''
+        fh.write('{}{}={}\n'.format('' if not prefix else prefix.upper() + '_', k.upper(), v_rstrip))
     fh.close()
 
     return fh.name

--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -136,6 +136,7 @@ parser.add_argument('-c', '--cov', help='Enable coverage', action='store_true')
 parser.add_argument('-m', '--metrics', help='Select Metrics waves output', action='store_true')
 parser.add_argument('--lsf', help='If applicable for output format, set LSF args to dispatch jobs')
 parser.add_argument('--make', help='Substitute for make command (to use short-cuts)')
+parser.add_argument('--makearg', action='append', help='Arguments to supply to each make command, can be specified multiple times')
 parser.add_argument('--sh', help='Select bash shell script output', action='store_true')
 parser.add_argument('--vsif', help='Select Vmanager VSIF output', action='store_true')
 
@@ -182,6 +183,7 @@ if args.sh:
     logger.info('Rendering template: regress_sh.j2 into: {}'.format(args.outfile))
     out_fh = open(args.outfile, 'w')
     out_fh.write(template.render(regressions=regressions,
+                                 makeargs=' '.join(args.makearg),
                                  unique_builds=unique_builds))
     out_fh.close()
     os.chmod(args.outfile, 0o775)
@@ -192,6 +194,7 @@ if args.metrics:
     logger.info('Rendering template: metrics.json.j2 into: {}'.format(args.outfile))
     out_fh = open(args.outfile, 'w')
     out_fh.write(template.render(regressions=regressions,
+                                 makeargs=' '.join(args.makearg),
                                  unique_builds=unique_builds))
     out_fh.close()
     os.chmod(args.outfile, 0o775)
@@ -206,6 +209,7 @@ if args.vsif:
                                  results_path=get_results_path(args.project),
                                  project=args.project,
                                  regressions=regressions,
+                                 makeargs=' '.join(args.makearg),
                                  lsf=args.lsf,
                                  sve=os.path.abspath(sve),
                                  simulator=args.simulator,

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -54,9 +54,9 @@ check_log () {
 
 {% for b in unique_builds.values() %}
 # Build:{{b.name}} {{b.description}}
-echo "script: Running build: [cd {{b.dir}} && {{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{regress_macros.yesorno(b.iss)}} COV={{regress_macros.yesorno(b.cov)}}]"
+echo "script: Running build: [cd {{b.dir}} && {{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{regress_macros.yesorno(b.iss)}} COV={{regress_macros.yesorno(b.cov)}}] {{makeargs}}"
 pushd {{b.dir}} > /dev/null
-{{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{regress_macros.yesorno(b.iss)}} COV={{regress_macros.yesorno(b.cov)}} >& /dev/null;
+{{b.cmd}} SIMULATOR={{b.simulator}} USE_ISS={{regress_macros.yesorno(b.iss)}} COV={{regress_macros.yesorno(b.cov)}} {{makeargs}} >& /dev/null;
 popd > /dev/null
 
 {% endfor -%}
@@ -70,9 +70,9 @@ popd > /dev/null
 # --> Test: {{t.name}} : {{t.description}}
 {% if t.precmd %}
 #  Test (Precommand): {{t.name}} {{t.description}}
-echo "script: Running precmd: [cd {{t.dir}} && {{t.precmd}} SIMULATOR={{t.simulator}} SEED=random GEN_NUM_TESTS={{t.num}}]"
+echo "script: Running precmd: [cd {{t.dir}} && {{t.precmd}} SIMULATOR={{t.simulator}} SEED=random GEN_NUM_TESTS={{t.num}}] {{makeargs}}"
 pushd {{t.dir}} > /dev/null
-{{t.precmd}} SIMULATOR={{t.simulator}} SEED=random GEN_NUM_TESTS={{t.num}} >& /dev/null;
+{{t.precmd}} SIMULATOR={{t.simulator}} SEED=random GEN_NUM_TESTS={{t.num}} {{makeargs}} >& /dev/null;
 popd > /dev/null
 
 {% endif %}
@@ -80,9 +80,9 @@ popd > /dev/null
 {% set test_cmd = t.cmd|replace('<RUN_INDEX>', run_index) %}
 {% set test_log = t.log|replace('<RUN_INDEX>', run_index) %}
 # --> Test (Index: {{run_index}}): {{t.cmd}} : {{t.description}}
-echo "script: Running test [cd {{t.dir}} && {{test_cmd}} SIMULATOR={{t.simulator}} COMP=0 USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} SEED=random]"
+echo "script: Running test [cd {{t.dir}} && {{test_cmd}} SIMULATOR={{t.simulator}} COMP=0 USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} SEED=random {{makeargs}}]"
 pushd {{t.dir}} > /dev/null
-{{test_cmd}} SIMULATOR={{t.simulator}} COMP=0 USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} SEED=random >& /dev/null;
+{{test_cmd}} SIMULATOR={{t.simulator}} COMP=0 USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} SEED=random {{makeargs}} >& /dev/null;
 popd > /dev/null
 log={{t.dir}}/{{t.simulator}}_results/{{test_log}}/{{t.simulator}}-{{test_log}}.log
 check_log ${log} "{{t.simulation_passed}}" {{test_log}} 

--- a/bin/templates/regress_vsif.j2
+++ b/bin/templates/regress_vsif.j2
@@ -39,7 +39,7 @@ group cv32e40p {
 {% endif %}
 {% for b in unique_builds.values() %}
     // Build:{{b.name}} {{b.description}}    
-    pre_group_script: "cd {{b.dir}} && {{b.cmd}} CV_SIM_PREFIX= SIMULATOR={{b.simulator}} USE_ISS={{b.iss}} COV={{regress_macros.yesorno(b.cov)}}";
+    pre_group_script: "cd {{b.dir}} && {{b.cmd}} CV_SIM_PREFIX= SIMULATOR={{b.simulator}} USE_ISS={{b.iss}} COV={{regress_macros.yesorno(b.cov)}} {{makeargs}}";
 
 {% endfor %}
 {% for r in regressions %}
@@ -51,7 +51,7 @@ group cv32e40p {
         test precmd {
             sv_seed: gen_random;
             count: 1;
-            run_script: "cd {{t.dir}} && {{t.precmd}} CV_SIM_PREFIX= SIMULATOR={{t.simulator}} RNDSEED=$RUN_ENV(BRUN_SV_SEED) NUM_TESTS={{t.num}}";
+            run_script: "cd {{t.dir}} && {{t.precmd}} CV_SIM_PREFIX= SIMULATOR={{t.simulator}} RNDSEED=$RUN_ENV(BRUN_SV_SEED) NUM_TESTS={{t.num}} {{makeargs}}";
         };
 {% else %}
 {% set indent = '' %}
@@ -65,7 +65,7 @@ group cv32e40p {
 {{indent}}            sv_seed: gen_random;
 {{indent}}            seed: [0..{{t.num-1}}];
 {{indent}}            count: {{t.num}};
-{{indent}}            run_script: "cd {{t.dir}} && {{t.cmd}} COMP=0 CV_SIM_PREFIX= SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=$RUN_ENV(BRUN_SEED) GEN_START_INDEX=$RUN_ENV(BRUN_SEED) RNDSEED=$RUN_ENV(BRUN_SV_SEED)";
+{{indent}}            run_script: "cd {{t.dir}} && {{t.cmd}} COMP=0 CV_SIM_PREFIX= SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=$RUN_ENV(BRUN_SEED) GEN_START_INDEX=$RUN_ENV(BRUN_SEED) RNDSEED=$RUN_ENV(BRUN_SV_SEED) {{makeargs}}";
 {% if simulator == 'vsim' %}
 {{indent}}            scan_script: "vm_scan.pl uvm.flt {{filter_dir}}/vsim_run.flt";
 {% endif %}

--- a/cv32/regress/cv32_ci_check.yaml
+++ b/cv32/regress/cv32_ci_check.yaml
@@ -36,7 +36,7 @@ tests:
     dir: cv32/sim/uvmt_cv32
     cmd: make test TEST=illegal
 
-csr_instructions:
+  csr_instructions:
     build: uvmt_cv32
     description: Directed CSR test
     dir: cv32/sim/uvmt_cv32

--- a/cv32/regress/cv32_ci_check.yaml
+++ b/cv32/regress/cv32_ci_check.yaml
@@ -28,19 +28,19 @@ tests:
     build: uvmt_cv32
     description: Static riscv-dv ebreak test
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=riscv_ebreak_test_0
+    cmd: make test TEST=riscv_ebreak_test_0
 
   illegal:
     build: uvmt_cv32
     description: Illegal instruction RISCV test
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=illegal
+    cmd: make test TEST=illegal
 
-  csr_instructions:
+csr_instructions:
     build: uvmt_cv32
     description: Directed CSR test
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=csr_instructions
+    cmd: make test TEST=csr_instructions
 
   interrupt_test:
     build: uvmt_cv32

--- a/cv32/regress/cv32_full.yaml
+++ b/cv32/regress/cv32_full.yaml
@@ -25,6 +25,12 @@ tests:
     dir: cv32/sim/uvmt_cv32
     cmd: make test TEST=hello-world
 
+  illegal:
+    build: uvmt_cv32
+    description: Illegal instruction test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make test TEST=illegal
+
   debug_test:
     build: uvmt_cv32
     description: Debug test
@@ -66,31 +72,34 @@ tests:
     description: Basic arithmetic test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_arithmetic_base_test
-    num: 25
+    num: 100
 
   corev_random_instruction_test:
     build: uvmt_cv32
     description: Random instruciton test
     dir: cv32/sim/uvmt_cv32
     cmd: make gen_corev-dv test TEST=corev_rand_instr_test
-    num: 25
+    num: 100
 
   corev_jump_stress_test:
     build: uvmt_cv32
     description: Jump stress test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_jump_stress_test
-    num: 25
+    num: 100
 
   corev_rand_interrupt:
     build: uvmt_cv32
     description: Random interrupt test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
-    num: 25
+    num: 100
 
-  illegal:
+  corev_rand_interrupt_wfi:
     build: uvmt_cv32
-    description: Illegal instruction test
-    dir: cv32/sim/uvmt_cv32
-    cmd: make test TEST=illegal
+    description: Random interrupt test with DWFI
+    dir: cv32/sim/uvmt_cv32    
+    cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi
+    num: 100
+
+    

--- a/cv32/regress/cv32_full.yaml
+++ b/cv32/regress/cv32_full.yaml
@@ -25,6 +25,12 @@ tests:
     dir: cv32/sim/uvmt_cv32
     cmd: make test TEST=hello-world
 
+  debug_test:
+    build: uvmt_cv32
+    description: Debug test
+    dir: cv32/sim/uvmt_cv32
+    cmd: make debug_test
+
   csr_instructions:
     build: uvmt_cv32
     description: CSR insturciton test
@@ -35,59 +41,53 @@ tests:
     build: uvmt_cv32
     description: CSR access test for CV32E40P
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=cv32e40p_csr_access_test
+    cmd: make test TEST=cv32e40p_csr_access_test
 
   requested_csr_por:
     build: uvmt_cv32
     description: CSR PoR test
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=requested_csr_por
+    cmd: make test TEST=requested_csr_por
 
   modeled_csr_por:
     build: uvmt_cv32
     description: Modeled CSR PoR test
     dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=modeled_csr_por
+    cmd: make test TEST=modeled_csr_por
 
-  csr_instructions:
-    build: uvmt_cv32
-    description: CSR Instruction Test
-    dir: cv32/sim/uvmt_cv32
-    cmd: make custom CUSTOM_PROG=csr_instructions
-
-  riscv_ebreak_test:
+  riscv_ebreak_test_0:
     build: uvmt_cv32
     description: Static corev-dv ebreak
     dir: cv32/sim/uvmt_cv32
-    cmd: make test TEST=riscv_ebreak_test
+    cmd: make test TEST=riscv_ebreak_test_0
 
   corev_arithmetic_base_test:
     build: uvmt_cv32
     description: Basic arithmetic test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_arithmetic_base_test
-    num: 100
+    num: 25
 
   corev_random_instruction_test:
     build: uvmt_cv32
     description: Random instruciton test
     dir: cv32/sim/uvmt_cv32
     cmd: make gen_corev-dv test TEST=corev_rand_instr_test
-    num: 100
+    num: 25
 
   corev_jump_stress_test:
     build: uvmt_cv32
     description: Jump stress test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_jump_stress_test
-    num: 100
+    num: 25
 
   corev_rand_interrupt:
     build: uvmt_cv32
     description: Random interrupt test
     dir: cv32/sim/uvmt_cv32    
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
-    num: 100
+    num: 25
 
   illegal:
     build: uvmt_cv32

--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -306,7 +306,7 @@ ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(CFG),)
 CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml --debug --prefix=CFG)
 ifeq ($(CFG_FLAGS_MAKE),)
-$(error ERROR Could not find configuration: $(CFG).yaml)
+$(error ERROR Error finding or parsing configuration: $(CFG).yaml)
 endif
 include $(CFG_FLAGS_MAKE)
 endif

--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -298,6 +298,20 @@ endif
 include $(TEST_FLAGS_MAKE)
 endif
 
+# If a test target is defined and a CFG is defined that read in build configuration file
+# CFG is optional
+CFGYAML2MAKE = $(PROJ_ROOT_DIR)/bin/cfgyaml2make
+CFG_YAML_PARSE_TARGETS=comp test
+ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
+ifneq ($(CFG),)
+CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml --debug --prefix=CFG)
+ifeq ($(CFG_FLAGS_MAKE),)
+$(error ERROR Could not find configuration: $(CFG).yaml)
+endif
+include $(CFG_FLAGS_MAKE)
+endif
+endif
+
 ###############################################################################
 # Rule to generate hex (loadable by simulators) from elf
 # Relocate debugger to last 16KB of mm_ram

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -246,6 +246,7 @@ clean_test_programs:
 	find $(PROJ_ROOT_DIR)/cv32/tests/programs -name *.map     -exec rm {} \;
 	find $(PROJ_ROOT_DIR)/cv32/tests/programs -name *.readelf -exec rm {} \;
 	find $(PROJ_ROOT_DIR)/cv32/tests/programs -name *.objdump -exec rm {} \;
+	find $(PROJ_ROOT_DIR)/cv32/tests/programs -name corev_*.S -exec rm {} \;
 
 clean_riscv-dv:
 	rm -rf $(RISCVDV_PKG)

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -64,6 +64,9 @@ SIMULATOR    ?= $(CV_SIMULATOR)
 # Optionally exclude the OVPsim (not recommended)
 USE_ISS      ?= YES
 
+# Common configuration variables
+CFG             ?= default
+
 # Common Generation variables
 GEN_START_INDEX ?= 0
 GEN_NUM_TESTS   ?= 1

--- a/cv32/sim/uvmt_cv32/README.md
+++ b/cv32/sim/uvmt_cv32/README.md
@@ -93,10 +93,10 @@ Running the envrionment with Metrics [dsim](https://metrics.ca)
 ----------------------
 The command **make SIMULATOR=dsim sanity** will run the sanity testcase using _dsim_.
 <br><br>
-Setting a shell environment variable `SIMULATOR` to "dsim" will also define the
+Setting a shell environment variable `CV_SIMULATOR` to "dsim" will also define the
 Makefile variable SIMULATOR to `dsim` and you can save yourself a lot of typing. For
 example, in a bash shell:
-<br>**export SIMULATOR=dsim**
+<br>**export CV_SIMULATOR=dsim**
 <br>**make sanity**
 <br><br>
 The Makefile for dsim also supports variables to control wave dumping.  For example:
@@ -139,7 +139,7 @@ Current supported simulators: <i>Note that eventually all simulators will be sup
 
 | SIMULATOR | Supported |
 |-----------|-----------|
-|dsim       | No        |
+|dsim       | Yes       |
 |xrun       | Yes       |
 |questa     | Yes       |
 |vcs        | Yes       |
@@ -159,7 +159,7 @@ To run a simulation in interactive mode (to enable single-stepping, breakpoints,
 
 If applicable for a simulator, line debugging will be enabled in the compile to enable single-stepping.
 
-**make hello-world GUI=1**
+**make test TEST=hello-world GUI=1**
 
 ### Set the UVM quit count
 
@@ -168,7 +168,7 @@ to allow up to 5 errors to be signaled before aborting the test.  There is a run
 tests.  Use the USER_RUN_FLAGS make variable with the standard UVM_MAX_QUIT_COUNT plusarg as below.  Please note that the NO is required
 and signals that you want UVM to use your plusarg over any internally configured quit count values.
 
-**make hello-world USER_RUN_FLAGS=+UVM_MAX_QUIT_COUNT=10,NO**
+**make test TEST=hello-world USER_RUN_FLAGS=+UVM_MAX_QUIT_COUNT=10,NO**
 
 ### Post-process Waveform Debug
 
@@ -178,7 +178,7 @@ To create waves during simulation, set the **WAVES=YES** flag.<br>
 
 The waveform dump will include all signals in the <i>uvmt_tb32</i> testbench and recursively throughout the hierarchy.
 
-**make hello-world WAVES=1**
+**make test TEST=hello-world WAVES=1**
 
 If applicable for a simulator, dumping waves for an advanced debug tool is available.
 
@@ -202,7 +202,7 @@ By default coverage information is not generated during a simulation for <i>xrun
 
 To generate coverage database, set **COV=1**.
 
-**make hello-world COV=1**
+**make test TEST=hello-world COV=1**
 
 To view coverage results a new target **cov** was added to the makefiles.  By default the target will generate a coverage report in the same directory as the output log files and the coverage database.<br>
 
@@ -249,7 +249,7 @@ Available Test Programs
 -----------------------
 The `make` commands here assume you have set your shell SIMULATION
 There are three targets that can run a specific test-program by name:
-* **make hello-world**:<br>run the hello_world program found at `../../tests/core/custom`.
+* **make test TEST=hello-world**:<br>run the hello_world program found at `../../tests/core/custom`.
 * **make cv32-riscv-tests**:<br>run the CV32-specific RISC-V tests found at `../../tests/core/cv32_riscv_tests_firmware`
 * **make cv32-riscv-compilance-tests**:<br>run the CV32-specific RISC-V tests found at `../../tests/core/cv32_riscv_compliance_tests_firmware`
 Some targets are simulator specific:
@@ -279,4 +279,39 @@ You can now run any test program in that directory:<br>
 ```
 make custom CUSTOM_PROJ=hello_world
 make custom CUSTOM_PROJ=smoke
+```
+
+Build Configurations
+--------------------
+The `uvmt_cv32` environment supports adding compile flags to the testbench to support a specialized configuration of the core.  The testbench
+flow supports a single compilation object at any point in time so it is recommended that any testbench options be supported as run-time
+options (see the Test Specification documentation for setting run-time plusargs).  However if, for instance, parameters to the DUT need to be
+changed then this flow needs to be used.<br>
+
+All build configurations are in the files:<br>
+
+```
+cv32/tests/cfg/<cfg>.yaml
+```
+
+The contents of the YAML file support the following tags:
+| YAML Tag      | Required | Description |
+|---------------|----------|---------------------|
+| name          | Yes      | The name of the configuration                |
+| description   | Yes      | Brief description of the intent of the build configuration |
+| compile_flags | No       | Compile flags passed to the simulator compile-step    |
+| ovpsim        | No       | Flags for the IC file for the OVPSim ISS   |
+
+<br>
+The following is an example build configuration:<br>
+
+```
+name: no_pulp
+description: Sets all PULP-related flags to 0
+compile_flags: >
+    +define+NO_PULP
+    +define+HAHAHA
+ovpsim: >
+    --override root/cpu0/misa_Extensions=0x1104
+    --showoverrides
 ```

--- a/cv32/sim/uvmt_cv32/vsim.mk
+++ b/cv32/sim/uvmt_cv32/vsim.mk
@@ -253,52 +253,6 @@ vopt_corev-dv:
 			-o corev_instr_gen_tb_top_vopt \
 			-l vopt.log
 
-gen_corev_arithmetic_base_test:
-	mkdir -p $(VSIM_COREVDV_RESULTS)/corev_arithmetic_base_test	
-	cd $(VSIM_COREVDV_RESULTS)/corev_arithmetic_base_test && \
-		$(VMAP) work ../work
-	cd $(VSIM_COREVDV_RESULTS)/corev_arithmetic_base_test && \
-		$(VSIM) $(VSIM_FLAGS) \
-			corev_instr_gen_tb_top_vopt \
-			$(DPILIB_VSIM_OPT) \
-			+UVM_TESTNAME=corev_instr_base_test  \
-			+num_of_tests=2  \
-			+start_idx=0  \
-			+asm_file_name_opts=riscv_arithmetic_basic_test  \
-			-l $(COREVDV_PKG)/out_$(DATE)/sim_riscv_arithmetic_basic_test_0.log \
-			+instr_cnt=10000 \
-			+num_of_sub_program=0 \
-			+directed_instr_0=riscv_int_numeric_corner_stream,4 \
-			+no_fence=1 \
-			+no_data_page=1 \
-			+no_branch_jump=1 \
-			+boot_mode=m \
-			+no_csr_instr=1
-	cp $(VSIM_COREVDV_RESULTS)/corev_arithmetic_base_test/*.S $(CORE_TEST_DIR)/custom
-
-gen_corev_rand_instr_test:
-	mkdir -p $(VSIM_COREVDV_RESULTS)/corev_rand_instr_test	
-	cd $(VSIM_COREVDV_RESULTS)/corev_rand_instr_test && \
-		$(VMAP) work ../work
-	cd $(VSIM_COREVDV_RESULTS)/corev_rand_instr_test && \
-		$(VSIM) $(VSIM_FLAGS) \
-			corev_instr_gen_tb_top_vopt \
-			$(DPILIB_VSIM_OPT) \
-			+UVM_TESTNAME=corev_instr_base_test  \
-			+num_of_tests=2  \
-			+start_idx=0  \
-			+asm_file_name_opts=corev_rand_instr_test  \
-			-l $(COREVDV_PKG)/out_$(DATE)/sim_corev_rand_instr_test_0.log \
-			+instr_cnt=10000 \
-			+num_of_sub_program=0 \
-			+directed_instr_0=riscv_int_numeric_corner_stream,4 \
-			+no_fence=1 \
-			+no_data_page=1 \
-			+no_branch_jump=1 \
-			+boot_mode=m \
-			+no_csr_instr=1
-	cp $(VSIM_COREVDV_RESULTS)/corev_rand_instr_test/*.S $(CORE_TEST_DIR)/custom
-
 gen_corev-dv: 
 	mkdir -p $(VSIM_COREVDV_RESULTS)/$(TEST)
 	# Clean old assembler generated tests in results
@@ -329,15 +283,25 @@ comp_corev-dv: $(RISCVDV_PKG) vlog_corev-dv vopt_corev-dv
 
 corev-dv: clean_riscv-dv \
           clone_riscv-dv \
-          comp_corev-dv \
-          gen_corev_arithmetic_base_test \
-          gen_corev_rand_instr_test
+          comp_corev-dv
 
 ################################################################################
 # Questa simulation targets
 
 mk_vsim_dir: 
 	$(MKDIR_P) $(VSIM_RESULTS)
+
+################################################################################
+# If the configuration specified OVPSIM arguments, generate an ovpsim.ic file and
+# set IMPERAS_TOOLS to point to it
+gen_ovpsim_ic:
+	@if [ ! -z "$(CFG_OVPSIM)" ]; then \
+		mkdir -p $(VSIM_RESULTS)/$(TEST_NAME); \
+		echo "$(CFG_OVPSIM)" > $(VSIM_RESULTS)/$(TEST_NAME)/ovpsim.ic; \
+	fi
+ifneq ($(CFG_OVPSIM),)
+export IMPERAS_TOOLS=$(VSIM_RESULTS)/$(TEST_NAME)/ovpsim.ic
+endif
 
 # Target to create work directory in $(VSIM_RESULTS)/
 lib: mk_vsim_dir $(CV32E40P_PKG) $(TBSRC_PKG) $(TBSRC)
@@ -356,6 +320,7 @@ vlog: lib
 			-work $(VWORK) \
 			-l vlog.log \
 			$(VLOG_FLAGS) \
+			$(CFG_COMPILE_FLAGS) \
 			+incdir+$(DV_UVME_CV32_PATH) \
 			+incdir+$(DV_UVMT_CV32_PATH) \
 			+incdir+$(UVM_HOME) \
@@ -381,7 +346,7 @@ opt: vlog
 comp: opt
 
 # Target to run VSIM (i.e. run the simulation)
-run: $(VSIM_RUN_PREREQ)
+run: $(VSIM_RUN_PREREQ) gen_ovpsim_ic
 	@echo "$(BANNER)"
 	@echo "* Running vsim in $(VSIM_RESULTS)/$(VSIM_TEST)"
 	@echo "* Log: $(VSIM_RESULTS)/$(VSIM_TEST)/vsim-$(VSIM_TEST).log"
@@ -404,25 +369,9 @@ run: $(VSIM_RUN_PREREQ)
 
 .PHONY: hello-world
 
-hello-world: VSIM_TEST=hello-world
-hello-world: VSIM_FLAGS += +firmware=$(CUSTOM)/hello-world.hex +elf_file=$(CUSTOM)/hello-world.elf
-hello-world: TEST_UVM_TEST=uvmt_cv32_firmware_test_c
-hello-world: $(CUSTOM)/hello-world.hex run
-
-misalign: VSIM_TEST=misalign
-misalign: VSIM_FLAGS += +firmware=$(CUSTOM)/misalign.hex +elf_file=$(CUSTOM)/misalign.elf
-misalign: TEST_UVM_TEST=uvmt_cv32_firmware_test_c
-misalign: $(CUSTOM)/misalign.hex run
-
-fibonacci: VSIM_TEST=fibonacci
-fibonacci: VSIM_FLAGS += +firmware=$(CUSTOM)/fibonacci.hex +elf_file=$(CUSTOM)/fibonacci.elf
-fibonacci: TEST_UVM_TEST=uvmt_cv32_firmware_test_c
-fibonacci: $(CUSTOM)/fibonacci.hex run
-
-dhrystone: VSIM_TEST=dhrystone
-dhrystone: VSIM_FLAGS += +firmware=$(CUSTOM)/dhrystone.hex +elf_file=$(CUSTOM)/dhrystone.elf
-dhrystone: TEST_UVM_TEST=uvmt_cv32_firmware_test_c
-dhrystone: $(CUSTOM)/dhrystone.hex run
+# This special target is to support the special sanity target in the Common Makefile
+hello-world:
+	$(MAKE) test TEST=hello-world
 
 custom: VSIM_TEST=$(CUSTOM_PROG)
 custom: VSIM_FLAGS += +firmware=$(CUSTOM_DIR)/$(CUSTOM_PROG).hex +elf_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).elf

--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -42,8 +42,8 @@ XRUN_RUN_BASE_FLAGS   ?= -64bit $(XRUN_GUI) +UVM_VERBOSITY=$(XRUN_UVM_VERBOSITY)
                          $(XRUN_PLUSARGS) -svseed $(RNDSEED) -sv_lib $(OVP_MODEL_DPI)
 XRUN_GUI         ?=
 XRUN_SINGLE_STEP ?=
-XRUN_ELAB_COV     = -covdut cv32e40p_core -coverage b:e:f:t:u
-XRUN_RUN_COV      = -covscope cv32e40p_core \
+XRUN_ELAB_COV     = -covdut uvmt_cv32_tb -coverage b:e:f:t:u
+XRUN_RUN_COV      = -covscope uvmt_cv32_tb \
 					-nowarn CGDEFN
 
 XRUN_UVM_VERBOSITY ?= UVM_MEDIUM

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_step_compare.sv
@@ -129,6 +129,7 @@ module uvmt_cv32_step_compare
            ignore = 0;
            csr_val = 0;
            case (index)
+             "marchid"       : csr_val = cv32e40p_pkg::MARCHID; // warning!  defined in cv32e40p_pkg
              "minstret"      : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][31:0];
              "minstreth"     : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][63:32];
              "mcycle"        : csr_val = `CV32E40P_CORE.cs_registers_i.mhpmcounter_q[`CV32E40P_CORE.cs_registers_i.csr_addr_i[4:0]][31:0];

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -31,6 +31,7 @@ module uvmt_cv32_tb;
    import uvmt_cv32_pkg::*;
    import uvme_cv32_pkg::*;
 
+
    // Capture regs for test status from Virtual Peripheral in dut_wrap.mem_i
    bit        tp;
    bit        tf;
@@ -57,6 +58,11 @@ module uvmt_cv32_tb;
    * a few mods to bring unused ports from the CORE to this level using SV interfaces.
    */
    uvmt_cv32_dut_wrap  #(
+`ifdef NO_PULP
+                         .PULP_XPULP        (0),
+                         .PULP_CLUSTER      (0),
+                         .PULP_ZFINX        (0),
+`endif
                          .INSTR_ADDR_WIDTH  (32),
                          .INSTR_RDATA_WIDTH (32),
                          .RAM_ADDR_WIDTH    (22)
@@ -171,7 +177,9 @@ module uvmt_cv32_tb;
         else if (core_sleep_o_d && irq_enabled)
           irq_deferint <= irq_enabled;
       end
-      assign iss_wrap.b1.irq_i = !iss_wrap.b1.deferint ? irq_deferint : irq_mip;
+      
+      always @*
+        iss_wrap.b1.irq_i = !iss_wrap.b1.deferint ? irq_deferint : irq_mip;
 
       /**
        * Interrupt assertion to iss_wrap, note this runs on the ISS clock (skewed from core clock)

--- a/cv32/tests/cfg/default.yaml
+++ b/cv32/tests/cfg/default.yaml
@@ -1,0 +1,6 @@
+name: default
+description: Default configuration for CV32E40P simulations
+compile_flags: 
+ovpsim: >
+    --override root/cpu0/marchid=4
+    --showoverrides

--- a/cv32/tests/cfg/no_pulp.yaml
+++ b/cv32/tests/cfg/no_pulp.yaml
@@ -1,0 +1,8 @@
+name: no_pulp
+description: Sets all PULP-related parameters to 0
+compile_flags: >
+    +define+NO_PULP
+    +define+HAHAHA
+ovpsim: >
+    --override root/cpu0/misa_Extensions=0x1104
+    --showoverrides

--- a/cv32/tests/cfg/no_pulp.yaml
+++ b/cv32/tests/cfg/no_pulp.yaml
@@ -4,5 +4,6 @@ compile_flags: >
     +define+NO_PULP
     +define+HAHAHA
 ovpsim: >
+    --override root/cpu0/marchid=4
     --override root/cpu0/misa_Extensions=0x1104
     --showoverrides


### PR DESCRIPTION
Build configurations enable a user to customize compile flags for their simulation build.
It also enables user to customize an Imperas ISS IC control file (one is built for each sim run now).  

Example:
% make test TEST=hello-world CFG=no_pulp

Notes:
- configs are in cv32/tests/cfg
- YAML is used for the configuration
- There is a "default.cfg"
- README.md added here:
https://github.com/strichmo/core-v-verif/blob/strichmo/pr/build_cfg/cv32/sim/uvmt_cv32/README.md#build-configurations
- Makes assumption that a single compilation configuration per workspace
- Always dumps ISS configuration via config file.  I like the self-documenting nature of that.
