### PR TITLE
Initialize RTL instruction memory even when ISS not used

### DIFF
--- a/cv32/tests/uvmt_cv32/compliance-tests/uvmt_cv32_firmware_test.sv
+++ b/cv32/tests/uvmt_cv32/compliance-tests/uvmt_cv32_firmware_test.sv
@@ -165,7 +165,7 @@ task uvmt_cv32_firmware_test_c::random_debug();
         uvme_cv32_random_debug_c debug_vseq;
         repeat (100) @(env_cntxt.debug_cntxt.vif.mon_cb);
         debug_vseq = uvme_cv32_random_debug_c::type_id::create("random_debug_vseqr");
-        debug_vseq.randomize();
+        void'(debug_vseq.randomize());
         debug_vseq.start(vsequencer);
         break;
     end     


### PR DESCRIPTION
Hi Greg.  You've probably forgotten, but back in May of this year you updated the `dut_wrap` module to initialize unused instruction memory which could lead to step-and-compare mismatches because the RTL and TB model 4-state values and the ISS models 2-state values.

In this PR I have slightly modified this code so that the RTL's instruction memory is _always_ initialized, even if the ISS is not used.  This resolves #263.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>