### PR TITLE
fix stray semicolon forcing mtvec_addr into ovpsim.ic

### DIFF
--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb_ifs.sv
@@ -175,13 +175,12 @@ interface uvmt_cv32_core_cntrl_if (
     hart_id           = 32'h0000_0000;
 
     // If a override is provided via plusarg then set bootstrap pins and adjust ISS model
-    if ($value$plusargs("mtvec_addr=0x%x", mtvec_addr));
-    begin
+    if ($value$plusargs("mtvec_addr=0x%x", mtvec_addr)) begin
       string override;
       int fh;
 
 `ifdef ISS
-      override = $sformatf("--override root/cpu/mtvec=0x%08x", mtvec_addr);
+      override = $sformatf("--override root/cpu/mtvec=0x%08x", {mtvec_addr[31:8], 8'h01});
       fh = $fopen("ovpsim.ic", "a");      
       $fwrite(fh, " %s\n", override);
       $fclose(fh);


### PR DESCRIPTION
fix alignment and vector mode when bootstrapping

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>