### PR TITLE
Fix for issue #256

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -98,6 +98,8 @@ module uvmt_cv32_tb;
     assign debug_cov_assert_if.id_stage_instr_valid_i = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.instr_valid_i;
     assign debug_cov_assert_if.id_stage_instr_rdata_i = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.instr_rdata_i;
     assign debug_cov_assert_if.id_stage_is_compressed = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.is_compressed_i;
+    assign debug_cov_assert_if.id_valid = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.id_valid_i;
+    assign debug_cov_assert_if.is_decoding = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.controller_i.is_decoding_o;
     assign debug_cov_assert_if.id_stage_pc = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.pc_id_i;
     assign debug_cov_assert_if.if_stage_pc = dut_wrap.cv32e40p_wrapper_i.core_i.if_stage_i.pc_if_o;
     assign debug_cov_assert_if.mie_q = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mstatus_q.mie;

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -111,7 +111,7 @@ module uvmt_cv32_tb;
     assign debug_cov_assert_if.depc_q = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.depc_q;
     assign debug_cov_assert_if.depc_n = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.depc_n;
     assign debug_cov_assert_if.mcause_q = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mcause_q;
-    assign debug_cov_assert_if.mtvec = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_addr_i;
+    assign debug_cov_assert_if.mtvec = {dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mtvec_q, 8'h00};
     assign debug_cov_assert_if.mepc_q = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mepc_q;
     assign debug_cov_assert_if.tdata1 = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.tmatch_control_rdata;
     assign debug_cov_assert_if.tdata2 = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.tmatch_value_rdata;

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -305,6 +305,8 @@ interface uvmt_cv32_debug_cov_assert_if
     input logic        id_stage_is_compressed,
     input logic [31:0] id_stage_pc, // Program counter in decode
     input logic [31:0] if_stage_pc, // Program counter in fetch
+    input logic        is_decoding,
+    input logic        id_valid,
     input ctrl_state_e  ctrl_fsm_cs,            // Controller FSM states with debug_req
     input logic        illegal_insn_i,
     input logic        illegal_insn_q, // output from controller

--- a/cv32/tb/uvmt_cv32/uvmt_cv32e40p_debug_assert.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32e40p_debug_assert.sv
@@ -42,11 +42,13 @@ module uvmt_cv32e40p_debug_assert
   default clocking @(posedge cov_assert_if.clk_i); endclocking
   default disable iff !(cov_assert_if.rst_ni);
   
-  assign cov_assert_if.is_ebreak = cov_assert_if.id_stage_instr_valid_i & 
+  assign cov_assert_if.is_ebreak = cov_assert_if.id_valid & 
+                                   cov_assert_if.is_decoding & 
                      (cov_assert_if.id_stage_instr_rdata_i == 32'h00100073) & 
                      cov_assert_if.id_stage_is_compressed == 1'b0;
 
-  assign cov_assert_if.is_cebreak = cov_assert_if.id_stage_instr_valid_i & 
+  assign cov_assert_if.is_cebreak = cov_assert_if.id_valid &
+                                    cov_assert_if.is_decoding &  
                      (cov_assert_if.id_stage_instr_rdata_i == 32'h00100073) & 
                      cov_assert_if.id_stage_is_compressed == 1'b1;
 
@@ -103,7 +105,7 @@ module uvmt_cv32e40p_debug_assert
 
     // c.ebreak during debug mode results in relaunch of debug mode
     property p_cebreak_during_debug_mode;
-        $rose(cov_assert_if.is_cebreak) && cov_assert_if.debug_mode_q  |-> ##[1:6] cov_assert_if.debug_mode_q  &&
+        $rose(cov_assert_if.is_cebreak) && cov_assert_if.debug_mode_q  |-> ##[1:40] cov_assert_if.debug_mode_q  &&
                                                        (cov_assert_if.id_stage_pc == cov_assert_if.dm_halt_addr_i); // TODO should check no change in dpc and dcsr
     endproperty
 
@@ -113,7 +115,7 @@ module uvmt_cv32e40p_debug_assert
 
     // ebreak during debug mode results in relaunch
     property p_ebreak_during_debug_mode;
-        $rose(cov_assert_if.is_ebreak) && cov_assert_if.debug_mode_q |-> ##[1:6] cov_assert_if.debug_mode_q && 
+        $rose(cov_assert_if.is_ebreak) && cov_assert_if.debug_mode_q |-> ##[1:40] cov_assert_if.debug_mode_q && 
                                                      (cov_assert_if.id_stage_pc == cov_assert_if.dm_halt_addr_i); // TODO should check no change in dpc and dcsr
     endproperty
 
@@ -296,7 +298,7 @@ module uvmt_cv32e40p_debug_assert
             end
 
             // Capture pc at ebreak
-            if(cov_assert_if.is_ebreak || cov_assert_if.is_cebreak) begin
+            if(cov_assert_if.is_ebreak || cov_assert_if.is_cebreak ) begin
                 pc_at_ebreak <= cov_assert_if.id_stage_pc;
             end
        end

--- a/cv32/tb/uvmt_cv32/uvmt_cv32e40p_debug_assert.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32e40p_debug_assert.sv
@@ -69,7 +69,7 @@ module uvmt_cv32e40p_debug_assert
 
     // c.ebreak with dcsr.ebreakm results in debug mode
     property p_cebreak_debug_mode;
-        $rose(cov_assert_if.is_cebreak) && cov_assert_if.dcsr_q[15] == 1'b1 |-> ##[1:6] cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40p_pkg::DBG_CAUSE_EBREAK) &&
+        $rose(cov_assert_if.is_cebreak) && cov_assert_if.dcsr_q[15] == 1'b1 |-> ##[1:40] cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40p_pkg::DBG_CAUSE_EBREAK) &&
                                                             (cov_assert_if.depc_q == pc_at_dbg_req) &&
                                                             (cov_assert_if.id_stage_pc == cov_assert_if.dm_halt_addr_i);
     endproperty
@@ -80,7 +80,7 @@ module uvmt_cv32e40p_debug_assert
 
     // ebreak with dcsr.ebreakm results in debug mode
     property p_ebreak_debug_mode;
-        $rose(cov_assert_if.is_ebreak) && cov_assert_if.dcsr_q[15] == 1'b1 |-> ##[1:6] cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40p_pkg::DBG_CAUSE_EBREAK) &&
+        $rose(cov_assert_if.is_ebreak) && cov_assert_if.dcsr_q[15] == 1'b1 |-> ##[1:40] cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40p_pkg::DBG_CAUSE_EBREAK) &&
                                                             (cov_assert_if.depc_q == pc_at_dbg_req) &&
                                                             (cov_assert_if.id_stage_pc == cov_assert_if.dm_halt_addr_i);
     endproperty
@@ -92,7 +92,7 @@ module uvmt_cv32e40p_debug_assert
 
     // c.ebreak without dcsr.ebreakm results in exception at mtvec
     property p_cebreak_exception;
-        $rose(cov_assert_if.is_cebreak) && cov_assert_if.dcsr_q[15] == 1'b0 && !cov_assert_if.debug_mode_q |-> ##[1:6] !cov_assert_if.debug_mode_q && (cov_assert_if.mcause_q[5:0] === cv32e40p_pkg::EXC_CAUSE_BREAKPOINT) &&
+        $rose(cov_assert_if.is_cebreak) && cov_assert_if.dcsr_q[15] == 1'b0 && !cov_assert_if.debug_mode_q |-> ##[1:40] !cov_assert_if.debug_mode_q && (cov_assert_if.mcause_q[5:0] === cv32e40p_pkg::EXC_CAUSE_BREAKPOINT) &&
                                                                              (cov_assert_if.mepc_q == pc_at_ebreak) &&
                                                                              (cov_assert_if.id_stage_pc == cov_assert_if.mtvec);
     endproperty


### PR DESCRIPTION
Detection of [c.]ebreak instructions were not robust, [c.]ebreak directly after taken branches would lead to properties expecting exception entry. Properties were also not checking enough cycles to allow long running instructions like DIV to complete before entering exception. Ebreak test now passes again.