### PR TITLE
XRUN now runs all ci_regression tests

### DIFF
--- a/ci/ci_check
+++ b/ci/ci_check
@@ -278,7 +278,7 @@ if (uvm):
                     if (run_cmd != ''):
                         run_cmd = run_cmd.replace('dsim', svtool)
                         # Only DSIM can run corev-dv (riscv-dv) at present
-                        if ( svtool == 'dsim' ):
+                        if ( svtool == 'dsim' or svtool == 'xrun'):
                             if (prcmd or debug):
                                 print(run_cmd)
                             else:


### PR DESCRIPTION
Easy, one-liner for you @strichmo.  This will add the corev-dv tests to ci_check with xrun.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>