### PR TITLE
Strichmo/pr/rand interrupt wfi

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32e40p_interrupt_assert.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32e40p_interrupt_assert.sv
@@ -83,6 +83,7 @@ module uvmt_cv32e40p_interrupt_assert
 
   reg[31:0] next_irq_q;    
   reg       next_irq_valid_q;
+  reg[31:0] saved_mie_q;
 
   reg[31:0] expected_irq;
   reg       expected_irq_ack;
@@ -126,7 +127,7 @@ module uvmt_cv32e40p_interrupt_assert
 
   // irq_id_o is never a disabled irq
   property p_irq_id_o_mie_enabled;
-    irq_ack_o |-> mie_q[irq_id_o];
+    irq_ack_o |-> saved_mie_q[irq_id_o];
   endproperty    
   a_irq_id_o_mie_enabled: assert property(p_irq_id_o_mie_enabled)
     else
@@ -233,11 +234,16 @@ module uvmt_cv32e40p_interrupt_assert
       exc_ctrl_cs_q <= 0;
       next_irq_q <= 0;
       next_irq_valid_q <= 0;
+      saved_mie_q <= 0;
     end    
     else begin
       exc_ctrl_cs_q <= exc_ctrl_cs;
-      next_irq_q <= next_irq;
-      next_irq_valid_q <= next_irq_valid;
+      // Only latch new interrupt if interrupt controller state machine is idel
+      if (exc_ctrl_cs == 0) begin
+        next_irq_q <= next_irq;
+        next_irq_valid_q <= next_irq_valid;
+        saved_mie_q <= mie_q;
+      end
     end
   end
 

--- a/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
+++ b/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
@@ -51,6 +51,8 @@ class corev_interrupt_csr_instr_stream extends riscv_load_store_rand_instr_strea
     soft wgt_random_mstatus_mie == 3; 
   }
 
+  riscv_instr_name_t allowed_mie_instr[$] = {CSRRW, CSRRC, CSRRS};
+
   `uvm_object_utils(corev_interrupt_csr_instr_stream)
   `uvm_object_new
 
@@ -82,12 +84,12 @@ class corev_interrupt_csr_instr_stream extends riscv_load_store_rand_instr_strea
     )
     // riscv_instr constraints don't handle psuedo-op LI immediate correctly (gets truncated)
     li_instr.imm = rand_mie_setting;
-    li_instr.comment = $sformatf("Set MIE to 0x%08x", rand_mie_setting);
+    li_instr.comment = $sformatf("corev-dv: Set MIE to 0x%08x", rand_mie_setting);
     li_instr.update_imm_str();
     inserted_instr_list.push_back(li_instr);
     
     // Instruction 1: Generate a write, set or clear to MIE
-    csr_instr = riscv_instr::get_rand_instr(.include_instr({CSRRW, CSRRC, CSRRS}));
+    csr_instr = riscv_instr::get_rand_instr(.include_instr(allowed_mie_instr));
     csr_instr.csr_c.constraint_mode(0);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(csr_instr,
       csr == MIE;    
@@ -113,6 +115,7 @@ class corev_interrupt_csr_instr_stream extends riscv_load_store_rand_instr_strea
       imm inside {'h8, 'h0};
       , "Cannot randomize MSTATUS_MIE CSR instruction"
     )
+    csr_instr.comment = "corev-dv: alter MSTATUS_MIE";
     insert_instr(csr_instr);
   endfunction : generate_mstatus_mie_write
 
@@ -133,5 +136,11 @@ class corev_interrupt_csr_wfi_instr_stream extends corev_interrupt_csr_instr_str
 
   `uvm_object_utils(corev_interrupt_csr_wfi_instr_stream)
   `uvm_object_new
+
+  function void post_randomize();
+    allowed_mie_instr = {CSRRW};
+
+    super.post_randomize();
+  endfunction : post_randomize
 
 endclass : corev_interrupt_csr_wfi_instr_stream

--- a/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
+++ b/vendor_lib/google/corev-dv/corev_interrupt_csr_instr_lib.sv
@@ -140,6 +140,10 @@ class corev_interrupt_csr_wfi_instr_stream extends corev_interrupt_csr_instr_str
   function void post_randomize();
     allowed_mie_instr = {CSRRW};
 
+    // Do not allow zero as destination register for LI (might clear MIE inadvertently)
+    reserved_rd = new[reserved_rd.size() + 1](reserved_rd);
+    reserved_rd[reserved_rd.size()-1] = ZERO;
+    
     super.post_randomize();
   endfunction : post_randomize
 


### PR DESCRIPTION
Assertion modeling fixes
WFI corev-vdv fixes to avoid test lockups by disabling all MIE interrupts then entering WFI