### PR TITLE
interrupt testbench updates to work with new simplified interrupt controller

### DIFF
--- a/cv32/sim/uvmt_cv32/xrun.mk
+++ b/cv32/sim/uvmt_cv32/xrun.mk
@@ -133,9 +133,11 @@ XRUN_UVM_MACROS_INC_FILE = $(DV_UVMT_CV32_PATH)/uvmt_cv32_uvm_macros_inc.sv
 XRUN_FILE_LIST ?= -f $(DV_UVMT_CV32_PATH)/uvmt_cv32.flist
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
     XRUN_FILE_LIST += -f $(DV_UVMT_CV32_PATH)/imperas_iss.flist
-    XRUN_USER_COMPILE_ARGS += "+define+ISS+CV32E40P_TRACE_EXECUTION"
+    XRUN_USER_COMPILE_ARGS += +define+ISS+CV32E40P_TRACE_EXECUTION
     XRUN_PLUSARGS +="+USE_ISS"
 #     XRUN_PLUSARGS += +USE_ISS +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
+else
+	XRUN_USER_COMPILE_ARGS += +define+CV32E40P_TRACE_EXECUTION
 endif
 
 # Simulate using latest elab

--- a/cv32/tb/uvmt_cv32/uvmt_cv32e40p_interrupt_assert.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32e40p_interrupt_assert.sv
@@ -20,7 +20,8 @@ module uvmt_cv32e40p_interrupt_assert
   import cv32e40p_pkg::*;
   (
     
-    input clk_i,
+    input clk,   // Gated clock
+    input clk_i, // Free-running core clock
     input rst_ni,
 
     // Core inputs
@@ -38,6 +39,7 @@ module uvmt_cv32e40p_interrupt_assert
     input [5:0]  mcause_n, // mcause_n[5]: interrupt, mcause_n[4]: vector
     input [31:0] mip,     // machine interrupt pending
     input [31:0] mie_q,   // machine interrupt enable
+    input [31:0] mie_n,   // machine interrupt enable
     input        mstatus_mie, // machine mode interrupt enable
     input [1:0]  mtvec_mode_q, // machine mode interrupt vector mode
 
@@ -49,7 +51,6 @@ module uvmt_cv32e40p_interrupt_assert
     input        id_stage_instr_valid_i, // instruction word is valid
     input [31:0] id_stage_instr_rdata_i, // Instruction word data
     input [4:0]  ctrl_fsm_cs,            // Controller FSM to get hint for interrupt taken
-    input [1:0]  exc_ctrl_cs,            // Controller FSM to get hint for interrupt pending (for arbitration)
 
     // WFI Interface
     input core_sleep_o
@@ -72,11 +73,12 @@ module uvmt_cv32e40p_interrupt_assert
   string info_tag = "CV32E40P_IRQ_ASSERT";
 
   wire [31:0] pending_enabled_irq;
+  wire [31:0] pending_enabled_irq_q;
 
   wire id_instr_is_wfi; // ID instruction is a WFI
   reg  in_wfi; // Local model of WFI state of core
-
-  reg[1:0]  exc_ctrl_cs_q;
+  
+  reg[31:0] irq_q;
 
   reg[31:0] next_irq;
   reg       next_irq_valid;
@@ -86,7 +88,7 @@ module uvmt_cv32e40p_interrupt_assert
   reg[31:0] saved_mie_q;
 
   reg[31:0] expected_irq;
-  reg       expected_irq_ack;
+  logic     expected_irq_ack;
 
   reg[31:0] last_instr_rdata;
 
@@ -101,7 +103,8 @@ module uvmt_cv32e40p_interrupt_assert
   // ---------------------------------------------------------------------------
   // Begin module code
   // ---------------------------------------------------------------------------
-  assign pending_enabled_irq = irq_i & mie_q;
+  assign pending_enabled_irq   = irq_i & mie_n;
+  assign pending_enabled_irq_q = irq_q & mie_n;
 
   // ---------------------------------------------------------------------------
   // Interrupt interface checks
@@ -127,12 +130,12 @@ module uvmt_cv32e40p_interrupt_assert
 
   // irq_id_o is never a disabled irq
   property p_irq_id_o_mie_enabled;
-    irq_ack_o |-> saved_mie_q[irq_id_o];
+    irq_ack_o |-> mie_n[irq_id_o];
   endproperty    
   a_irq_id_o_mie_enabled: assert property(p_irq_id_o_mie_enabled)
     else
       `uvm_error(info_tag,
-                 $sformatf("int_id_o output is 0x%0x which is disabled in MIE: 0x%08x", irq_id_o, mie_q));
+                 $sformatf("irq_id_o output is 0x%0x which is disabled in MIE: 0x%08x", irq_id_o, mie_n));
 
   // irq_ack_o cannot be asserted if mstatus_mie is deasserted
   property p_irq_id_o_mstatus_mie_enabled;
@@ -206,7 +209,7 @@ module uvmt_cv32e40p_interrupt_assert
   always @* begin
     next_irq_valid = 1'b0;
     next_irq = '0;
-    casex ({pending_enabled_irq[31:16], pending_enabled_irq[11], pending_enabled_irq[3], pending_enabled_irq[7]})
+    casex ({pending_enabled_irq_q[31:16], pending_enabled_irq_q[11], pending_enabled_irq_q[3], pending_enabled_irq_q[7]})
       19'b1???_????_????_????_???: begin next_irq = 'd31; next_irq_valid = '1; end
       19'b01??_????_????_????_???: begin next_irq = 'd30; next_irq_valid = '1; end
       19'b001?_????_????_????_???: begin next_irq = 'd29; next_irq_valid = '1; end
@@ -231,46 +234,36 @@ module uvmt_cv32e40p_interrupt_assert
 
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      exc_ctrl_cs_q <= 0;
+      irq_q <= 0;
       next_irq_q <= 0;
       next_irq_valid_q <= 0;
       saved_mie_q <= 0;
     end    
     else begin
-      exc_ctrl_cs_q <= exc_ctrl_cs;
-      // Only latch new interrupt if interrupt controller state machine is idel
-      if (exc_ctrl_cs == 0) begin
-        next_irq_q <= next_irq;
-        next_irq_valid_q <= next_irq_valid;
-        saved_mie_q <= mie_q;
-      end
+      irq_q <= irq_i;
+      next_irq_q <= next_irq;
+      next_irq_valid_q <= next_irq_valid;
+      saved_mie_q <= mie_q;
     end
   end
 
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)
       expected_irq <= 0;
-    else if (exc_ctrl_cs == 1 && exc_ctrl_cs_q == 0)
+    else
       expected_irq <= next_irq_q;
   end
 
-  always @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)
-      expected_irq_ack <= 0;
-    else if (irq_ack_o)
-      expected_irq_ack <= 0;
-    else if (exc_ctrl_cs == 1 && exc_ctrl_cs_q == 0 && next_irq_valid_q)
-      expected_irq_ack <= 1;
-  end
+  assign expected_irq_ack = next_irq_valid & mstatus_mie;
 
   // Check expected interrupt wins
   property p_irq_arb;
-    irq_ack_o |-> irq_id_o == expected_irq;
+    irq_ack_o |-> irq_id_o == next_irq;
   endproperty
   a_irq_arb: assert property(p_irq_arb)
     else
       `uvm_error(info_tag,
-                 $sformatf("Expected winning interrupt: %0d, actual interrupt: %0d", expected_irq, irq_id_o))  
+                 $sformatf("Expected winning interrupt: %0d, actual interrupt: %0d", next_irq, irq_id_o))  
 
   // Check that an interrupt is expected
   property p_irq_expected;
@@ -290,14 +283,16 @@ module uvmt_cv32e40p_interrupt_assert
       `uvm_error(info_tag,
                  $sformatf("MCAUSE[4:0] is reserved value 0x%0x when reporting interrupt", mcause_n[4:0]));
 
-  // mip reflects input (irq_i) regardless of other configuration
+  // mip reflects flopped interrupt inputs (irq_i) regardless of other configuration
+  // Note that this runs on the gated clock
   property p_mip_irq_i;
-    mip == (irq_i & VALID_IRQ_MASK);
+    @(posedge clk)
+      ##1 mip == ($past(irq_i) & VALID_IRQ_MASK);
   endproperty
   a_mip_irq_i: assert property(p_mip_irq_i)
     else 
       `uvm_error(info_tag,
-                 $sformatf("MIP of 0x%08x does not follow irq_i input: 0x%08x", mip, irq_i));
+                 $sformatf("MIP of 0x%08x does not follow flopped irq_i input: 0x%08x", mip, $past(irq_i)));
 
   // mip should not be reserved
   property p_mip_not_reserved;
@@ -323,8 +318,8 @@ module uvmt_cv32e40p_interrupt_assert
 
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni)
-      take_cov <= 1'b0;
-    else if (ctrl_fsm_cs == IRQ_TAKEN_ID)
+      take_cov <= 1'b0;      
+    else if (irq_ack_o)
       take_cov <= 1'b1;
     else
       take_cov <= 1'b0;

--- a/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
+++ b/vendor_lib/google/corev-dv/corev_asm_program_gen.sv
@@ -107,6 +107,85 @@ class corev_asm_program_gen extends riscv_asm_program_gen;
     end
   endfunction : gen_interrupt_vector_table
 
+  // Interrupt handler routine
+  // Override from risc-dv since interrupts are auto-cleared, mip will not track through the ISS 
+  // to GPR properly with autoclear
+  virtual function void gen_interrupt_handler_section(privileged_mode_t mode, int hart);
+    string mode_prefix;
+    string ls_unit;
+    privileged_reg_t status, ip, ie, scratch;
+    string interrupt_handler_instr[$];
+    ls_unit = (XLEN == 32) ? "w" : "d";
+    if (mode < cfg.init_privileged_mode) return;
+    if (mode == USER_MODE && !riscv_instr_pkg::support_umode_trap) return;
+    case(mode)
+      MACHINE_MODE: begin
+        mode_prefix = "m";
+        status = MSTATUS;
+        ip = MIP;
+        ie = MIE;
+        scratch = MSCRATCH;
+      end
+      SUPERVISOR_MODE: begin
+        mode_prefix = "s";
+        status = SSTATUS;
+        ip = SIP;
+        ie = SIE;
+        scratch = SSCRATCH;
+      end
+      USER_MODE: begin
+        mode_prefix = "u";
+        status = USTATUS;
+        ip = UIP;
+        ie = UIE;
+        scratch = USCRATCH;
+      end
+      default: `uvm_fatal(get_full_name(), $sformatf("Unsupported mode: %0s", mode.name()))
+    endcase
+      // If nested interrupts are enabled, set xSTATUS.xIE in the interrupt handler
+      // to re-enable interrupt handling capabilities
+      if (cfg.enable_nested_interrupt) begin
+        interrupt_handler_instr.push_back($sformatf("csrr x%0d, 0x%0x", cfg.gpr[0], scratch));
+        interrupt_handler_instr.push_back($sformatf("bgtz x%0d, 1f", cfg.gpr[0]));
+        interrupt_handler_instr.push_back($sformatf("csrwi 0x%0x, 0x1", scratch));
+        case (status)
+          MSTATUS: begin
+            interrupt_handler_instr.push_back($sformatf("csrsi 0x%0x, 0x%0x", status, 8));
+          end
+          SSTATUS: begin
+            interrupt_handler_instr.push_back($sformatf("csrsi 0x%0x, 0x%0x", status, 2));
+          end
+          USTATUS: begin
+            interrupt_handler_instr.push_back($sformatf("csrsi 0x%0x, 0x%0x", status, 1));
+          end
+          default: `uvm_fatal(`gfn, $sformatf("Unsupported status %0s", status))
+        endcase
+        interrupt_handler_instr.push_back($sformatf("1: csrwi 0x%0x,0", scratch));
+      end
+    // Read back interrupt related privileged CSR
+    // The value of these CSR are checked by comparing with spike simulation result.
+    interrupt_handler_instr = {
+           interrupt_handler_instr,
+           $sformatf("csrr  x%0d, 0x%0x # %0s;", cfg.gpr[0], status, status.name()),
+           $sformatf("csrr  x%0d, 0x%0x # %0s;", cfg.gpr[0], ie, ie.name())
+    };
+    gen_plic_section(interrupt_handler_instr);
+    // Restore user mode GPR value from kernel stack before return
+    pop_gpr_from_kernel_stack(status, scratch, cfg.mstatus_mprv,
+                              cfg.sp, cfg.tp, interrupt_handler_instr);
+    interrupt_handler_instr = {interrupt_handler_instr,
+                               $sformatf("%0sret;", mode_prefix)
+    };
+    if (SATP_MODE != BARE) begin
+      // The interrupt handler will use one 4KB page
+      instr_stream.push_back(".align 12");
+    end else begin
+      instr_stream.push_back(".align 2");
+    end
+    gen_section(get_label($sformatf("%0smode_intr_handler", mode_prefix), hart),
+                interrupt_handler_instr);
+  endfunction : gen_interrupt_handler_section
+
   virtual function void gen_test_done();
     instr_stream.push_back("");
     instr_stream.push_back("#Start: Extracted from riscv_compliance_tests/riscv_test.h");

--- a/vendor_lib/google/corev-dv/corev_instr_base_test.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_base_test.sv
@@ -45,6 +45,7 @@ class corev_instr_base_test extends riscv_instr_base_test;
   virtual function void build_phase(uvm_phase phase);
     override_gen_config();
     override_privil_reg();
+    override_privil_seq();
     override_debug_rom_gen();
     super.build_phase(phase);
   endfunction
@@ -57,6 +58,11 @@ class corev_instr_base_test extends riscv_instr_base_test;
   virtual function void override_privil_reg();    
     uvm_factory::get().set_type_override_by_type(riscv_privil_reg::get_type(),
                                                  corev_privil_reg::get_type());
+  endfunction
+
+  virtual function void override_privil_seq();
+    uvm_factory::get().set_type_override_by_type(riscv_privileged_common_seq::get_type(),
+                                                 corev_privileged_common_seq::get_type());
   endfunction
 
   virtual function void override_debug_rom_gen();

--- a/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
+++ b/vendor_lib/google/corev-dv/corev_instr_test_pkg.sv
@@ -25,6 +25,7 @@ package corev_instr_test_pkg;
   `include "corev_interrupt_csr_instr_lib.sv"
 
   `include "corev_privil_reg.sv"
+  `include "corev_privileged_common_seq.sv"
   `include "corev_instr_gen_config.sv"
   `include "corev_debug_rom_gen.sv"
   `include "corev_asm_program_gen.sv"

--- a/vendor_lib/google/corev-dv/corev_privileged_common_seq.sv
+++ b/vendor_lib/google/corev-dv/corev_privileged_common_seq.sv
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 Google LLC
+ * Copyright 2020 Andes Technology Co., Ltd.
+ * Copyright 2020 OpenHW Group
+ * Copyright 2020 Silicon Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------------------
+// CORE-V privileged mode sequence customizations
+//
+// Overrides enter_privileged_mode()
+//-----------------------------------------------------------------------------------------
+
+class corev_privileged_common_seq extends riscv_privileged_common_seq;
+
+    `uvm_object_utils(corev_privileged_common_seq)
+
+    function new(string name = "");
+        super.new(name);
+    endfunction
+
+    // Override this function to use "ret" instead of "mret" to exit the function
+    // in the assembly.
+    // When initializing a mode this section can enable interrupts, which would blow away
+    // any value in *epc register.  Therefore a manual j->mret calling routine does not work
+    // and can cause infinite loop.
+    // Therefore the calling section will use jal and expect a ret to return (using x1)
+    virtual function void enter_privileged_mode(input privileged_mode_t mode,
+                                                output string instrs[$]);
+        string label = format_string({$sformatf("%0sinit_%0s:",
+                                    hart_prefix(hart), mode.name())}, LABEL_STR_LEN);
+        string ret_instr[] = {"ret"};
+        riscv_privil_reg regs[$];
+        label = label.tolower();
+        setup_mmode_reg(mode, regs);
+        if(mode == SUPERVISOR_MODE) begin
+            setup_smode_reg(mode, regs);
+        end
+        if(mode == USER_MODE) begin
+            setup_umode_reg(mode, regs);
+        end
+        if(cfg.virtual_addr_translation_on) begin
+            setup_satp(instrs);
+        end
+        gen_csr_instr(regs, instrs);
+        // Use mret/sret to switch to the target privileged mode
+        instrs.push_back(ret_instr[0]);
+        foreach(instrs[i]) begin
+            instrs[i] = {indent, instrs[i]};
+        end
+        instrs.push_front(label);
+    endfunction : enter_privileged_mode
+
+endclass : corev_privileged_common_seq


### PR DESCRIPTION
Rewrite all interrupts and "deferint modeling" code with the ISS to work with the new interrupt controller introduced in this PR:

https://github.com/openhwgroup/cv32e40p/pull/511

These changes should regress clean against all current cv32e40p directed and random interrupt tests.

Note that the above RTL PR update to the git hash in core-v-verif must occur in conjunction with merging this PR.
