### PR TITLE
add the interrupt_bootstrap directed test to verify mtvec_addr_i pins

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -378,10 +378,20 @@ TEST_FILES        = $(filter %.c %.S,$(wildcard $(dir $*)*))
 
 # Patterned targets to generate ELF.  Used only if explicit targets do not match.
 #
-# This target selected if both %.c and %.S exist
 .PRECIOUS : %.elf
+# This target selected if both %.c and %.S exist
+# Note that this target will pass both sources to gcc
+%.elf: %.c %.S
+	make bsp
+	test_asm_src=$(basename )
+	$(RISCV_EXE_PREFIX)gcc $(CFLAGS) -o $@ \
+		-nostartfiles \
+		$^ -T $(BSP)/link.ld -L $(BSP) -lcv-verif
+
+# This target selected if only %.c
 %.elf: %.c
 	make bsp
+	test_asm_src=$(basename )
 	$(RISCV_EXE_PREFIX)gcc $(CFLAGS) -o $@ \
 		-nostartfiles \
 		$^ -T $(BSP)/link.ld -L $(BSP) -lcv-verif
@@ -393,7 +403,6 @@ TEST_FILES        = $(filter %.c %.S,$(wildcard $(dir $*)*))
 		-nostartfiles \
 		-I $(ASM) \
 		$^ -T $(BSP)/link.ld -L $(BSP) -lcv-verif
-
 
 # compile and dump RISCV_TESTS only
 #$(CV32_RISCV_TESTS_FIRMWARE)/cv32_riscv_tests_firmware.elf: $(CV32_RISCV_TESTS_FIRMWARE_OBJS) $(RISCV_TESTS_OBJS) \

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -174,6 +174,20 @@ interface uvmt_cv32_core_cntrl_if (
     dm_exception_addr = 32'h1A11_1000;
     hart_id           = 32'h0000_0000;
 
+    // If a override is provided via plusarg then set bootstrap pins and adjust ISS model
+    if ($value$plusargs("mtvec_addr=0x%x", mtvec_addr));
+    begin
+      string override;
+      int fh;
+
+`ifdef ISS
+      override = $sformatf("--override root/cpu/mtvec=0x%08x", mtvec_addr);
+      fh = $fopen("ovpsim.ic", "a");
+      $fwrite(fh, "%s", override);
+      $fclose(fh);
+`endif
+    end
+
     qsc_stat_str =                $sformatf("\tclock_en          = %0d\n", clock_en);
     qsc_stat_str = {qsc_stat_str, $sformatf("\tscan_cg_en        = %0d\n", scan_cg_en)};
     qsc_stat_str = {qsc_stat_str, $sformatf("\tboot_addr         = %8h\n", boot_addr)};

--- a/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.S
+++ b/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.S
@@ -1,0 +1,57 @@
+/* Make sure the vector table gets linked into the binary.  */
+.global vector_table
+
+/* Entry point for bare metal programs */
+.section .text.start
+.global _start
+.type _start, @function
+
+_start:
+/* initialize global pointer */
+.option push
+.option norelax
+1:	auipc gp, %pcrel_hi(__global_pointer$)
+	addi  gp, gp, %pcrel_lo(1b)
+.option pop
+
+/* initialize stack pointer */
+	la sp, __stack_end
+
+/* clear the bss segment */
+	la a0, _edata
+	la a2, _end
+	sub a2, a2, a0
+	li a1, 0
+	call memset
+
+/* new-style constructors and destructors */
+	la a0, __libc_fini_array
+	call atexit
+	call __libc_init_array
+
+/* call main */
+//	lw a0, 0(sp)                    /* a0 = argc */
+//	addi a1, sp, __SIZEOF_POINTER__ /* a1 = argv */
+//	li a2, 0                        /* a2 = envp = NULL */
+// Initialize these variables to 0. Cannot use argc or argv
+// since the stack is not initialized
+	li a0, 0
+	li a1, 0
+	li a2, 0
+
+	call main
+	tail exit
+
+.size  _start, .-_start
+
+.global _init
+.type   _init, @function
+.global _fini
+.type   _fini, @function
+_init:
+_fini:
+ /* These don't have to do anything since we use init_array/fini_array. Prevent
+    missing symbol error */
+	ret
+.size  _init, .-_init
+.size _fini, .-_fini

--- a/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.c
+++ b/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.c
@@ -1,0 +1,336 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <string.h>
+
+#include "interrupt_test.h"
+
+// There is no way to commnicate UVM side information to firmware currently
+// so use a fixed value for moving mtvec
+// This should be safely away from the code area and yet safely "down" the stack area
+#define BOOTSTRAP_MTVEC 0x00000200
+
+volatile uint32_t irq_id                  = 0;
+volatile uint32_t irq_id_q[IRQ_NUM];
+volatile uint32_t irq_id_q_ptr            = 0;
+volatile uint32_t mmcause                 = 0;
+volatile uint32_t active_test             = 0;
+volatile uint32_t nested_irq              = 0;
+volatile uint32_t nested_irq_valid        = 0;
+volatile uint32_t in_direct_handler       = 0;
+
+uint32_t IRQ_ID_PRIORITY [IRQ_NUM] = {
+    FAST15_IRQ_ID   ,
+    FAST14_IRQ_ID   ,
+    FAST13_IRQ_ID   ,
+    FAST12_IRQ_ID   ,
+    FAST11_IRQ_ID   ,
+    FAST10_IRQ_ID   ,
+    FAST9_IRQ_ID    ,
+    FAST8_IRQ_ID    ,
+    FAST7_IRQ_ID    ,
+    FAST6_IRQ_ID    ,
+    FAST5_IRQ_ID    ,
+    FAST4_IRQ_ID    ,
+    FAST3_IRQ_ID    ,
+    FAST2_IRQ_ID    ,
+    FAST1_IRQ_ID    ,
+    FAST0_IRQ_ID    ,
+    EXTERNAL_IRQ_ID ,
+    SOFTWARE_IRQ_ID ,
+    TIMER_IRQ_ID
+};
+
+void delay(int count) {
+    for (volatile int d = 0; d < count; d++);
+}
+
+void mstatus_mie_enable() {
+    int mie_bit = 0x1 << MSTATUS_MIE_BIT;
+    asm volatile("csrrs x0, mstatus, %0" : : "r" (mie_bit));
+}
+
+void mstatus_mie_disable() {
+    int mie_bit = 0x1 << MSTATUS_MIE_BIT;
+    asm volatile("csrrc x0, mstatus, %0" : : "r" (mie_bit));
+}
+
+void mie_enable_all() {
+    uint32_t mie_mask = (uint32_t) -1;
+    asm volatile("csrrs x0, mie, %0" : : "r" (mie_mask));
+}
+
+void mie_disable_all() {
+    uint32_t mie_mask = (uint32_t) -1;
+    asm volatile("csrrc x0, mie, %0" : : "r" (mie_mask));
+}
+
+void mie_enable(uint32_t irq) {
+    // Enable the interrupt irq in MIE
+    uint32_t mie_bit = 0x1 << irq;
+    asm volatile("csrrs x0, mie, %0" : : "r" (mie_bit));
+}
+
+void mie_disable(uint32_t irq) {
+    // Disable the interrupt irq in MIE
+    uint32_t mie_bit = 0x1 << irq;
+    asm volatile("csrrc x0, mie, %0" : : "r" (mie_bit));
+}
+
+void mm_ram_assert_irq(uint32_t mask, uint32_t cycle_delay) {
+    *TIMER_REG_ADDR = mask;
+    *TIMER_VAL_ADDR = 1 + cycle_delay;
+}
+
+uint32_t random_num(uint32_t upper_bound, uint32_t lower_bound) {
+    uint32_t random_num = *((volatile int *)0x15001000);
+    uint32_t num = (random_num  % (upper_bound - lower_bound + 1)) + lower_bound;
+    return num;
+}
+
+uint32_t random_num32() {
+    uint32_t num = *((volatile int *)0x15001000);
+    return num;
+}
+
+extern void __no_irq_handler();
+
+void nested_irq_handler(uint32_t id) {
+    // First stack mie, mepc and mstatus
+    // Must be done in critical section with MSTATUS.MIE == 0
+    volatile uint32_t mie, mepc, mstatus;    
+    asm volatile("csrr %0, mie" : "=r" (mie));
+    asm volatile("csrr %0, mepc" :"=r" (mepc));
+    asm volatile("csrr %0, mstatus" : "=r" (mstatus));
+
+    // Re enable interrupts and create window to enable nested irqs
+    mstatus_mie_enable();
+    for (volatile int i = 0; i < 20; i++);
+
+    // Disable MSTATUS.MIE and restore from critical section
+    mstatus_mie_disable();
+    asm volatile("csrw mie, %0" : : "r" (mie));
+    asm volatile("csrw mepc, %0" : : "r" (mepc));
+    asm volatile("csrw mstatus, %0" : : "r" (mstatus));
+}
+
+void generic_irq_handler(uint32_t id) {
+    asm volatile("csrr %0, mcause": "=r" (mmcause));
+    irq_id = id;
+
+    if (active_test == 2 || active_test == 3 || active_test == 4) {
+        irq_id_q[irq_id_q_ptr++] = id;
+    } 
+    if (active_test == 3) {
+        if (nested_irq_valid) {
+            nested_irq_valid = 0;
+            mm_ram_assert_irq(0x1 << nested_irq, random_num(10,0));
+        }
+        nested_irq_handler(id);
+    }
+}
+
+void m_software_irq_handler(void) { generic_irq_handler(SOFTWARE_IRQ_ID); }
+void m_timer_irq_handler(void) { generic_irq_handler(TIMER_IRQ_ID); }
+void m_external_irq_handler(void) { generic_irq_handler(EXTERNAL_IRQ_ID); }
+void m_fast0_irq_handler(void) { generic_irq_handler(FAST0_IRQ_ID); }
+void m_fast1_irq_handler(void) { generic_irq_handler(FAST1_IRQ_ID); }
+void m_fast2_irq_handler(void) { generic_irq_handler(FAST2_IRQ_ID); }
+void m_fast3_irq_handler(void) { generic_irq_handler(FAST3_IRQ_ID); }
+void m_fast4_irq_handler(void) { generic_irq_handler(FAST4_IRQ_ID); }
+void m_fast5_irq_handler(void) { generic_irq_handler(FAST5_IRQ_ID); }
+void m_fast6_irq_handler(void) { generic_irq_handler(FAST6_IRQ_ID); }
+void m_fast7_irq_handler(void) { generic_irq_handler(FAST7_IRQ_ID); }
+void m_fast8_irq_handler(void) { generic_irq_handler(FAST8_IRQ_ID); }
+void m_fast9_irq_handler(void) { generic_irq_handler(FAST9_IRQ_ID); }
+void m_fast10_irq_handler(void) { generic_irq_handler(FAST10_IRQ_ID); }
+void m_fast11_irq_handler(void) { generic_irq_handler(FAST11_IRQ_ID); }
+void m_fast12_irq_handler(void) { generic_irq_handler(FAST12_IRQ_ID); }
+void m_fast13_irq_handler(void) { generic_irq_handler(FAST13_IRQ_ID); }
+void m_fast14_irq_handler(void) { generic_irq_handler(FAST14_IRQ_ID); }
+void m_fast15_irq_handler(void) { generic_irq_handler(FAST15_IRQ_ID); }
+
+// A Special version of the SW Handler (vector 0) used in the direct mode
+__attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void)  {
+    in_direct_handler = 1;
+    asm volatile("csrr %0, mcause" : "=r" (mmcause));
+}
+
+int test_mtvec() {
+    uint32_t mtvec_act;
+    uint32_t mtvec_exp = BOOTSTRAP_MTVEC | 0x1;
+
+    asm volatile("csrr %0, mtvec" : "=r" (mtvec_act));
+    if (mtvec_act != mtvec_exp) {
+        printf("MTVEC bootstrap failure, exp 0x%08lx, act 0x%08lx\n", mtvec_exp, mtvec_act);
+        return 1;
+    }
+    return EXIT_SUCCESS;
+}
+
+int main(int argc, char *argv[]) {
+    int retval;
+
+    // Trash the "default" 0 table
+    for (int i = 0; i < 32; i++) {
+        volatile uint32_t *ptr = (volatile uint32_t *) (0 + i*4);
+        *ptr = 0x0;
+    }
+
+    // Test that mtvec is correct
+    retval = test_mtvec();
+    if (retval != EXIT_SUCCESS)
+        return retval;
+
+    // Test 1
+    retval = test1();
+    if (retval != EXIT_SUCCESS)
+        return retval;    
+}
+
+// Test 1 will issue individual interrupts one at a time and ensure that each ISR is entered
+int test1() {
+    printf("TEST 1 - TRIGGER ALL IRQS IN SEQUENCE:\n");
+
+    active_test = 1;
+
+    if (test1_impl(0) != EXIT_SUCCESS)
+        return ERR_CODE_TEST_1;
+
+    return EXIT_SUCCESS;
+}
+
+// To share implementation of basic interrupt test with vector relocation tests,
+// break out the test 1 implementation here
+int test1_impl(int direct_mode) {
+    for (uint32_t i = 0; i < 32; i++) {
+#ifdef DEBUG_MSG
+        printf("Test1 -> Testing interrupt %lu\n", i);
+#endif
+        for (uint32_t gmie = 0; gmie <= 1; gmie++) {
+            for (uint32_t mie = 0; mie <= 1; mie++) {
+                uint32_t mip;
+
+                // Set global MIE
+                if (gmie) mstatus_mie_enable();
+                else mstatus_mie_disable();
+
+                // Set individual mie
+                if (mie) mie_enable(i);
+                else mie_disable(i);
+
+                in_direct_handler = 0;
+                mmcause = 0;
+                mm_ram_assert_irq(0x1 << i, 1);    
+
+                if (((0x1 << i) & IRQ_MASK) && mie && gmie) {
+                    // Interrupt is valid and enabled 
+                    // wait for the irq to be served
+                    while (!mmcause);
+                
+                    if ((mmcause & (0x1 << 31)) == 0) {
+                        printf("MCAUSE[31] was not set: mmcause = 0x%08lx\n", (uint32_t) mmcause);
+
+                        return ERR_CODE_TEST_1;
+                    }
+                    if ((mmcause & MCAUSE_IRQ_MASK) != i) {
+                        printf("MCAUSE reported wrong irq, exp = %lu, act = 0x%08lx", i, mmcause);
+
+                        return ERR_CODE_TEST_1;                    
+                    }                    
+                } else {
+                    // Unimplemented interrupts, or is a masked irq, delay a bit, waiting for any mmcause
+                    for (int j = 0; j < 20; j++) {
+                        if (mmcause != 0) {
+                            printf("MMCAUSE = 0x%08lx when unimplmented interrupt %lu first", mmcause, i);
+                            return ERR_CODE_TEST_1;
+                        }
+                    }                    
+                }
+                
+                // Check MIP
+                // For unimplemented irqs, this should always be 0
+                // For masked irqs, this should always be 0
+                // If the IRQ occurred then acking will cause it to clear by here, so do not check
+                __asm__ volatile ("csrr %0,mip" : "=r" (mip));
+                if (((0x1 << i) & IRQ_MASK) && (!mie || !gmie)) {
+                    // Implemented, masked IRQ
+                    if (!(mip & (0x1 << i))) {
+                        printf("MIP for IRQ[%lu] not set\n", i);
+                        return ERR_CODE_TEST_1;
+                    }
+                } else {
+                    // Unimplemented IRQ
+                    if (mip & (0x1 << i)) {
+                        printf("MIP for unimplemented IRQ[%lu] set\n", i);
+                        return ERR_CODE_TEST_1;
+                    }                    
+                }
+
+                // Check flag at direct mode handler
+                if (((0x1 << i) & IRQ_MASK) && mie && gmie) {
+                    if (direct_mode && !in_direct_handler) {
+                        printf("In direct mode, the direct sw handler was not entered, irq: %lu\n", i);
+                        return ERR_CODE_TEST_1;
+                    }
+                    if (!direct_mode && in_direct_handler) {
+                        printf("In vector mode, the direct sw handler was entered, irq: %lu\n", i);
+                        return ERR_CODE_TEST_1;
+                    }
+                }
+
+                // Clear vp irq
+                mm_ram_assert_irq(0, 0);   
+            }
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+
+    asm (
+        ".global alt_vector_table\n"
+        ".option norvc\n"
+        ".align 8\n"
+        "alt_vector_table:\n"
+	    "j u_sw_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_software_irq_handler\n"
+	    "j __no_irq_handler\n"        
+        "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_timer_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_external_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_fast0_irq_handler\n"
+	    "j m_fast1_irq_handler\n"
+	    "j m_fast2_irq_handler\n"
+	    "j m_fast3_irq_handler\n"
+	    "j m_fast4_irq_handler\n"
+	    "j m_fast5_irq_handler\n"
+	    "j m_fast6_irq_handler\n"
+	    "j m_fast7_irq_handler\n"
+	    "j m_fast8_irq_handler\n"
+	    "j m_fast9_irq_handler\n"
+	    "j m_fast10_irq_handler\n"
+	    "j m_fast11_irq_handler\n"
+	    "j m_fast12_irq_handler\n"
+	    "j m_fast13_irq_handler\n"
+	    "j m_fast14_irq_handler\n"
+	    "j m_fast15_irq_handler\n"
+    );
+
+    asm (
+        ".global alt_direct_vector_table\n"
+        ".option norvc\n"
+        ".align 8\n"
+        "alt_direct_vector_table:\n"
+	    "j u_sw_direct_irq_handler\n"	
+    );

--- a/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_test.h
+++ b/cv32/tests/programs/custom/interrupt_bootstrap/interrupt_test.h
@@ -1,0 +1,1 @@
+../interrupt_test/interrupt_test.h

--- a/cv32/tests/programs/custom/interrupt_bootstrap/test.yaml
+++ b/cv32/tests/programs/custom/interrupt_bootstrap/test.yaml
@@ -1,0 +1,6 @@
+name: interrupt_bootstrap
+uvm_test: uvmt_cv32_firmware_test_c
+description: >
+    Interrupt directed test for mtvec_addr_i bootstrap pins
+plusargs: >
+    +mtvec_addr=0x00000201

--- a/cv32/tests/programs/custom/interrupt_test/test.yaml
+++ b/cv32/tests/programs/custom/interrupt_test/test.yaml
@@ -1,6 +1,3 @@
-# Test definition YAML for test
-
-# Interrupt directed test
 name: interrupt_test
 uvm_test: uvmt_cv32_firmware_test_c
 description: >


### PR DESCRIPTION
Very simple directed test of mtvec_addr_i.  

Also adds following:

- Adds plusarg hook to set mtvec_addr_i as a short-term fix to set pins using existing interface initial block
- Add common makefile target to allow tests with both assembly and C source.  The bootstrap test uses this to implement a different start routine to avoid BSP's setting of mtvec.


Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>