### PR TITLE
mcy: add license headers 

### DIFF
--- a/cv32/sim/mcy/alu_div/Makefile
+++ b/cv32/sim/mcy/alu_div/Makefile
@@ -1,3 +1,21 @@
+#
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Symbiotic EDA
+#
+# Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
 
 VERI_CFLAGS += -DMCY
 

--- a/cv32/sim/mcy/alu_div/miter.sv
+++ b/cv32/sim/mcy/alu_div/miter.sv
@@ -1,3 +1,22 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Symbiotic EDA
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+
 module miter
 (
     input  logic                    clk,

--- a/cv32/sim/mcy/alu_div/riscv_alu_div_mutated_wrapper.sv
+++ b/cv32/sim/mcy/alu_div/riscv_alu_div_mutated_wrapper.sv
@@ -1,3 +1,22 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Symbiotic EDA
+//
+// Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+
 module riscv_alu_div
   #(
      parameter C_WIDTH     = 32,

--- a/cv32/sim/mcy/alu_div/test_eq.sh
+++ b/cv32/sim/mcy/alu_div/test_eq.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-
+#
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Symbiotic EDA
+#
+# Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
 exec 2>&1
 set -ex
 

--- a/cv32/sim/mcy/alu_div/test_sim.sh
+++ b/cv32/sim/mcy/alu_div/test_sim.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+#
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Symbiotic EDA
+#
+# Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+
 exec 2>&1
 set -ex
 


### PR DESCRIPTION
Fixes #242.

`config.mcy` and `test_eq.sby` don't support comments and therefore cannot have license headers included.