### PR TITLE
fix default.yaml

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -182,8 +182,8 @@ interface uvmt_cv32_core_cntrl_if (
 
 `ifdef ISS
       override = $sformatf("--override root/cpu/mtvec=0x%08x", mtvec_addr);
-      fh = $fopen("ovpsim.ic", "a");
-      $fwrite(fh, "%s", override);
+      fh = $fopen("ovpsim.ic", "a");      
+      $fwrite(fh, " %s\n", override);
       $fclose(fh);
 `endif
     end

--- a/cv32/tests/cfg/default.yaml
+++ b/cv32/tests/cfg/default.yaml
@@ -1,12 +1,16 @@
 name: default
 description: Default configuration for CV32E40P simulations
 compile_flags: 
+    
+# Imperas ISS Options (in ovpsim section)
+# PULP_XPULP=1
+#--override root/cpu/misa_Extensions=0x801104
+# PULP_XPULP=0
+# Set as below
+# Debug options (add to ovpsim section as needed)
+#--trace --tracechange --traceshowicount --monitornets --tracemode
+#--showoverrides
 ovpsim: >
-    # PULP_XPULP=1
-    #--override root/cpu/misa_Extensions=0x801104
-    # PULP_XPULP=0
-    --override root/cpu/misa_Extensions=0x001104
+    --override root/cpu/misa_Extensions=0x801104
     --override root/cpu/marchid=4
     --override root/cpu/noinhibit_mask=0xFFFFFFF0
-    #--trace --tracechange --traceshowicount --monitornets --tracemode
-    #--showoverrides


### PR DESCRIPTION
Fixes issue with default.yaml usage.  YAML string does not support inline comments so simply moved comments out of the ovpsim: section.
