### PR TITLE
Bigger CSR access test

### DIFF
--- a/cv32/tests/programs/custom/cv32e40p_csr_access_test/cv32e40p_csr_access_test.S
+++ b/cv32/tests/programs/custom/cv32e40p_csr_access_test/cv32e40p_csr_access_test.S
@@ -20,1592 +20,41498 @@ _start_main:
 # Generated code starts...
 #
 ###############################################################################
-
-riscv_csr_test_start:
-
+_start0:
+	# mcycle
+	li x7, 0xa5a5a5a5
+	csrrw x12, 2816, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 2816, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x12, csr_fail
+	li x7, 0xd5583a6b
+	csrrw x12, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 2816, x7
+	li x7, 0xd5583a6b
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 2816, x7
+	li x7, 0xf5fdbfef
+	bne x7, x12, csr_fail
+	li x7, 0x1ac809f1
+	csrrs x12, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xe34ffa80
+	csrrc x12, 2816, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 2816, 0b01111
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x7, 0x0000000f
+	bne x7, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x7, 0x0000000f
+	bne x7, x12, csr_fail
+	csrrsi x12, 2816, 0b01100
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 2816, 0b11001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	# mcycleh
+	li x7, 0xa5a5a5a5
+	csrrw x12, 2944, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 2944, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x12, csr_fail
+	li x7, 0x7c57f465
+	csrrw x12, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 2944, x7
+	li x7, 0x7c57f465
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 2944, x7
+	li x7, 0xfdf7f5e5
+	bne x7, x12, csr_fail
+	li x7, 0xef4868d3
+	csrrs x12, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xcd7239a8
+	csrrc x12, 2944, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 2944, 0b00000
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrsi x12, 2944, 0b10101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 2944, 0b10001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	# minstret
+	li x7, 0xa5a5a5a5
+	csrrw x12, 2818, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 2818, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x12, csr_fail
+	li x7, 0xc245502d
+	csrrw x12, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 2818, x7
+	li x7, 0xc245502d
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 2818, x7
+	li x7, 0xe7e5f5ad
+	bne x7, x12, csr_fail
+	li x7, 0x7c402043
+	csrrs x12, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0x036e3278
+	csrrc x12, 2818, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 2818, 0b00111
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x7, 0x00000007
+	bne x7, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x7, 0x00000007
+	bne x7, x12, csr_fail
+	csrrsi x12, 2818, 0b00010
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 2818, 0b00111
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	# minstreth
+	li x7, 0xa5a5a5a5
+	csrrw x12, 2946, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 2946, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x12, csr_fail
+	li x7, 0x7204fa53
+	csrrw x12, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 2946, x7
+	li x7, 0x7204fa53
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 2946, x7
+	li x7, 0xf7a5fff7
+	bne x7, x12, csr_fail
+	li x7, 0xa48088a2
+	csrrs x12, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa8784df5
+	csrrc x12, 2946, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 2946, 0b01111
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x7, 0x0000000f
+	bne x7, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x7, 0x0000000f
+	bne x7, x12, csr_fail
+	csrrsi x12, 2946, 0b01010
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 2946, 0b00111
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mstatus
-	li x14, 0xa5a5a5a5
-	csrrw x11, 768, x14
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 768, x14
-	li x14, 0x00001880
-	bne x14, x11, csr_fail
-	li x14, 0xb41992e5
-	csrrw x11, 768, x14
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 768, x14
-	li x14, 0x00001880
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 768, x14
-	li x14, 0x00001880
-	bne x14, x11, csr_fail
-	li x14, 0x7e8f3536
-	csrrs x11, 768, x14
-	li x14, 0x00001888
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 768, x14
-	li x14, 0x00001888
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 768, x14
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	li x14, 0xded26b04
-	csrrc x11, 768, x14
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	csrrwi x11, 768, 0b00101
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	csrrwi x11, 768, 0b11010
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	csrrwi x11, 768, 0b10011
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	csrrsi x11, 768, 0b00101
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	csrrsi x11, 768, 0b11010
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
-	csrrsi x11, 768, 0b00000
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	csrrci x11, 768, 0b00101
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	csrrci x11, 768, 0b11010
-	li x14, 0x00001808
-	bne x14, x11, csr_fail
-	csrrci x11, 768, 0b01010
-	li x14, 0x00001800
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 768, x7
+	li x7, 0x00001800
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 768, x7
+	li x7, 0x00001880
+	bne x7, x12, csr_fail
+	li x7, 0x197aa0ad
+	csrrw x12, 768, x7
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 768, x7
+	li x7, 0x00001888
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 768, x7
+	li x7, 0x00001888
+	bne x7, x12, csr_fail
+	li x7, 0xd3d179f8
+	csrrs x12, 768, x7
+	li x7, 0x00001888
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 768, x7
+	li x7, 0x00001888
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 768, x7
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	li x7, 0x111776a9
+	csrrc x12, 768, x7
+	li x7, 0x00001800
+	bne x7, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x7, 0x00001800
+	bne x7, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x7, 0x00001800
+	bne x7, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrsi x12, 768, 0b11000
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x12, csr_fail
+	csrrci x12, 768, 0b00111
+	li x7, 0x00001800
+	bne x7, x12, csr_fail
 	# misa
-	li x14, 0xa5a5a5a5
-	csrrw x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x4c9d627a
-	csrrw x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x32e0471e
-	csrrs x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	li x14, 0x452597a5
-	csrrc x11, 769, x14
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrwi x11, 769, 0b00101
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrwi x11, 769, 0b11010
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrwi x11, 769, 0b00101
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrsi x11, 769, 0b00101
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrsi x11, 769, 0b11010
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrsi x11, 769, 0b00001
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrci x11, 769, 0b00101
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrci x11, 769, 0b11010
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
-	csrrci x11, 769, 0b11011
-	li x14, 0x40801104
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0xb2883b3e
+	csrrw x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0x9e6fcd65
+	csrrs x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	li x7, 0xb741d0fc
+	csrrc x12, 769, x7
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrwi x12, 769, 0b01011
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrsi x12, 769, 0b00010
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
+	csrrci x12, 769, 0b01100
+	li x7, 0x40801104
+	bne x7, x12, csr_fail
 	# mie
-	li x14, 0xa5a5a5a5
-	csrrw x11, 772, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 772, x14
-	li x14, 0xa5a50080
-	bne x14, x11, csr_fail
-	li x14, 0x1422257a
-	csrrw x11, 772, x14
-	li x14, 0x5a5a0808
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 772, x14
-	li x14, 0x14220008
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 772, x14
-	li x14, 0xb5a70088
-	bne x14, x11, csr_fail
-	li x14, 0x42bab81c
-	csrrs x11, 772, x14
-	li x14, 0xffff0888
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 772, x14
-	li x14, 0xffff0888
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 772, x14
-	li x14, 0x5a5a0808
-	bne x14, x11, csr_fail
-	li x14, 0xf436365b
-	csrrc x11, 772, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 772, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 772, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 772, 0b01011
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrsi x11, 772, 0b00101
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrsi x11, 772, 0b11010
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrsi x11, 772, 0b11000
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrci x11, 772, 0b00101
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrci x11, 772, 0b11010
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrci x11, 772, 0b01011
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 772, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 772, x7
+	li x7, 0xa5a50080
+	bne x7, x12, csr_fail
+	li x7, 0xcfda7cd3
+	csrrw x12, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 772, x7
+	li x7, 0xcfda0880
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 772, x7
+	li x7, 0xefff0880
+	bne x7, x12, csr_fail
+	li x7, 0xce01f5b0
+	csrrs x12, 772, x7
+	li x7, 0xffff0888
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 772, x7
+	li x7, 0xffff0888
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x12, csr_fail
+	li x7, 0x5c762563
+	csrrc x12, 772, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 772, 0b10100
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 772, 0b11101
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrci x12, 772, 0b11100
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mtvec
-	li x14, 0xa5a5a5a5
-	csrrw x11, 773, x14
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 773, x14
-	li x14, 0xa5a5a501
-	bne x14, x11, csr_fail
-	li x14, 0x7f865be0
-	csrrw x11, 773, x14
-	li x14, 0x5a5a5a00
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 773, x14
-	li x14, 0x7f865b00
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 773, x14
-	li x14, 0xffa7ff01
-	bne x14, x11, csr_fail
-	li x14, 0x17642d7b
-	csrrs x11, 773, x14
-	li x14, 0xffffff01
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 773, x14
-	li x14, 0xffffff01
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 773, x14
-	li x14, 0x5a5a5a00
-	bne x14, x11, csr_fail
-	li x14, 0xd1fc3ec5
-	csrrc x11, 773, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 773, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 773, 0b11010
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	csrrwi x11, 773, 0b10010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 773, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 773, 0b11010
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	csrrsi x11, 773, 0b11110
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	csrrci x11, 773, 0b00101
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	csrrci x11, 773, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 773, 0b00111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 773, x7
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 773, x7
+	li x7, 0xa5a5a501
+	bne x7, x12, csr_fail
+	li x7, 0xce3aa43b
+	csrrw x12, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 773, x7
+	li x7, 0xce3aa401
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 773, x7
+	li x7, 0xefbfa501
+	bne x7, x12, csr_fail
+	li x7, 0x7bb81c4c
+	csrrs x12, 773, x7
+	li x7, 0xffffff01
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 773, x7
+	li x7, 0xffffff01
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x12, csr_fail
+	li x7, 0x2020b509
+	csrrc x12, 773, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	csrrwi x12, 773, 0b01001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	csrrsi x12, 773, 0b11011
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 773, 0b01011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mcountinhibit
-	li x14, 0xa5a5a5a5
-	csrrw x11, 800, x14
-	li x14, 0x0000000d
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 800, x14
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	li x14, 0x3f040ca7
-	csrrw x11, 800, x14
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 800, x14
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 800, x14
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	li x14, 0x6a9da72a
-	csrrs x11, 800, x14
-	li x14, 0x0000000d
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 800, x14
-	li x14, 0x0000000d
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 800, x14
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	li x14, 0xf9b378b9
-	csrrc x11, 800, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 800, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 800, 0b11010
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 800, 0b10100
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrsi x11, 800, 0b00101
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 800, 0b11010
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrsi x11, 800, 0b11101
-	li x14, 0x0000000d
-	bne x14, x11, csr_fail
-	csrrci x11, 800, 0b00101
-	li x14, 0x0000000d
-	bne x14, x11, csr_fail
-	csrrci x11, 800, 0b11010
-	li x14, 0x00000008
-	bne x14, x11, csr_fail
-	csrrci x11, 800, 0b01011
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 800, x7
+	li x7, 0x0000000d
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 800, x7
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	li x7, 0x2dc3eb63
+	csrrw x12, 800, x7
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 800, x7
+	li x7, 0x00000001
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 800, x7
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	li x7, 0xa81fc44d
+	csrrs x12, 800, x7
+	li x7, 0x0000000d
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 800, x7
+	li x7, 0x0000000d
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 800, x7
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	li x7, 0xff3578a4
+	csrrc x12, 800, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 800, 0b00000
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrsi x12, 800, 0b01010
+	li x7, 0x0000000d
+	bne x7, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x7, 0x0000000d
+	bne x7, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x7, 0x00000008
+	bne x7, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mscratch
-	li x14, 0xa5a5a5a5
-	csrrw x11, 832, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 832, x14
-	li x14, 0xa5a5a5a5
-	bne x14, x11, csr_fail
-	li x14, 0xeaa18704
-	csrrw x11, 832, x14
-	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 832, x14
-	li x14, 0xeaa18704
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 832, x14
-	li x14, 0xefa5a7a5
-	bne x14, x11, csr_fail
-	li x14, 0x05a4c086
-	csrrs x11, 832, x14
-	li x14, 0xffffffff
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 832, x14
-	li x14, 0xffffffff
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 832, x14
-	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0x0f5c1af7
-	csrrc x11, 832, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 832, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 832, 0b11010
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 832, 0b00001
-	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 832, 0b00101
-	li x14, 0x00000001
-	bne x14, x11, csr_fail
-	csrrsi x11, 832, 0b11010
-	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrsi x11, 832, 0b00111
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 832, 0b00101
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 832, 0b11010
-	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 832, 0b10011
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 832, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 832, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x12, csr_fail
+	li x7, 0x72136fe8
+	csrrw x12, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 832, x7
+	li x7, 0x72136fe8
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 832, x7
+	li x7, 0xf7b7efed
+	bne x7, x12, csr_fail
+	li x7, 0x920a0ef1
+	csrrs x12, 832, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 832, x7
+	li x7, 0xffffffff
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0x923ec2eb
+	csrrc x12, 832, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x7, 0x00000005
+	bne x7, x12, csr_fail
+	csrrwi x12, 832, 0b10001
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x7, 0x00000011
+	bne x7, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x7, 0x00000015
+	bne x7, x12, csr_fail
+	csrrsi x12, 832, 0b10010
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x7, 0x0000001f
+	bne x7, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 832, 0b10010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mepc
-	li x14, 0xa5a5a5a5
-	csrrw x11, 833, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 833, x14
-	li x14, 0xa5a5a5a4
-	bne x14, x11, csr_fail
-	li x14, 0x4c47a22a
-	csrrw x11, 833, x14
-	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 833, x14
-	li x14, 0x4c47a22a
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 833, x14
-	li x14, 0xede7a7ae
-	bne x14, x11, csr_fail
-	li x14, 0xd41aa2f1
-	csrrs x11, 833, x14
-	li x14, 0xfffffffe
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 833, x14
-	li x14, 0xfffffffe
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 833, x14
-	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0xf945cb66
-	csrrc x11, 833, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 833, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 833, 0b11010
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrwi x11, 833, 0b00101
-	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 833, 0b00101
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 833, 0b11010
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 833, 0b00100
-	li x14, 0x0000001e
-	bne x14, x11, csr_fail
-	csrrci x11, 833, 0b00101
-	li x14, 0x0000001e
-	bne x14, x11, csr_fail
-	csrrci x11, 833, 0b11010
-	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 833, 0b11111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 833, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 833, x7
+	li x7, 0xa5a5a5a4
+	bne x7, x12, csr_fail
+	li x7, 0x639c1c12
+	csrrw x12, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 833, x7
+	li x7, 0x639c1c12
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 833, x7
+	li x7, 0xe7bdbdb6
+	bne x7, x12, csr_fail
+	li x7, 0xa3e37261
+	csrrs x12, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x12, csr_fail
+	li x7, 0xa53dcea5
+	csrrc x12, 833, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrwi x12, 833, 0b10001
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x7, 0x00000010
+	bne x7, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x7, 0x00000014
+	bne x7, x12, csr_fail
+	csrrsi x12, 833, 0b00010
+	li x7, 0x0000001e
+	bne x7, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x7, 0x0000001e
+	bne x7, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x7, 0x0000001a
+	bne x7, x12, csr_fail
+	csrrci x12, 833, 0b01001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mtval
-	li x14, 0xa5a5a5a5
-	csrrw x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xdbe6512e
-	csrrw x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xca7f632a
-	csrrs x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xc7734f7c
-	csrrc x11, 835, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 835, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 835, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 835, 0b11001
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 835, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 835, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 835, 0b01001
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 835, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 835, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 835, 0b11110
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x6b35d786
+	csrrw x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xe7cc0919
+	csrrs x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x016a89d4
+	csrrc x12, 835, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 835, 0b01011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 835, 0b10101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 835, 0b00011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# mip
-	li x14, 0xa5a5a5a5
-	csrrw x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xf4498767
-	csrrw x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xbd8b4cb5
-	csrrs x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xb205a13a
-	csrrc x11, 836, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 836, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 836, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 836, 0b00000
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 836, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 836, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 836, 0b10010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 836, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 836, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 836, 0b10111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x797e2c9a
+	csrrw x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x8bc5b8a9
+	csrrs x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xab9f955b
+	csrrc x12, 836, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 836, 0b01010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 836, 0b11100
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 836, 0b10001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# tselect
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x2ac0e8a5
-	csrrw x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xab1f346b
-	csrrs x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x550102f7
-	csrrc x11, 1952, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1952, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1952, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1952, 0b11111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1952, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1952, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1952, 0b10111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1952, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1952, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1952, 0b10111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa0957842
+	csrrw x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xae52c0f4
+	csrrs x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xaa86978b
+	csrrc x12, 1952, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1952, 0b10011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1952, 0b10110
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1952, 0b01011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# tdata1
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x3f7509e6
-	csrrw x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x4a21d54e
-	csrrs x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	li x14, 0x5f8c0de1
-	csrrc x11, 1953, x14
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrwi x11, 1953, 0b00101
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrwi x11, 1953, 0b11010
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrwi x11, 1953, 0b11001
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrsi x11, 1953, 0b00101
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrsi x11, 1953, 0b11010
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrsi x11, 1953, 0b00100
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrci x11, 1953, 0b00101
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrci x11, 1953, 0b11010
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
-	csrrci x11, 1953, 0b11000
-	li x14, 0x28001040
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0x66b68206
+	csrrw x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0xc1232135
+	csrrs x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	li x7, 0x4f01b170
+	csrrc x12, 1953, x7
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrwi x12, 1953, 0b10101
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrsi x12, 1953, 0b11101
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
+	csrrci x12, 1953, 0b11011
+	li x7, 0x28001040
+	bne x7, x12, csr_fail
 	# tdata2
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xbac34ba7
-	csrrw x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xeb1445ff
-	csrrs x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xf668afb3
-	csrrc x11, 1954, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1954, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1954, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1954, 0b10000
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1954, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1954, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1954, 0b10000
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1954, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1954, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1954, 0b01111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x142b4aea
+	csrrw x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x40e36845
+	csrrs x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x718075de
+	csrrc x12, 1954, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1954, 0b11110
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1954, 0b00100
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1954, 0b00001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# tdata3
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xbc96a5bf
-	csrrw x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x05710324
-	csrrs x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x3e1ea2ed
-	csrrc x11, 1955, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1955, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1955, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1955, 0b00000
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1955, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1955, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1955, 0b01111
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1955, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1955, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1955, 0b10000
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xe1d67979
+	csrrw x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xfd1c2100
+	csrrs x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x47ee224b
+	csrrc x12, 1955, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1955, 0b11111
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1955, 0b10001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1955, 0b11001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# tinfo
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0xd0717c40
-	csrrw x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0xb033aa53
-	csrrs x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	li x14, 0x1e4fd459
-	csrrc x11, 1956, x14
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrwi x11, 1956, 0b00101
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrwi x11, 1956, 0b11010
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrwi x11, 1956, 0b00111
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 1956, 0b00101
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 1956, 0b11010
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrsi x11, 1956, 0b11000
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrci x11, 1956, 0b00101
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrci x11, 1956, 0b11010
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
-	csrrci x11, 1956, 0b00001
-	li x14, 0x00000004
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0xcca72456
+	csrrw x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0xc9a71c0b
+	csrrs x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	li x7, 0x5ff548b9
+	csrrc x12, 1956, x7
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrwi x12, 1956, 0b11011
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrsi x12, 1956, 0b00001
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
+	csrrci x12, 1956, 0b10101
+	li x7, 0x00000004
+	bne x7, x12, csr_fail
 	# mcontext
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xd076dfb3
-	csrrw x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x4edb3b36
-	csrrs x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x849b0d82
-	csrrc x11, 1960, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1960, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1960, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1960, 0b11110
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1960, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1960, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1960, 0b10100
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1960, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1960, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1960, 0b01011
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x35bafe7e
+	csrrw x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x187984cd
+	csrrs x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x0927fc2d
+	csrrc x12, 1960, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1960, 0b11111
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1960, 0b10101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1960, 0b01110
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
 	# scontext
-	li x14, 0xa5a5a5a5
-	csrrw x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrw x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xdabb83a6
-	csrrw x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrs x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrs x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x14c7fcc5
-	csrrs x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0xa5a5a5a5
-	csrrc x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x5a5a5a5a
-	csrrc x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	li x14, 0x4b886f01
-	csrrc x11, 1962, x14
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1962, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1962, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 1962, 0b00100
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1962, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1962, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrsi x11, 1962, 0b10011
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1962, 0b00101
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1962, 0b11010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrci x11, 1962, 0b00010
-	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrw x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x98cea90e
+	csrrw x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xfad6e152
+	csrrs x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	li x7, 0x29e48640
+	csrrc x12, 1962, x7
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrwi x12, 1962, 0b11001
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrsi x12, 1962, 0b10011
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrrci x12, 1962, 0b10101
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+	csrr x12, 1962
+	li x7, 0x00000000
+	bne x7, x12, csr_fail
+_end0:
 ###############################################################################
 # Manually added code to inhibit mcycle(h) and minstret(h).
 	li x14, 0x0000000d
-	csrrw x11, 800, x14  # set mcountinhibit to disable counting
+	csrw 800, x14  # set mcountinhibit to disable counting
 	li x14, 0x00000000
-	csrrw x11, 2816, x14 # reset cycle count
-	csrrw x11, 2944, x14
-	csrrw x11, 2818, x14 # reset instruction retired count
-	csrrw x11, 2946, x14
+	csrw 2816, x14 # reset cycle count
+	csrw 2944, x14
+	csrw 2818, x14 # reset instruction retired count
+	csrw 2946, x14
+	li x14, 0x00000001
+	csrw 773,  x14 # reset mtvec
 ###############################################################################
+_start1:
 	# mcycle
 	li x14, 0xa5a5a5a5
-	csrrw x11, 2816, x14
+	csrrw x1, 2816, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrw x11, 2816, x14
+	csrrw x1, 2816, x14
 	li x14, 0xa5a5a5a5
-	bne x14, x11, csr_fail
-	li x14, 0x80f2e34e
-	csrrw x11, 2816, x14
+	bne x14, x1, csr_fail
+	li x14, 0x67612e03
+	csrrw x1, 2816, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrs x11, 2816, x14
-	li x14, 0x80f2e34e
-	bne x14, x11, csr_fail
+	csrrs x1, 2816, x14
+	li x14, 0x67612e03
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrs x11, 2816, x14
-	li x14, 0xa5f7e7ef
-	bne x14, x11, csr_fail
-	li x14, 0x7b5ff5bb
-	csrrs x11, 2816, x14
+	csrrs x1, 2816, x14
+	li x14, 0xe7e5afa7
+	bne x14, x1, csr_fail
+	li x14, 0xc2fde971
+	csrrs x1, 2816, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrc x11, 2816, x14
+	csrrc x1, 2816, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrc x11, 2816, x14
+	csrrc x1, 2816, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0x46c37b82
-	csrrc x11, 2816, x14
+	bne x14, x1, csr_fail
+	li x14, 0x13bdcdaf
+	csrrc x1, 2816, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2816, 0b00101
+	bne x14, x1, csr_fail
+	csrrwi x1, 2816, 0b00101
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2816, 0b11010
+	bne x14, x1, csr_fail
+	csrrwi x1, 2816, 0b11010
 	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 2816, 0b11111
+	bne x14, x1, csr_fail
+	csrrwi x1, 2816, 0b01000
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 2816, 0b00101
+	bne x14, x1, csr_fail
+	csrrsi x1, 2816, 0b00101
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 2816, 0b11010
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrsi x1, 2816, 0b00001
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrsi x11, 2816, 0b11010
+	bne x14, x1, csr_fail
+	csrrci x1, 2816, 0b00101
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrsi x11, 2816, 0b01010
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2816, 0b00101
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2816, 0b11010
+	bne x14, x1, csr_fail
+	csrrci x1, 2816, 0b11010
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 2816, 0b11000
+	bne x14, x1, csr_fail
+	csrrci x1, 2816, 0b01001
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	# mcycleh
 	li x14, 0xa5a5a5a5
-	csrrw x11, 2944, x14
+	csrrw x1, 2944, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrw x11, 2944, x14
+	csrrw x1, 2944, x14
 	li x14, 0xa5a5a5a5
-	bne x14, x11, csr_fail
-	li x14, 0x32089337
-	csrrw x11, 2944, x14
+	bne x14, x1, csr_fail
+	li x14, 0x7cc71997
+	csrrw x1, 2944, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrs x11, 2944, x14
-	li x14, 0x32089337
-	bne x14, x11, csr_fail
+	csrrs x1, 2944, x14
+	li x14, 0x7cc71997
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrs x11, 2944, x14
-	li x14, 0xb7adb7b7
-	bne x14, x11, csr_fail
-	li x14, 0x9aee3d19
-	csrrs x11, 2944, x14
+	csrrs x1, 2944, x14
+	li x14, 0xfde7bdb7
+	bne x14, x1, csr_fail
+	li x14, 0x736bdfe1
+	csrrs x1, 2944, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrc x11, 2944, x14
+	csrrc x1, 2944, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrc x11, 2944, x14
+	csrrc x1, 2944, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0x77ea84fc
-	csrrc x11, 2944, x14
+	bne x14, x1, csr_fail
+	li x14, 0x79eeae53
+	csrrc x1, 2944, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2944, 0b00101
+	bne x14, x1, csr_fail
+	csrrwi x1, 2944, 0b00101
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2944, 0b11010
+	bne x14, x1, csr_fail
+	csrrwi x1, 2944, 0b11010
 	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 2944, 0b11011
+	bne x14, x1, csr_fail
+	csrrwi x1, 2944, 0b01111
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 2944, 0b00101
-	li x14, 0x0000001b
-	bne x14, x11, csr_fail
-	csrrsi x11, 2944, 0b11010
+	bne x14, x1, csr_fail
+	csrrsi x1, 2944, 0b00101
+	li x14, 0x0000000f
+	bne x14, x1, csr_fail
+	csrrsi x1, 2944, 0b11010
+	li x14, 0x0000000f
+	bne x14, x1, csr_fail
+	csrrsi x1, 2944, 0b10010
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrsi x11, 2944, 0b10110
+	bne x14, x1, csr_fail
+	csrrci x1, 2944, 0b00101
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2944, 0b00101
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2944, 0b11010
+	bne x14, x1, csr_fail
+	csrrci x1, 2944, 0b11010
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 2944, 0b00010
+	bne x14, x1, csr_fail
+	csrrci x1, 2944, 0b01100
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	# minstret
 	li x14, 0xa5a5a5a5
-	csrrw x11, 2818, x14
+	csrrw x1, 2818, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrw x11, 2818, x14
+	csrrw x1, 2818, x14
 	li x14, 0xa5a5a5a5
-	bne x14, x11, csr_fail
-	li x14, 0xabdd6baa
-	csrrw x11, 2818, x14
+	bne x14, x1, csr_fail
+	li x14, 0xcdada499
+	csrrw x1, 2818, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrs x11, 2818, x14
-	li x14, 0xabdd6baa
-	bne x14, x11, csr_fail
+	csrrs x1, 2818, x14
+	li x14, 0xcdada499
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrs x11, 2818, x14
-	li x14, 0xaffdefaf
-	bne x14, x11, csr_fail
-	li x14, 0x08af6ff2
-	csrrs x11, 2818, x14
+	csrrs x1, 2818, x14
+	li x14, 0xedada5bd
+	bne x14, x1, csr_fail
+	li x14, 0x5bb4c508
+	csrrs x1, 2818, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrc x11, 2818, x14
+	csrrc x1, 2818, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrc x11, 2818, x14
+	csrrc x1, 2818, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0x008e315b
-	csrrc x11, 2818, x14
+	bne x14, x1, csr_fail
+	li x14, 0x5dec4a9d
+	csrrc x1, 2818, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2818, 0b00101
+	bne x14, x1, csr_fail
+	csrrwi x1, 2818, 0b00101
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2818, 0b11010
+	bne x14, x1, csr_fail
+	csrrwi x1, 2818, 0b11010
 	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 2818, 0b10001
+	bne x14, x1, csr_fail
+	csrrwi x1, 2818, 0b01000
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 2818, 0b00101
-	li x14, 0x00000011
-	bne x14, x11, csr_fail
-	csrrsi x11, 2818, 0b11010
-	li x14, 0x00000015
-	bne x14, x11, csr_fail
-	csrrsi x11, 2818, 0b01010
+	bne x14, x1, csr_fail
+	csrrsi x1, 2818, 0b00101
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 2818, 0b11010
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrsi x1, 2818, 0b10101
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2818, 0b00101
+	bne x14, x1, csr_fail
+	csrrci x1, 2818, 0b00101
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2818, 0b11010
+	bne x14, x1, csr_fail
+	csrrci x1, 2818, 0b11010
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 2818, 0b10010
+	bne x14, x1, csr_fail
+	csrrci x1, 2818, 0b10000
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	# minstreth
 	li x14, 0xa5a5a5a5
-	csrrw x11, 2946, x14
+	csrrw x1, 2946, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrw x11, 2946, x14
+	csrrw x1, 2946, x14
 	li x14, 0xa5a5a5a5
-	bne x14, x11, csr_fail
-	li x14, 0x5bfecb00
-	csrrw x11, 2946, x14
+	bne x14, x1, csr_fail
+	li x14, 0xfad8839d
+	csrrw x1, 2946, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrs x11, 2946, x14
-	li x14, 0x5bfecb00
-	bne x14, x11, csr_fail
+	csrrs x1, 2946, x14
+	li x14, 0xfad8839d
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrs x11, 2946, x14
-	li x14, 0xffffefa5
-	bne x14, x11, csr_fail
-	li x14, 0x211e5f90
-	csrrs x11, 2946, x14
+	csrrs x1, 2946, x14
+	li x14, 0xfffda7bd
+	bne x14, x1, csr_fail
+	li x14, 0xa6693a54
+	csrrs x1, 2946, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-	csrrc x11, 2946, x14
+	csrrc x1, 2946, x14
 	li x14, 0xffffffff
-	bne x14, x11, csr_fail
+	bne x14, x1, csr_fail
 	li x14, 0x5a5a5a5a
-	csrrc x11, 2946, x14
+	csrrc x1, 2946, x14
 	li x14, 0x5a5a5a5a
-	bne x14, x11, csr_fail
-	li x14, 0x1cbbe3d7
-	csrrc x11, 2946, x14
+	bne x14, x1, csr_fail
+	li x14, 0xc700f18d
+	csrrc x1, 2946, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2946, 0b00101
+	bne x14, x1, csr_fail
+	csrrwi x1, 2946, 0b00101
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-	csrrwi x11, 2946, 0b11010
+	bne x14, x1, csr_fail
+	csrrwi x1, 2946, 0b11010
 	li x14, 0x00000005
-	bne x14, x11, csr_fail
-	csrrwi x11, 2946, 0b11110
+	bne x14, x1, csr_fail
+	csrrwi x1, 2946, 0b00011
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrsi x11, 2946, 0b00101
-	li x14, 0x0000001e
-	bne x14, x11, csr_fail
-	csrrsi x11, 2946, 0b11010
+	bne x14, x1, csr_fail
+	csrrsi x1, 2946, 0b00101
+	li x14, 0x00000003
+	bne x14, x1, csr_fail
+	csrrsi x1, 2946, 0b11010
+	li x14, 0x00000007
+	bne x14, x1, csr_fail
+	csrrsi x1, 2946, 0b11010
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrsi x11, 2946, 0b01001
+	bne x14, x1, csr_fail
+	csrrci x1, 2946, 0b00101
 	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2946, 0b00101
-	li x14, 0x0000001f
-	bne x14, x11, csr_fail
-	csrrci x11, 2946, 0b11010
+	bne x14, x1, csr_fail
+	csrrci x1, 2946, 0b11010
 	li x14, 0x0000001a
-	bne x14, x11, csr_fail
-	csrrci x11, 2946, 0b00111
+	bne x14, x1, csr_fail
+	csrrci x1, 2946, 0b00100
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-
-###############################################################################
-# The bulk of the mvendorid test is commented out due to a bug in the RTL:
-# writes to this CSR should be ignored, but instead they cause and illegal
-# instruction exception.  For now this code simply checks the PoR value.
-# https://github.com/openhwgroup/cv32e40p/issues/543
-###############################################################################
-	# mvendorid
+	bne x14, x1, csr_fail
+	# mstatus
 	li x14, 0xa5a5a5a5
-#	csrrw x11, 3857, x14
-	csrr x11, 3857
-	li x14, 0x00000602
-	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrw x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0x7bcafca5
-#	csrrw x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrs x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrs x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0x3c067621
-#	csrrs x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrc x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrc x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	li x14, 0x4175c41a
-#	csrrc x11, 3857, x14
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3857, 0b00101
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3857, 0b11010
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3857, 0b01011
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3857, 0b00101
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3857, 0b11010
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3857, 0b10101
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3857, 0b00101
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3857, 0b11010
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3857, 0b01111
-#	li x14, 0x00000602
-#	bne x14, x11, csr_fail
-
-###############################################################################
-# The bulk of the marchid test is commented out due to a bug in the RTL:
-# writes to this CSR should be ignored, but instead they cause and illegal
-# instruction exception.  For now this code simply checks the PoR value.
-# https://github.com/openhwgroup/cv32e40p/issues/543
-###############################################################################
-	# marchid
+	csrrw x1, 768, x14
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 768, x14
+	li x14, 0x00001880
+	bne x14, x1, csr_fail
+	li x14, 0x42b2dbf7
+	csrrw x1, 768, x14
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
 	li x14, 0xa5a5a5a5
-#	csrrw x11, 3858, x14
-	csrr x11, 3858
+	csrrs x1, 768, x14
+	li x14, 0x00001880
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 768, x14
+	li x14, 0x00001880
+	bne x14, x1, csr_fail
+	li x14, 0xdbaded82
+	csrrs x1, 768, x14
+	li x14, 0x00001888
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 768, x14
+	li x14, 0x00001888
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 768, x14
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
+	li x14, 0x3b29374d
+	csrrc x1, 768, x14
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	csrrwi x1, 768, 0b00101
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	csrrwi x1, 768, 0b11010
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	csrrwi x1, 768, 0b10100
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
+	csrrsi x1, 768, 0b00101
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	csrrsi x1, 768, 0b11010
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	csrrsi x1, 768, 0b10010
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
+	csrrci x1, 768, 0b00101
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
+	csrrci x1, 768, 0b11010
+	li x14, 0x00001808
+	bne x14, x1, csr_fail
+	csrrci x1, 768, 0b10111
+	li x14, 0x00001800
+	bne x14, x1, csr_fail
+	# misa
+	li x14, 0xa5a5a5a5
+	csrrw x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0x41aa72be
+	csrrw x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0xfb40315d
+	csrrs x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	li x14, 0xa8e8d4aa
+	csrrc x1, 769, x14
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrwi x1, 769, 0b00101
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrwi x1, 769, 0b11100
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrsi x1, 769, 0b00101
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrsi x1, 769, 0b11010
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrsi x1, 769, 0b01000
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrci x1, 769, 0b00101
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrci x1, 769, 0b11010
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	csrrci x1, 769, 0b00000
+	li x14, 0x40801104
+	bne x14, x1, csr_fail
+	# mie
+	li x14, 0xa5a5a5a5
+	csrrw x1, 772, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 772, x14
+	li x14, 0xa5a50080
+	bne x14, x1, csr_fail
+	li x14, 0x41938d04
+	csrrw x1, 772, x14
+	li x14, 0x5a5a0808
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 772, x14
+	li x14, 0x41930800
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 772, x14
+	li x14, 0xe5b70880
+	bne x14, x1, csr_fail
+	li x14, 0xf2b9f651
+	csrrs x1, 772, x14
+	li x14, 0xffff0888
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 772, x14
+	li x14, 0xffff0888
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 772, x14
+	li x14, 0x5a5a0808
+	bne x14, x1, csr_fail
+	li x14, 0x6f4d19b6
+	csrrc x1, 772, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 772, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 772, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 772, 0b11100
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 772, 0b00101
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 772, 0b11010
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 772, 0b11101
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrci x1, 772, 0b00101
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrci x1, 772, 0b11010
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrci x1, 772, 0b10100
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# mtvec
+	li x14, 0xa5a5a5a5
+	csrrw x1, 773, x14
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 773, x14
+	li x14, 0xa5a5a501
+	bne x14, x1, csr_fail
+	li x14, 0x577f7192
+	csrrw x1, 773, x14
+	li x14, 0x5a5a5a00
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 773, x14
+	li x14, 0x577f7100
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 773, x14
+	li x14, 0xf7fff501
+	bne x14, x1, csr_fail
+	li x14, 0x3ca8ceb1
+	csrrs x1, 773, x14
+	li x14, 0xffffff01
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 773, x14
+	li x14, 0xffffff01
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 773, x14
+	li x14, 0x5a5a5a00
+	bne x14, x1, csr_fail
+	li x14, 0x4b1396ae
+	csrrc x1, 773, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 773, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 773, 0b11010
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	csrrwi x1, 773, 0b11001
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 773, 0b00101
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	csrrsi x1, 773, 0b11010
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	csrrsi x1, 773, 0b10100
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	csrrci x1, 773, 0b00101
+	li x14, 0x00000001
+	bne x14, x1, csr_fail
+	csrrci x1, 773, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 773, 0b01100
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# mcountinhibit
+	li x14, 0xa5a5a5a5
+	csrrw x1, 800, x14
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 800, x14
+	li x14, 0x00000005
+	bne x14, x1, csr_fail
+	li x14, 0x452e7695
+	csrrw x1, 800, x14
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 800, x14
+	li x14, 0x00000005
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 800, x14
+	li x14, 0x00000005
+	bne x14, x1, csr_fail
+	li x14, 0xd401def5
+	csrrs x1, 800, x14
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 800, x14
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 800, x14
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	li x14, 0xffd097e7
+	csrrc x1, 800, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 800, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 800, 0b11010
+	li x14, 0x00000005
+	bne x14, x1, csr_fail
+	csrrwi x1, 800, 0b11111
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrsi x1, 800, 0b00101
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrsi x1, 800, 0b11010
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrsi x1, 800, 0b00110
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrci x1, 800, 0b00101
+	li x14, 0x0000000d
+	bne x14, x1, csr_fail
+	csrrci x1, 800, 0b11010
+	li x14, 0x00000008
+	bne x14, x1, csr_fail
+	csrrci x1, 800, 0b10011
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# mscratch
+	li x14, 0xa5a5a5a5
+	csrrw x1, 832, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 832, x14
+	li x14, 0xa5a5a5a5
+	bne x14, x1, csr_fail
+	li x14, 0x2801df6e
+	csrrw x1, 832, x14
+	li x14, 0x5a5a5a5a
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 832, x14
+	li x14, 0x2801df6e
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 832, x14
+	li x14, 0xada5ffef
+	bne x14, x1, csr_fail
+	li x14, 0x0523e821
+	csrrs x1, 832, x14
+	li x14, 0xffffffff
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 832, x14
+	li x14, 0xffffffff
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 832, x14
+	li x14, 0x5a5a5a5a
+	bne x14, x1, csr_fail
+	li x14, 0xc1c4c721
+	csrrc x1, 832, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 832, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 832, 0b11010
+	li x14, 0x00000005
+	bne x14, x1, csr_fail
+	csrrwi x1, 832, 0b10010
+	li x14, 0x0000001a
+	bne x14, x1, csr_fail
+	csrrsi x1, 832, 0b00101
+	li x14, 0x00000012
+	bne x14, x1, csr_fail
+	csrrsi x1, 832, 0b11010
+	li x14, 0x00000017
+	bne x14, x1, csr_fail
+	csrrsi x1, 832, 0b10011
+	li x14, 0x0000001f
+	bne x14, x1, csr_fail
+	csrrci x1, 832, 0b00101
+	li x14, 0x0000001f
+	bne x14, x1, csr_fail
+	csrrci x1, 832, 0b11010
+	li x14, 0x0000001a
+	bne x14, x1, csr_fail
+	csrrci x1, 832, 0b01001
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# mepc
+	li x14, 0xa5a5a5a5
+	csrrw x1, 833, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 833, x14
+	li x14, 0xa5a5a5a4
+	bne x14, x1, csr_fail
+	li x14, 0x62cc5ca6
+	csrrw x1, 833, x14
+	li x14, 0x5a5a5a5a
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 833, x14
+	li x14, 0x62cc5ca6
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 833, x14
+	li x14, 0xe7edfda6
+	bne x14, x1, csr_fail
+	li x14, 0xeb1f2397
+	csrrs x1, 833, x14
+	li x14, 0xfffffffe
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 833, x14
+	li x14, 0xfffffffe
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 833, x14
+	li x14, 0x5a5a5a5a
+	bne x14, x1, csr_fail
+	li x14, 0x59114820
+	csrrc x1, 833, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 833, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 833, 0b11010
 	li x14, 0x00000004
-	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrw x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0xccaf8f89
-#	csrrw x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrs x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrs x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0x0aa31a50
-#	csrrs x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrc x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrc x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	li x14, 0x3f892473
-#	csrrc x11, 3858, x14
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3858, 0b00101
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3858, 0b11010
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3858, 0b11001
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3858, 0b00101
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3858, 0b11010
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3858, 0b11110
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3858, 0b00101
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3858, 0b11010
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3858, 0b10100
-#	li x14, 0x00000004
-#	bne x14, x11, csr_fail
-
-###############################################################################
-# The bulk of the mimpid test is commented out due to a bug in the RTL:
-# writes to this CSR should be ignored, but instead they cause and illegal
-# instruction exception.  For now this code simply checks the PoR value.
-# https://github.com/openhwgroup/cv32e40p/issues/543
-###############################################################################
-	# mimpid
-	li x14, 0xa5a5a5a5
-#	csrrw x11, 3859, x14
-	csrr x11, 3859
+	bne x14, x1, csr_fail
+	csrrwi x1, 833, 0b11001
+	li x14, 0x0000001a
+	bne x14, x1, csr_fail
+	csrrsi x1, 833, 0b00101
+	li x14, 0x00000018
+	bne x14, x1, csr_fail
+	csrrsi x1, 833, 0b11010
+	li x14, 0x0000001c
+	bne x14, x1, csr_fail
+	csrrsi x1, 833, 0b01110
+	li x14, 0x0000001e
+	bne x14, x1, csr_fail
+	csrrci x1, 833, 0b00101
+	li x14, 0x0000001e
+	bne x14, x1, csr_fail
+	csrrci x1, 833, 0b11010
+	li x14, 0x0000001a
+	bne x14, x1, csr_fail
+	csrrci x1, 833, 0b00100
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrw x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x775c0ff8
-#	csrrw x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrs x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrs x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xc9a8edcf
-#	csrrs x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrc x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrc x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x3846ce8d
-#	csrrc x11, 3859, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3859, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3859, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3859, 0b01000
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3859, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3859, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3859, 0b10000
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3859, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3859, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3859, 0b11011
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-
-###############################################################################
-# The bulk of the mhartid test is commented out due to a bug in the RTL:
-# writes to this CSR should be ignored, but instead they cause and illegal
-# instruction exception.  For now this code simply checks the PoR value.
-# https://github.com/openhwgroup/cv32e40p/issues/543
-###############################################################################
-	# mhartid
+	bne x14, x1, csr_fail
+	# mtval
 	li x14, 0xa5a5a5a5
-#	csrrw x11, 3860, x14
-	csrr x11, 3860
+	csrrw x1, 835, x14
 	li x14, 0x00000000
-	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrw x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x9a1a9c33
-#	csrrw x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrs x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrs x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x6d7a55de
-#	csrrs x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xa5a5a5a5
-#	csrrc x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0x5a5a5a5a
-#	csrrc x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	li x14, 0xf4c85073
-#	csrrc x11, 3860, x14
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3860, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3860, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrwi x11, 3860, 0b11101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3860, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3860, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrsi x11, 3860, 0b11111
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3860, 0b00101
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3860, 0b11010
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrrci x11, 3860, 0b11100
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-#	csrr x11, 3860
-#	li x14, 0x00000000
-#	bne x14, x11, csr_fail
-
-riscv_csr_test_end:
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x9e742625
+	csrrw x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x8ddcd293
+	csrrs x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x276a0174
+	csrrc x1, 835, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 835, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 835, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 835, 0b10110
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 835, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 835, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 835, 0b01111
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 835, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 835, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 835, 0b11101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# mip
+	li x14, 0xa5a5a5a5
+	csrrw x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x92c6d654
+	csrrw x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x7717ab54
+	csrrs x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xd1e8d84b
+	csrrc x1, 836, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 836, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 836, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 836, 0b00111
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 836, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 836, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 836, 0b00010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 836, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 836, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 836, 0b01000
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# tselect
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x8a3f5963
+	csrrw x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xb384141a
+	csrrs x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x894f6d96
+	csrrc x1, 1952, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1952, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1952, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1952, 0b00100
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1952, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1952, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1952, 0b10010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1952, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1952, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1952, 0b11100
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# tdata1
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0x9bb8f088
+	csrrw x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0x0d7a2498
+	csrrs x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	li x14, 0xd6cc64bc
+	csrrc x1, 1953, x14
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrwi x1, 1953, 0b00101
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrwi x1, 1953, 0b11010
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrwi x1, 1953, 0b10001
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrsi x1, 1953, 0b00101
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrsi x1, 1953, 0b11010
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrsi x1, 1953, 0b10111
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrci x1, 1953, 0b00101
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrci x1, 1953, 0b11010
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	csrrci x1, 1953, 0b01110
+	li x14, 0x28001040
+	bne x14, x1, csr_fail
+	# tdata2
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x9879dec2
+	csrrw x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x15ecb5a8
+	csrrs x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x7abcda42
+	csrrc x1, 1954, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1954, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1954, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1954, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1954, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1954, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1954, 0b11111
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1954, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1954, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1954, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# tdata3
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xc71255ad
+	csrrw x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x077ad5e7
+	csrrs x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x09d28a17
+	csrrc x1, 1955, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1955, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1955, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1955, 0b11111
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1955, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1955, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1955, 0b10110
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1955, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1955, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1955, 0b01000
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# tinfo
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0x9ec56798
+	csrrw x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0x8950a6f0
+	csrrs x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	li x14, 0xbadb006d
+	csrrc x1, 1956, x14
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrwi x1, 1956, 0b00101
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrwi x1, 1956, 0b11010
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrwi x1, 1956, 0b01011
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrsi x1, 1956, 0b00101
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrsi x1, 1956, 0b11010
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrsi x1, 1956, 0b10010
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrci x1, 1956, 0b00101
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrci x1, 1956, 0b11010
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	csrrci x1, 1956, 0b00111
+	li x14, 0x00000004
+	bne x14, x1, csr_fail
+	# mcontext
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x1fcd2c14
+	csrrw x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xb5ea4d3e
+	csrrs x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x60cdc20c
+	csrrc x1, 1960, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1960, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1960, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1960, 0b01111
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1960, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1960, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1960, 0b11011
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1960, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1960, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1960, 0b00000
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	# scontext
+	li x14, 0xa5a5a5a5
+	csrrw x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrw x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x1c7a4ffd
+	csrrw x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrs x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrs x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x658c6a75
+	csrrs x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0xa5a5a5a5
+	csrrc x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x5a5a5a5a
+	csrrc x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	li x14, 0x66bd7381
+	csrrc x1, 1962, x14
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1962, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1962, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrwi x1, 1962, 0b01001
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1962, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1962, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrsi x1, 1962, 0b11000
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1962, 0b00101
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1962, 0b11010
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrrci x1, 1962, 0b01110
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+	csrr x1, 1962
+	li x14, 0x00000000
+	bne x14, x1, csr_fail
+_end1:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x15, 0x0000000d
+	csrw 800,  x15 # set mcountinhibit to disable counting
+	li x15, 0x00000000
+	csrw 2816, x15 # reset cycle count
+	csrw 2944, x15
+	csrw 2818, x15 # reset instruction retired count
+	csrw 2946, x15
+	li x15, 0x00000001
+	csrw 773,  x15 # reset mtvec
+###############################################################################
+_start2:
+	# mcycle
+	li x8, 0xa5a5a5a5
+	csrrw x1, 2816, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 2816, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x1, csr_fail
+	li x8, 0xabac880f
+	csrrw x1, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 2816, x8
+	li x8, 0xabac880f
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 2816, x8
+	li x8, 0xafadadaf
+	bne x8, x1, csr_fail
+	li x8, 0xe5ef4911
+	csrrs x1, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa7c76691
+	csrrc x1, 2816, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2816, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2816, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 2816, 0b01011
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 2816, 0b00101
+	li x8, 0x0000000b
+	bne x8, x1, csr_fail
+	csrrsi x1, 2816, 0b11010
+	li x8, 0x0000000f
+	bne x8, x1, csr_fail
+	csrrsi x1, 2816, 0b01011
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2816, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 2816, 0b10110
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mcycleh
+	li x8, 0xa5a5a5a5
+	csrrw x1, 2944, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 2944, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x1, csr_fail
+	li x8, 0xc48984fa
+	csrrw x1, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 2944, x8
+	li x8, 0xc48984fa
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 2944, x8
+	li x8, 0xe5ada5ff
+	bne x8, x1, csr_fail
+	li x8, 0x3f06cf08
+	csrrs x1, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xbc90196c
+	csrrc x1, 2944, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2944, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2944, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 2944, 0b10111
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 2944, 0b00101
+	li x8, 0x00000017
+	bne x8, x1, csr_fail
+	csrrsi x1, 2944, 0b11010
+	li x8, 0x00000017
+	bne x8, x1, csr_fail
+	csrrsi x1, 2944, 0b10110
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2944, 0b00101
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2944, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 2944, 0b11101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# minstret
+	li x8, 0xa5a5a5a5
+	csrrw x1, 2818, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 2818, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x1, csr_fail
+	li x8, 0x94d5c51a
+	csrrw x1, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 2818, x8
+	li x8, 0x94d5c51a
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 2818, x8
+	li x8, 0xb5f5e5bf
+	bne x8, x1, csr_fail
+	li x8, 0xee84b2d6
+	csrrs x1, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0x4fc08a67
+	csrrc x1, 2818, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2818, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2818, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 2818, 0b10100
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 2818, 0b00101
+	li x8, 0x00000014
+	bne x8, x1, csr_fail
+	csrrsi x1, 2818, 0b11010
+	li x8, 0x00000015
+	bne x8, x1, csr_fail
+	csrrsi x1, 2818, 0b01010
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2818, 0b00101
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2818, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 2818, 0b00010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# minstreth
+	li x8, 0xa5a5a5a5
+	csrrw x1, 2946, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 2946, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x1, csr_fail
+	li x8, 0x5d77c0d0
+	csrrw x1, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 2946, x8
+	li x8, 0x5d77c0d0
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 2946, x8
+	li x8, 0xfdf7e5f5
+	bne x8, x1, csr_fail
+	li x8, 0xa219cf00
+	csrrs x1, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0x8762d8b6
+	csrrc x1, 2946, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2946, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 2946, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 2946, 0b10110
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 2946, 0b00101
+	li x8, 0x00000016
+	bne x8, x1, csr_fail
+	csrrsi x1, 2946, 0b11010
+	li x8, 0x00000017
+	bne x8, x1, csr_fail
+	csrrsi x1, 2946, 0b10000
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2946, 0b00101
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 2946, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 2946, 0b11111
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mstatus
+	li x8, 0xa5a5a5a5
+	csrrw x1, 768, x8
+	li x8, 0x00001800
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 768, x8
+	li x8, 0x00001880
+	bne x8, x1, csr_fail
+	li x8, 0xa0e19a2b
+	csrrw x1, 768, x8
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 768, x8
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 768, x8
+	li x8, 0x00001888
+	bne x8, x1, csr_fail
+	li x8, 0x746ea947
+	csrrs x1, 768, x8
+	li x8, 0x00001888
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 768, x8
+	li x8, 0x00001888
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 768, x8
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	li x8, 0x6d45688c
+	csrrc x1, 768, x8
+	li x8, 0x00001800
+	bne x8, x1, csr_fail
+	csrrwi x1, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x1, csr_fail
+	csrrwi x1, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x1, csr_fail
+	csrrwi x1, 768, 0b01100
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrsi x1, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrsi x1, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrsi x1, 768, 0b01000
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrci x1, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrci x1, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x1, csr_fail
+	csrrci x1, 768, 0b01100
+	li x8, 0x00001800
+	bne x8, x1, csr_fail
+	# misa
+	li x8, 0xa5a5a5a5
+	csrrw x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0xabafa291
+	csrrw x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0xdd5beb59
+	csrrs x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	li x8, 0x71755cfe
+	csrrc x1, 769, x8
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrwi x1, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrsi x1, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrsi x1, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrsi x1, 769, 0b01101
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrci x1, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrci x1, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	csrrci x1, 769, 0b01010
+	li x8, 0x40801104
+	bne x8, x1, csr_fail
+	# mie
+	li x8, 0xa5a5a5a5
+	csrrw x1, 772, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 772, x8
+	li x8, 0xa5a50080
+	bne x8, x1, csr_fail
+	li x8, 0x0f44d2f8
+	csrrw x1, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 772, x8
+	li x8, 0x0f440088
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 772, x8
+	li x8, 0xafe50088
+	bne x8, x1, csr_fail
+	li x8, 0x48108a60
+	csrrs x1, 772, x8
+	li x8, 0xffff0888
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 772, x8
+	li x8, 0xffff0888
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x1, csr_fail
+	li x8, 0xd4f99d2d
+	csrrc x1, 772, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 772, 0b00010
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrsi x1, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 772, 0b00001
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrci x1, 772, 0b00101
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrci x1, 772, 0b11010
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrci x1, 772, 0b00110
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mtvec
+	li x8, 0xa5a5a5a5
+	csrrw x1, 773, x8
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 773, x8
+	li x8, 0xa5a5a501
+	bne x8, x1, csr_fail
+	li x8, 0xbc44b619
+	csrrw x1, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 773, x8
+	li x8, 0xbc44b601
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 773, x8
+	li x8, 0xbde5b701
+	bne x8, x1, csr_fail
+	li x8, 0x82289823
+	csrrs x1, 773, x8
+	li x8, 0xffffff01
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 773, x8
+	li x8, 0xffffff01
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x1, csr_fail
+	li x8, 0x598b44be
+	csrrc x1, 773, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	csrrwi x1, 773, 0b01011
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	csrrsi x1, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	csrrsi x1, 773, 0b11000
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	csrrci x1, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x1, csr_fail
+	csrrci x1, 773, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 773, 0b11000
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mcountinhibit
+	li x8, 0xa5a5a5a5
+	csrrw x1, 800, x8
+	li x8, 0x0000000d
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 800, x8
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	li x8, 0x274e3295
+	csrrw x1, 800, x8
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 800, x8
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 800, x8
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	li x8, 0xc96f0f41
+	csrrs x1, 800, x8
+	li x8, 0x0000000d
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 800, x8
+	li x8, 0x0000000d
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 800, x8
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	li x8, 0x966f4778
+	csrrc x1, 800, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 800, 0b00010
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrsi x1, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrsi x1, 800, 0b11010
+	li x8, 0x0000000d
+	bne x8, x1, csr_fail
+	csrrci x1, 800, 0b00101
+	li x8, 0x0000000d
+	bne x8, x1, csr_fail
+	csrrci x1, 800, 0b11010
+	li x8, 0x00000008
+	bne x8, x1, csr_fail
+	csrrci x1, 800, 0b10101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mscratch
+	li x8, 0xa5a5a5a5
+	csrrw x1, 832, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 832, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x1, csr_fail
+	li x8, 0x40179872
+	csrrw x1, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 832, x8
+	li x8, 0x40179872
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 832, x8
+	li x8, 0xe5b7bdf7
+	bne x8, x1, csr_fail
+	li x8, 0xb68f399e
+	csrrs x1, 832, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 832, x8
+	li x8, 0xffffffff
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0x318ba06f
+	csrrc x1, 832, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 832, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 832, 0b11010
+	li x8, 0x00000005
+	bne x8, x1, csr_fail
+	csrrwi x1, 832, 0b10010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 832, 0b00101
+	li x8, 0x00000012
+	bne x8, x1, csr_fail
+	csrrsi x1, 832, 0b11010
+	li x8, 0x00000017
+	bne x8, x1, csr_fail
+	csrrsi x1, 832, 0b11011
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 832, 0b00101
+	li x8, 0x0000001f
+	bne x8, x1, csr_fail
+	csrrci x1, 832, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 832, 0b10010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mepc
+	li x8, 0xa5a5a5a5
+	csrrw x1, 833, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 833, x8
+	li x8, 0xa5a5a5a4
+	bne x8, x1, csr_fail
+	li x8, 0xb157b5a9
+	csrrw x1, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 833, x8
+	li x8, 0xb157b5a8
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 833, x8
+	li x8, 0xb5f7b5ac
+	bne x8, x1, csr_fail
+	li x8, 0x21b516ca
+	csrrs x1, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x1, csr_fail
+	li x8, 0x1601b127
+	csrrc x1, 833, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 833, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 833, 0b11010
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrwi x1, 833, 0b10011
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrsi x1, 833, 0b00101
+	li x8, 0x00000012
+	bne x8, x1, csr_fail
+	csrrsi x1, 833, 0b11010
+	li x8, 0x00000016
+	bne x8, x1, csr_fail
+	csrrsi x1, 833, 0b01111
+	li x8, 0x0000001e
+	bne x8, x1, csr_fail
+	csrrci x1, 833, 0b00101
+	li x8, 0x0000001e
+	bne x8, x1, csr_fail
+	csrrci x1, 833, 0b11010
+	li x8, 0x0000001a
+	bne x8, x1, csr_fail
+	csrrci x1, 833, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mtval
+	li x8, 0xa5a5a5a5
+	csrrw x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x802ce118
+	csrrw x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x92418dd4
+	csrrs x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xf8f45bb9
+	csrrc x1, 835, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 835, 0b00011
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 835, 0b10000
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 835, 0b00100
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# mip
+	li x8, 0xa5a5a5a5
+	csrrw x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x190a0e1d
+	csrrw x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x274f8728
+	csrrs x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x8c3f83c8
+	csrrc x1, 836, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 836, 0b01111
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 836, 0b11001
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 836, 0b11000
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# tselect
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xdf2086e3
+	csrrw x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x63806c17
+	csrrs x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x204ae6b5
+	csrrc x1, 1952, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1952, 0b01101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1952, 0b01111
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1952, 0b00000
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# tdata1
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0x5be109cf
+	csrrw x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0x1902c43a
+	csrrs x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	li x8, 0xe5750326
+	csrrc x1, 1953, x8
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrwi x1, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrwi x1, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrwi x1, 1953, 0b00110
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrsi x1, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrsi x1, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrsi x1, 1953, 0b01101
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrci x1, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrci x1, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	csrrci x1, 1953, 0b10001
+	li x8, 0x28001040
+	bne x8, x1, csr_fail
+	# tdata2
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xfec027b4
+	csrrw x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x0f294a71
+	csrrs x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x6e837ed4
+	csrrc x1, 1954, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1954, 0b01100
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1954, 0b11000
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1954, 0b10110
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# tdata3
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa1523501
+	csrrw x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xeaf2c437
+	csrrs x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xfe245bc8
+	csrrc x1, 1955, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1955, 0b00010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1955, 0b11011
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1955, 0b10111
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# tinfo
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0x52734373
+	csrrw x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0xbd778cce
+	csrrs x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	li x8, 0x7026f23c
+	csrrc x1, 1956, x8
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrwi x1, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrwi x1, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrwi x1, 1956, 0b10100
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrsi x1, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrsi x1, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrsi x1, 1956, 0b01001
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrci x1, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrci x1, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	csrrci x1, 1956, 0b01111
+	li x8, 0x00000004
+	bne x8, x1, csr_fail
+	# mcontext
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x14a71fda
+	csrrw x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x02dc43c8
+	csrrs x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x24d92232
+	csrrc x1, 1960, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1960, 0b00100
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1960, 0b01100
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	# scontext
+	li x8, 0xa5a5a5a5
+	csrrw x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x70b3cd4d
+	csrrw x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xc2ffd0b7
+	csrrs x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	li x8, 0x5428f4f9
+	csrrc x1, 1962, x8
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrwi x1, 1962, 0b10011
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrsi x1, 1962, 0b01101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrrci x1, 1962, 0b00001
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+	csrr x1, 1962
+	li x8, 0x00000000
+	bne x8, x1, csr_fail
+_end2:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x16, 0x0000000d
+	csrw 800,  x16 # set mcountinhibit to disable counting
+	li x16, 0x00000000
+	csrw 2816, x16 # reset cycle count
+	csrw 2944, x16
+	csrw 2818, x16 # reset instruction retired count
+	csrw 2946, x16
+	li x16, 0x00000001
+	csrw 773,  x16 # reset mtvec
+###############################################################################
+_start3:
+	# mcycle
+	li x8, 0xa5a5a5a5
+	csrrw x12, 2816, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 2816, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x12, csr_fail
+	li x8, 0x2fc7d00c
+	csrrw x12, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 2816, x8
+	li x8, 0x2fc7d00c
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 2816, x8
+	li x8, 0xafe7f5ad
+	bne x8, x12, csr_fail
+	li x8, 0xeb8e2f64
+	csrrs x12, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0x966b2049
+	csrrc x12, 2816, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrsi x12, 2816, 0b11110
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 2816, 0b00110
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mcycleh
+	li x8, 0xa5a5a5a5
+	csrrw x12, 2944, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 2944, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x12, csr_fail
+	li x8, 0x1b6ea587
+	csrrw x12, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 2944, x8
+	li x8, 0x1b6ea587
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 2944, x8
+	li x8, 0xbfefa5a7
+	bne x8, x12, csr_fail
+	li x8, 0x157bb399
+	csrrs x12, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0x1db984ae
+	csrrc x12, 2944, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrsi x12, 2944, 0b01100
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 2944, 0b00011
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# minstret
+	li x8, 0xa5a5a5a5
+	csrrw x12, 2818, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 2818, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x12, csr_fail
+	li x8, 0x7714a5f8
+	csrrw x12, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 2818, x8
+	li x8, 0x7714a5f8
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 2818, x8
+	li x8, 0xf7b5a5fd
+	bne x8, x12, csr_fail
+	li x8, 0x355f37b1
+	csrrs x12, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xe135ce46
+	csrrc x12, 2818, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 2818, 0b00010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x8, 0x00000002
+	bne x8, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x8, 0x00000007
+	bne x8, x12, csr_fail
+	csrrsi x12, 2818, 0b01100
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 2818, 0b11101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# minstreth
+	li x8, 0xa5a5a5a5
+	csrrw x12, 2946, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 2946, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x12, csr_fail
+	li x8, 0xdd9eec62
+	csrrw x12, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 2946, x8
+	li x8, 0xdd9eec62
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 2946, x8
+	li x8, 0xfdbfede7
+	bne x8, x12, csr_fail
+	li x8, 0x85886530
+	csrrs x12, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xd886471f
+	csrrc x12, 2946, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 2946, 0b10101
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x8, 0x00000015
+	bne x8, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x8, 0x00000015
+	bne x8, x12, csr_fail
+	csrrsi x12, 2946, 0b10001
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 2946, 0b10101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mstatus
+	li x8, 0xa5a5a5a5
+	csrrw x12, 768, x8
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 768, x8
+	li x8, 0x00001880
+	bne x8, x12, csr_fail
+	li x8, 0xb511a673
+	csrrw x12, 768, x8
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 768, x8
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 768, x8
+	li x8, 0x00001880
+	bne x8, x12, csr_fail
+	li x8, 0x3975286f
+	csrrs x12, 768, x8
+	li x8, 0x00001888
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 768, x8
+	li x8, 0x00001888
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 768, x8
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	li x8, 0x62ce8bf5
+	csrrc x12, 768, x8
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	csrrwi x12, 768, 0b00011
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	csrrsi x12, 768, 0b10110
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x12, csr_fail
+	csrrci x12, 768, 0b10000
+	li x8, 0x00001800
+	bne x8, x12, csr_fail
+	# misa
+	li x8, 0xa5a5a5a5
+	csrrw x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x5eef06d2
+	csrrw x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x9e48e762
+	csrrs x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	li x8, 0x87adfdef
+	csrrc x12, 769, x8
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrwi x12, 769, 0b01010
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrsi x12, 769, 0b01010
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	csrrci x12, 769, 0b01110
+	li x8, 0x40801104
+	bne x8, x12, csr_fail
+	# mie
+	li x8, 0xa5a5a5a5
+	csrrw x12, 772, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 772, x8
+	li x8, 0xa5a50080
+	bne x8, x12, csr_fail
+	li x8, 0xd362cd6c
+	csrrw x12, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 772, x8
+	li x8, 0xd3620808
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 772, x8
+	li x8, 0xf7e70888
+	bne x8, x12, csr_fail
+	li x8, 0x40ddaa51
+	csrrs x12, 772, x8
+	li x8, 0xffff0888
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 772, x8
+	li x8, 0xffff0888
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x12, csr_fail
+	li x8, 0x2d9175fa
+	csrrc x12, 772, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 772, 0b11101
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrsi x12, 772, 0b00001
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrci x12, 772, 0b10101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mtvec
+	li x8, 0xa5a5a5a5
+	csrrw x12, 773, x8
+	li x8, 0x00000001
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 773, x8
+	li x8, 0xa5a5a501
+	bne x8, x12, csr_fail
+	li x8, 0x12aa2246
+	csrrw x12, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 773, x8
+	li x8, 0x12aa2200
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 773, x8
+	li x8, 0xb7afa701
+	bne x8, x12, csr_fail
+	li x8, 0x7aee4d66
+	csrrs x12, 773, x8
+	li x8, 0xffffff01
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 773, x8
+	li x8, 0xffffff01
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x12, csr_fail
+	li x8, 0xe3e2c781
+	csrrc x12, 773, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x12, csr_fail
+	csrrwi x12, 773, 0b01100
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x12, csr_fail
+	csrrsi x12, 773, 0b01110
+	li x8, 0x00000001
+	bne x8, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 773, 0b01000
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mcountinhibit
+	li x8, 0xa5a5a5a5
+	csrrw x12, 800, x8
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 800, x8
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	li x8, 0x7dce7f14
+	csrrw x12, 800, x8
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 800, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 800, x8
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	li x8, 0xd619cb09
+	csrrs x12, 800, x8
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 800, x8
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 800, x8
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	li x8, 0x17741d66
+	csrrc x12, 800, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 800, 0b11110
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x8, 0x0000000c
+	bne x8, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	csrrsi x12, 800, 0b10100
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x8, 0x0000000d
+	bne x8, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x8, 0x00000008
+	bne x8, x12, csr_fail
+	csrrci x12, 800, 0b11111
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mscratch
+	li x8, 0xa5a5a5a5
+	csrrw x12, 832, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 832, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x12, csr_fail
+	li x8, 0x1492ac32
+	csrrw x12, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 832, x8
+	li x8, 0x1492ac32
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 832, x8
+	li x8, 0xb5b7adb7
+	bne x8, x12, csr_fail
+	li x8, 0x4e827a33
+	csrrs x12, 832, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 832, x8
+	li x8, 0xffffffff
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0x65952971
+	csrrc x12, 832, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x8, 0x00000005
+	bne x8, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrsi x12, 832, 0b10101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x8, 0x0000001f
+	bne x8, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 832, 0b01011
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mepc
+	li x8, 0xa5a5a5a5
+	csrrw x12, 833, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 833, x8
+	li x8, 0xa5a5a5a4
+	bne x8, x12, csr_fail
+	li x8, 0x94b8f839
+	csrrw x12, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 833, x8
+	li x8, 0x94b8f838
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 833, x8
+	li x8, 0xb5bdfdbc
+	bne x8, x12, csr_fail
+	li x8, 0x1dbae408
+	csrrs x12, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x12, csr_fail
+	li x8, 0xa8e02e9b
+	csrrc x12, 833, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrwi x12, 833, 0b10001
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x8, 0x00000010
+	bne x8, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x8, 0x00000014
+	bne x8, x12, csr_fail
+	csrrsi x12, 833, 0b10000
+	li x8, 0x0000001e
+	bne x8, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x8, 0x0000001e
+	bne x8, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x8, 0x0000001a
+	bne x8, x12, csr_fail
+	csrrci x12, 833, 0b01001
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mtval
+	li x8, 0xa5a5a5a5
+	csrrw x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x89b46608
+	csrrw x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x69e8dccb
+	csrrs x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x99d59cae
+	csrrc x12, 835, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 835, 0b10101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 835, 0b00010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 835, 0b00001
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# mip
+	li x8, 0xa5a5a5a5
+	csrrw x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x7452e5cf
+	csrrw x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xb6990bf0
+	csrrs x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x9bfbb00a
+	csrrc x12, 836, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 836, 0b11001
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 836, 0b01010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 836, 0b00110
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# tselect
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xf000bfba
+	csrrw x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xb95c2932
+	csrrs x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x6edb2698
+	csrrc x12, 1952, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1952, 0b01111
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1952, 0b01001
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1952, 0b11000
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# tdata1
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0x990f5118
+	csrrw x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0xcf6d2f2c
+	csrrs x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	li x8, 0x46472dfa
+	csrrc x12, 1953, x8
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrwi x12, 1953, 0b01101
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrsi x12, 1953, 0b01100
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	csrrci x12, 1953, 0b11001
+	li x8, 0x28001040
+	bne x8, x12, csr_fail
+	# tdata2
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xbd861cfe
+	csrrw x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x6a5df380
+	csrrs x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x8a4c907e
+	csrrc x12, 1954, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1954, 0b10110
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1954, 0b01111
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1954, 0b01111
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# tdata3
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x7e851a48
+	csrrw x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x0807fe33
+	csrrs x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x47ccdfaf
+	csrrc x12, 1955, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1955, 0b11011
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1955, 0b01001
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1955, 0b10110
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# tinfo
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x099e3805
+	csrrw x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x34ea8174
+	csrrs x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	li x8, 0xc1d3186b
+	csrrc x12, 1956, x8
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrsi x12, 1956, 0b00001
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	csrrci x12, 1956, 0b00111
+	li x8, 0x00000004
+	bne x8, x12, csr_fail
+	# mcontext
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xd7d416dc
+	csrrw x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x09d37423
+	csrrs x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x621eb520
+	csrrc x12, 1960, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1960, 0b01010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1960, 0b01000
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1960, 0b00011
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	# scontext
+	li x8, 0xa5a5a5a5
+	csrrw x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x53d21331
+	csrrw x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xe40916e8
+	csrrs x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	li x8, 0x34f4ad44
+	csrrc x12, 1962, x8
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrwi x12, 1962, 0b11111
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrrci x12, 1962, 0b11110
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+	csrr x12, 1962
+	li x8, 0x00000000
+	bne x8, x12, csr_fail
+_end3:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x17, 0x0000000d
+	csrw 800,  x17 # set mcountinhibit to disable counting
+	li x17, 0x00000000
+	csrw 2816, x17 # reset cycle count
+	csrw 2944, x17
+	csrw 2818, x17 # reset instruction retired count
+	csrw 2946, x17
+	li x17, 0x00000001
+	csrw 773,  x17 # reset mtvec
+###############################################################################
+_start4:
+	# mcycle
+	li x2, 0xa5a5a5a5
+	csrrw x4, 2816, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 2816, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x4, csr_fail
+	li x2, 0x89f8ef7d
+	csrrw x4, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 2816, x2
+	li x2, 0x89f8ef7d
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 2816, x2
+	li x2, 0xadfdeffd
+	bne x2, x4, csr_fail
+	li x2, 0xb801a209
+	csrrs x4, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0x8a04b721
+	csrrc x4, 2816, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2816, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2816, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 2816, 0b00110
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 2816, 0b00101
+	li x2, 0x00000006
+	bne x2, x4, csr_fail
+	csrrsi x4, 2816, 0b11010
+	li x2, 0x00000007
+	bne x2, x4, csr_fail
+	csrrsi x4, 2816, 0b11001
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2816, 0b00101
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2816, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 2816, 0b01011
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mcycleh
+	li x2, 0xa5a5a5a5
+	csrrw x4, 2944, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 2944, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x4, csr_fail
+	li x2, 0xf4b2bc3d
+	csrrw x4, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 2944, x2
+	li x2, 0xf4b2bc3d
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 2944, x2
+	li x2, 0xf5b7bdbd
+	bne x2, x4, csr_fail
+	li x2, 0x393dac80
+	csrrs x4, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0x7086bc52
+	csrrc x4, 2944, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2944, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2944, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 2944, 0b10010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 2944, 0b00101
+	li x2, 0x00000012
+	bne x2, x4, csr_fail
+	csrrsi x4, 2944, 0b11010
+	li x2, 0x00000017
+	bne x2, x4, csr_fail
+	csrrsi x4, 2944, 0b01110
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2944, 0b00101
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2944, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 2944, 0b10100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# minstret
+	li x2, 0xa5a5a5a5
+	csrrw x4, 2818, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 2818, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x4, csr_fail
+	li x2, 0x345e337a
+	csrrw x4, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 2818, x2
+	li x2, 0x345e337a
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 2818, x2
+	li x2, 0xb5ffb7ff
+	bne x2, x4, csr_fail
+	li x2, 0x9731855c
+	csrrs x4, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0x0b626418
+	csrrc x4, 2818, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2818, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2818, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 2818, 0b01001
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 2818, 0b00101
+	li x2, 0x00000009
+	bne x2, x4, csr_fail
+	csrrsi x4, 2818, 0b11010
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	csrrsi x4, 2818, 0b00100
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2818, 0b00101
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2818, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 2818, 0b11001
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# minstreth
+	li x2, 0xa5a5a5a5
+	csrrw x4, 2946, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 2946, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x4, csr_fail
+	li x2, 0x8dea5a85
+	csrrw x4, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 2946, x2
+	li x2, 0x8dea5a85
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 2946, x2
+	li x2, 0xadefffa5
+	bne x2, x4, csr_fail
+	li x2, 0x6a4faa83
+	csrrs x4, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xfaf20e69
+	csrrc x4, 2946, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2946, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 2946, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 2946, 0b11110
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 2946, 0b00101
+	li x2, 0x0000001e
+	bne x2, x4, csr_fail
+	csrrsi x4, 2946, 0b11010
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrsi x4, 2946, 0b10001
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2946, 0b00101
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 2946, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 2946, 0b01010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mstatus
+	li x2, 0xa5a5a5a5
+	csrrw x4, 768, x2
+	li x2, 0x00001800
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 768, x2
+	li x2, 0x00001880
+	bne x2, x4, csr_fail
+	li x2, 0x8a0e21a3
+	csrrw x4, 768, x2
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 768, x2
+	li x2, 0x00001880
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 768, x2
+	li x2, 0x00001880
+	bne x2, x4, csr_fail
+	li x2, 0x2e7c6e7a
+	csrrs x4, 768, x2
+	li x2, 0x00001888
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 768, x2
+	li x2, 0x00001888
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 768, x2
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	li x2, 0x94dda6f3
+	csrrc x4, 768, x2
+	li x2, 0x00001800
+	bne x2, x4, csr_fail
+	csrrwi x4, 768, 0b00101
+	li x2, 0x00001800
+	bne x2, x4, csr_fail
+	csrrwi x4, 768, 0b11010
+	li x2, 0x00001800
+	bne x2, x4, csr_fail
+	csrrwi x4, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrsi x4, 768, 0b00101
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrsi x4, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrsi x4, 768, 0b00001
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrci x4, 768, 0b00101
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrci x4, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x4, csr_fail
+	csrrci x4, 768, 0b00101
+	li x2, 0x00001800
+	bne x2, x4, csr_fail
+	# misa
+	li x2, 0xa5a5a5a5
+	csrrw x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0xf3b25313
+	csrrw x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0x1b69b0fd
+	csrrs x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	li x2, 0x7effc614
+	csrrc x4, 769, x2
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrwi x4, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrwi x4, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrwi x4, 769, 0b01100
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrsi x4, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrsi x4, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrsi x4, 769, 0b11001
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrci x4, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrci x4, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	csrrci x4, 769, 0b00110
+	li x2, 0x40801104
+	bne x2, x4, csr_fail
+	# mie
+	li x2, 0xa5a5a5a5
+	csrrw x4, 772, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 772, x2
+	li x2, 0xa5a50080
+	bne x2, x4, csr_fail
+	li x2, 0xf0eda368
+	csrrw x4, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 772, x2
+	li x2, 0xf0ed0008
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 772, x2
+	li x2, 0xf5ed0088
+	bne x2, x4, csr_fail
+	li x2, 0x07065ac4
+	csrrs x4, 772, x2
+	li x2, 0xffff0888
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 772, x2
+	li x2, 0xffff0888
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x4, csr_fail
+	li x2, 0xfc97aabb
+	csrrc x4, 772, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 772, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 772, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 772, 0b01001
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrsi x4, 772, 0b00101
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrsi x4, 772, 0b11010
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrsi x4, 772, 0b00101
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrci x4, 772, 0b00101
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrci x4, 772, 0b11010
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrci x4, 772, 0b00011
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mtvec
+	li x2, 0xa5a5a5a5
+	csrrw x4, 773, x2
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 773, x2
+	li x2, 0xa5a5a501
+	bne x2, x4, csr_fail
+	li x2, 0x1ac3c2ac
+	csrrw x4, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 773, x2
+	li x2, 0x1ac3c200
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 773, x2
+	li x2, 0xbfe7e701
+	bne x2, x4, csr_fail
+	li x2, 0x18d47079
+	csrrs x4, 773, x2
+	li x2, 0xffffff01
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 773, x2
+	li x2, 0xffffff01
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x4, csr_fail
+	li x2, 0x4e9cdd03
+	csrrc x4, 773, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 773, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrwi x4, 773, 0b00001
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 773, 0b00101
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrsi x4, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrsi x4, 773, 0b01110
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrci x4, 773, 0b00101
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrci x4, 773, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 773, 0b01100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mcountinhibit
+	li x2, 0xa5a5a5a5
+	csrrw x4, 800, x2
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 800, x2
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	li x2, 0x00dd3d1c
+	csrrw x4, 800, x2
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 800, x2
+	li x2, 0x0000000c
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 800, x2
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	li x2, 0x5c496d94
+	csrrs x4, 800, x2
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 800, x2
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 800, x2
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	li x2, 0x243a5e86
+	csrrc x4, 800, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 800, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 800, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 800, 0b10011
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrsi x4, 800, 0b00101
+	li x2, 0x00000001
+	bne x2, x4, csr_fail
+	csrrsi x4, 800, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrsi x4, 800, 0b00100
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	csrrci x4, 800, 0b00101
+	li x2, 0x0000000d
+	bne x2, x4, csr_fail
+	csrrci x4, 800, 0b11010
+	li x2, 0x00000008
+	bne x2, x4, csr_fail
+	csrrci x4, 800, 0b01001
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mscratch
+	li x2, 0xa5a5a5a5
+	csrrw x4, 832, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 832, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x4, csr_fail
+	li x2, 0x675a7502
+	csrrw x4, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 832, x2
+	li x2, 0x675a7502
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 832, x2
+	li x2, 0xe7fff5a7
+	bne x2, x4, csr_fail
+	li x2, 0xfb39b716
+	csrrs x4, 832, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 832, x2
+	li x2, 0xffffffff
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0x53ab7982
+	csrrc x4, 832, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 832, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 832, 0b11010
+	li x2, 0x00000005
+	bne x2, x4, csr_fail
+	csrrwi x4, 832, 0b10010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 832, 0b00101
+	li x2, 0x00000012
+	bne x2, x4, csr_fail
+	csrrsi x4, 832, 0b11010
+	li x2, 0x00000017
+	bne x2, x4, csr_fail
+	csrrsi x4, 832, 0b10011
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 832, 0b00101
+	li x2, 0x0000001f
+	bne x2, x4, csr_fail
+	csrrci x4, 832, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 832, 0b10010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mepc
+	li x2, 0xa5a5a5a5
+	csrrw x4, 833, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 833, x2
+	li x2, 0xa5a5a5a4
+	bne x2, x4, csr_fail
+	li x2, 0xc3f52009
+	csrrw x4, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 833, x2
+	li x2, 0xc3f52008
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 833, x2
+	li x2, 0xe7f5a5ac
+	bne x2, x4, csr_fail
+	li x2, 0x3f23e391
+	csrrs x4, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x4, csr_fail
+	li x2, 0x2238ad63
+	csrrc x4, 833, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 833, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 833, 0b11010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrwi x4, 833, 0b00000
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrsi x4, 833, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 833, 0b11010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrsi x4, 833, 0b00000
+	li x2, 0x0000001e
+	bne x2, x4, csr_fail
+	csrrci x4, 833, 0b00101
+	li x2, 0x0000001e
+	bne x2, x4, csr_fail
+	csrrci x4, 833, 0b11010
+	li x2, 0x0000001a
+	bne x2, x4, csr_fail
+	csrrci x4, 833, 0b00100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mtval
+	li x2, 0xa5a5a5a5
+	csrrw x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xf2991824
+	csrrw x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xbd1a2256
+	csrrs x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x414d9b0e
+	csrrc x4, 835, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 835, 0b11001
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 835, 0b11100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 835, 0b01111
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# mip
+	li x2, 0xa5a5a5a5
+	csrrw x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xd5787f04
+	csrrw x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x23d27c2e
+	csrrs x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xb05133b1
+	csrrc x4, 836, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 836, 0b10000
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 836, 0b10001
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 836, 0b11011
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# tselect
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x511921b9
+	csrrw x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xc6027dd2
+	csrrs x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xfdceff8d
+	csrrc x4, 1952, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1952, 0b01010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1952, 0b10100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1952, 0b01100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# tdata1
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0x21f86dd8
+	csrrw x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0xfc65c996
+	csrrs x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	li x2, 0xe0df72ac
+	csrrc x4, 1953, x2
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrwi x4, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrwi x4, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrwi x4, 1953, 0b01101
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrsi x4, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrsi x4, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrsi x4, 1953, 0b10001
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrci x4, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrci x4, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	csrrci x4, 1953, 0b10101
+	li x2, 0x28001040
+	bne x2, x4, csr_fail
+	# tdata2
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x9ae30778
+	csrrw x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x70f15b00
+	csrrs x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x8e4b8b35
+	csrrc x4, 1954, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1954, 0b10111
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1954, 0b01110
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1954, 0b10000
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# tdata3
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x80993834
+	csrrw x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x6b345ea6
+	csrrs x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x56ccbd93
+	csrrc x4, 1955, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1955, 0b11111
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1955, 0b10010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1955, 0b00010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# tinfo
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0xf05290b0
+	csrrw x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0x6b341b28
+	csrrs x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	li x2, 0x8ecf4cc0
+	csrrc x4, 1956, x2
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrwi x4, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrwi x4, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrwi x4, 1956, 0b01100
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrsi x4, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrsi x4, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrsi x4, 1956, 0b00010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrci x4, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrci x4, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	csrrci x4, 1956, 0b00010
+	li x2, 0x00000004
+	bne x2, x4, csr_fail
+	# mcontext
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x672f087d
+	csrrw x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x2ce7c361
+	csrrs x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xe0741740
+	csrrc x4, 1960, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1960, 0b10100
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1960, 0b00111
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	# scontext
+	li x2, 0xa5a5a5a5
+	csrrw x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x743ad08c
+	csrrw x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x81863560
+	csrrs x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	li x2, 0x0300eabc
+	csrrc x4, 1962, x2
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrwi x4, 1962, 0b10000
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrsi x4, 1962, 0b10101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrrci x4, 1962, 0b11111
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+	csrr x4, 1962
+	li x2, 0x00000000
+	bne x2, x4, csr_fail
+_end4:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x18, 0x0000000d
+	csrw 800,  x18 # set mcountinhibit to disable counting
+	li x18, 0x00000000
+	csrw 2816, x18 # reset cycle count
+	csrw 2944, x18
+	csrw 2818, x18 # reset instruction retired count
+	csrw 2946, x18
+	li x18, 0x00000001
+	csrw 773,  x18 # reset mtvec
+###############################################################################
+_start5:
+	# mcycle
+	li x13, 0xa5a5a5a5
+	csrrw x6, 2816, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 2816, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x6, csr_fail
+	li x13, 0x8e376af2
+	csrrw x6, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 2816, x13
+	li x13, 0x8e376af2
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 2816, x13
+	li x13, 0xafb7eff7
+	bne x13, x6, csr_fail
+	li x13, 0xccbc0005
+	csrrs x6, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0x1ad03d09
+	csrrc x6, 2816, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2816, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2816, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 2816, 0b00101
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 2816, 0b00101
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrsi x6, 2816, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrsi x6, 2816, 0b11000
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2816, 0b00101
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2816, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 2816, 0b00100
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mcycleh
+	li x13, 0xa5a5a5a5
+	csrrw x6, 2944, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 2944, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x6, csr_fail
+	li x13, 0x375ddbf2
+	csrrw x6, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 2944, x13
+	li x13, 0x375ddbf2
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 2944, x13
+	li x13, 0xb7fdfff7
+	bne x13, x6, csr_fail
+	li x13, 0x712f9d2c
+	csrrs x6, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xab5d0eb6
+	csrrc x6, 2944, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2944, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2944, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 2944, 0b01110
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 2944, 0b00101
+	li x13, 0x0000000e
+	bne x13, x6, csr_fail
+	csrrsi x6, 2944, 0b11010
+	li x13, 0x0000000f
+	bne x13, x6, csr_fail
+	csrrsi x6, 2944, 0b01111
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2944, 0b00101
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2944, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 2944, 0b11011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# minstret
+	li x13, 0xa5a5a5a5
+	csrrw x6, 2818, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 2818, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x6, csr_fail
+	li x13, 0x95fcad1b
+	csrrw x6, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 2818, x13
+	li x13, 0x95fcad1b
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 2818, x13
+	li x13, 0xb5fdadbf
+	bne x13, x6, csr_fail
+	li x13, 0xe033523b
+	csrrs x6, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0x3e1866dd
+	csrrc x6, 2818, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2818, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2818, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 2818, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 2818, 0b00101
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 2818, 0b11010
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrsi x6, 2818, 0b11001
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2818, 0b00101
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2818, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 2818, 0b10010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# minstreth
+	li x13, 0xa5a5a5a5
+	csrrw x6, 2946, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 2946, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x6, csr_fail
+	li x13, 0xc11ffaac
+	csrrw x6, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 2946, x13
+	li x13, 0xc11ffaac
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 2946, x13
+	li x13, 0xe5bfffad
+	bne x13, x6, csr_fail
+	li x13, 0x1b3f1bbb
+	csrrs x6, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xc9912221
+	csrrc x6, 2946, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2946, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 2946, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 2946, 0b11000
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 2946, 0b00101
+	li x13, 0x00000018
+	bne x13, x6, csr_fail
+	csrrsi x6, 2946, 0b11010
+	li x13, 0x0000001d
+	bne x13, x6, csr_fail
+	csrrsi x6, 2946, 0b11000
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2946, 0b00101
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 2946, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 2946, 0b01111
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mstatus
+	li x13, 0xa5a5a5a5
+	csrrw x6, 768, x13
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 768, x13
+	li x13, 0x00001880
+	bne x13, x6, csr_fail
+	li x13, 0x68c7c730
+	csrrw x6, 768, x13
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 768, x13
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 768, x13
+	li x13, 0x00001880
+	bne x13, x6, csr_fail
+	li x13, 0xe711d08f
+	csrrs x6, 768, x13
+	li x13, 0x00001888
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 768, x13
+	li x13, 0x00001888
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 768, x13
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	li x13, 0xe6277d3f
+	csrrc x6, 768, x13
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	csrrwi x6, 768, 0b00101
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	csrrwi x6, 768, 0b11010
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	csrrwi x6, 768, 0b01111
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrsi x6, 768, 0b00101
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrsi x6, 768, 0b11010
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrsi x6, 768, 0b01101
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrci x6, 768, 0b00101
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrci x6, 768, 0b11010
+	li x13, 0x00001808
+	bne x13, x6, csr_fail
+	csrrci x6, 768, 0b11110
+	li x13, 0x00001800
+	bne x13, x6, csr_fail
+	# misa
+	li x13, 0xa5a5a5a5
+	csrrw x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0x338f1ae7
+	csrrw x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0xe9ce5d97
+	csrrs x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	li x13, 0xb41e7108
+	csrrc x6, 769, x13
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrwi x6, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrwi x6, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrwi x6, 769, 0b00110
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrsi x6, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrsi x6, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrsi x6, 769, 0b11011
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrci x6, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrci x6, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	csrrci x6, 769, 0b10101
+	li x13, 0x40801104
+	bne x13, x6, csr_fail
+	# mie
+	li x13, 0xa5a5a5a5
+	csrrw x6, 772, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 772, x13
+	li x13, 0xa5a50080
+	bne x13, x6, csr_fail
+	li x13, 0x5a8baa9b
+	csrrw x6, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 772, x13
+	li x13, 0x5a8b0888
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 772, x13
+	li x13, 0xffaf0888
+	bne x13, x6, csr_fail
+	li x13, 0x7c0b1f15
+	csrrs x6, 772, x13
+	li x13, 0xffff0888
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 772, x13
+	li x13, 0xffff0888
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x6, csr_fail
+	li x13, 0xa36d6afd
+	csrrc x6, 772, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 772, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 772, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 772, 0b00000
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrsi x6, 772, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 772, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 772, 0b00000
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrci x6, 772, 0b00101
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrci x6, 772, 0b11010
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrci x6, 772, 0b11110
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mtvec
+	li x13, 0xa5a5a5a5
+	csrrw x6, 773, x13
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 773, x13
+	li x13, 0xa5a5a501
+	bne x13, x6, csr_fail
+	li x13, 0xa9afa461
+	csrrw x6, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 773, x13
+	li x13, 0xa9afa401
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 773, x13
+	li x13, 0xadafa501
+	bne x13, x6, csr_fail
+	li x13, 0xfda8857e
+	csrrs x6, 773, x13
+	li x13, 0xffffff01
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 773, x13
+	li x13, 0xffffff01
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x6, csr_fail
+	li x13, 0x1b94467a
+	csrrc x6, 773, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 773, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	csrrwi x6, 773, 0b11011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	csrrsi x6, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	csrrsi x6, 773, 0b10100
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	csrrci x6, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x6, csr_fail
+	csrrci x6, 773, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 773, 0b10101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mcountinhibit
+	li x13, 0xa5a5a5a5
+	csrrw x6, 800, x13
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 800, x13
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	li x13, 0x5f641c4b
+	csrrw x6, 800, x13
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 800, x13
+	li x13, 0x00000009
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 800, x13
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	li x13, 0x558d16af
+	csrrs x6, 800, x13
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 800, x13
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 800, x13
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	li x13, 0x9e3848ec
+	csrrc x6, 800, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 800, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 800, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 800, 0b00101
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrsi x6, 800, 0b00101
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrsi x6, 800, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrsi x6, 800, 0b01111
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	csrrci x6, 800, 0b00101
+	li x13, 0x0000000d
+	bne x13, x6, csr_fail
+	csrrci x6, 800, 0b11010
+	li x13, 0x00000008
+	bne x13, x6, csr_fail
+	csrrci x6, 800, 0b01101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mscratch
+	li x13, 0xa5a5a5a5
+	csrrw x6, 832, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 832, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x6, csr_fail
+	li x13, 0x030278ae
+	csrrw x6, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 832, x13
+	li x13, 0x030278ae
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 832, x13
+	li x13, 0xa7a7fdaf
+	bne x13, x6, csr_fail
+	li x13, 0x9be92b2f
+	csrrs x6, 832, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 832, x13
+	li x13, 0xffffffff
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0x2e24ffe0
+	csrrc x6, 832, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 832, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 832, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrwi x6, 832, 0b00000
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 832, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 832, 0b11010
+	li x13, 0x00000005
+	bne x13, x6, csr_fail
+	csrrsi x6, 832, 0b10100
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 832, 0b00101
+	li x13, 0x0000001f
+	bne x13, x6, csr_fail
+	csrrci x6, 832, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 832, 0b01001
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mepc
+	li x13, 0xa5a5a5a5
+	csrrw x6, 833, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 833, x13
+	li x13, 0xa5a5a5a4
+	bne x13, x6, csr_fail
+	li x13, 0x38d01a8c
+	csrrw x6, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 833, x13
+	li x13, 0x38d01a8c
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 833, x13
+	li x13, 0xbdf5bfac
+	bne x13, x6, csr_fail
+	li x13, 0x3d3eb481
+	csrrs x6, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x6, csr_fail
+	li x13, 0x58599f15
+	csrrc x6, 833, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 833, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 833, 0b11010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrwi x6, 833, 0b00010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrsi x6, 833, 0b00101
+	li x13, 0x00000002
+	bne x13, x6, csr_fail
+	csrrsi x6, 833, 0b11010
+	li x13, 0x00000006
+	bne x13, x6, csr_fail
+	csrrsi x6, 833, 0b00101
+	li x13, 0x0000001e
+	bne x13, x6, csr_fail
+	csrrci x6, 833, 0b00101
+	li x13, 0x0000001e
+	bne x13, x6, csr_fail
+	csrrci x6, 833, 0b11010
+	li x13, 0x0000001a
+	bne x13, x6, csr_fail
+	csrrci x6, 833, 0b01011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mtval
+	li x13, 0xa5a5a5a5
+	csrrw x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x4e5da786
+	csrrw x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xf3978fb4
+	csrrs x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x47b63ca2
+	csrrc x6, 835, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 835, 0b10010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 835, 0b01100
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 835, 0b00001
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# mip
+	li x13, 0xa5a5a5a5
+	csrrw x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x81f0b0e2
+	csrrw x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x19680cd5
+	csrrs x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x0e722987
+	csrrc x6, 836, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 836, 0b10011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 836, 0b00011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 836, 0b10000
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# tselect
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xd6a2dfc2
+	csrrw x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xe4f15002
+	csrrs x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xbf9d9386
+	csrrc x6, 1952, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1952, 0b11110
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1952, 0b01010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1952, 0b10001
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# tdata1
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x7e7e073f
+	csrrw x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x5903a8aa
+	csrrs x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	li x13, 0x7853a16d
+	csrrc x6, 1953, x13
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrwi x6, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrwi x6, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrwi x6, 1953, 0b10101
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrsi x6, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrsi x6, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrsi x6, 1953, 0b00111
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrci x6, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrci x6, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	csrrci x6, 1953, 0b01010
+	li x13, 0x28001040
+	bne x13, x6, csr_fail
+	# tdata2
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xd6aac6c8
+	csrrw x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x017b1d9b
+	csrrs x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x3408a8d2
+	csrrc x6, 1954, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1954, 0b00100
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1954, 0b10110
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1954, 0b11000
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# tdata3
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x1435be29
+	csrrw x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xdf73e627
+	csrrs x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xe8a50b80
+	csrrc x6, 1955, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1955, 0b01100
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1955, 0b10100
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1955, 0b10101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# tinfo
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0x2b5b570c
+	csrrw x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0xa209f5cc
+	csrrs x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	li x13, 0xe6f4c076
+	csrrc x6, 1956, x13
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrwi x6, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrwi x6, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrwi x6, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrsi x6, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrsi x6, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrsi x6, 1956, 0b00010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrci x6, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrci x6, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	csrrci x6, 1956, 0b00011
+	li x13, 0x00000004
+	bne x13, x6, csr_fail
+	# mcontext
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x338d3c8d
+	csrrw x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x4ff4e9fc
+	csrrs x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x7ec2b6a7
+	csrrc x6, 1960, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1960, 0b11110
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1960, 0b11001
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1960, 0b10000
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	# scontext
+	li x13, 0xa5a5a5a5
+	csrrw x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xe750b2c7
+	csrrw x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xbd21e0ea
+	csrrs x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	li x13, 0xb3c19630
+	csrrc x6, 1962, x13
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrwi x6, 1962, 0b10001
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrsi x6, 1962, 0b10011
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrrci x6, 1962, 0b01111
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+	csrr x6, 1962
+	li x13, 0x00000000
+	bne x13, x6, csr_fail
+_end5:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x19, 0x0000000d
+	csrw 800,  x19 # set mcountinhibit to disable counting
+	li x19, 0x00000000
+	csrw 2816, x19 # reset cycle count
+	csrw 2944, x19
+	csrw 2818, x19 # reset instruction retired count
+	csrw 2946, x19
+	li x19, 0x00000001
+	csrw 773,  x19 # reset mtvec
+###############################################################################
+_start6:
+	# mcycle
+	li x13, 0xa5a5a5a5
+	csrrw x1, 2816, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 2816, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x1, csr_fail
+	li x13, 0x97115a0c
+	csrrw x1, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 2816, x13
+	li x13, 0x97115a0c
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 2816, x13
+	li x13, 0xb7b5ffad
+	bne x13, x1, csr_fail
+	li x13, 0xcc9fdf76
+	csrrs x1, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0x9ece283d
+	csrrc x1, 2816, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2816, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2816, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 2816, 0b01111
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 2816, 0b00101
+	li x13, 0x0000000f
+	bne x13, x1, csr_fail
+	csrrsi x1, 2816, 0b11010
+	li x13, 0x0000000f
+	bne x13, x1, csr_fail
+	csrrsi x1, 2816, 0b01011
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2816, 0b00101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2816, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 2816, 0b11000
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mcycleh
+	li x13, 0xa5a5a5a5
+	csrrw x1, 2944, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 2944, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x1, csr_fail
+	li x13, 0xdf661745
+	csrrw x1, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 2944, x13
+	li x13, 0xdf661745
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 2944, x13
+	li x13, 0xffe7b7e5
+	bne x13, x1, csr_fail
+	li x13, 0x72081379
+	csrrs x1, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xda0f6f0f
+	csrrc x1, 2944, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2944, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2944, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 2944, 0b01010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 2944, 0b00101
+	li x13, 0x0000000a
+	bne x13, x1, csr_fail
+	csrrsi x1, 2944, 0b11010
+	li x13, 0x0000000f
+	bne x13, x1, csr_fail
+	csrrsi x1, 2944, 0b01110
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2944, 0b00101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2944, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 2944, 0b10001
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# minstret
+	li x13, 0xa5a5a5a5
+	csrrw x1, 2818, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 2818, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x1, csr_fail
+	li x13, 0x21f4794f
+	csrrw x1, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 2818, x13
+	li x13, 0x21f4794f
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 2818, x13
+	li x13, 0xa5f5fdef
+	bne x13, x1, csr_fail
+	li x13, 0x462002c1
+	csrrs x1, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xd456afb1
+	csrrc x1, 2818, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2818, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2818, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 2818, 0b01111
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 2818, 0b00101
+	li x13, 0x0000000f
+	bne x13, x1, csr_fail
+	csrrsi x1, 2818, 0b11010
+	li x13, 0x0000000f
+	bne x13, x1, csr_fail
+	csrrsi x1, 2818, 0b01101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2818, 0b00101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2818, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 2818, 0b01000
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# minstreth
+	li x13, 0xa5a5a5a5
+	csrrw x1, 2946, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 2946, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x1, csr_fail
+	li x13, 0x276d1c83
+	csrrw x1, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 2946, x13
+	li x13, 0x276d1c83
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 2946, x13
+	li x13, 0xa7edbda7
+	bne x13, x1, csr_fail
+	li x13, 0xdb5b6b17
+	csrrs x1, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xab802132
+	csrrc x1, 2946, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2946, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 2946, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 2946, 0b00101
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 2946, 0b00101
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrsi x1, 2946, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrsi x1, 2946, 0b10001
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2946, 0b00101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 2946, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 2946, 0b11000
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mstatus
+	li x13, 0xa5a5a5a5
+	csrrw x1, 768, x13
+	li x13, 0x00001800
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 768, x13
+	li x13, 0x00001880
+	bne x13, x1, csr_fail
+	li x13, 0x522ce33d
+	csrrw x1, 768, x13
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 768, x13
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 768, x13
+	li x13, 0x00001888
+	bne x13, x1, csr_fail
+	li x13, 0x3f5b7b72
+	csrrs x1, 768, x13
+	li x13, 0x00001888
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 768, x13
+	li x13, 0x00001888
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 768, x13
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	li x13, 0x2961b1fd
+	csrrc x1, 768, x13
+	li x13, 0x00001800
+	bne x13, x1, csr_fail
+	csrrwi x1, 768, 0b00101
+	li x13, 0x00001800
+	bne x13, x1, csr_fail
+	csrrwi x1, 768, 0b11010
+	li x13, 0x00001800
+	bne x13, x1, csr_fail
+	csrrwi x1, 768, 0b11001
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrsi x1, 768, 0b00101
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrsi x1, 768, 0b11010
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrsi x1, 768, 0b11001
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrci x1, 768, 0b00101
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrci x1, 768, 0b11010
+	li x13, 0x00001808
+	bne x13, x1, csr_fail
+	csrrci x1, 768, 0b10101
+	li x13, 0x00001800
+	bne x13, x1, csr_fail
+	# misa
+	li x13, 0xa5a5a5a5
+	csrrw x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0xefaf3e01
+	csrrw x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0xea436c39
+	csrrs x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	li x13, 0xab0cb7d6
+	csrrc x1, 769, x13
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrwi x1, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrwi x1, 769, 0b01010
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrsi x1, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrsi x1, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrsi x1, 769, 0b11001
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrci x1, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrci x1, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	csrrci x1, 769, 0b00111
+	li x13, 0x40801104
+	bne x13, x1, csr_fail
+	# mie
+	li x13, 0xa5a5a5a5
+	csrrw x1, 772, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 772, x13
+	li x13, 0xa5a50080
+	bne x13, x1, csr_fail
+	li x13, 0x77981a2e
+	csrrw x1, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 772, x13
+	li x13, 0x77980808
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 772, x13
+	li x13, 0xf7bd0888
+	bne x13, x1, csr_fail
+	li x13, 0x0fc9f97c
+	csrrs x1, 772, x13
+	li x13, 0xffff0888
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 772, x13
+	li x13, 0xffff0888
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x1, csr_fail
+	li x13, 0xc5fe386c
+	csrrc x1, 772, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 772, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 772, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 772, 0b00101
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrsi x1, 772, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 772, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 772, 0b11001
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrci x1, 772, 0b00101
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrci x1, 772, 0b11010
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrci x1, 772, 0b11111
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mtvec
+	li x13, 0xa5a5a5a5
+	csrrw x1, 773, x13
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 773, x13
+	li x13, 0xa5a5a501
+	bne x13, x1, csr_fail
+	li x13, 0x243694e8
+	csrrw x1, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 773, x13
+	li x13, 0x24369400
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 773, x13
+	li x13, 0xa5b7b501
+	bne x13, x1, csr_fail
+	li x13, 0xb3641e22
+	csrrs x1, 773, x13
+	li x13, 0xffffff01
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 773, x13
+	li x13, 0xffffff01
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x1, csr_fail
+	li x13, 0x9b1c7a94
+	csrrc x1, 773, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 773, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	csrrwi x1, 773, 0b11111
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	csrrsi x1, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	csrrsi x1, 773, 0b00010
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	csrrci x1, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	csrrci x1, 773, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 773, 0b11011
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mcountinhibit
+	li x13, 0xa5a5a5a5
+	csrrw x1, 800, x13
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 800, x13
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	li x13, 0x55ab7043
+	csrrw x1, 800, x13
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 800, x13
+	li x13, 0x00000001
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 800, x13
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	li x13, 0xc508e5ac
+	csrrs x1, 800, x13
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 800, x13
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 800, x13
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	li x13, 0x2dc5f1d3
+	csrrc x1, 800, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 800, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 800, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 800, 0b01111
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrsi x1, 800, 0b00101
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	csrrsi x1, 800, 0b11010
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	csrrsi x1, 800, 0b10111
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	csrrci x1, 800, 0b00101
+	li x13, 0x0000000d
+	bne x13, x1, csr_fail
+	csrrci x1, 800, 0b11010
+	li x13, 0x00000008
+	bne x13, x1, csr_fail
+	csrrci x1, 800, 0b10110
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mscratch
+	li x13, 0xa5a5a5a5
+	csrrw x1, 832, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 832, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x1, csr_fail
+	li x13, 0x62c7d64b
+	csrrw x1, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 832, x13
+	li x13, 0x62c7d64b
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 832, x13
+	li x13, 0xe7e7f7ef
+	bne x13, x1, csr_fail
+	li x13, 0xdd5353de
+	csrrs x1, 832, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 832, x13
+	li x13, 0xffffffff
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xe789bb27
+	csrrc x1, 832, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 832, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 832, 0b11010
+	li x13, 0x00000005
+	bne x13, x1, csr_fail
+	csrrwi x1, 832, 0b10110
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 832, 0b00101
+	li x13, 0x00000016
+	bne x13, x1, csr_fail
+	csrrsi x1, 832, 0b11010
+	li x13, 0x00000017
+	bne x13, x1, csr_fail
+	csrrsi x1, 832, 0b00110
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 832, 0b00101
+	li x13, 0x0000001f
+	bne x13, x1, csr_fail
+	csrrci x1, 832, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 832, 0b00001
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mepc
+	li x13, 0xa5a5a5a5
+	csrrw x1, 833, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 833, x13
+	li x13, 0xa5a5a5a4
+	bne x13, x1, csr_fail
+	li x13, 0xdb457c5d
+	csrrw x1, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 833, x13
+	li x13, 0xdb457c5c
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 833, x13
+	li x13, 0xffe5fdfc
+	bne x13, x1, csr_fail
+	li x13, 0x9637b03b
+	csrrs x1, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x1, csr_fail
+	li x13, 0x8c5d018a
+	csrrc x1, 833, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 833, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 833, 0b11010
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrwi x1, 833, 0b10100
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrsi x1, 833, 0b00101
+	li x13, 0x00000014
+	bne x13, x1, csr_fail
+	csrrsi x1, 833, 0b11010
+	li x13, 0x00000014
+	bne x13, x1, csr_fail
+	csrrsi x1, 833, 0b00011
+	li x13, 0x0000001e
+	bne x13, x1, csr_fail
+	csrrci x1, 833, 0b00101
+	li x13, 0x0000001e
+	bne x13, x1, csr_fail
+	csrrci x1, 833, 0b11010
+	li x13, 0x0000001a
+	bne x13, x1, csr_fail
+	csrrci x1, 833, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mtval
+	li x13, 0xa5a5a5a5
+	csrrw x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x81978237
+	csrrw x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xd5c3e91f
+	csrrs x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa27f0c00
+	csrrc x1, 835, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 835, 0b10110
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 835, 0b10100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 835, 0b10100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# mip
+	li x13, 0xa5a5a5a5
+	csrrw x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x8168c21e
+	csrrw x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x3680e625
+	csrrs x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xf789ff3e
+	csrrc x1, 836, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 836, 0b11110
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 836, 0b10010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 836, 0b10100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# tselect
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x6838b806
+	csrrw x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x0d34f43c
+	csrrs x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x259d738f
+	csrrc x1, 1952, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1952, 0b10100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1952, 0b11101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1952, 0b01011
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# tdata1
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0x8e857296
+	csrrw x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0xe36c99db
+	csrrs x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	li x13, 0x8ab9a270
+	csrrc x1, 1953, x13
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrwi x1, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrwi x1, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrwi x1, 1953, 0b10011
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrsi x1, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrsi x1, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrsi x1, 1953, 0b10000
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrci x1, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrci x1, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	csrrci x1, 1953, 0b00100
+	li x13, 0x28001040
+	bne x13, x1, csr_fail
+	# tdata2
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x890e4a33
+	csrrw x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xe28dc122
+	csrrs x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x6d38dba7
+	csrrc x1, 1954, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1954, 0b01100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1954, 0b10101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# tdata3
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x90d97eab
+	csrrw x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xef9ea5d9
+	csrrs x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x0c9c10fc
+	csrrc x1, 1955, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1955, 0b01110
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1955, 0b01010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1955, 0b11011
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# tinfo
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0xdab5e694
+	csrrw x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0xc5779de2
+	csrrs x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	li x13, 0x76c303c9
+	csrrc x1, 1956, x13
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrwi x1, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrwi x1, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrwi x1, 1956, 0b00001
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrsi x1, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrsi x1, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrsi x1, 1956, 0b01100
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrci x1, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrci x1, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	csrrci x1, 1956, 0b00001
+	li x13, 0x00000004
+	bne x13, x1, csr_fail
+	# mcontext
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x171b00bb
+	csrrw x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x625a2d96
+	csrrs x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x46081893
+	csrrc x1, 1960, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1960, 0b11001
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	# scontext
+	li x13, 0xa5a5a5a5
+	csrrw x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xff99d532
+	csrrw x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xdac6d3ec
+	csrrs x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	li x13, 0xed3a3561
+	csrrc x1, 1962, x13
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrwi x1, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrsi x1, 1962, 0b01100
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrrci x1, 1962, 0b01001
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+	csrr x1, 1962
+	li x13, 0x00000000
+	bne x13, x1, csr_fail
+_end6:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x20, 0x0000000d
+	csrw 800,  x20 # set mcountinhibit to disable counting
+	li x20, 0x00000000
+	csrw 2816, x20 # reset cycle count
+	csrw 2944, x20
+	csrw 2818, x20 # reset instruction retired count
+	csrw 2946, x20
+	li x20, 0x00000001
+	csrw 773,  x20 # reset mtvec
+###############################################################################
+_start7:
+	# mcycle
+	li x15, 0xa5a5a5a5
+	csrrw x11, 2816, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 2816, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x11, csr_fail
+	li x15, 0x037a4d7e
+	csrrw x11, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 2816, x15
+	li x15, 0x037a4d7e
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 2816, x15
+	li x15, 0xa7ffedff
+	bne x15, x11, csr_fail
+	li x15, 0x82c591ae
+	csrrs x11, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xaa0d0311
+	csrrc x11, 2816, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2816, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 2816, 0b00001
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 2816, 0b00101
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrsi x11, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrsi x11, 2816, 0b11100
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2816, 0b00101
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2816, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 2816, 0b10101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mcycleh
+	li x15, 0xa5a5a5a5
+	csrrw x11, 2944, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 2944, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x11, csr_fail
+	li x15, 0xc99d4560
+	csrrw x11, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 2944, x15
+	li x15, 0xc99d4560
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 2944, x15
+	li x15, 0xedbde5e5
+	bne x15, x11, csr_fail
+	li x15, 0x73e85962
+	csrrs x11, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xeb39c893
+	csrrc x11, 2944, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2944, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2944, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 2944, 0b10100
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 2944, 0b00101
+	li x15, 0x00000014
+	bne x15, x11, csr_fail
+	csrrsi x11, 2944, 0b11010
+	li x15, 0x00000015
+	bne x15, x11, csr_fail
+	csrrsi x11, 2944, 0b01100
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2944, 0b00101
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2944, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 2944, 0b10101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# minstret
+	li x15, 0xa5a5a5a5
+	csrrw x11, 2818, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 2818, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x11, csr_fail
+	li x15, 0x1153ed03
+	csrrw x11, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 2818, x15
+	li x15, 0x1153ed03
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 2818, x15
+	li x15, 0xb5f7eda7
+	bne x15, x11, csr_fail
+	li x15, 0x86a93f43
+	csrrs x11, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0x74829a86
+	csrrc x11, 2818, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2818, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2818, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 2818, 0b00101
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 2818, 0b00101
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrsi x11, 2818, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrsi x11, 2818, 0b00111
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2818, 0b00101
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2818, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 2818, 0b10001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# minstreth
+	li x15, 0xa5a5a5a5
+	csrrw x11, 2946, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 2946, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x11, csr_fail
+	li x15, 0x356cc0dd
+	csrrw x11, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 2946, x15
+	li x15, 0x356cc0dd
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 2946, x15
+	li x15, 0xb5ede5fd
+	bne x15, x11, csr_fail
+	li x15, 0xd4b66026
+	csrrs x11, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0x3b3d5dc0
+	csrrc x11, 2946, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2946, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 2946, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 2946, 0b11011
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 2946, 0b00101
+	li x15, 0x0000001b
+	bne x15, x11, csr_fail
+	csrrsi x11, 2946, 0b11010
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrsi x11, 2946, 0b10000
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2946, 0b00101
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 2946, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 2946, 0b10000
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mstatus
+	li x15, 0xa5a5a5a5
+	csrrw x11, 768, x15
+	li x15, 0x00001800
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 768, x15
+	li x15, 0x00001880
+	bne x15, x11, csr_fail
+	li x15, 0x539d6068
+	csrrw x11, 768, x15
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 768, x15
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 768, x15
+	li x15, 0x00001888
+	bne x15, x11, csr_fail
+	li x15, 0xb61f748a
+	csrrs x11, 768, x15
+	li x15, 0x00001888
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 768, x15
+	li x15, 0x00001888
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 768, x15
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	li x15, 0x6beadff6
+	csrrc x11, 768, x15
+	li x15, 0x00001800
+	bne x15, x11, csr_fail
+	csrrwi x11, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x11, csr_fail
+	csrrwi x11, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x11, csr_fail
+	csrrwi x11, 768, 0b01000
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrsi x11, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrsi x11, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrsi x11, 768, 0b00111
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrci x11, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrci x11, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x11, csr_fail
+	csrrci x11, 768, 0b11110
+	li x15, 0x00001800
+	bne x15, x11, csr_fail
+	# misa
+	li x15, 0xa5a5a5a5
+	csrrw x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0x51563d97
+	csrrw x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0xd903616d
+	csrrs x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	li x15, 0x0b1bae48
+	csrrc x11, 769, x15
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrwi x11, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrwi x11, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrwi x11, 769, 0b01110
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrsi x11, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrsi x11, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrsi x11, 769, 0b11001
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrci x11, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrci x11, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	csrrci x11, 769, 0b10011
+	li x15, 0x40801104
+	bne x15, x11, csr_fail
+	# mie
+	li x15, 0xa5a5a5a5
+	csrrw x11, 772, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 772, x15
+	li x15, 0xa5a50080
+	bne x15, x11, csr_fail
+	li x15, 0xc3689c57
+	csrrw x11, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 772, x15
+	li x15, 0xc3680800
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 772, x15
+	li x15, 0xe7ed0880
+	bne x15, x11, csr_fail
+	li x15, 0x489d9027
+	csrrs x11, 772, x15
+	li x15, 0xffff0888
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 772, x15
+	li x15, 0xffff0888
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x11, csr_fail
+	li x15, 0x1885d672
+	csrrc x11, 772, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 772, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 772, 0b01010
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrsi x11, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrsi x11, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrsi x11, 772, 0b01110
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrci x11, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrci x11, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrci x11, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mtvec
+	li x15, 0xa5a5a5a5
+	csrrw x11, 773, x15
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 773, x15
+	li x15, 0xa5a5a501
+	bne x15, x11, csr_fail
+	li x15, 0x56d215d0
+	csrrw x11, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 773, x15
+	li x15, 0x56d21500
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 773, x15
+	li x15, 0xf7f7b501
+	bne x15, x11, csr_fail
+	li x15, 0x6e8836f4
+	csrrs x11, 773, x15
+	li x15, 0xffffff01
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 773, x15
+	li x15, 0xffffff01
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x11, csr_fail
+	li x15, 0xbe7cc2d7
+	csrrc x11, 773, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrwi x11, 773, 0b00111
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrsi x11, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrsi x11, 773, 0b11011
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrci x11, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x11, csr_fail
+	csrrci x11, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 773, 0b01010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mcountinhibit
+	li x15, 0xa5a5a5a5
+	csrrw x11, 800, x15
+	li x15, 0x0000000d
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 800, x15
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	li x15, 0x3986c710
+	csrrw x11, 800, x15
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 800, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 800, x15
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	li x15, 0x0cbb4e10
+	csrrs x11, 800, x15
+	li x15, 0x0000000d
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 800, x15
+	li x15, 0x0000000d
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 800, x15
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	li x15, 0x462ce286
+	csrrc x11, 800, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 800, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 800, 0b10010
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrsi x11, 800, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrsi x11, 800, 0b00011
+	li x15, 0x0000000d
+	bne x15, x11, csr_fail
+	csrrci x11, 800, 0b00101
+	li x15, 0x0000000d
+	bne x15, x11, csr_fail
+	csrrci x11, 800, 0b11010
+	li x15, 0x00000008
+	bne x15, x11, csr_fail
+	csrrci x11, 800, 0b10000
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mscratch
+	li x15, 0xa5a5a5a5
+	csrrw x11, 832, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 832, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x11, csr_fail
+	li x15, 0xdf436e15
+	csrrw x11, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 832, x15
+	li x15, 0xdf436e15
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 832, x15
+	li x15, 0xffe7efb5
+	bne x15, x11, csr_fail
+	li x15, 0xdf402052
+	csrrs x11, 832, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 832, x15
+	li x15, 0xffffffff
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0x63767684
+	csrrc x11, 832, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 832, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 832, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrwi x11, 832, 0b00100
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 832, 0b00101
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrsi x11, 832, 0b11010
+	li x15, 0x00000005
+	bne x15, x11, csr_fail
+	csrrsi x11, 832, 0b01110
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 832, 0b00101
+	li x15, 0x0000001f
+	bne x15, x11, csr_fail
+	csrrci x11, 832, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 832, 0b11001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mepc
+	li x15, 0xa5a5a5a5
+	csrrw x11, 833, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 833, x15
+	li x15, 0xa5a5a5a4
+	bne x15, x11, csr_fail
+	li x15, 0xcd97bf3f
+	csrrw x11, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 833, x15
+	li x15, 0xcd97bf3e
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 833, x15
+	li x15, 0xedb7bfbe
+	bne x15, x11, csr_fail
+	li x15, 0xebffb33d
+	csrrs x11, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x11, csr_fail
+	li x15, 0x0a2f9bc1
+	csrrc x11, 833, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 833, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 833, 0b11010
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrwi x11, 833, 0b11110
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrsi x11, 833, 0b00101
+	li x15, 0x0000001e
+	bne x15, x11, csr_fail
+	csrrsi x11, 833, 0b11010
+	li x15, 0x0000001e
+	bne x15, x11, csr_fail
+	csrrsi x11, 833, 0b01010
+	li x15, 0x0000001e
+	bne x15, x11, csr_fail
+	csrrci x11, 833, 0b00101
+	li x15, 0x0000001e
+	bne x15, x11, csr_fail
+	csrrci x11, 833, 0b11010
+	li x15, 0x0000001a
+	bne x15, x11, csr_fail
+	csrrci x11, 833, 0b00110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mtval
+	li x15, 0xa5a5a5a5
+	csrrw x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xebf3f9a7
+	csrrw x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xc1f986d8
+	csrrs x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xd1e45cbd
+	csrrc x11, 835, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 835, 0b11100
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 835, 0b10001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 835, 0b11101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# mip
+	li x15, 0xa5a5a5a5
+	csrrw x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xaa9c30ba
+	csrrw x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x0c8d49e0
+	csrrs x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xae98b82e
+	csrrc x11, 836, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 836, 0b00001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 836, 0b10110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 836, 0b00110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# tselect
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x91579cf9
+	csrrw x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xbb469d13
+	csrrs x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xcb478a8a
+	csrrc x11, 1952, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1952, 0b01111
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1952, 0b01001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1952, 0b01110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# tdata1
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0x5b2cb858
+	csrrw x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0xe1b945b9
+	csrrs x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	li x15, 0x77929968
+	csrrc x11, 1953, x15
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrwi x11, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrwi x11, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrwi x11, 1953, 0b10000
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrsi x11, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrsi x11, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrsi x11, 1953, 0b11011
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrci x11, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrci x11, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	csrrci x11, 1953, 0b11000
+	li x15, 0x28001040
+	bne x15, x11, csr_fail
+	# tdata2
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x9464885e
+	csrrw x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa2d1c4da
+	csrrs x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x329011d7
+	csrrc x11, 1954, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1954, 0b00000
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1954, 0b01011
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# tdata3
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xad0e09dc
+	csrrw x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x24207b79
+	csrrs x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x86b0048a
+	csrrc x11, 1955, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1955, 0b00011
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1955, 0b01010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1955, 0b01100
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# tinfo
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0x20a9fdab
+	csrrw x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0x955d6b90
+	csrrs x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	li x15, 0xeb6d2745
+	csrrc x11, 1956, x15
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrwi x11, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrwi x11, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrwi x11, 1956, 0b00000
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrsi x11, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrsi x11, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrsi x11, 1956, 0b10101
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrci x11, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrci x11, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	csrrci x11, 1956, 0b11001
+	li x15, 0x00000004
+	bne x15, x11, csr_fail
+	# mcontext
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x4fe6424d
+	csrrw x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x4867126e
+	csrrs x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xe555fddb
+	csrrc x11, 1960, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1960, 0b10001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1960, 0b00110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1960, 0b00110
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	# scontext
+	li x15, 0xa5a5a5a5
+	csrrw x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x46de2dac
+	csrrw x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xc5d72514
+	csrrs x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	li x15, 0x160024cb
+	csrrc x11, 1962, x15
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrwi x11, 1962, 0b10111
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrsi x11, 1962, 0b00001
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrrci x11, 1962, 0b01000
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+	csrr x11, 1962
+	li x15, 0x00000000
+	bne x15, x11, csr_fail
+_end7:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x21, 0x0000000d
+	csrw 800,  x21 # set mcountinhibit to disable counting
+	li x21, 0x00000000
+	csrw 2816, x21 # reset cycle count
+	csrw 2944, x21
+	csrw 2818, x21 # reset instruction retired count
+	csrw 2946, x21
+	li x21, 0x00000001
+	csrw 773,  x21 # reset mtvec
+###############################################################################
+_start8:
+	# mcycle
+	li x3, 0xa5a5a5a5
+	csrrw x11, 2816, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 2816, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x11, csr_fail
+	li x3, 0x47260ab3
+	csrrw x11, 2816, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 2816, x3
+	li x3, 0x47260ab3
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 2816, x3
+	li x3, 0xe7a7afb7
+	bne x3, x11, csr_fail
+	li x3, 0x11feffc5
+	csrrs x11, 2816, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 2816, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 2816, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0x637206b3
+	csrrc x11, 2816, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2816, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2816, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 2816, 0b00101
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 2816, 0b00101
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrsi x11, 2816, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrsi x11, 2816, 0b10101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2816, 0b00101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2816, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 2816, 0b01101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mcycleh
+	li x3, 0xa5a5a5a5
+	csrrw x11, 2944, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 2944, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x11, csr_fail
+	li x3, 0x259cf63c
+	csrrw x11, 2944, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 2944, x3
+	li x3, 0x259cf63c
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 2944, x3
+	li x3, 0xa5bdf7bd
+	bne x3, x11, csr_fail
+	li x3, 0xb2795be1
+	csrrs x11, 2944, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 2944, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 2944, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0x7692c415
+	csrrc x11, 2944, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2944, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2944, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 2944, 0b00001
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 2944, 0b00101
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrsi x11, 2944, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrsi x11, 2944, 0b01101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2944, 0b00101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2944, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 2944, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# minstret
+	li x3, 0xa5a5a5a5
+	csrrw x11, 2818, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 2818, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x11, csr_fail
+	li x3, 0x4ab2c4f2
+	csrrw x11, 2818, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 2818, x3
+	li x3, 0x4ab2c4f2
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 2818, x3
+	li x3, 0xefb7e5f7
+	bne x3, x11, csr_fail
+	li x3, 0x1ffffc02
+	csrrs x11, 2818, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 2818, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 2818, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xafb89b46
+	csrrc x11, 2818, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2818, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2818, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 2818, 0b00111
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 2818, 0b00101
+	li x3, 0x00000007
+	bne x3, x11, csr_fail
+	csrrsi x11, 2818, 0b11010
+	li x3, 0x00000007
+	bne x3, x11, csr_fail
+	csrrsi x11, 2818, 0b10000
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2818, 0b00101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2818, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 2818, 0b01011
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# minstreth
+	li x3, 0xa5a5a5a5
+	csrrw x11, 2946, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 2946, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x11, csr_fail
+	li x3, 0x287a35b2
+	csrrw x11, 2946, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 2946, x3
+	li x3, 0x287a35b2
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 2946, x3
+	li x3, 0xadffb5b7
+	bne x3, x11, csr_fail
+	li x3, 0x5b838d17
+	csrrs x11, 2946, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 2946, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 2946, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xeed40156
+	csrrc x11, 2946, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2946, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 2946, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 2946, 0b11000
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 2946, 0b00101
+	li x3, 0x00000018
+	bne x3, x11, csr_fail
+	csrrsi x11, 2946, 0b11010
+	li x3, 0x0000001d
+	bne x3, x11, csr_fail
+	csrrsi x11, 2946, 0b11110
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2946, 0b00101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 2946, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 2946, 0b01001
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mstatus
+	li x3, 0xa5a5a5a5
+	csrrw x11, 768, x3
+	li x3, 0x00001800
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 768, x3
+	li x3, 0x00001880
+	bne x3, x11, csr_fail
+	li x3, 0x670734ed
+	csrrw x11, 768, x3
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 768, x3
+	li x3, 0x00001888
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 768, x3
+	li x3, 0x00001888
+	bne x3, x11, csr_fail
+	li x3, 0xc7016933
+	csrrs x11, 768, x3
+	li x3, 0x00001888
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 768, x3
+	li x3, 0x00001888
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 768, x3
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	li x3, 0xb65d115a
+	csrrc x11, 768, x3
+	li x3, 0x00001800
+	bne x3, x11, csr_fail
+	csrrwi x11, 768, 0b00101
+	li x3, 0x00001800
+	bne x3, x11, csr_fail
+	csrrwi x11, 768, 0b11010
+	li x3, 0x00001800
+	bne x3, x11, csr_fail
+	csrrwi x11, 768, 0b11111
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrsi x11, 768, 0b00101
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrsi x11, 768, 0b11010
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrsi x11, 768, 0b10100
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrci x11, 768, 0b00101
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrci x11, 768, 0b11010
+	li x3, 0x00001808
+	bne x3, x11, csr_fail
+	csrrci x11, 768, 0b11010
+	li x3, 0x00001800
+	bne x3, x11, csr_fail
+	# misa
+	li x3, 0xa5a5a5a5
+	csrrw x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0x365440a5
+	csrrw x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0xa46086ce
+	csrrs x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	li x3, 0xf7b9c667
+	csrrc x11, 769, x3
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrwi x11, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrwi x11, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrwi x11, 769, 0b01111
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrsi x11, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrsi x11, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrsi x11, 769, 0b11000
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrci x11, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrci x11, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	csrrci x11, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x11, csr_fail
+	# mie
+	li x3, 0xa5a5a5a5
+	csrrw x11, 772, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 772, x3
+	li x3, 0xa5a50080
+	bne x3, x11, csr_fail
+	li x3, 0x0db57259
+	csrrw x11, 772, x3
+	li x3, 0x5a5a0808
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 772, x3
+	li x3, 0x0db50008
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 772, x3
+	li x3, 0xadb50088
+	bne x3, x11, csr_fail
+	li x3, 0x73c4dc20
+	csrrs x11, 772, x3
+	li x3, 0xffff0888
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 772, x3
+	li x3, 0xffff0888
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 772, x3
+	li x3, 0x5a5a0808
+	bne x3, x11, csr_fail
+	li x3, 0xe851c92e
+	csrrc x11, 772, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 772, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 772, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 772, 0b00111
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrsi x11, 772, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 772, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 772, 0b00100
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrci x11, 772, 0b00101
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrci x11, 772, 0b11010
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrci x11, 772, 0b01100
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mtvec
+	li x3, 0xa5a5a5a5
+	csrrw x11, 773, x3
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 773, x3
+	li x3, 0xa5a5a501
+	bne x3, x11, csr_fail
+	li x3, 0x033fbf4e
+	csrrw x11, 773, x3
+	li x3, 0x5a5a5a00
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 773, x3
+	li x3, 0x033fbf00
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 773, x3
+	li x3, 0xa7bfbf01
+	bne x3, x11, csr_fail
+	li x3, 0xcdf37008
+	csrrs x11, 773, x3
+	li x3, 0xffffff01
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 773, x3
+	li x3, 0xffffff01
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 773, x3
+	li x3, 0x5a5a5a00
+	bne x3, x11, csr_fail
+	li x3, 0x8143ed84
+	csrrc x11, 773, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 773, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 773, 0b11010
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrwi x11, 773, 0b11001
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 773, 0b00101
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrsi x11, 773, 0b11010
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrsi x11, 773, 0b00100
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrci x11, 773, 0b00101
+	li x3, 0x00000001
+	bne x3, x11, csr_fail
+	csrrci x11, 773, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 773, 0b00010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mcountinhibit
+	li x3, 0xa5a5a5a5
+	csrrw x11, 800, x3
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 800, x3
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	li x3, 0xe8c5d059
+	csrrw x11, 800, x3
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 800, x3
+	li x3, 0x00000009
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 800, x3
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	li x3, 0x1a076bd2
+	csrrs x11, 800, x3
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 800, x3
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 800, x3
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	li x3, 0x9f6eb7b8
+	csrrc x11, 800, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 800, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 800, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 800, 0b01111
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrsi x11, 800, 0b00101
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	csrrsi x11, 800, 0b11010
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	csrrsi x11, 800, 0b00000
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	csrrci x11, 800, 0b00101
+	li x3, 0x0000000d
+	bne x3, x11, csr_fail
+	csrrci x11, 800, 0b11010
+	li x3, 0x00000008
+	bne x3, x11, csr_fail
+	csrrci x11, 800, 0b10101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mscratch
+	li x3, 0xa5a5a5a5
+	csrrw x11, 832, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 832, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x11, csr_fail
+	li x3, 0xc31302ae
+	csrrw x11, 832, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 832, x3
+	li x3, 0xc31302ae
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 832, x3
+	li x3, 0xe7b7a7af
+	bne x3, x11, csr_fail
+	li x3, 0xc6888bf8
+	csrrs x11, 832, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 832, x3
+	li x3, 0xffffffff
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 832, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0x682956ec
+	csrrc x11, 832, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 832, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 832, 0b11010
+	li x3, 0x00000005
+	bne x3, x11, csr_fail
+	csrrwi x11, 832, 0b01111
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 832, 0b00101
+	li x3, 0x0000000f
+	bne x3, x11, csr_fail
+	csrrsi x11, 832, 0b11010
+	li x3, 0x0000000f
+	bne x3, x11, csr_fail
+	csrrsi x11, 832, 0b10101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 832, 0b00101
+	li x3, 0x0000001f
+	bne x3, x11, csr_fail
+	csrrci x11, 832, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 832, 0b01101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mepc
+	li x3, 0xa5a5a5a5
+	csrrw x11, 833, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 833, x3
+	li x3, 0xa5a5a5a4
+	bne x3, x11, csr_fail
+	li x3, 0x72e562e4
+	csrrw x11, 833, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 833, x3
+	li x3, 0x72e562e4
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 833, x3
+	li x3, 0xf7e5e7e4
+	bne x3, x11, csr_fail
+	li x3, 0x42fcdbe7
+	csrrs x11, 833, x3
+	li x3, 0xfffffffe
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 833, x3
+	li x3, 0xfffffffe
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 833, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x11, csr_fail
+	li x3, 0x4cb9e2ca
+	csrrc x11, 833, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 833, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 833, 0b11010
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrwi x11, 833, 0b10100
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrsi x11, 833, 0b00101
+	li x3, 0x00000014
+	bne x3, x11, csr_fail
+	csrrsi x11, 833, 0b11010
+	li x3, 0x00000014
+	bne x3, x11, csr_fail
+	csrrsi x11, 833, 0b10010
+	li x3, 0x0000001e
+	bne x3, x11, csr_fail
+	csrrci x11, 833, 0b00101
+	li x3, 0x0000001e
+	bne x3, x11, csr_fail
+	csrrci x11, 833, 0b11010
+	li x3, 0x0000001a
+	bne x3, x11, csr_fail
+	csrrci x11, 833, 0b01110
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mtval
+	li x3, 0xa5a5a5a5
+	csrrw x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xd50063dc
+	csrrw x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x10abd45b
+	csrrs x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa907a04a
+	csrrc x11, 835, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 835, 0b00000
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 835, 0b11110
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 835, 0b11011
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# mip
+	li x3, 0xa5a5a5a5
+	csrrw x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5304c02d
+	csrrw x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x64772603
+	csrrs x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x6fcd852b
+	csrrc x11, 836, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 836, 0b11110
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 836, 0b11000
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 836, 0b10001
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# tselect
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xdc9ed532
+	csrrw x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xcd2ed4dd
+	csrrs x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xe3f480b7
+	csrrc x11, 1952, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1952, 0b01000
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# tdata1
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x453d4bbb
+	csrrw x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x07147c14
+	csrrs x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	li x3, 0x9e085730
+	csrrc x11, 1953, x3
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrwi x11, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrwi x11, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrwi x11, 1953, 0b00001
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrsi x11, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrsi x11, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrsi x11, 1953, 0b00000
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrci x11, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrci x11, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	csrrci x11, 1953, 0b11000
+	li x3, 0x28001040
+	bne x3, x11, csr_fail
+	# tdata2
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xdadcb043
+	csrrw x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xf66cc215
+	csrrs x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x34b495ec
+	csrrc x11, 1954, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1954, 0b01111
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1954, 0b00010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1954, 0b11110
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# tdata3
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x8d3fe638
+	csrrw x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x58609823
+	csrrs x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x2e89c6a6
+	csrrc x11, 1955, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1955, 0b00110
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1955, 0b01001
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1955, 0b01000
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# tinfo
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0xcfffe5f2
+	csrrw x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0x2a76e9bb
+	csrrs x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	li x3, 0x404a9b33
+	csrrc x11, 1956, x3
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrwi x11, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrwi x11, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrwi x11, 1956, 0b10001
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrsi x11, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrsi x11, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrsi x11, 1956, 0b10100
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrci x11, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrci x11, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	csrrci x11, 1956, 0b01011
+	li x3, 0x00000004
+	bne x3, x11, csr_fail
+	# mcontext
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5eba50a3
+	csrrw x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5037fde5
+	csrrs x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x4ce06bd1
+	csrrc x11, 1960, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1960, 0b01111
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1960, 0b00010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1960, 0b00001
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	# scontext
+	li x3, 0xa5a5a5a5
+	csrrw x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x956a0075
+	csrrw x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x3fee2c68
+	csrrs x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	li x3, 0x2d336dee
+	csrrc x11, 1962, x3
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrwi x11, 1962, 0b10100
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrsi x11, 1962, 0b11011
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrrci x11, 1962, 0b01100
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+	csrr x11, 1962
+	li x3, 0x00000000
+	bne x3, x11, csr_fail
+_end8:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x22, 0x0000000d
+	csrw 800,  x22 # set mcountinhibit to disable counting
+	li x22, 0x00000000
+	csrw 2816, x22 # reset cycle count
+	csrw 2944, x22
+	csrw 2818, x22 # reset instruction retired count
+	csrw 2946, x22
+	li x22, 0x00000001
+	csrw 773,  x22 # reset mtvec
+###############################################################################
+_start9:
+	# mcycle
+	li x13, 0xa5a5a5a5
+	csrrw x10, 2816, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 2816, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x10, csr_fail
+	li x13, 0xdda4cad4
+	csrrw x10, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 2816, x13
+	li x13, 0xdda4cad4
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 2816, x13
+	li x13, 0xfda5eff5
+	bne x13, x10, csr_fail
+	li x13, 0x8f07ef33
+	csrrs x10, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 2816, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 2816, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xd806e9b0
+	csrrc x10, 2816, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2816, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2816, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 2816, 0b00110
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 2816, 0b00101
+	li x13, 0x00000006
+	bne x13, x10, csr_fail
+	csrrsi x10, 2816, 0b11010
+	li x13, 0x00000007
+	bne x13, x10, csr_fail
+	csrrsi x10, 2816, 0b10110
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2816, 0b00101
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2816, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 2816, 0b10100
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mcycleh
+	li x13, 0xa5a5a5a5
+	csrrw x10, 2944, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 2944, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x10, csr_fail
+	li x13, 0xfa1bc962
+	csrrw x10, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 2944, x13
+	li x13, 0xfa1bc962
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 2944, x13
+	li x13, 0xffbfede7
+	bne x13, x10, csr_fail
+	li x13, 0x0193d6e1
+	csrrs x10, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 2944, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 2944, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xd630bc22
+	csrrc x10, 2944, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2944, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2944, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 2944, 0b01101
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 2944, 0b00101
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	csrrsi x10, 2944, 0b11010
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	csrrsi x10, 2944, 0b10001
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2944, 0b00101
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2944, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 2944, 0b10011
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# minstret
+	li x13, 0xa5a5a5a5
+	csrrw x10, 2818, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 2818, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x10, csr_fail
+	li x13, 0xae185ab0
+	csrrw x10, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 2818, x13
+	li x13, 0xae185ab0
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 2818, x13
+	li x13, 0xafbdffb5
+	bne x13, x10, csr_fail
+	li x13, 0x28369d72
+	csrrs x10, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 2818, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 2818, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0x64996d93
+	csrrc x10, 2818, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2818, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2818, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 2818, 0b11000
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 2818, 0b00101
+	li x13, 0x00000018
+	bne x13, x10, csr_fail
+	csrrsi x10, 2818, 0b11010
+	li x13, 0x0000001d
+	bne x13, x10, csr_fail
+	csrrsi x10, 2818, 0b00011
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2818, 0b00101
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2818, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 2818, 0b01001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# minstreth
+	li x13, 0xa5a5a5a5
+	csrrw x10, 2946, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 2946, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x10, csr_fail
+	li x13, 0xd26ad94e
+	csrrw x10, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 2946, x13
+	li x13, 0xd26ad94e
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 2946, x13
+	li x13, 0xf7effdef
+	bne x13, x10, csr_fail
+	li x13, 0x07bf6c62
+	csrrs x10, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 2946, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 2946, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xd7a2a285
+	csrrc x10, 2946, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2946, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 2946, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 2946, 0b00100
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 2946, 0b00101
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrsi x10, 2946, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrsi x10, 2946, 0b00010
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2946, 0b00101
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 2946, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 2946, 0b01101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mstatus
+	li x13, 0xa5a5a5a5
+	csrrw x10, 768, x13
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 768, x13
+	li x13, 0x00001880
+	bne x13, x10, csr_fail
+	li x13, 0x102c239f
+	csrrw x10, 768, x13
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 768, x13
+	li x13, 0x00001888
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 768, x13
+	li x13, 0x00001888
+	bne x13, x10, csr_fail
+	li x13, 0x90d9af7c
+	csrrs x10, 768, x13
+	li x13, 0x00001888
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 768, x13
+	li x13, 0x00001888
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 768, x13
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	li x13, 0x9e3c631e
+	csrrc x10, 768, x13
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	csrrwi x10, 768, 0b00101
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	csrrwi x10, 768, 0b11010
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	csrrwi x10, 768, 0b10100
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	csrrsi x10, 768, 0b00101
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	csrrsi x10, 768, 0b11010
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	csrrsi x10, 768, 0b10101
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	csrrci x10, 768, 0b00101
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	csrrci x10, 768, 0b11010
+	li x13, 0x00001808
+	bne x13, x10, csr_fail
+	csrrci x10, 768, 0b10110
+	li x13, 0x00001800
+	bne x13, x10, csr_fail
+	# misa
+	li x13, 0xa5a5a5a5
+	csrrw x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0xbd668431
+	csrrw x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0x282da37d
+	csrrs x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	li x13, 0x7f9f2bc8
+	csrrc x10, 769, x13
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrwi x10, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrwi x10, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrwi x10, 769, 0b10000
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrsi x10, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrsi x10, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrsi x10, 769, 0b01100
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrci x10, 769, 0b00101
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrci x10, 769, 0b11010
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	csrrci x10, 769, 0b10101
+	li x13, 0x40801104
+	bne x13, x10, csr_fail
+	# mie
+	li x13, 0xa5a5a5a5
+	csrrw x10, 772, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 772, x13
+	li x13, 0xa5a50080
+	bne x13, x10, csr_fail
+	li x13, 0x4ae135e5
+	csrrw x10, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 772, x13
+	li x13, 0x4ae10080
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 772, x13
+	li x13, 0xefe50080
+	bne x13, x10, csr_fail
+	li x13, 0x73753901
+	csrrs x10, 772, x13
+	li x13, 0xffff0888
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 772, x13
+	li x13, 0xffff0888
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 772, x13
+	li x13, 0x5a5a0808
+	bne x13, x10, csr_fail
+	li x13, 0xc789b3e1
+	csrrc x10, 772, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 772, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 772, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 772, 0b01000
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrsi x10, 772, 0b00101
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrsi x10, 772, 0b11010
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrsi x10, 772, 0b00010
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrci x10, 772, 0b00101
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrci x10, 772, 0b11010
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrci x10, 772, 0b01111
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mtvec
+	li x13, 0xa5a5a5a5
+	csrrw x10, 773, x13
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 773, x13
+	li x13, 0xa5a5a501
+	bne x13, x10, csr_fail
+	li x13, 0xbf59e5c3
+	csrrw x10, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 773, x13
+	li x13, 0xbf59e501
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 773, x13
+	li x13, 0xbffde501
+	bne x13, x10, csr_fail
+	li x13, 0x29cee811
+	csrrs x10, 773, x13
+	li x13, 0xffffff01
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 773, x13
+	li x13, 0xffffff01
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 773, x13
+	li x13, 0x5a5a5a00
+	bne x13, x10, csr_fail
+	li x13, 0xd4c0eb73
+	csrrc x10, 773, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 773, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	csrrwi x10, 773, 0b01011
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	csrrsi x10, 773, 0b11010
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	csrrsi x10, 773, 0b10110
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	csrrci x10, 773, 0b00101
+	li x13, 0x00000001
+	bne x13, x10, csr_fail
+	csrrci x10, 773, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 773, 0b10001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mcountinhibit
+	li x13, 0xa5a5a5a5
+	csrrw x10, 800, x13
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 800, x13
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	li x13, 0x750adc10
+	csrrw x10, 800, x13
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 800, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 800, x13
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	li x13, 0xf76f2e04
+	csrrs x10, 800, x13
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 800, x13
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 800, x13
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	li x13, 0x8fdb22b7
+	csrrc x10, 800, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 800, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 800, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 800, 0b11110
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrsi x10, 800, 0b00101
+	li x13, 0x0000000c
+	bne x13, x10, csr_fail
+	csrrsi x10, 800, 0b11010
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	csrrsi x10, 800, 0b00101
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	csrrci x10, 800, 0b00101
+	li x13, 0x0000000d
+	bne x13, x10, csr_fail
+	csrrci x10, 800, 0b11010
+	li x13, 0x00000008
+	bne x13, x10, csr_fail
+	csrrci x10, 800, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mscratch
+	li x13, 0xa5a5a5a5
+	csrrw x10, 832, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 832, x13
+	li x13, 0xa5a5a5a5
+	bne x13, x10, csr_fail
+	li x13, 0x0806976d
+	csrrw x10, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 832, x13
+	li x13, 0x0806976d
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 832, x13
+	li x13, 0xada7b7ed
+	bne x13, x10, csr_fail
+	li x13, 0x582a0bca
+	csrrs x10, 832, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 832, x13
+	li x13, 0xffffffff
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 832, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0x3cad4625
+	csrrc x10, 832, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 832, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 832, 0b11010
+	li x13, 0x00000005
+	bne x13, x10, csr_fail
+	csrrwi x10, 832, 0b10101
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 832, 0b00101
+	li x13, 0x00000015
+	bne x13, x10, csr_fail
+	csrrsi x10, 832, 0b11010
+	li x13, 0x00000015
+	bne x13, x10, csr_fail
+	csrrsi x10, 832, 0b00010
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 832, 0b00101
+	li x13, 0x0000001f
+	bne x13, x10, csr_fail
+	csrrci x10, 832, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 832, 0b00011
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mepc
+	li x13, 0xa5a5a5a5
+	csrrw x10, 833, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 833, x13
+	li x13, 0xa5a5a5a4
+	bne x13, x10, csr_fail
+	li x13, 0xb3319bc3
+	csrrw x10, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 833, x13
+	li x13, 0xb3319bc2
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 833, x13
+	li x13, 0xb7b5bfe6
+	bne x13, x10, csr_fail
+	li x13, 0xa10cc3d1
+	csrrs x10, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 833, x13
+	li x13, 0xfffffffe
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 833, x13
+	li x13, 0x5a5a5a5a
+	bne x13, x10, csr_fail
+	li x13, 0x09677700
+	csrrc x10, 833, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 833, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 833, 0b11010
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrwi x10, 833, 0b10011
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrsi x10, 833, 0b00101
+	li x13, 0x00000012
+	bne x13, x10, csr_fail
+	csrrsi x10, 833, 0b11010
+	li x13, 0x00000016
+	bne x13, x10, csr_fail
+	csrrsi x10, 833, 0b10100
+	li x13, 0x0000001e
+	bne x13, x10, csr_fail
+	csrrci x10, 833, 0b00101
+	li x13, 0x0000001e
+	bne x13, x10, csr_fail
+	csrrci x10, 833, 0b11010
+	li x13, 0x0000001a
+	bne x13, x10, csr_fail
+	csrrci x10, 833, 0b00000
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mtval
+	li x13, 0xa5a5a5a5
+	csrrw x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x65007b6f
+	csrrw x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa1f2c3c4
+	csrrs x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x22abf9d3
+	csrrc x10, 835, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 835, 0b01110
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 835, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 835, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 835, 0b00011
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# mip
+	li x13, 0xa5a5a5a5
+	csrrw x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xef8e0f1b
+	csrrw x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x471ff430
+	csrrs x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x65ed36b2
+	csrrc x10, 836, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 836, 0b01100
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 836, 0b00001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 836, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 836, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 836, 0b10010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# tselect
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xf40e1d26
+	csrrw x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x947c0ff8
+	csrrs x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x4ba5f197
+	csrrc x10, 1952, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1952, 0b01010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1952, 0b01001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1952, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1952, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1952, 0b01110
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# tdata1
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0xcbaca07c
+	csrrw x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0x9142a7fd
+	csrrs x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	li x13, 0xd24ea87b
+	csrrc x10, 1953, x13
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrwi x10, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrwi x10, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrwi x10, 1953, 0b01110
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrsi x10, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrsi x10, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrsi x10, 1953, 0b00100
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrci x10, 1953, 0b00101
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrci x10, 1953, 0b11010
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	csrrci x10, 1953, 0b10110
+	li x13, 0x28001040
+	bne x13, x10, csr_fail
+	# tdata2
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a1a0b45
+	csrrw x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x8e56bb2d
+	csrrs x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xd7f4fc91
+	csrrc x10, 1954, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1954, 0b11000
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1954, 0b01110
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1954, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1954, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1954, 0b11100
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# tdata3
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xc5de5693
+	csrrw x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xc703bb75
+	csrrs x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xc46d9911
+	csrrc x10, 1955, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1955, 0b11001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1955, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1955, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1955, 0b10111
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# tinfo
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0xfa9d05bc
+	csrrw x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0x87ada96e
+	csrrs x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	li x13, 0xd0d3bd18
+	csrrc x10, 1956, x13
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrwi x10, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrwi x10, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrwi x10, 1956, 0b10101
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrsi x10, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrsi x10, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrsi x10, 1956, 0b00000
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrci x10, 1956, 0b00101
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrci x10, 1956, 0b11010
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	csrrci x10, 1956, 0b11100
+	li x13, 0x00000004
+	bne x13, x10, csr_fail
+	# mcontext
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x2ab77597
+	csrrw x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x94cbe503
+	csrrs x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x7a0fb086
+	csrrc x10, 1960, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1960, 0b01110
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1960, 0b00100
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1960, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1960, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1960, 0b00000
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	# scontext
+	li x13, 0xa5a5a5a5
+	csrrw x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrw x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xf2d0139f
+	csrrw x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrs x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrs x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x256114e2
+	csrrs x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0xa5a5a5a5
+	csrrc x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x5a5a5a5a
+	csrrc x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	li x13, 0x538ae17d
+	csrrc x10, 1962, x13
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrwi x10, 1962, 0b11001
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrsi x10, 1962, 0b01111
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1962, 0b00101
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1962, 0b11010
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrrci x10, 1962, 0b11100
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+	csrr x10, 1962
+	li x13, 0x00000000
+	bne x13, x10, csr_fail
+_end9:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x23, 0x0000000d
+	csrw 800,  x23 # set mcountinhibit to disable counting
+	li x23, 0x00000000
+	csrw 2816, x23 # reset cycle count
+	csrw 2944, x23
+	csrw 2818, x23 # reset instruction retired count
+	csrw 2946, x23
+	li x23, 0x00000001
+	csrw 773,  x23 # reset mtvec
+###############################################################################
+_start10:
+	# mcycle
+	li x5, 0xa5a5a5a5
+	csrrw x6, 2816, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 2816, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x6, csr_fail
+	li x5, 0xb4144635
+	csrrw x6, 2816, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 2816, x5
+	li x5, 0xb4144635
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 2816, x5
+	li x5, 0xb5b5e7b5
+	bne x5, x6, csr_fail
+	li x5, 0x6d91e3b7
+	csrrs x6, 2816, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 2816, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 2816, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0x6cbd1c5f
+	csrrc x6, 2816, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2816, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2816, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 2816, 0b10110
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 2816, 0b00101
+	li x5, 0x00000016
+	bne x5, x6, csr_fail
+	csrrsi x6, 2816, 0b11010
+	li x5, 0x00000017
+	bne x5, x6, csr_fail
+	csrrsi x6, 2816, 0b01100
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2816, 0b00101
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2816, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 2816, 0b11001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mcycleh
+	li x5, 0xa5a5a5a5
+	csrrw x6, 2944, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 2944, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x6, csr_fail
+	li x5, 0x647a831a
+	csrrw x6, 2944, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 2944, x5
+	li x5, 0x647a831a
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 2944, x5
+	li x5, 0xe5ffa7bf
+	bne x5, x6, csr_fail
+	li x5, 0xa79deba4
+	csrrs x6, 2944, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 2944, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 2944, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xc2f51f6b
+	csrrc x6, 2944, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2944, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2944, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 2944, 0b10001
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 2944, 0b00101
+	li x5, 0x00000011
+	bne x5, x6, csr_fail
+	csrrsi x6, 2944, 0b11010
+	li x5, 0x00000015
+	bne x5, x6, csr_fail
+	csrrsi x6, 2944, 0b11000
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2944, 0b00101
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2944, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 2944, 0b10110
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# minstret
+	li x5, 0xa5a5a5a5
+	csrrw x6, 2818, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 2818, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x6, csr_fail
+	li x5, 0x419aa77b
+	csrrw x6, 2818, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 2818, x5
+	li x5, 0x419aa77b
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 2818, x5
+	li x5, 0xe5bfa7ff
+	bne x5, x6, csr_fail
+	li x5, 0x27eb5856
+	csrrs x6, 2818, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 2818, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 2818, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0x02dc103b
+	csrrc x6, 2818, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2818, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2818, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 2818, 0b10100
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 2818, 0b00101
+	li x5, 0x00000014
+	bne x5, x6, csr_fail
+	csrrsi x6, 2818, 0b11010
+	li x5, 0x00000015
+	bne x5, x6, csr_fail
+	csrrsi x6, 2818, 0b11011
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2818, 0b00101
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2818, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 2818, 0b11000
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# minstreth
+	li x5, 0xa5a5a5a5
+	csrrw x6, 2946, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 2946, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x6, csr_fail
+	li x5, 0x2074869c
+	csrrw x6, 2946, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 2946, x5
+	li x5, 0x2074869c
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 2946, x5
+	li x5, 0xa5f5a7bd
+	bne x5, x6, csr_fail
+	li x5, 0xe2f1c57c
+	csrrs x6, 2946, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 2946, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 2946, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xe0e807aa
+	csrrc x6, 2946, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2946, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 2946, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 2946, 0b10010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 2946, 0b00101
+	li x5, 0x00000012
+	bne x5, x6, csr_fail
+	csrrsi x6, 2946, 0b11010
+	li x5, 0x00000017
+	bne x5, x6, csr_fail
+	csrrsi x6, 2946, 0b01100
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2946, 0b00101
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 2946, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 2946, 0b10010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mstatus
+	li x5, 0xa5a5a5a5
+	csrrw x6, 768, x5
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 768, x5
+	li x5, 0x00001880
+	bne x5, x6, csr_fail
+	li x5, 0xd6188de4
+	csrrw x6, 768, x5
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 768, x5
+	li x5, 0x00001880
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 768, x5
+	li x5, 0x00001880
+	bne x5, x6, csr_fail
+	li x5, 0xb52760c4
+	csrrs x6, 768, x5
+	li x5, 0x00001888
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 768, x5
+	li x5, 0x00001888
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 768, x5
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	li x5, 0x6f721966
+	csrrc x6, 768, x5
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	csrrwi x6, 768, 0b00101
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	csrrwi x6, 768, 0b11010
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	csrrwi x6, 768, 0b00000
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	csrrsi x6, 768, 0b00101
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	csrrsi x6, 768, 0b11010
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	csrrsi x6, 768, 0b00001
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	csrrci x6, 768, 0b00101
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	csrrci x6, 768, 0b11010
+	li x5, 0x00001808
+	bne x5, x6, csr_fail
+	csrrci x6, 768, 0b10101
+	li x5, 0x00001800
+	bne x5, x6, csr_fail
+	# misa
+	li x5, 0xa5a5a5a5
+	csrrw x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0xb06df5b1
+	csrrw x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0x651e9278
+	csrrs x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	li x5, 0x6c6efcd0
+	csrrc x6, 769, x5
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrwi x6, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrwi x6, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrwi x6, 769, 0b10010
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrsi x6, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrsi x6, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrsi x6, 769, 0b01010
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrci x6, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrci x6, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	csrrci x6, 769, 0b10011
+	li x5, 0x40801104
+	bne x5, x6, csr_fail
+	# mie
+	li x5, 0xa5a5a5a5
+	csrrw x6, 772, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 772, x5
+	li x5, 0xa5a50080
+	bne x5, x6, csr_fail
+	li x5, 0xc392c7b9
+	csrrw x6, 772, x5
+	li x5, 0x5a5a0808
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 772, x5
+	li x5, 0xc3920088
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 772, x5
+	li x5, 0xe7b70088
+	bne x5, x6, csr_fail
+	li x5, 0x54e83bee
+	csrrs x6, 772, x5
+	li x5, 0xffff0888
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 772, x5
+	li x5, 0xffff0888
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 772, x5
+	li x5, 0x5a5a0808
+	bne x5, x6, csr_fail
+	li x5, 0x6dcaa87e
+	csrrc x6, 772, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 772, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 772, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 772, 0b11011
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrsi x6, 772, 0b00101
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrsi x6, 772, 0b11010
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrsi x6, 772, 0b11010
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrci x6, 772, 0b00101
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrci x6, 772, 0b11010
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrci x6, 772, 0b10001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mtvec
+	li x5, 0xa5a5a5a5
+	csrrw x6, 773, x5
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 773, x5
+	li x5, 0xa5a5a501
+	bne x5, x6, csr_fail
+	li x5, 0xc574f6d0
+	csrrw x6, 773, x5
+	li x5, 0x5a5a5a00
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 773, x5
+	li x5, 0xc574f600
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 773, x5
+	li x5, 0xe5f5f701
+	bne x5, x6, csr_fail
+	li x5, 0x52cdba45
+	csrrs x6, 773, x5
+	li x5, 0xffffff01
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 773, x5
+	li x5, 0xffffff01
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 773, x5
+	li x5, 0x5a5a5a00
+	bne x5, x6, csr_fail
+	li x5, 0x43836ec9
+	csrrc x6, 773, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 773, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 773, 0b11010
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	csrrwi x6, 773, 0b10101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 773, 0b00101
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	csrrsi x6, 773, 0b11010
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	csrrsi x6, 773, 0b10000
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	csrrci x6, 773, 0b00101
+	li x5, 0x00000001
+	bne x5, x6, csr_fail
+	csrrci x6, 773, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 773, 0b01000
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mcountinhibit
+	li x5, 0xa5a5a5a5
+	csrrw x6, 800, x5
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 800, x5
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	li x5, 0xde191c99
+	csrrw x6, 800, x5
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 800, x5
+	li x5, 0x00000009
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 800, x5
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	li x5, 0x2c8ac1e1
+	csrrs x6, 800, x5
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 800, x5
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 800, x5
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	li x5, 0xa68c3976
+	csrrc x6, 800, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 800, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 800, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 800, 0b11001
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrsi x6, 800, 0b00101
+	li x5, 0x00000009
+	bne x5, x6, csr_fail
+	csrrsi x6, 800, 0b11010
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	csrrsi x6, 800, 0b10110
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	csrrci x6, 800, 0b00101
+	li x5, 0x0000000d
+	bne x5, x6, csr_fail
+	csrrci x6, 800, 0b11010
+	li x5, 0x00000008
+	bne x5, x6, csr_fail
+	csrrci x6, 800, 0b01101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mscratch
+	li x5, 0xa5a5a5a5
+	csrrw x6, 832, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 832, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x6, csr_fail
+	li x5, 0x3c6cbe13
+	csrrw x6, 832, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 832, x5
+	li x5, 0x3c6cbe13
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 832, x5
+	li x5, 0xbdedbfb7
+	bne x5, x6, csr_fail
+	li x5, 0x1632c1bd
+	csrrs x6, 832, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 832, x5
+	li x5, 0xffffffff
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 832, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0x2a19671a
+	csrrc x6, 832, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 832, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 832, 0b11010
+	li x5, 0x00000005
+	bne x5, x6, csr_fail
+	csrrwi x6, 832, 0b01011
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 832, 0b00101
+	li x5, 0x0000000b
+	bne x5, x6, csr_fail
+	csrrsi x6, 832, 0b11010
+	li x5, 0x0000000f
+	bne x5, x6, csr_fail
+	csrrsi x6, 832, 0b00000
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 832, 0b00101
+	li x5, 0x0000001f
+	bne x5, x6, csr_fail
+	csrrci x6, 832, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 832, 0b00001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mepc
+	li x5, 0xa5a5a5a5
+	csrrw x6, 833, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 833, x5
+	li x5, 0xa5a5a5a4
+	bne x5, x6, csr_fail
+	li x5, 0x3f50a4f0
+	csrrw x6, 833, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 833, x5
+	li x5, 0x3f50a4f0
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 833, x5
+	li x5, 0xbff5a5f4
+	bne x5, x6, csr_fail
+	li x5, 0x8db6b7ff
+	csrrs x6, 833, x5
+	li x5, 0xfffffffe
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 833, x5
+	li x5, 0xfffffffe
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 833, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x6, csr_fail
+	li x5, 0xd170f6d5
+	csrrc x6, 833, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 833, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 833, 0b11010
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrwi x6, 833, 0b11000
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrsi x6, 833, 0b00101
+	li x5, 0x00000018
+	bne x5, x6, csr_fail
+	csrrsi x6, 833, 0b11010
+	li x5, 0x0000001c
+	bne x5, x6, csr_fail
+	csrrsi x6, 833, 0b10101
+	li x5, 0x0000001e
+	bne x5, x6, csr_fail
+	csrrci x6, 833, 0b00101
+	li x5, 0x0000001e
+	bne x5, x6, csr_fail
+	csrrci x6, 833, 0b11010
+	li x5, 0x0000001a
+	bne x5, x6, csr_fail
+	csrrci x6, 833, 0b11100
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mtval
+	li x5, 0xa5a5a5a5
+	csrrw x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa4d627f2
+	csrrw x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x55b27511
+	csrrs x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa7fba71a
+	csrrc x6, 835, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 835, 0b11001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 835, 0b10100
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# mip
+	li x5, 0xa5a5a5a5
+	csrrw x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5fc48b5a
+	csrrw x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x9c20ea98
+	csrrs x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xd0f67129
+	csrrc x6, 836, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 836, 0b00001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 836, 0b01110
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# tselect
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xc2d94dd0
+	csrrw x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x765f4ce8
+	csrrs x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xba958d9f
+	csrrc x6, 1952, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1952, 0b11011
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1952, 0b10111
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1952, 0b11000
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# tdata1
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0x229ee84d
+	csrrw x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0x678ea1d5
+	csrrs x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	li x5, 0xacc11f32
+	csrrc x6, 1953, x5
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrwi x6, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrwi x6, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrwi x6, 1953, 0b10111
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrsi x6, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrsi x6, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrsi x6, 1953, 0b11101
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrci x6, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrci x6, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	csrrci x6, 1953, 0b01001
+	li x5, 0x28001040
+	bne x5, x6, csr_fail
+	# tdata2
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xc225163c
+	csrrw x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x0766712b
+	csrrs x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x06e25665
+	csrrc x6, 1954, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1954, 0b11001
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1954, 0b01010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1954, 0b10000
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# tdata3
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x20912924
+	csrrw x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x01c73f57
+	csrrs x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x32b80985
+	csrrc x6, 1955, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1955, 0b11011
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1955, 0b01110
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1955, 0b10100
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# tinfo
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x6dfc9daf
+	csrrw x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x46e89cf7
+	csrrs x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	li x5, 0x5a392e8d
+	csrrc x6, 1956, x5
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrwi x6, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrwi x6, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrwi x6, 1956, 0b00000
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrsi x6, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrsi x6, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrsi x6, 1956, 0b01111
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrci x6, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrci x6, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	csrrci x6, 1956, 0b00111
+	li x5, 0x00000004
+	bne x5, x6, csr_fail
+	# mcontext
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xb355aa2b
+	csrrw x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x67163802
+	csrrs x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xe6658d45
+	csrrc x6, 1960, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1960, 0b11110
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1960, 0b11111
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1960, 0b01100
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	# scontext
+	li x5, 0xa5a5a5a5
+	csrrw x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xd6ceaa59
+	csrrw x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xdb04fdb2
+	csrrs x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	li x5, 0x77a367e3
+	csrrc x6, 1962, x5
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrwi x6, 1962, 0b01011
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrsi x6, 1962, 0b11111
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrrci x6, 1962, 0b10000
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+	csrr x6, 1962
+	li x5, 0x00000000
+	bne x5, x6, csr_fail
+_end10:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x24, 0x0000000d
+	csrw 800,  x24 # set mcountinhibit to disable counting
+	li x24, 0x00000000
+	csrw 2816, x24 # reset cycle count
+	csrw 2944, x24
+	csrw 2818, x24 # reset instruction retired count
+	csrw 2946, x24
+	li x24, 0x00000001
+	csrw 773,  x24 # reset mtvec
+###############################################################################
+_start11:
+	# mcycle
+	li x11, 0xa5a5a5a5
+	csrrw x3, 2816, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 2816, x11
+	li x11, 0xa5a5a5a5
+	bne x11, x3, csr_fail
+	li x11, 0xff75e27b
+	csrrw x3, 2816, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 2816, x11
+	li x11, 0xff75e27b
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 2816, x11
+	li x11, 0xfff5e7ff
+	bne x11, x3, csr_fail
+	li x11, 0xfaf0507b
+	csrrs x3, 2816, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 2816, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 2816, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0x0b065e95
+	csrrc x3, 2816, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2816, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2816, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 2816, 0b10100
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 2816, 0b00101
+	li x11, 0x00000014
+	bne x11, x3, csr_fail
+	csrrsi x3, 2816, 0b11010
+	li x11, 0x00000015
+	bne x11, x3, csr_fail
+	csrrsi x3, 2816, 0b11001
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2816, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2816, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 2816, 0b01111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mcycleh
+	li x11, 0xa5a5a5a5
+	csrrw x3, 2944, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 2944, x11
+	li x11, 0xa5a5a5a5
+	bne x11, x3, csr_fail
+	li x11, 0x92007db6
+	csrrw x3, 2944, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 2944, x11
+	li x11, 0x92007db6
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 2944, x11
+	li x11, 0xb7a5fdb7
+	bne x11, x3, csr_fail
+	li x11, 0x332c80ed
+	csrrs x3, 2944, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 2944, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 2944, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xd21da365
+	csrrc x3, 2944, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2944, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2944, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 2944, 0b01000
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 2944, 0b00101
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrsi x3, 2944, 0b11010
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	csrrsi x3, 2944, 0b10001
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2944, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2944, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 2944, 0b10001
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# minstret
+	li x11, 0xa5a5a5a5
+	csrrw x3, 2818, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 2818, x11
+	li x11, 0xa5a5a5a5
+	bne x11, x3, csr_fail
+	li x11, 0x79cac8ec
+	csrrw x3, 2818, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 2818, x11
+	li x11, 0x79cac8ec
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 2818, x11
+	li x11, 0xfdefeded
+	bne x11, x3, csr_fail
+	li x11, 0x24eaec50
+	csrrs x3, 2818, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 2818, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 2818, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0x691b4213
+	csrrc x3, 2818, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2818, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2818, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 2818, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 2818, 0b00101
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 2818, 0b11010
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrsi x3, 2818, 0b10111
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2818, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2818, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 2818, 0b01101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# minstreth
+	li x11, 0xa5a5a5a5
+	csrrw x3, 2946, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 2946, x11
+	li x11, 0xa5a5a5a5
+	bne x11, x3, csr_fail
+	li x11, 0xbc857244
+	csrrw x3, 2946, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 2946, x11
+	li x11, 0xbc857244
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 2946, x11
+	li x11, 0xbda5f7e5
+	bne x11, x3, csr_fail
+	li x11, 0xccd55bf9
+	csrrs x3, 2946, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 2946, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 2946, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xaf391278
+	csrrc x3, 2946, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2946, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 2946, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 2946, 0b10110
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 2946, 0b00101
+	li x11, 0x00000016
+	bne x11, x3, csr_fail
+	csrrsi x3, 2946, 0b11010
+	li x11, 0x00000017
+	bne x11, x3, csr_fail
+	csrrsi x3, 2946, 0b01001
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2946, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 2946, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 2946, 0b10000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mstatus
+	li x11, 0xa5a5a5a5
+	csrrw x3, 768, x11
+	li x11, 0x00001800
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 768, x11
+	li x11, 0x00001880
+	bne x11, x3, csr_fail
+	li x11, 0xa703f9b2
+	csrrw x3, 768, x11
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 768, x11
+	li x11, 0x00001880
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 768, x11
+	li x11, 0x00001880
+	bne x11, x3, csr_fail
+	li x11, 0x1ebf86c5
+	csrrs x3, 768, x11
+	li x11, 0x00001888
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 768, x11
+	li x11, 0x00001888
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 768, x11
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	li x11, 0xd5c5f1ac
+	csrrc x3, 768, x11
+	li x11, 0x00001800
+	bne x11, x3, csr_fail
+	csrrwi x3, 768, 0b00101
+	li x11, 0x00001800
+	bne x11, x3, csr_fail
+	csrrwi x3, 768, 0b11010
+	li x11, 0x00001800
+	bne x11, x3, csr_fail
+	csrrwi x3, 768, 0b11010
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrsi x3, 768, 0b00101
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrsi x3, 768, 0b11010
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrsi x3, 768, 0b11111
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrci x3, 768, 0b00101
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrci x3, 768, 0b11010
+	li x11, 0x00001808
+	bne x11, x3, csr_fail
+	csrrci x3, 768, 0b01000
+	li x11, 0x00001800
+	bne x11, x3, csr_fail
+	# misa
+	li x11, 0xa5a5a5a5
+	csrrw x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0xcb9fd9b8
+	csrrw x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0xf5f874fb
+	csrrs x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	li x11, 0x2e787069
+	csrrc x3, 769, x11
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrwi x3, 769, 0b00101
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrwi x3, 769, 0b11010
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrwi x3, 769, 0b01111
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrsi x3, 769, 0b00101
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrsi x3, 769, 0b11010
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrsi x3, 769, 0b00100
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrci x3, 769, 0b00101
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrci x3, 769, 0b11010
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	csrrci x3, 769, 0b10111
+	li x11, 0x40801104
+	bne x11, x3, csr_fail
+	# mie
+	li x11, 0xa5a5a5a5
+	csrrw x3, 772, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 772, x11
+	li x11, 0xa5a50080
+	bne x11, x3, csr_fail
+	li x11, 0x33378a65
+	csrrw x3, 772, x11
+	li x11, 0x5a5a0808
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 772, x11
+	li x11, 0x33370800
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 772, x11
+	li x11, 0xb7b70880
+	bne x11, x3, csr_fail
+	li x11, 0x527b862b
+	csrrs x3, 772, x11
+	li x11, 0xffff0888
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 772, x11
+	li x11, 0xffff0888
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 772, x11
+	li x11, 0x5a5a0808
+	bne x11, x3, csr_fail
+	li x11, 0xed68418d
+	csrrc x3, 772, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 772, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 772, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 772, 0b10011
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrsi x3, 772, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 772, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 772, 0b11101
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrci x3, 772, 0b00101
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrci x3, 772, 0b11010
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrci x3, 772, 0b11101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mtvec
+	li x11, 0xa5a5a5a5
+	csrrw x3, 773, x11
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 773, x11
+	li x11, 0xa5a5a501
+	bne x11, x3, csr_fail
+	li x11, 0x6f0577e7
+	csrrw x3, 773, x11
+	li x11, 0x5a5a5a00
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 773, x11
+	li x11, 0x6f057701
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 773, x11
+	li x11, 0xefa5f701
+	bne x11, x3, csr_fail
+	li x11, 0x0cedabd2
+	csrrs x3, 773, x11
+	li x11, 0xffffff01
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 773, x11
+	li x11, 0xffffff01
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 773, x11
+	li x11, 0x5a5a5a00
+	bne x11, x3, csr_fail
+	li x11, 0x45769cb4
+	csrrc x3, 773, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 773, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 773, 0b11010
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	csrrwi x3, 773, 0b11011
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 773, 0b00101
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	csrrsi x3, 773, 0b11010
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	csrrsi x3, 773, 0b01001
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	csrrci x3, 773, 0b00101
+	li x11, 0x00000001
+	bne x11, x3, csr_fail
+	csrrci x3, 773, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 773, 0b01100
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mcountinhibit
+	li x11, 0xa5a5a5a5
+	csrrw x3, 800, x11
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 800, x11
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	li x11, 0x6860e8af
+	csrrw x3, 800, x11
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 800, x11
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 800, x11
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	li x11, 0xbb0c5c24
+	csrrs x3, 800, x11
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 800, x11
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 800, x11
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	li x11, 0x7837a7d1
+	csrrc x3, 800, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 800, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 800, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 800, 0b10111
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrsi x3, 800, 0b00101
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrsi x3, 800, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrsi x3, 800, 0b10001
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	csrrci x3, 800, 0b00101
+	li x11, 0x0000000d
+	bne x11, x3, csr_fail
+	csrrci x3, 800, 0b11010
+	li x11, 0x00000008
+	bne x11, x3, csr_fail
+	csrrci x3, 800, 0b10111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mscratch
+	li x11, 0xa5a5a5a5
+	csrrw x3, 832, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 832, x11
+	li x11, 0xa5a5a5a5
+	bne x11, x3, csr_fail
+	li x11, 0x086af753
+	csrrw x3, 832, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 832, x11
+	li x11, 0x086af753
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 832, x11
+	li x11, 0xadeff7f7
+	bne x11, x3, csr_fail
+	li x11, 0x5f388002
+	csrrs x3, 832, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 832, x11
+	li x11, 0xffffffff
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 832, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0x8ab59c8c
+	csrrc x3, 832, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 832, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 832, 0b11010
+	li x11, 0x00000005
+	bne x11, x3, csr_fail
+	csrrwi x3, 832, 0b11111
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 832, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrsi x3, 832, 0b11010
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrsi x3, 832, 0b10001
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 832, 0b00101
+	li x11, 0x0000001f
+	bne x11, x3, csr_fail
+	csrrci x3, 832, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 832, 0b01111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mepc
+	li x11, 0xa5a5a5a5
+	csrrw x3, 833, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 833, x11
+	li x11, 0xa5a5a5a4
+	bne x11, x3, csr_fail
+	li x11, 0x9373e06c
+	csrrw x3, 833, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 833, x11
+	li x11, 0x9373e06c
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 833, x11
+	li x11, 0xb7f7e5ec
+	bne x11, x3, csr_fail
+	li x11, 0x2c645730
+	csrrs x3, 833, x11
+	li x11, 0xfffffffe
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 833, x11
+	li x11, 0xfffffffe
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 833, x11
+	li x11, 0x5a5a5a5a
+	bne x11, x3, csr_fail
+	li x11, 0xc4e905bd
+	csrrc x3, 833, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 833, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 833, 0b11010
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrwi x3, 833, 0b11001
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrsi x3, 833, 0b00101
+	li x11, 0x00000018
+	bne x11, x3, csr_fail
+	csrrsi x3, 833, 0b11010
+	li x11, 0x0000001c
+	bne x11, x3, csr_fail
+	csrrsi x3, 833, 0b11101
+	li x11, 0x0000001e
+	bne x11, x3, csr_fail
+	csrrci x3, 833, 0b00101
+	li x11, 0x0000001e
+	bne x11, x3, csr_fail
+	csrrci x3, 833, 0b11010
+	li x11, 0x0000001a
+	bne x11, x3, csr_fail
+	csrrci x3, 833, 0b11000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mtval
+	li x11, 0xa5a5a5a5
+	csrrw x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x08b341da
+	csrrw x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa7eaf0f6
+	csrrs x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xeba09819
+	csrrc x3, 835, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 835, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 835, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 835, 0b10000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 835, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 835, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 835, 0b10010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 835, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 835, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 835, 0b01010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# mip
+	li x11, 0xa5a5a5a5
+	csrrw x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x44593a0c
+	csrrw x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa7b84442
+	csrrs x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x22fa1c7b
+	csrrc x3, 836, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 836, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 836, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 836, 0b10101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 836, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 836, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 836, 0b01011
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 836, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 836, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 836, 0b00000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# tselect
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xd00e6724
+	csrrw x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xd3f7fa21
+	csrrs x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xba86c521
+	csrrc x3, 1952, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1952, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1952, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1952, 0b10101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1952, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1952, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1952, 0b11011
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1952, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1952, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1952, 0b01001
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# tdata1
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0x12b5b822
+	csrrw x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0xdb2ab8d9
+	csrrs x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	li x11, 0x34a843af
+	csrrc x3, 1953, x11
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrwi x3, 1953, 0b00101
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrwi x3, 1953, 0b11010
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrwi x3, 1953, 0b10011
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrsi x3, 1953, 0b00101
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrsi x3, 1953, 0b11010
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrsi x3, 1953, 0b01110
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrci x3, 1953, 0b00101
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrci x3, 1953, 0b11010
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	csrrci x3, 1953, 0b01010
+	li x11, 0x28001040
+	bne x11, x3, csr_fail
+	# tdata2
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xc95a8da1
+	csrrw x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xf08c247c
+	csrrs x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xc765ee80
+	csrrc x3, 1954, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1954, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1954, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1954, 0b00111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1954, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1954, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1954, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1954, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1954, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1954, 0b00010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# tdata3
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x105e8a94
+	csrrw x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xd6678266
+	csrrs x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xf4f108bb
+	csrrc x3, 1955, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1955, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1955, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1955, 0b01000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1955, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1955, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1955, 0b00111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1955, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1955, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1955, 0b01101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# tinfo
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x68e75d28
+	csrrw x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x0d0b94d1
+	csrrs x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	li x11, 0x82a7d74b
+	csrrc x3, 1956, x11
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrwi x3, 1956, 0b00101
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrwi x3, 1956, 0b11010
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrwi x3, 1956, 0b10111
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrsi x3, 1956, 0b00101
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrsi x3, 1956, 0b11010
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrsi x3, 1956, 0b01100
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrci x3, 1956, 0b00101
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrci x3, 1956, 0b11010
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	csrrci x3, 1956, 0b10011
+	li x11, 0x00000004
+	bne x11, x3, csr_fail
+	# mcontext
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x19f5f3a0
+	csrrw x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xc39fcceb
+	csrrs x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xc4ba7402
+	csrrc x3, 1960, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1960, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1960, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1960, 0b10111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1960, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1960, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1960, 0b10011
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1960, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1960, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1960, 0b01111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	# scontext
+	li x11, 0xa5a5a5a5
+	csrrw x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrw x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x14d47728
+	csrrw x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrs x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrs x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xabe436c8
+	csrrs x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xa5a5a5a5
+	csrrc x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0x5a5a5a5a
+	csrrc x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	li x11, 0xab231b42
+	csrrc x3, 1962, x11
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1962, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1962, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrwi x3, 1962, 0b11000
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1962, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1962, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrsi x3, 1962, 0b10111
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1962, 0b00101
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1962, 0b11010
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrrci x3, 1962, 0b11001
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+	csrr x3, 1962
+	li x11, 0x00000000
+	bne x11, x3, csr_fail
+_end11:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x25, 0x0000000d
+	csrw 800,  x25 # set mcountinhibit to disable counting
+	li x25, 0x00000000
+	csrw 2816, x25 # reset cycle count
+	csrw 2944, x25
+	csrw 2818, x25 # reset instruction retired count
+	csrw 2946, x25
+	li x25, 0x00000001
+	csrw 773,  x25 # reset mtvec
+###############################################################################
+_start12:
+	# mcycle
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2816, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2816, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x50407523
+	csrrw x12, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2816, x15
+	li x15, 0x50407523
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2816, x15
+	li x15, 0xf5e5f5a7
+	bne x15, x12, csr_fail
+	li x15, 0x570df8a6
+	csrrs x12, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xab837d95
+	csrrc x12, 2816, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b00111
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x15, 0x00000007
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x15, 0x00000007
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b01001
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b00001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mcycleh
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2944, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2944, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0xad94618c
+	csrrw x12, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2944, x15
+	li x15, 0xad94618c
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2944, x15
+	li x15, 0xadb5e5ad
+	bne x15, x12, csr_fail
+	li x15, 0x29bc75e1
+	csrrs x12, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x8462f903
+	csrrc x12, 2944, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b00100
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b11101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b01001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# minstret
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2818, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2818, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x34ec929d
+	csrrw x12, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2818, x15
+	li x15, 0x34ec929d
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2818, x15
+	li x15, 0xb5edb7bd
+	bne x15, x12, csr_fail
+	li x15, 0x52d15c83
+	csrrs x12, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x73d9d2c1
+	csrrc x12, 2818, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b01011
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x15, 0x0000000b
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x15, 0x0000000f
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b10001
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b01011
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# minstreth
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2946, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2946, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0xb48afd9b
+	csrrw x12, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2946, x15
+	li x15, 0xb48afd9b
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2946, x15
+	li x15, 0xb5affdbf
+	bne x15, x12, csr_fail
+	li x15, 0x2fabf971
+	csrrs x12, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x421db379
+	csrrc x12, 2946, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b10001
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x15, 0x00000011
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x15, 0x00000015
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b10110
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b01001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mstatus
+	li x15, 0xa5a5a5a5
+	csrrw x12, 768, x15
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 768, x15
+	li x15, 0x00001880
+	bne x15, x12, csr_fail
+	li x15, 0x1c1fa688
+	csrrw x12, 768, x15
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0x929e21d8
+	csrrs x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 768, x15
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	li x15, 0x22e459c1
+	csrrc x12, 768, x15
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b00110
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b11100
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b00111
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	# misa
+	li x15, 0xa5a5a5a5
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x85d8ecd4
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x0a69a79e
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x76781d93
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b10010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b10001
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	# mie
+	li x15, 0xa5a5a5a5
+	csrrw x12, 772, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 772, x15
+	li x15, 0xa5a50080
+	bne x15, x12, csr_fail
+	li x15, 0x33bba39e
+	csrrw x12, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 772, x15
+	li x15, 0x33bb0088
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 772, x15
+	li x15, 0xb7bf0088
+	bne x15, x12, csr_fail
+	li x15, 0x454212fb
+	csrrs x12, 772, x15
+	li x15, 0xffff0888
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 772, x15
+	li x15, 0xffff0888
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x12, csr_fail
+	li x15, 0xbb0d0089
+	csrrc x12, 772, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b11000
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b11011
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mtvec
+	li x15, 0xa5a5a5a5
+	csrrw x12, 773, x15
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 773, x15
+	li x15, 0xa5a5a501
+	bne x15, x12, csr_fail
+	li x15, 0xd7e30ab3
+	csrrw x12, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 773, x15
+	li x15, 0xd7e30a01
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 773, x15
+	li x15, 0xf7e7af01
+	bne x15, x12, csr_fail
+	li x15, 0x5f14b23a
+	csrrs x12, 773, x15
+	li x15, 0xffffff01
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 773, x15
+	li x15, 0xffffff01
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x12, csr_fail
+	li x15, 0x1f9ab724
+	csrrc x12, 773, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b10011
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mcountinhibit
+	li x15, 0xa5a5a5a5
+	csrrw x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 800, x15
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	li x15, 0x87dd2181
+	csrrw x12, 800, x15
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 800, x15
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 800, x15
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	li x15, 0xc6121bda
+	csrrs x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 800, x15
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	li x15, 0x9df56cbc
+	csrrc x12, 800, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b01111
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b01111
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b11000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mscratch
+	li x15, 0xa5a5a5a5
+	csrrw x12, 832, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 832, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x43f671f3
+	csrrw x12, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 832, x15
+	li x15, 0x43f671f3
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 832, x15
+	li x15, 0xe7f7f5f7
+	bne x15, x12, csr_fail
+	li x15, 0x06381d34
+	csrrs x12, 832, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 832, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x36ccbc45
+	csrrc x12, 832, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b01000
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b01110
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b10010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mepc
+	li x15, 0xa5a5a5a5
+	csrrw x12, 833, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 833, x15
+	li x15, 0xa5a5a5a4
+	bne x15, x12, csr_fail
+	li x15, 0xcb5807e2
+	csrrw x12, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 833, x15
+	li x15, 0xcb5807e2
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 833, x15
+	li x15, 0xeffda7e6
+	bne x15, x12, csr_fail
+	li x15, 0x3c3cdb80
+	csrrs x12, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xae19dbc6
+	csrrc x12, 833, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b11101
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x15, 0x0000001c
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x15, 0x0000001c
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b00000
+	li x15, 0x0000001e
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x15, 0x0000001e
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b01000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mtval
+	li x15, 0xa5a5a5a5
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x6005ac77
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x7d91d11a
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x51605234
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b00100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b11000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mip
+	li x15, 0xa5a5a5a5
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xfb56939e
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xfb6e8e54
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x944ea808
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b10110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b10000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b10001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tselect
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x61681e37
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x79a762f8
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x09dbf81a
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b00000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b10100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b00011
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tdata1
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x0449c19b
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xdadfa637
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x124c006b
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b01110
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b11000
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	# tdata2
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x2f0de692
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x50683208
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x4c17be7d
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b01010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b01111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tdata3
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5bbdb9cf
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x0ae97ba3
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x805c4dfb
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b00110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b01000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tinfo
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x59684231
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x23c4eeae
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x59dea9a7
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b11001
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b10101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b01000
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	# mcontext
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa884188b
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x3c69046b
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xda8fa8d5
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b01001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b01101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b10110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# scontext
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x3196f916
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xde37ee8c
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xf3d5c478
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrr x12, 1962
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+_end12:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x26, 0x0000000d
+	csrw 800,  x26 # set mcountinhibit to disable counting
+	li x26, 0x00000000
+	csrw 2816, x26 # reset cycle count
+	csrw 2944, x26
+	csrw 2818, x26 # reset instruction retired count
+	csrw 2946, x26
+	li x26, 0x00000001
+	csrw 773,  x26 # reset mtvec
+###############################################################################
+_start13:
+	# mcycle
+	li x15, 0xa5a5a5a5
+	csrrw x9, 2816, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 2816, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x9, csr_fail
+	li x15, 0xce2c8b76
+	csrrw x9, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 2816, x15
+	li x15, 0xce2c8b76
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 2816, x15
+	li x15, 0xefadaff7
+	bne x15, x9, csr_fail
+	li x15, 0x4fdb262b
+	csrrs x9, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xd40f873c
+	csrrc x9, 2816, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2816, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 2816, 0b11110
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 2816, 0b00101
+	li x15, 0x0000001e
+	bne x15, x9, csr_fail
+	csrrsi x9, 2816, 0b11010
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrsi x9, 2816, 0b11001
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2816, 0b00101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2816, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 2816, 0b10100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mcycleh
+	li x15, 0xa5a5a5a5
+	csrrw x9, 2944, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 2944, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x9, csr_fail
+	li x15, 0x2be4cfdf
+	csrrw x9, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 2944, x15
+	li x15, 0x2be4cfdf
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 2944, x15
+	li x15, 0xafe5efff
+	bne x15, x9, csr_fail
+	li x15, 0xa9b8a54e
+	csrrs x9, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0x54e3b687
+	csrrc x9, 2944, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2944, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2944, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 2944, 0b11100
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 2944, 0b00101
+	li x15, 0x0000001c
+	bne x15, x9, csr_fail
+	csrrsi x9, 2944, 0b11010
+	li x15, 0x0000001d
+	bne x15, x9, csr_fail
+	csrrsi x9, 2944, 0b01101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2944, 0b00101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2944, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 2944, 0b00100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# minstret
+	li x15, 0xa5a5a5a5
+	csrrw x9, 2818, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 2818, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x9, csr_fail
+	li x15, 0x4f4acf18
+	csrrw x9, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 2818, x15
+	li x15, 0x4f4acf18
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 2818, x15
+	li x15, 0xefefefbd
+	bne x15, x9, csr_fail
+	li x15, 0xfd62f592
+	csrrs x9, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0x51acb75a
+	csrrc x9, 2818, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2818, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2818, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 2818, 0b01100
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 2818, 0b00101
+	li x15, 0x0000000c
+	bne x15, x9, csr_fail
+	csrrsi x9, 2818, 0b11010
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	csrrsi x9, 2818, 0b01001
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2818, 0b00101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2818, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 2818, 0b10100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# minstreth
+	li x15, 0xa5a5a5a5
+	csrrw x9, 2946, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 2946, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x9, csr_fail
+	li x15, 0x40cb1762
+	csrrw x9, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 2946, x15
+	li x15, 0x40cb1762
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 2946, x15
+	li x15, 0xe5efb7e7
+	bne x15, x9, csr_fail
+	li x15, 0xa1b1b62b
+	csrrs x9, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0x5b1d0438
+	csrrc x9, 2946, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2946, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 2946, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 2946, 0b11000
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 2946, 0b00101
+	li x15, 0x00000018
+	bne x15, x9, csr_fail
+	csrrsi x9, 2946, 0b11010
+	li x15, 0x0000001d
+	bne x15, x9, csr_fail
+	csrrsi x9, 2946, 0b10010
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2946, 0b00101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 2946, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 2946, 0b01100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mstatus
+	li x15, 0xa5a5a5a5
+	csrrw x9, 768, x15
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 768, x15
+	li x15, 0x00001880
+	bne x15, x9, csr_fail
+	li x15, 0xe3bb0b51
+	csrrw x9, 768, x15
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 768, x15
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 768, x15
+	li x15, 0x00001880
+	bne x15, x9, csr_fail
+	li x15, 0xe2bd3b59
+	csrrs x9, 768, x15
+	li x15, 0x00001888
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 768, x15
+	li x15, 0x00001888
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 768, x15
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	li x15, 0x741c3cdb
+	csrrc x9, 768, x15
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	csrrwi x9, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	csrrwi x9, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	csrrwi x9, 768, 0b10100
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	csrrsi x9, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	csrrsi x9, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	csrrsi x9, 768, 0b01101
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	csrrci x9, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	csrrci x9, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x9, csr_fail
+	csrrci x9, 768, 0b01110
+	li x15, 0x00001800
+	bne x15, x9, csr_fail
+	# misa
+	li x15, 0xa5a5a5a5
+	csrrw x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0x633f7462
+	csrrw x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0xbdd37b7e
+	csrrs x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	li x15, 0x0a7b084a
+	csrrc x9, 769, x15
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrwi x9, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrwi x9, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrwi x9, 769, 0b10010
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrsi x9, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrsi x9, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrsi x9, 769, 0b00000
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrci x9, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrci x9, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	csrrci x9, 769, 0b00001
+	li x15, 0x40801104
+	bne x15, x9, csr_fail
+	# mie
+	li x15, 0xa5a5a5a5
+	csrrw x9, 772, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 772, x15
+	li x15, 0xa5a50080
+	bne x15, x9, csr_fail
+	li x15, 0xead23aef
+	csrrw x9, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 772, x15
+	li x15, 0xead20888
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 772, x15
+	li x15, 0xeff70888
+	bne x15, x9, csr_fail
+	li x15, 0x05eb5c5d
+	csrrs x9, 772, x15
+	li x15, 0xffff0888
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 772, x15
+	li x15, 0xffff0888
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x9, csr_fail
+	li x15, 0x32d9ec77
+	csrrc x9, 772, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 772, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 772, 0b11000
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrsi x9, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrsi x9, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrsi x9, 772, 0b11000
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrci x9, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrci x9, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrci x9, 772, 0b11101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mtvec
+	li x15, 0xa5a5a5a5
+	csrrw x9, 773, x15
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 773, x15
+	li x15, 0xa5a5a501
+	bne x15, x9, csr_fail
+	li x15, 0x3afb6399
+	csrrw x9, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 773, x15
+	li x15, 0x3afb6301
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 773, x15
+	li x15, 0xbfffe701
+	bne x15, x9, csr_fail
+	li x15, 0xfb4ceeb5
+	csrrs x9, 773, x15
+	li x15, 0xffffff01
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 773, x15
+	li x15, 0xffffff01
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x9, csr_fail
+	li x15, 0x8d5850ac
+	csrrc x9, 773, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	csrrwi x9, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	csrrsi x9, 773, 0b10000
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	csrrci x9, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	csrrci x9, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 773, 0b11110
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mcountinhibit
+	li x15, 0xa5a5a5a5
+	csrrw x9, 800, x15
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 800, x15
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	li x15, 0xdc6022c1
+	csrrw x9, 800, x15
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 800, x15
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 800, x15
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	li x15, 0x2175f14b
+	csrrs x9, 800, x15
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 800, x15
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 800, x15
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	li x15, 0xcc6deee2
+	csrrc x9, 800, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 800, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 800, 0b00001
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrsi x9, 800, 0b00101
+	li x15, 0x00000001
+	bne x15, x9, csr_fail
+	csrrsi x9, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrsi x9, 800, 0b01001
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	csrrci x9, 800, 0b00101
+	li x15, 0x0000000d
+	bne x15, x9, csr_fail
+	csrrci x9, 800, 0b11010
+	li x15, 0x00000008
+	bne x15, x9, csr_fail
+	csrrci x9, 800, 0b10111
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mscratch
+	li x15, 0xa5a5a5a5
+	csrrw x9, 832, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 832, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x9, csr_fail
+	li x15, 0xcf1d0faa
+	csrrw x9, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 832, x15
+	li x15, 0xcf1d0faa
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 832, x15
+	li x15, 0xefbdafaf
+	bne x15, x9, csr_fail
+	li x15, 0x4ec53be4
+	csrrs x9, 832, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 832, x15
+	li x15, 0xffffffff
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xb5b2a829
+	csrrc x9, 832, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 832, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 832, 0b11010
+	li x15, 0x00000005
+	bne x15, x9, csr_fail
+	csrrwi x9, 832, 0b11100
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 832, 0b00101
+	li x15, 0x0000001c
+	bne x15, x9, csr_fail
+	csrrsi x9, 832, 0b11010
+	li x15, 0x0000001d
+	bne x15, x9, csr_fail
+	csrrsi x9, 832, 0b01111
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 832, 0b00101
+	li x15, 0x0000001f
+	bne x15, x9, csr_fail
+	csrrci x9, 832, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 832, 0b01001
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mepc
+	li x15, 0xa5a5a5a5
+	csrrw x9, 833, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 833, x15
+	li x15, 0xa5a5a5a4
+	bne x15, x9, csr_fail
+	li x15, 0x43beb070
+	csrrw x9, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 833, x15
+	li x15, 0x43beb070
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 833, x15
+	li x15, 0xe7bfb5f4
+	bne x15, x9, csr_fail
+	li x15, 0xd4ef415d
+	csrrs x9, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x9, csr_fail
+	li x15, 0xe71ab4b9
+	csrrc x9, 833, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 833, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 833, 0b11010
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrwi x9, 833, 0b10000
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrsi x9, 833, 0b00101
+	li x15, 0x00000010
+	bne x15, x9, csr_fail
+	csrrsi x9, 833, 0b11010
+	li x15, 0x00000014
+	bne x15, x9, csr_fail
+	csrrsi x9, 833, 0b11101
+	li x15, 0x0000001e
+	bne x15, x9, csr_fail
+	csrrci x9, 833, 0b00101
+	li x15, 0x0000001e
+	bne x15, x9, csr_fail
+	csrrci x9, 833, 0b11010
+	li x15, 0x0000001a
+	bne x15, x9, csr_fail
+	csrrci x9, 833, 0b11100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mtval
+	li x15, 0xa5a5a5a5
+	csrrw x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x83c0d4f2
+	csrrw x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xfeb43063
+	csrrs x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xacfc5a33
+	csrrc x9, 835, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 835, 0b11100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 835, 0b11000
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 835, 0b11111
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# mip
+	li x15, 0xa5a5a5a5
+	csrrw x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x199f0f42
+	csrrw x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x342f3e79
+	csrrs x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x26176dd6
+	csrrc x9, 836, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 836, 0b00010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 836, 0b00010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 836, 0b01000
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# tselect
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x8519d0f5
+	csrrw x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x0dba84c7
+	csrrs x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa3a985ba
+	csrrc x9, 1952, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1952, 0b01110
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1952, 0b01010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1952, 0b00110
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# tdata1
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0xf686d172
+	csrrw x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0x2e17f3b9
+	csrrs x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	li x15, 0xfd7505d4
+	csrrc x9, 1953, x15
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrwi x9, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrwi x9, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrwi x9, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrsi x9, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrsi x9, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrsi x9, 1953, 0b10010
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrci x9, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrci x9, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	csrrci x9, 1953, 0b11110
+	li x15, 0x28001040
+	bne x15, x9, csr_fail
+	# tdata2
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa13b1a75
+	csrrw x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xc4a60220
+	csrrs x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x63ce313b
+	csrrc x9, 1954, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1954, 0b01001
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1954, 0b01010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# tdata3
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xf808bfe3
+	csrrw x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xdf827b89
+	csrrs x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x47206859
+	csrrc x9, 1955, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1955, 0b01100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1955, 0b00111
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1955, 0b11110
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# tinfo
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0xa6165206
+	csrrw x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0xf184c456
+	csrrs x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	li x15, 0x430c0d48
+	csrrc x9, 1956, x15
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrwi x9, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrwi x9, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrwi x9, 1956, 0b11011
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrsi x9, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrsi x9, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrsi x9, 1956, 0b10000
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrci x9, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrci x9, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	csrrci x9, 1956, 0b11000
+	li x15, 0x00000004
+	bne x15, x9, csr_fail
+	# mcontext
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xae3ce8b2
+	csrrw x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x623e7632
+	csrrs x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x6445f243
+	csrrc x9, 1960, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1960, 0b10110
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1960, 0b01100
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1960, 0b01011
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	# scontext
+	li x15, 0xa5a5a5a5
+	csrrw x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x4a532dc0
+	csrrw x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xf1ceae17
+	csrrs x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	li x15, 0xeab490f8
+	csrrc x9, 1962, x15
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrwi x9, 1962, 0b01010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrsi x9, 1962, 0b10000
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrrci x9, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+	csrr x9, 1962
+	li x15, 0x00000000
+	bne x15, x9, csr_fail
+_end13:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x27, 0x0000000d
+	csrw 800,  x27 # set mcountinhibit to disable counting
+	li x27, 0x00000000
+	csrw 2816, x27 # reset cycle count
+	csrw 2944, x27
+	csrw 2818, x27 # reset instruction retired count
+	csrw 2946, x27
+	li x27, 0x00000001
+	csrw 773,  x27 # reset mtvec
+###############################################################################
+_start14:
+	# mcycle
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2816, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2816, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x369734de
+	csrrw x12, 2816, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2816, x10
+	li x10, 0x369734de
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2816, x10
+	li x10, 0xb7b7b5ff
+	bne x10, x12, csr_fail
+	li x10, 0x9be2244e
+	csrrs x12, 2816, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2816, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2816, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xcd6531d1
+	csrrc x12, 2816, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b11011
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x10, 0x0000001b
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b10100
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b00111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mcycleh
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2944, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2944, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x18ebba4f
+	csrrw x12, 2944, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2944, x10
+	li x10, 0x18ebba4f
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2944, x10
+	li x10, 0xbdefbfef
+	bne x10, x12, csr_fail
+	li x10, 0x2244cbc4
+	csrrs x12, 2944, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2944, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2944, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x66f52c33
+	csrrc x12, 2944, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b10101
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x10, 0x00000015
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x10, 0x00000015
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b00011
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b11000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# minstret
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2818, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2818, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x306ae550
+	csrrw x12, 2818, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2818, x10
+	li x10, 0x306ae550
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2818, x10
+	li x10, 0xb5efe5f5
+	bne x10, x12, csr_fail
+	li x10, 0xde2930d9
+	csrrs x12, 2818, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2818, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2818, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x32395f16
+	csrrc x12, 2818, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b10010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x10, 0x00000012
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x10, 0x00000017
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b01000
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b11101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# minstreth
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2946, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2946, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x788bcb1a
+	csrrw x12, 2946, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2946, x10
+	li x10, 0x788bcb1a
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2946, x10
+	li x10, 0xfdafefbf
+	bne x10, x12, csr_fail
+	li x10, 0xb4a6711d
+	csrrs x12, 2946, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2946, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2946, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x489c4258
+	csrrc x12, 2946, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b10010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x10, 0x00000012
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x10, 0x00000017
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b00010
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b11101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mstatus
+	li x10, 0xa5a5a5a5
+	csrrw x12, 768, x10
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 768, x10
+	li x10, 0x00001880
+	bne x10, x12, csr_fail
+	li x10, 0xcb257085
+	csrrw x12, 768, x10
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 768, x10
+	li x10, 0x00001880
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 768, x10
+	li x10, 0x00001880
+	bne x10, x12, csr_fail
+	li x10, 0xeff062da
+	csrrs x12, 768, x10
+	li x10, 0x00001888
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 768, x10
+	li x10, 0x00001888
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 768, x10
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	li x10, 0xbe546676
+	csrrc x12, 768, x10
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b11101
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b10011
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b10001
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	# misa
+	li x10, 0xa5a5a5a5
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x2b6072c4
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x02d41fd3
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x1c5f3c0e
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b10110
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b01111
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b11100
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	# mie
+	li x10, 0xa5a5a5a5
+	csrrw x12, 772, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 772, x10
+	li x10, 0xa5a50080
+	bne x10, x12, csr_fail
+	li x10, 0x0884b377
+	csrrw x12, 772, x10
+	li x10, 0x5a5a0808
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 772, x10
+	li x10, 0x08840000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 772, x10
+	li x10, 0xada50080
+	bne x10, x12, csr_fail
+	li x10, 0x04104641
+	csrrs x12, 772, x10
+	li x10, 0xffff0888
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 772, x10
+	li x10, 0xffff0888
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 772, x10
+	li x10, 0x5a5a0808
+	bne x10, x12, csr_fail
+	li x10, 0x56bd88eb
+	csrrc x12, 772, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b00010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b00001
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b11001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mtvec
+	li x10, 0xa5a5a5a5
+	csrrw x12, 773, x10
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 773, x10
+	li x10, 0xa5a5a501
+	bne x10, x12, csr_fail
+	li x10, 0xeb37fef5
+	csrrw x12, 773, x10
+	li x10, 0x5a5a5a00
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 773, x10
+	li x10, 0xeb37fe01
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 773, x10
+	li x10, 0xefb7ff01
+	bne x10, x12, csr_fail
+	li x10, 0x0a125946
+	csrrs x12, 773, x10
+	li x10, 0xffffff01
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 773, x10
+	li x10, 0xffffff01
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 773, x10
+	li x10, 0x5a5a5a00
+	bne x10, x12, csr_fail
+	li x10, 0xc57b0a25
+	csrrc x12, 773, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b00010
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mcountinhibit
+	li x10, 0xa5a5a5a5
+	csrrw x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 800, x10
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	li x10, 0x75f207b0
+	csrrw x12, 800, x10
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 800, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 800, x10
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	li x10, 0xacc22446
+	csrrs x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 800, x10
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	li x10, 0xcfeeeae8
+	csrrc x12, 800, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b00110
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b01011
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b01111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mscratch
+	li x10, 0xa5a5a5a5
+	csrrw x12, 832, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 832, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x581991f9
+	csrrw x12, 832, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 832, x10
+	li x10, 0x581991f9
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 832, x10
+	li x10, 0xfdbdb5fd
+	bne x10, x12, csr_fail
+	li x10, 0x6b84858c
+	csrrs x12, 832, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 832, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 832, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xdedda164
+	csrrc x12, 832, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b11000
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x10, 0x00000018
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x10, 0x0000001d
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b10110
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b10100
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mepc
+	li x10, 0xa5a5a5a5
+	csrrw x12, 833, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 833, x10
+	li x10, 0xa5a5a5a4
+	bne x10, x12, csr_fail
+	li x10, 0x312727f1
+	csrrw x12, 833, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 833, x10
+	li x10, 0x312727f0
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 833, x10
+	li x10, 0xb5a7a7f4
+	bne x10, x12, csr_fail
+	li x10, 0x066dae41
+	csrrs x12, 833, x10
+	li x10, 0xfffffffe
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 833, x10
+	li x10, 0xfffffffe
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 833, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x1957b151
+	csrrc x12, 833, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b01001
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x10, 0x0000000c
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b10010
+	li x10, 0x0000001e
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x10, 0x0000001e
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b01001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mtval
+	li x10, 0xa5a5a5a5
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x44551b4b
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xc262c0c8
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xbf7f4c0d
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b01000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b01110
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b01010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mip
+	li x10, 0xa5a5a5a5
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x3fe37172
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x24b3e16f
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xd1b426c0
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b10101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b10100
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b11100
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tselect
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xb557e2ca
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x076f299c
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x4a7e99fd
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b01111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b01011
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tdata1
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x50261544
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xfd437ac3
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xbb997ca0
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b11011
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b10100
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b01000
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	# tdata2
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xdb82aac9
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xfc6a8669
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x46e56659
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b10111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b10001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tdata3
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xf94d56b7
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x1a073d2d
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8a3cc5df
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b10000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b10000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tinfo
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x4e2c62e6
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x78d07c67
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xb00e2eec
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b10100
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b10111
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b00100
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	# mcontext
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x72f38055
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xdebd1162
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xdb7a2d4b
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b01001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b01110
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b01000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# scontext
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xf3b1f4a0
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xdd52f9ce
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x0be54544
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b10000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b11001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrr x12, 1962
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+_end14:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x28, 0x0000000d
+	csrw 800,  x28 # set mcountinhibit to disable counting
+	li x28, 0x00000000
+	csrw 2816, x28 # reset cycle count
+	csrw 2944, x28
+	csrw 2818, x28 # reset instruction retired count
+	csrw 2946, x28
+	li x28, 0x00000001
+	csrw 773,  x28 # reset mtvec
+###############################################################################
+_start15:
+	# mcycle
+	li x12, 0xa5a5a5a5
+	csrrw x14, 2816, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 2816, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x14, csr_fail
+	li x12, 0xa031e56e
+	csrrw x14, 2816, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 2816, x12
+	li x12, 0xa031e56e
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 2816, x12
+	li x12, 0xa5b5e5ef
+	bne x12, x14, csr_fail
+	li x12, 0xcaf69be6
+	csrrs x14, 2816, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 2816, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 2816, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xeff1067c
+	csrrc x14, 2816, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2816, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2816, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 2816, 0b10100
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 2816, 0b00101
+	li x12, 0x00000014
+	bne x12, x14, csr_fail
+	csrrsi x14, 2816, 0b11010
+	li x12, 0x00000015
+	bne x12, x14, csr_fail
+	csrrsi x14, 2816, 0b01001
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2816, 0b00101
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2816, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 2816, 0b00110
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mcycleh
+	li x12, 0xa5a5a5a5
+	csrrw x14, 2944, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 2944, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x14, csr_fail
+	li x12, 0x615271ad
+	csrrw x14, 2944, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 2944, x12
+	li x12, 0x615271ad
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 2944, x12
+	li x12, 0xe5f7f5ad
+	bne x12, x14, csr_fail
+	li x12, 0x11fdca44
+	csrrs x14, 2944, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 2944, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 2944, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xb9379032
+	csrrc x14, 2944, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2944, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2944, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 2944, 0b10001
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 2944, 0b00101
+	li x12, 0x00000011
+	bne x12, x14, csr_fail
+	csrrsi x14, 2944, 0b11010
+	li x12, 0x00000015
+	bne x12, x14, csr_fail
+	csrrsi x14, 2944, 0b11100
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2944, 0b00101
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2944, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 2944, 0b00011
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# minstret
+	li x12, 0xa5a5a5a5
+	csrrw x14, 2818, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 2818, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x14, csr_fail
+	li x12, 0x549f8c5e
+	csrrw x14, 2818, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 2818, x12
+	li x12, 0x549f8c5e
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 2818, x12
+	li x12, 0xf5bfadff
+	bne x12, x14, csr_fail
+	li x12, 0x51fd39bd
+	csrrs x14, 2818, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 2818, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 2818, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0x29609d0e
+	csrrc x14, 2818, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2818, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2818, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 2818, 0b00101
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 2818, 0b00101
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrsi x14, 2818, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrsi x14, 2818, 0b11001
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2818, 0b00101
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2818, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 2818, 0b00000
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# minstreth
+	li x12, 0xa5a5a5a5
+	csrrw x14, 2946, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 2946, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x14, csr_fail
+	li x12, 0x23d7d786
+	csrrw x14, 2946, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 2946, x12
+	li x12, 0x23d7d786
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 2946, x12
+	li x12, 0xa7f7f7a7
+	bne x12, x14, csr_fail
+	li x12, 0x50b001c1
+	csrrs x14, 2946, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 2946, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 2946, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0x860aabda
+	csrrc x14, 2946, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2946, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 2946, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 2946, 0b00000
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 2946, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 2946, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrsi x14, 2946, 0b01000
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2946, 0b00101
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 2946, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 2946, 0b10001
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mstatus
+	li x12, 0xa5a5a5a5
+	csrrw x14, 768, x12
+	li x12, 0x00001800
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 768, x12
+	li x12, 0x00001880
+	bne x12, x14, csr_fail
+	li x12, 0x4c01bfc7
+	csrrw x14, 768, x12
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 768, x12
+	li x12, 0x00001880
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 768, x12
+	li x12, 0x00001880
+	bne x12, x14, csr_fail
+	li x12, 0x20b8ac50
+	csrrs x14, 768, x12
+	li x12, 0x00001888
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 768, x12
+	li x12, 0x00001888
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 768, x12
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	li x12, 0x97f831b8
+	csrrc x14, 768, x12
+	li x12, 0x00001800
+	bne x12, x14, csr_fail
+	csrrwi x14, 768, 0b00101
+	li x12, 0x00001800
+	bne x12, x14, csr_fail
+	csrrwi x14, 768, 0b11010
+	li x12, 0x00001800
+	bne x12, x14, csr_fail
+	csrrwi x14, 768, 0b11011
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrsi x14, 768, 0b00101
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrsi x14, 768, 0b11010
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrsi x14, 768, 0b00110
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrci x14, 768, 0b00101
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrci x14, 768, 0b11010
+	li x12, 0x00001808
+	bne x12, x14, csr_fail
+	csrrci x14, 768, 0b01101
+	li x12, 0x00001800
+	bne x12, x14, csr_fail
+	# misa
+	li x12, 0xa5a5a5a5
+	csrrw x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0xa8bd5551
+	csrrw x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0xd3365821
+	csrrs x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	li x12, 0xb5fac192
+	csrrc x14, 769, x12
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrwi x14, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrwi x14, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrwi x14, 769, 0b11001
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrsi x14, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrsi x14, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrsi x14, 769, 0b11100
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrci x14, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrci x14, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	csrrci x14, 769, 0b01111
+	li x12, 0x40801104
+	bne x12, x14, csr_fail
+	# mie
+	li x12, 0xa5a5a5a5
+	csrrw x14, 772, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 772, x12
+	li x12, 0xa5a50080
+	bne x12, x14, csr_fail
+	li x12, 0x432dfdf9
+	csrrw x14, 772, x12
+	li x12, 0x5a5a0808
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 772, x12
+	li x12, 0x432d0888
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 772, x12
+	li x12, 0xe7ad0888
+	bne x12, x14, csr_fail
+	li x12, 0x1f846f70
+	csrrs x14, 772, x12
+	li x12, 0xffff0888
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 772, x12
+	li x12, 0xffff0888
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 772, x12
+	li x12, 0x5a5a0808
+	bne x12, x14, csr_fail
+	li x12, 0x5e4e27d3
+	csrrc x14, 772, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 772, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 772, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 772, 0b01101
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrsi x14, 772, 0b00101
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrsi x14, 772, 0b11010
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrsi x14, 772, 0b10001
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrci x14, 772, 0b00101
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrci x14, 772, 0b11010
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrci x14, 772, 0b00010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mtvec
+	li x12, 0xa5a5a5a5
+	csrrw x14, 773, x12
+	li x12, 0x00000001
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 773, x12
+	li x12, 0xa5a5a501
+	bne x12, x14, csr_fail
+	li x12, 0xa33b1d37
+	csrrw x14, 773, x12
+	li x12, 0x5a5a5a00
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 773, x12
+	li x12, 0xa33b1d01
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 773, x12
+	li x12, 0xa7bfbd01
+	bne x12, x14, csr_fail
+	li x12, 0xa2211f82
+	csrrs x14, 773, x12
+	li x12, 0xffffff01
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 773, x12
+	li x12, 0xffffff01
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 773, x12
+	li x12, 0x5a5a5a00
+	bne x12, x14, csr_fail
+	li x12, 0x74b43125
+	csrrc x14, 773, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 773, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 773, 0b11010
+	li x12, 0x00000001
+	bne x12, x14, csr_fail
+	csrrwi x14, 773, 0b10110
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 773, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 773, 0b11010
+	li x12, 0x00000001
+	bne x12, x14, csr_fail
+	csrrsi x14, 773, 0b11110
+	li x12, 0x00000001
+	bne x12, x14, csr_fail
+	csrrci x14, 773, 0b00101
+	li x12, 0x00000001
+	bne x12, x14, csr_fail
+	csrrci x14, 773, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 773, 0b10101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mcountinhibit
+	li x12, 0xa5a5a5a5
+	csrrw x14, 800, x12
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 800, x12
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	li x12, 0xc8d459ea
+	csrrw x14, 800, x12
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 800, x12
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 800, x12
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	li x12, 0x124f5d37
+	csrrs x14, 800, x12
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 800, x12
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 800, x12
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	li x12, 0xf1c9bc0b
+	csrrc x14, 800, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 800, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 800, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 800, 0b11011
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrsi x14, 800, 0b00101
+	li x12, 0x00000009
+	bne x12, x14, csr_fail
+	csrrsi x14, 800, 0b11010
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	csrrsi x14, 800, 0b11011
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	csrrci x14, 800, 0b00101
+	li x12, 0x0000000d
+	bne x12, x14, csr_fail
+	csrrci x14, 800, 0b11010
+	li x12, 0x00000008
+	bne x12, x14, csr_fail
+	csrrci x14, 800, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mscratch
+	li x12, 0xa5a5a5a5
+	csrrw x14, 832, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 832, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x14, csr_fail
+	li x12, 0x0f5946d3
+	csrrw x14, 832, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 832, x12
+	li x12, 0x0f5946d3
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 832, x12
+	li x12, 0xaffde7f7
+	bne x12, x14, csr_fail
+	li x12, 0xbf8d080c
+	csrrs x14, 832, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 832, x12
+	li x12, 0xffffffff
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 832, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0x62ebf79f
+	csrrc x14, 832, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 832, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 832, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrwi x14, 832, 0b00101
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 832, 0b00101
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrsi x14, 832, 0b11010
+	li x12, 0x00000005
+	bne x12, x14, csr_fail
+	csrrsi x14, 832, 0b10001
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 832, 0b00101
+	li x12, 0x0000001f
+	bne x12, x14, csr_fail
+	csrrci x14, 832, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 832, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mepc
+	li x12, 0xa5a5a5a5
+	csrrw x14, 833, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 833, x12
+	li x12, 0xa5a5a5a4
+	bne x12, x14, csr_fail
+	li x12, 0x1d490b28
+	csrrw x14, 833, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 833, x12
+	li x12, 0x1d490b28
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 833, x12
+	li x12, 0xbdedafac
+	bne x12, x14, csr_fail
+	li x12, 0xcafb5c9c
+	csrrs x14, 833, x12
+	li x12, 0xfffffffe
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 833, x12
+	li x12, 0xfffffffe
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 833, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x14, csr_fail
+	li x12, 0x6313210a
+	csrrc x14, 833, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 833, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 833, 0b11010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrwi x14, 833, 0b00101
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrsi x14, 833, 0b00101
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrsi x14, 833, 0b11010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrsi x14, 833, 0b00110
+	li x12, 0x0000001e
+	bne x12, x14, csr_fail
+	csrrci x14, 833, 0b00101
+	li x12, 0x0000001e
+	bne x12, x14, csr_fail
+	csrrci x14, 833, 0b11010
+	li x12, 0x0000001a
+	bne x12, x14, csr_fail
+	csrrci x14, 833, 0b01011
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mtval
+	li x12, 0xa5a5a5a5
+	csrrw x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xb1f693e1
+	csrrw x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x114d86d4
+	csrrs x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x6c78adc7
+	csrrc x14, 835, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 835, 0b00111
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 835, 0b11101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 835, 0b00111
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# mip
+	li x12, 0xa5a5a5a5
+	csrrw x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x3231b2c7
+	csrrw x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x7efa7940
+	csrrs x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x62a5d288
+	csrrc x14, 836, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 836, 0b00100
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 836, 0b01011
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 836, 0b00100
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# tselect
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xb7f19534
+	csrrw x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x869ef61e
+	csrrs x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x694a47b2
+	csrrc x14, 1952, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1952, 0b10010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1952, 0b11101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1952, 0b10110
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# tdata1
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0xcd7c5bdd
+	csrrw x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0xac93a173
+	csrrs x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	li x12, 0xabe6ea6c
+	csrrc x14, 1953, x12
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrwi x14, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrwi x14, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrwi x14, 1953, 0b10000
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrsi x14, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrsi x14, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrsi x14, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrci x14, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrci x14, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	csrrci x14, 1953, 0b11110
+	li x12, 0x28001040
+	bne x12, x14, csr_fail
+	# tdata2
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x2d612ea9
+	csrrw x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x07c2d120
+	csrrs x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xbf80098f
+	csrrc x14, 1954, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1954, 0b11000
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1954, 0b11101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1954, 0b10011
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# tdata3
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa2132b8c
+	csrrw x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x7b170e27
+	csrrs x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x45a4228d
+	csrrc x14, 1955, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1955, 0b10010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1955, 0b00110
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# tinfo
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0xa60d7223
+	csrrw x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0x2e66d4a3
+	csrrs x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	li x12, 0x024a4618
+	csrrc x14, 1956, x12
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrwi x14, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrwi x14, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrwi x14, 1956, 0b01010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrsi x14, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrsi x14, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrsi x14, 1956, 0b11100
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrci x14, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrci x14, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	csrrci x14, 1956, 0b10000
+	li x12, 0x00000004
+	bne x12, x14, csr_fail
+	# mcontext
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xfc9e1cef
+	csrrw x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xff0978da
+	csrrs x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xca69135f
+	csrrc x14, 1960, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1960, 0b11000
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1960, 0b01111
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1960, 0b00010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	# scontext
+	li x12, 0xa5a5a5a5
+	csrrw x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xc594790d
+	csrrw x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x9f2632f8
+	csrrs x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	li x12, 0xd4928d88
+	csrrc x14, 1962, x12
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrwi x14, 1962, 0b00000
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrsi x14, 1962, 0b10100
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrrci x14, 1962, 0b11100
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+	csrr x14, 1962
+	li x12, 0x00000000
+	bne x12, x14, csr_fail
+_end15:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x29, 0x0000000d
+	csrw 800,  x29 # set mcountinhibit to disable counting
+	li x29, 0x00000000
+	csrw 2816, x29 # reset cycle count
+	csrw 2944, x29
+	csrw 2818, x29 # reset instruction retired count
+	csrw 2946, x29
+	li x29, 0x00000001
+	csrw 773,  x29 # reset mtvec
+###############################################################################
+_start16:
+	# mcycle
+	li x3, 0xa5a5a5a5
+	csrrw x14, 2816, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 2816, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x14, csr_fail
+	li x3, 0x5e0c55ac
+	csrrw x14, 2816, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 2816, x3
+	li x3, 0x5e0c55ac
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 2816, x3
+	li x3, 0xffadf5ad
+	bne x3, x14, csr_fail
+	li x3, 0x1c277b11
+	csrrs x14, 2816, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 2816, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 2816, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xaea9ab95
+	csrrc x14, 2816, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2816, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2816, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 2816, 0b10011
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 2816, 0b00101
+	li x3, 0x00000013
+	bne x3, x14, csr_fail
+	csrrsi x14, 2816, 0b11010
+	li x3, 0x00000017
+	bne x3, x14, csr_fail
+	csrrsi x14, 2816, 0b11100
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2816, 0b00101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2816, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 2816, 0b10011
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mcycleh
+	li x3, 0xa5a5a5a5
+	csrrw x14, 2944, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 2944, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x14, csr_fail
+	li x3, 0x185677b1
+	csrrw x14, 2944, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 2944, x3
+	li x3, 0x185677b1
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 2944, x3
+	li x3, 0xbdf7f7b5
+	bne x3, x14, csr_fail
+	li x3, 0x6acd6a83
+	csrrs x14, 2944, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 2944, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 2944, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xc3b2cda3
+	csrrc x14, 2944, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2944, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2944, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 2944, 0b00011
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 2944, 0b00101
+	li x3, 0x00000003
+	bne x3, x14, csr_fail
+	csrrsi x14, 2944, 0b11010
+	li x3, 0x00000007
+	bne x3, x14, csr_fail
+	csrrsi x14, 2944, 0b00100
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2944, 0b00101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2944, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 2944, 0b11100
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# minstret
+	li x3, 0xa5a5a5a5
+	csrrw x14, 2818, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 2818, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x14, csr_fail
+	li x3, 0x4442855d
+	csrrw x14, 2818, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 2818, x3
+	li x3, 0x4442855d
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 2818, x3
+	li x3, 0xe5e7a5fd
+	bne x3, x14, csr_fail
+	li x3, 0x6b6d92fe
+	csrrs x14, 2818, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 2818, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 2818, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0x28fb2e08
+	csrrc x14, 2818, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2818, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2818, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 2818, 0b01001
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 2818, 0b00101
+	li x3, 0x00000009
+	bne x3, x14, csr_fail
+	csrrsi x14, 2818, 0b11010
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	csrrsi x14, 2818, 0b01101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2818, 0b00101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2818, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 2818, 0b11110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# minstreth
+	li x3, 0xa5a5a5a5
+	csrrw x14, 2946, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 2946, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x14, csr_fail
+	li x3, 0x1730ffac
+	csrrw x14, 2946, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 2946, x3
+	li x3, 0x1730ffac
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 2946, x3
+	li x3, 0xb7b5ffad
+	bne x3, x14, csr_fail
+	li x3, 0xc7fa9ea6
+	csrrs x14, 2946, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 2946, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 2946, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xff5f488d
+	csrrc x14, 2946, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2946, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 2946, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 2946, 0b01100
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 2946, 0b00101
+	li x3, 0x0000000c
+	bne x3, x14, csr_fail
+	csrrsi x14, 2946, 0b11010
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	csrrsi x14, 2946, 0b10110
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2946, 0b00101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 2946, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 2946, 0b00010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mstatus
+	li x3, 0xa5a5a5a5
+	csrrw x14, 768, x3
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 768, x3
+	li x3, 0x00001880
+	bne x3, x14, csr_fail
+	li x3, 0x50aed442
+	csrrw x14, 768, x3
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 768, x3
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 768, x3
+	li x3, 0x00001880
+	bne x3, x14, csr_fail
+	li x3, 0xdc758590
+	csrrs x14, 768, x3
+	li x3, 0x00001888
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 768, x3
+	li x3, 0x00001888
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 768, x3
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	li x3, 0x309c3de2
+	csrrc x14, 768, x3
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	csrrwi x14, 768, 0b00101
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	csrrwi x14, 768, 0b11010
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	csrrwi x14, 768, 0b01011
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrsi x14, 768, 0b00101
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrsi x14, 768, 0b11010
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrsi x14, 768, 0b11110
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrci x14, 768, 0b00101
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrci x14, 768, 0b11010
+	li x3, 0x00001808
+	bne x3, x14, csr_fail
+	csrrci x14, 768, 0b11011
+	li x3, 0x00001800
+	bne x3, x14, csr_fail
+	# misa
+	li x3, 0xa5a5a5a5
+	csrrw x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x6a8c9449
+	csrrw x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x89c3b1a6
+	csrrs x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	li x3, 0x2c69b812
+	csrrc x14, 769, x3
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrwi x14, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrwi x14, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrwi x14, 769, 0b10110
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrsi x14, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrsi x14, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrsi x14, 769, 0b01001
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrci x14, 769, 0b00101
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrci x14, 769, 0b11010
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	csrrci x14, 769, 0b01000
+	li x3, 0x40801104
+	bne x3, x14, csr_fail
+	# mie
+	li x3, 0xa5a5a5a5
+	csrrw x14, 772, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 772, x3
+	li x3, 0xa5a50080
+	bne x3, x14, csr_fail
+	li x3, 0x84c0a317
+	csrrw x14, 772, x3
+	li x3, 0x5a5a0808
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 772, x3
+	li x3, 0x84c00000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 772, x3
+	li x3, 0xa5e50080
+	bne x3, x14, csr_fail
+	li x3, 0xc2527f43
+	csrrs x14, 772, x3
+	li x3, 0xffff0888
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 772, x3
+	li x3, 0xffff0888
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 772, x3
+	li x3, 0x5a5a0808
+	bne x3, x14, csr_fail
+	li x3, 0x63d5dc23
+	csrrc x14, 772, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 772, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 772, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 772, 0b10011
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrsi x14, 772, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 772, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 772, 0b00011
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrci x14, 772, 0b00101
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrci x14, 772, 0b11010
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrci x14, 772, 0b01010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mtvec
+	li x3, 0xa5a5a5a5
+	csrrw x14, 773, x3
+	li x3, 0x00000001
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 773, x3
+	li x3, 0xa5a5a501
+	bne x3, x14, csr_fail
+	li x3, 0x0cf51492
+	csrrw x14, 773, x3
+	li x3, 0x5a5a5a00
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 773, x3
+	li x3, 0x0cf51400
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 773, x3
+	li x3, 0xadf5b501
+	bne x3, x14, csr_fail
+	li x3, 0x1bae9542
+	csrrs x14, 773, x3
+	li x3, 0xffffff01
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 773, x3
+	li x3, 0xffffff01
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 773, x3
+	li x3, 0x5a5a5a00
+	bne x3, x14, csr_fail
+	li x3, 0x38fc3d14
+	csrrc x14, 773, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 773, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 773, 0b11010
+	li x3, 0x00000001
+	bne x3, x14, csr_fail
+	csrrwi x14, 773, 0b11110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 773, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 773, 0b11010
+	li x3, 0x00000001
+	bne x3, x14, csr_fail
+	csrrsi x14, 773, 0b10000
+	li x3, 0x00000001
+	bne x3, x14, csr_fail
+	csrrci x14, 773, 0b00101
+	li x3, 0x00000001
+	bne x3, x14, csr_fail
+	csrrci x14, 773, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 773, 0b00000
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mcountinhibit
+	li x3, 0xa5a5a5a5
+	csrrw x14, 800, x3
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 800, x3
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	li x3, 0xe01a36b7
+	csrrw x14, 800, x3
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 800, x3
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 800, x3
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	li x3, 0x85b77cfa
+	csrrs x14, 800, x3
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 800, x3
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 800, x3
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	li x3, 0xc287c8ea
+	csrrc x14, 800, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 800, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 800, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 800, 0b00101
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrsi x14, 800, 0b00101
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrsi x14, 800, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrsi x14, 800, 0b01001
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	csrrci x14, 800, 0b00101
+	li x3, 0x0000000d
+	bne x3, x14, csr_fail
+	csrrci x14, 800, 0b11010
+	li x3, 0x00000008
+	bne x3, x14, csr_fail
+	csrrci x14, 800, 0b01101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mscratch
+	li x3, 0xa5a5a5a5
+	csrrw x14, 832, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 832, x3
+	li x3, 0xa5a5a5a5
+	bne x3, x14, csr_fail
+	li x3, 0xa768a4be
+	csrrw x14, 832, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 832, x3
+	li x3, 0xa768a4be
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 832, x3
+	li x3, 0xa7eda5bf
+	bne x3, x14, csr_fail
+	li x3, 0x81776b13
+	csrrs x14, 832, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 832, x3
+	li x3, 0xffffffff
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 832, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xbad21323
+	csrrc x14, 832, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 832, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 832, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrwi x14, 832, 0b00100
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 832, 0b00101
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrsi x14, 832, 0b11010
+	li x3, 0x00000005
+	bne x3, x14, csr_fail
+	csrrsi x14, 832, 0b11000
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 832, 0b00101
+	li x3, 0x0000001f
+	bne x3, x14, csr_fail
+	csrrci x14, 832, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 832, 0b01111
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mepc
+	li x3, 0xa5a5a5a5
+	csrrw x14, 833, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 833, x3
+	li x3, 0xa5a5a5a4
+	bne x3, x14, csr_fail
+	li x3, 0x4107dd87
+	csrrw x14, 833, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 833, x3
+	li x3, 0x4107dd86
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 833, x3
+	li x3, 0xe5a7fda6
+	bne x3, x14, csr_fail
+	li x3, 0x6fb77dc5
+	csrrs x14, 833, x3
+	li x3, 0xfffffffe
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 833, x3
+	li x3, 0xfffffffe
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 833, x3
+	li x3, 0x5a5a5a5a
+	bne x3, x14, csr_fail
+	li x3, 0x06dc1acf
+	csrrc x14, 833, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 833, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 833, 0b11010
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrwi x14, 833, 0b00011
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrsi x14, 833, 0b00101
+	li x3, 0x00000002
+	bne x3, x14, csr_fail
+	csrrsi x14, 833, 0b11010
+	li x3, 0x00000006
+	bne x3, x14, csr_fail
+	csrrsi x14, 833, 0b01011
+	li x3, 0x0000001e
+	bne x3, x14, csr_fail
+	csrrci x14, 833, 0b00101
+	li x3, 0x0000001e
+	bne x3, x14, csr_fail
+	csrrci x14, 833, 0b11010
+	li x3, 0x0000001a
+	bne x3, x14, csr_fail
+	csrrci x14, 833, 0b01101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mtval
+	li x3, 0xa5a5a5a5
+	csrrw x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xdf34aa21
+	csrrw x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x581e2866
+	csrrs x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x1b729783
+	csrrc x14, 835, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 835, 0b11100
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 835, 0b01010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 835, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 835, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 835, 0b01110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# mip
+	li x3, 0xa5a5a5a5
+	csrrw x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xcfee6f1c
+	csrrw x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x52db321e
+	csrrs x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x2407a2be
+	csrrc x14, 836, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 836, 0b10101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 836, 0b01111
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 836, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 836, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 836, 0b00110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# tselect
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x6833eb4c
+	csrrw x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x6ddad297
+	csrrs x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xf1b21236
+	csrrc x14, 1952, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1952, 0b00001
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1952, 0b11110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1952, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1952, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1952, 0b01101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# tdata1
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x0277a79d
+	csrrw x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x6251e4ed
+	csrrs x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	li x3, 0x0230eae6
+	csrrc x14, 1953, x3
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrwi x14, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrwi x14, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrwi x14, 1953, 0b10110
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrsi x14, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrsi x14, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrsi x14, 1953, 0b11100
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrci x14, 1953, 0b00101
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrci x14, 1953, 0b11010
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	csrrci x14, 1953, 0b01110
+	li x3, 0x28001040
+	bne x3, x14, csr_fail
+	# tdata2
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xd8cfe0ec
+	csrrw x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xe370ac46
+	csrrs x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x19fbe4c6
+	csrrc x14, 1954, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1954, 0b10111
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1954, 0b00000
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1954, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1954, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1954, 0b00111
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# tdata3
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x18c241b2
+	csrrw x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x09e30c0d
+	csrrs x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x6f2c8259
+	csrrc x14, 1955, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1955, 0b00110
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1955, 0b10010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1955, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1955, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1955, 0b00010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# tinfo
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0xf1e9d031
+	csrrw x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0xac4a664f
+	csrrs x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	li x3, 0xd3f32a48
+	csrrc x14, 1956, x3
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrwi x14, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrwi x14, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrwi x14, 1956, 0b10111
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrsi x14, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrsi x14, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrsi x14, 1956, 0b00001
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrci x14, 1956, 0b00101
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrci x14, 1956, 0b11010
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	csrrci x14, 1956, 0b10100
+	li x3, 0x00000004
+	bne x3, x14, csr_fail
+	# mcontext
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xaa730ce7
+	csrrw x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x315dd966
+	csrrs x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x16258fc0
+	csrrc x14, 1960, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1960, 0b01100
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1960, 0b00001
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1960, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1960, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1960, 0b11101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	# scontext
+	li x3, 0xa5a5a5a5
+	csrrw x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrw x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x811246ca
+	csrrw x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrs x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrs x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xc5f50e8b
+	csrrs x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa5a5a5a5
+	csrrc x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0x5a5a5a5a
+	csrrc x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	li x3, 0xa1e041ad
+	csrrc x14, 1962, x3
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrwi x14, 1962, 0b01001
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrsi x14, 1962, 0b01011
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1962, 0b00101
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1962, 0b11010
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrrci x14, 1962, 0b00111
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+	csrr x14, 1962
+	li x3, 0x00000000
+	bne x3, x14, csr_fail
+_end16:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x30, 0x0000000d
+	csrw 800,  x30 # set mcountinhibit to disable counting
+	li x30, 0x00000000
+	csrw 2816, x30 # reset cycle count
+	csrw 2944, x30
+	csrw 2818, x30 # reset instruction retired count
+	csrw 2946, x30
+	li x30, 0x00000001
+	csrw 773,  x30 # reset mtvec
+###############################################################################
+_start17:
+	# mcycle
+	li x1, 0xa5a5a5a5
+	csrrw x15, 2816, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 2816, x1
+	li x1, 0xa5a5a5a5
+	bne x1, x15, csr_fail
+	li x1, 0x33da1336
+	csrrw x15, 2816, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 2816, x1
+	li x1, 0x33da1336
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 2816, x1
+	li x1, 0xb7ffb7b7
+	bne x1, x15, csr_fail
+	li x1, 0xfdc04508
+	csrrs x15, 2816, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 2816, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 2816, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0x6b73fb15
+	csrrc x15, 2816, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2816, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2816, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 2816, 0b01111
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 2816, 0b00101
+	li x1, 0x0000000f
+	bne x1, x15, csr_fail
+	csrrsi x15, 2816, 0b11010
+	li x1, 0x0000000f
+	bne x1, x15, csr_fail
+	csrrsi x15, 2816, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2816, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2816, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 2816, 0b11111
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mcycleh
+	li x1, 0xa5a5a5a5
+	csrrw x15, 2944, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 2944, x1
+	li x1, 0xa5a5a5a5
+	bne x1, x15, csr_fail
+	li x1, 0xccfe2631
+	csrrw x15, 2944, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 2944, x1
+	li x1, 0xccfe2631
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 2944, x1
+	li x1, 0xedffa7b5
+	bne x1, x15, csr_fail
+	li x1, 0x44d22ea6
+	csrrs x15, 2944, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 2944, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 2944, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xad88a0ce
+	csrrc x15, 2944, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2944, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2944, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 2944, 0b10101
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 2944, 0b00101
+	li x1, 0x00000015
+	bne x1, x15, csr_fail
+	csrrsi x15, 2944, 0b11010
+	li x1, 0x00000015
+	bne x1, x15, csr_fail
+	csrrsi x15, 2944, 0b10000
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2944, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2944, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 2944, 0b01111
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# minstret
+	li x1, 0xa5a5a5a5
+	csrrw x15, 2818, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 2818, x1
+	li x1, 0xa5a5a5a5
+	bne x1, x15, csr_fail
+	li x1, 0xb3350dfe
+	csrrw x15, 2818, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 2818, x1
+	li x1, 0xb3350dfe
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 2818, x1
+	li x1, 0xb7b5adff
+	bne x1, x15, csr_fail
+	li x1, 0x9d38d71b
+	csrrs x15, 2818, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 2818, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 2818, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xbe1a7592
+	csrrc x15, 2818, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2818, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2818, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 2818, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 2818, 0b00101
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 2818, 0b11010
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrsi x15, 2818, 0b11100
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2818, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2818, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 2818, 0b01100
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# minstreth
+	li x1, 0xa5a5a5a5
+	csrrw x15, 2946, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 2946, x1
+	li x1, 0xa5a5a5a5
+	bne x1, x15, csr_fail
+	li x1, 0x16a76826
+	csrrw x15, 2946, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 2946, x1
+	li x1, 0x16a76826
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 2946, x1
+	li x1, 0xb7a7eda7
+	bne x1, x15, csr_fail
+	li x1, 0xc7dcfda5
+	csrrs x15, 2946, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 2946, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 2946, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0x5e6cf2ea
+	csrrc x15, 2946, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2946, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 2946, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 2946, 0b11001
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 2946, 0b00101
+	li x1, 0x00000019
+	bne x1, x15, csr_fail
+	csrrsi x15, 2946, 0b11010
+	li x1, 0x0000001d
+	bne x1, x15, csr_fail
+	csrrsi x15, 2946, 0b11111
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2946, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 2946, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 2946, 0b10110
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mstatus
+	li x1, 0xa5a5a5a5
+	csrrw x15, 768, x1
+	li x1, 0x00001800
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 768, x1
+	li x1, 0x00001880
+	bne x1, x15, csr_fail
+	li x1, 0xe3382eb6
+	csrrw x15, 768, x1
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 768, x1
+	li x1, 0x00001880
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 768, x1
+	li x1, 0x00001880
+	bne x1, x15, csr_fail
+	li x1, 0x6481fcaf
+	csrrs x15, 768, x1
+	li x1, 0x00001888
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 768, x1
+	li x1, 0x00001888
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 768, x1
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	li x1, 0x19d0d6a7
+	csrrc x15, 768, x1
+	li x1, 0x00001800
+	bne x1, x15, csr_fail
+	csrrwi x15, 768, 0b00101
+	li x1, 0x00001800
+	bne x1, x15, csr_fail
+	csrrwi x15, 768, 0b11010
+	li x1, 0x00001800
+	bne x1, x15, csr_fail
+	csrrwi x15, 768, 0b01110
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrsi x15, 768, 0b00101
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrsi x15, 768, 0b11010
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrsi x15, 768, 0b00011
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrci x15, 768, 0b00101
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrci x15, 768, 0b11010
+	li x1, 0x00001808
+	bne x1, x15, csr_fail
+	csrrci x15, 768, 0b11111
+	li x1, 0x00001800
+	bne x1, x15, csr_fail
+	# misa
+	li x1, 0xa5a5a5a5
+	csrrw x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0x6c49924e
+	csrrw x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0xa8c05cc1
+	csrrs x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	li x1, 0xb1546c64
+	csrrc x15, 769, x1
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrwi x15, 769, 0b00101
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrwi x15, 769, 0b11010
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrwi x15, 769, 0b00100
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrsi x15, 769, 0b00101
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrsi x15, 769, 0b11010
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrsi x15, 769, 0b10100
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrci x15, 769, 0b00101
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrci x15, 769, 0b11010
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	csrrci x15, 769, 0b01001
+	li x1, 0x40801104
+	bne x1, x15, csr_fail
+	# mie
+	li x1, 0xa5a5a5a5
+	csrrw x15, 772, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 772, x1
+	li x1, 0xa5a50080
+	bne x1, x15, csr_fail
+	li x1, 0xb2af0fe0
+	csrrw x15, 772, x1
+	li x1, 0x5a5a0808
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 772, x1
+	li x1, 0xb2af0880
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 772, x1
+	li x1, 0xb7af0880
+	bne x1, x15, csr_fail
+	li x1, 0x7f84dc94
+	csrrs x15, 772, x1
+	li x1, 0xffff0888
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 772, x1
+	li x1, 0xffff0888
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 772, x1
+	li x1, 0x5a5a0808
+	bne x1, x15, csr_fail
+	li x1, 0x64e4356e
+	csrrc x15, 772, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 772, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 772, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 772, 0b00010
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrsi x15, 772, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 772, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 772, 0b00110
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrci x15, 772, 0b00101
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrci x15, 772, 0b11010
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrci x15, 772, 0b00010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mtvec
+	li x1, 0xa5a5a5a5
+	csrrw x15, 773, x1
+	li x1, 0x00000001
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 773, x1
+	li x1, 0xa5a5a501
+	bne x1, x15, csr_fail
+	li x1, 0xb8a01958
+	csrrw x15, 773, x1
+	li x1, 0x5a5a5a00
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 773, x1
+	li x1, 0xb8a01900
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 773, x1
+	li x1, 0xbda5bd01
+	bne x1, x15, csr_fail
+	li x1, 0x9c34992d
+	csrrs x15, 773, x1
+	li x1, 0xffffff01
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 773, x1
+	li x1, 0xffffff01
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 773, x1
+	li x1, 0x5a5a5a00
+	bne x1, x15, csr_fail
+	li x1, 0x8f79c810
+	csrrc x15, 773, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 773, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 773, 0b11010
+	li x1, 0x00000001
+	bne x1, x15, csr_fail
+	csrrwi x15, 773, 0b10000
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 773, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 773, 0b11010
+	li x1, 0x00000001
+	bne x1, x15, csr_fail
+	csrrsi x15, 773, 0b01111
+	li x1, 0x00000001
+	bne x1, x15, csr_fail
+	csrrci x15, 773, 0b00101
+	li x1, 0x00000001
+	bne x1, x15, csr_fail
+	csrrci x15, 773, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 773, 0b00010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mcountinhibit
+	li x1, 0xa5a5a5a5
+	csrrw x15, 800, x1
+	li x1, 0x0000000d
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 800, x1
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	li x1, 0xd07ecbb6
+	csrrw x15, 800, x1
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 800, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 800, x1
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	li x1, 0x376c2aa5
+	csrrs x15, 800, x1
+	li x1, 0x0000000d
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 800, x1
+	li x1, 0x0000000d
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 800, x1
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	li x1, 0x6de1f97e
+	csrrc x15, 800, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 800, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 800, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 800, 0b10000
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrsi x15, 800, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 800, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrsi x15, 800, 0b01011
+	li x1, 0x0000000d
+	bne x1, x15, csr_fail
+	csrrci x15, 800, 0b00101
+	li x1, 0x0000000d
+	bne x1, x15, csr_fail
+	csrrci x15, 800, 0b11010
+	li x1, 0x00000008
+	bne x1, x15, csr_fail
+	csrrci x15, 800, 0b10000
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mscratch
+	li x1, 0xa5a5a5a5
+	csrrw x15, 832, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 832, x1
+	li x1, 0xa5a5a5a5
+	bne x1, x15, csr_fail
+	li x1, 0xa135062c
+	csrrw x15, 832, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 832, x1
+	li x1, 0xa135062c
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 832, x1
+	li x1, 0xa5b5a7ad
+	bne x1, x15, csr_fail
+	li x1, 0x798e5bdc
+	csrrs x15, 832, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 832, x1
+	li x1, 0xffffffff
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 832, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0x00a4477f
+	csrrc x15, 832, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 832, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 832, 0b11010
+	li x1, 0x00000005
+	bne x1, x15, csr_fail
+	csrrwi x15, 832, 0b11100
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 832, 0b00101
+	li x1, 0x0000001c
+	bne x1, x15, csr_fail
+	csrrsi x15, 832, 0b11010
+	li x1, 0x0000001d
+	bne x1, x15, csr_fail
+	csrrsi x15, 832, 0b00100
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 832, 0b00101
+	li x1, 0x0000001f
+	bne x1, x15, csr_fail
+	csrrci x15, 832, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 832, 0b10001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mepc
+	li x1, 0xa5a5a5a5
+	csrrw x15, 833, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 833, x1
+	li x1, 0xa5a5a5a4
+	bne x1, x15, csr_fail
+	li x1, 0x1ebd5c89
+	csrrw x15, 833, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 833, x1
+	li x1, 0x1ebd5c88
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 833, x1
+	li x1, 0xbfbdfdac
+	bne x1, x15, csr_fail
+	li x1, 0x53d2a7eb
+	csrrs x15, 833, x1
+	li x1, 0xfffffffe
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 833, x1
+	li x1, 0xfffffffe
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 833, x1
+	li x1, 0x5a5a5a5a
+	bne x1, x15, csr_fail
+	li x1, 0x8b87fb85
+	csrrc x15, 833, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 833, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 833, 0b11010
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrwi x15, 833, 0b11000
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrsi x15, 833, 0b00101
+	li x1, 0x00000018
+	bne x1, x15, csr_fail
+	csrrsi x15, 833, 0b11010
+	li x1, 0x0000001c
+	bne x1, x15, csr_fail
+	csrrsi x15, 833, 0b00100
+	li x1, 0x0000001e
+	bne x1, x15, csr_fail
+	csrrci x15, 833, 0b00101
+	li x1, 0x0000001e
+	bne x1, x15, csr_fail
+	csrrci x15, 833, 0b11010
+	li x1, 0x0000001a
+	bne x1, x15, csr_fail
+	csrrci x15, 833, 0b00100
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mtval
+	li x1, 0xa5a5a5a5
+	csrrw x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x1c95ca96
+	csrrw x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x2c370a13
+	csrrs x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x641d161b
+	csrrc x15, 835, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 835, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 835, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 835, 0b10000
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 835, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 835, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 835, 0b11110
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 835, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 835, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 835, 0b11011
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# mip
+	li x1, 0xa5a5a5a5
+	csrrw x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x19738f95
+	csrrw x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x2de30394
+	csrrs x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x02bdf465
+	csrrc x15, 836, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 836, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 836, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 836, 0b00011
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 836, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 836, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 836, 0b11101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 836, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 836, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 836, 0b11001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# tselect
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xf7f5f786
+	csrrw x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x554d51f5
+	csrrs x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xb59d245e
+	csrrc x15, 1952, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1952, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1952, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1952, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1952, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1952, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1952, 0b11001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1952, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1952, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1952, 0b10010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# tdata1
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0x10117224
+	csrrw x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0xfcdc717f
+	csrrs x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	li x1, 0xe50ce88f
+	csrrc x15, 1953, x1
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrwi x15, 1953, 0b00101
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrwi x15, 1953, 0b11010
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrwi x15, 1953, 0b00010
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrsi x15, 1953, 0b00101
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrsi x15, 1953, 0b11010
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrsi x15, 1953, 0b00011
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrci x15, 1953, 0b00101
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrci x15, 1953, 0b11010
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	csrrci x15, 1953, 0b00110
+	li x1, 0x28001040
+	bne x1, x15, csr_fail
+	# tdata2
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x2f85e2fa
+	csrrw x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xca2d9611
+	csrrs x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x8cc357b7
+	csrrc x15, 1954, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1954, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1954, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1954, 0b00111
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1954, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1954, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1954, 0b01110
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1954, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1954, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1954, 0b00110
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# tdata3
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x0c0f1dfa
+	csrrw x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x20818965
+	csrrs x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xf268620a
+	csrrc x15, 1955, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1955, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1955, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1955, 0b00100
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1955, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1955, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1955, 0b11101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1955, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1955, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1955, 0b00001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# tinfo
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x03bcc9fd
+	csrrw x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x6ffaaa0f
+	csrrs x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	li x1, 0xc7c7d2ae
+	csrrc x15, 1956, x1
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrwi x15, 1956, 0b00101
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrwi x15, 1956, 0b11010
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrwi x15, 1956, 0b01001
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrsi x15, 1956, 0b00101
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrsi x15, 1956, 0b11010
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrsi x15, 1956, 0b00001
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrci x15, 1956, 0b00101
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrci x15, 1956, 0b11010
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	csrrci x15, 1956, 0b11011
+	li x1, 0x00000004
+	bne x1, x15, csr_fail
+	# mcontext
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xe084c9d8
+	csrrw x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa147dca9
+	csrrs x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x0c8473ed
+	csrrc x15, 1960, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1960, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1960, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1960, 0b00011
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1960, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1960, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1960, 0b11111
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1960, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1960, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1960, 0b00001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	# scontext
+	li x1, 0xa5a5a5a5
+	csrrw x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrw x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5ee47526
+	csrrw x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrs x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrs x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x9829c304
+	csrrs x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xa5a5a5a5
+	csrrc x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0x5a5a5a5a
+	csrrc x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	li x1, 0xec412cd7
+	csrrc x15, 1962, x1
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1962, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1962, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrwi x15, 1962, 0b11001
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1962, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1962, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrsi x15, 1962, 0b11110
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1962, 0b00101
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1962, 0b11010
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrrci x15, 1962, 0b01111
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+	csrr x15, 1962
+	li x1, 0x00000000
+	bne x1, x15, csr_fail
+_end17:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x31, 0x0000000d
+	csrw 800,  x31 # set mcountinhibit to disable counting
+	li x31, 0x00000000
+	csrw 2816, x31 # reset cycle count
+	csrw 2944, x31
+	csrw 2818, x31 # reset instruction retired count
+	csrw 2946, x31
+	li x31, 0x00000001
+	csrw 773,  x31 # reset mtvec
+###############################################################################
+_start18:
+	# mcycle
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2816, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2816, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x5a2f90b6
+	csrrw x12, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2816, x15
+	li x15, 0x5a2f90b6
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2816, x15
+	li x15, 0xffafb5b7
+	bne x15, x12, csr_fail
+	li x15, 0xfd3e4930
+	csrrs x12, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2816, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2816, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x7be63bf8
+	csrrc x12, 2816, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrsi x12, 2816, 0b11101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2816, 0b10101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mcycleh
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2944, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2944, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x76dd6d0e
+	csrrw x12, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2944, x15
+	li x15, 0x76dd6d0e
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2944, x15
+	li x15, 0xf7fdedaf
+	bne x15, x12, csr_fail
+	li x15, 0x49c0487b
+	csrrs x12, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2944, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2944, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x8193a22a
+	csrrc x12, 2944, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2944, 0b00010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x15, 0x00000002
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x15, 0x00000007
+	bne x15, x12, csr_fail
+	csrrsi x12, 2944, 0b01000
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2944, 0b01101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# minstret
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2818, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2818, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x0e4b8a81
+	csrrw x12, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2818, x15
+	li x15, 0x0e4b8a81
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2818, x15
+	li x15, 0xafefafa5
+	bne x15, x12, csr_fail
+	li x15, 0xd4dcd3b7
+	csrrs x12, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2818, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2818, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xe45b1679
+	csrrc x12, 2818, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2818, 0b10101
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x15, 0x00000015
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x15, 0x00000015
+	bne x15, x12, csr_fail
+	csrrsi x12, 2818, 0b10111
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2818, 0b01101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# minstreth
+	li x15, 0xa5a5a5a5
+	csrrw x12, 2946, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 2946, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x0cb7a8ac
+	csrrw x12, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 2946, x15
+	li x15, 0x0cb7a8ac
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 2946, x15
+	li x15, 0xadb7adad
+	bne x15, x12, csr_fail
+	li x15, 0xa8a91bd7
+	csrrs x12, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 2946, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 2946, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xbc9faeb8
+	csrrc x12, 2946, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 2946, 0b01011
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x15, 0x0000000b
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x15, 0x0000000f
+	bne x15, x12, csr_fail
+	csrrsi x12, 2946, 0b10001
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 2946, 0b00110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mstatus
+	li x15, 0xa5a5a5a5
+	csrrw x12, 768, x15
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 768, x15
+	li x15, 0x00001880
+	bne x15, x12, csr_fail
+	li x15, 0xd3985593
+	csrrw x12, 768, x15
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 768, x15
+	li x15, 0x00001880
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 768, x15
+	li x15, 0x00001880
+	bne x15, x12, csr_fail
+	li x15, 0x06338dee
+	csrrs x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 768, x15
+	li x15, 0x00001888
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 768, x15
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	li x15, 0x3f31406b
+	csrrc x12, 768, x15
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	csrrwi x12, 768, 0b11100
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrsi x12, 768, 0b10000
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x15, 0x00001808
+	bne x15, x12, csr_fail
+	csrrci x12, 768, 0b10101
+	li x15, 0x00001800
+	bne x15, x12, csr_fail
+	# misa
+	li x15, 0xa5a5a5a5
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5925f427
+	csrrw x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0xd672d6d6
+	csrrs x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	li x15, 0x1c4a9673
+	csrrc x12, 769, x15
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrsi x12, 769, 0b00100
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	csrrci x12, 769, 0b01110
+	li x15, 0x40801104
+	bne x15, x12, csr_fail
+	# mie
+	li x15, 0xa5a5a5a5
+	csrrw x12, 772, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 772, x15
+	li x15, 0xa5a50080
+	bne x15, x12, csr_fail
+	li x15, 0x2bf8f120
+	csrrw x12, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 772, x15
+	li x15, 0x2bf80000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 772, x15
+	li x15, 0xaffd0080
+	bne x15, x12, csr_fail
+	li x15, 0x02f67d44
+	csrrs x12, 772, x15
+	li x15, 0xffff0888
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 772, x15
+	li x15, 0xffff0888
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 772, x15
+	li x15, 0x5a5a0808
+	bne x15, x12, csr_fail
+	li x15, 0x5bc40181
+	csrrc x12, 772, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 772, 0b10010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 772, 0b11101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 772, 0b01111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mtvec
+	li x15, 0xa5a5a5a5
+	csrrw x12, 773, x15
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 773, x15
+	li x15, 0xa5a5a501
+	bne x15, x12, csr_fail
+	li x15, 0xf26e6fc9
+	csrrw x12, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 773, x15
+	li x15, 0xf26e6f01
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 773, x15
+	li x15, 0xf7efef01
+	bne x15, x12, csr_fail
+	li x15, 0xca0f4ab4
+	csrrs x12, 773, x15
+	li x15, 0xffffff01
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 773, x15
+	li x15, 0xffffff01
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 773, x15
+	li x15, 0x5a5a5a00
+	bne x15, x12, csr_fail
+	li x15, 0x3c2fec1f
+	csrrc x12, 773, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrwi x12, 773, 0b01111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrsi x12, 773, 0b00100
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 773, 0b11111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mcountinhibit
+	li x15, 0xa5a5a5a5
+	csrrw x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 800, x15
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	li x15, 0x974d3221
+	csrrw x12, 800, x15
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 800, x15
+	li x15, 0x00000001
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 800, x15
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	li x15, 0xe8ec596a
+	csrrs x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 800, x15
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 800, x15
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	li x15, 0xa2433ae7
+	csrrc x12, 800, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrsi x12, 800, 0b00001
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x15, 0x0000000d
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x15, 0x00000008
+	bne x15, x12, csr_fail
+	csrrci x12, 800, 0b11110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mscratch
+	li x15, 0xa5a5a5a5
+	csrrw x12, 832, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 832, x15
+	li x15, 0xa5a5a5a5
+	bne x15, x12, csr_fail
+	li x15, 0x52066253
+	csrrw x12, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 832, x15
+	li x15, 0x52066253
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 832, x15
+	li x15, 0xf7a7e7f7
+	bne x15, x12, csr_fail
+	li x15, 0x706017cd
+	csrrs x12, 832, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 832, x15
+	li x15, 0xffffffff
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 832, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x3c49de47
+	csrrc x12, 832, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x15, 0x00000005
+	bne x15, x12, csr_fail
+	csrrwi x12, 832, 0b10000
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x15, 0x00000010
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x15, 0x00000015
+	bne x15, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x15, 0x0000001f
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 832, 0b10100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mepc
+	li x15, 0xa5a5a5a5
+	csrrw x12, 833, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 833, x15
+	li x15, 0xa5a5a5a4
+	bne x15, x12, csr_fail
+	li x15, 0x6e0ce3ba
+	csrrw x12, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 833, x15
+	li x15, 0x6e0ce3ba
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 833, x15
+	li x15, 0xefade7be
+	bne x15, x12, csr_fail
+	li x15, 0xf602459d
+	csrrs x12, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 833, x15
+	li x15, 0xfffffffe
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 833, x15
+	li x15, 0x5a5a5a5a
+	bne x15, x12, csr_fail
+	li x15, 0x2f40ea81
+	csrrc x12, 833, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 833, 0b00010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x15, 0x00000002
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x15, 0x00000006
+	bne x15, x12, csr_fail
+	csrrsi x12, 833, 0b01000
+	li x15, 0x0000001e
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x15, 0x0000001e
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x15, 0x0000001a
+	bne x15, x12, csr_fail
+	csrrci x12, 833, 0b11101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mtval
+	li x15, 0xa5a5a5a5
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x6993181f
+	csrrw x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x21c8e99a
+	csrrs x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x4dc5e0eb
+	csrrc x12, 835, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 835, 0b10010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 835, 0b11110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 835, 0b00000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# mip
+	li x15, 0xa5a5a5a5
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x8124d420
+	csrrw x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xd2a43387
+	csrrs x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xf4630df9
+	csrrc x12, 836, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 836, 0b00010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 836, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tselect
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x92e0293d
+	csrrw x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x68b73c31
+	csrrs x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5790dd82
+	csrrc x12, 1952, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1952, 0b01111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1952, 0b10101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1952, 0b00110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tdata1
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x6cb31aea
+	csrrw x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xaac969db
+	csrrs x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	li x15, 0x5468aacc
+	csrrc x12, 1953, x15
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrwi x12, 1953, 0b00110
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	csrrci x12, 1953, 0b11100
+	li x15, 0x28001040
+	bne x15, x12, csr_fail
+	# tdata2
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x015c481d
+	csrrw x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x449b2d7f
+	csrrs x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x663e49d3
+	csrrc x12, 1954, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1954, 0b10111
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1954, 0b10100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tdata3
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xf2537633
+	csrrw x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x93788d0f
+	csrrs x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x0d59be05
+	csrrc x12, 1955, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1955, 0b01100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1955, 0b10110
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# tinfo
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x6f957998
+	csrrw x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x9a254458
+	csrrs x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	li x15, 0x576e4725
+	csrrc x12, 1956, x15
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrwi x12, 1956, 0b00111
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	csrrci x12, 1956, 0b00110
+	li x15, 0x00000004
+	bne x15, x12, csr_fail
+	# mcontext
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x13156f3f
+	csrrw x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xc0d41820
+	csrrs x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x4a58c9c0
+	csrrc x12, 1960, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1960, 0b01000
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1960, 0b11100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1960, 0b10001
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	# scontext
+	li x15, 0xa5a5a5a5
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa4a91526
+	csrrw x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xb520bb1b
+	csrrs x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0xa5a5a5a5
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5a5a5a5a
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	li x15, 0x5da738bb
+	csrrc x12, 1962, x15
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrwi x12, 1962, 0b11100
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrsi x12, 1962, 0b00011
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrrci x12, 1962, 0b00010
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+	csrr x12, 1962
+	li x15, 0x00000000
+	bne x15, x12, csr_fail
+_end18:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x1, 0x0000000d
+	csrw 800,  x1 # set mcountinhibit to disable counting
+	li x0, 0x00000000
+	csrw 2816, x0 # reset cycle count
+	csrw 2944, x0
+	csrw 2818, x0 # reset instruction retired count
+	csrw 2946, x0
+	li x1, 0x00000001
+	csrw 773,  x1 # reset mtvec
+###############################################################################
+_start19:
+	# mcycle
+	li x2, 0xa5a5a5a5
+	csrrw x6, 2816, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 2816, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x6, csr_fail
+	li x2, 0xe2bf05f6
+	csrrw x6, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 2816, x2
+	li x2, 0xe2bf05f6
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 2816, x2
+	li x2, 0xe7bfa5f7
+	bne x2, x6, csr_fail
+	li x2, 0xf222e071
+	csrrs x6, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0x46318da0
+	csrrc x6, 2816, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2816, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2816, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 2816, 0b01010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 2816, 0b00101
+	li x2, 0x0000000a
+	bne x2, x6, csr_fail
+	csrrsi x6, 2816, 0b11010
+	li x2, 0x0000000f
+	bne x2, x6, csr_fail
+	csrrsi x6, 2816, 0b10110
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2816, 0b00101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2816, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 2816, 0b01000
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mcycleh
+	li x2, 0xa5a5a5a5
+	csrrw x6, 2944, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 2944, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x6, csr_fail
+	li x2, 0xd23c6e97
+	csrrw x6, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 2944, x2
+	li x2, 0xd23c6e97
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 2944, x2
+	li x2, 0xf7bdefb7
+	bne x2, x6, csr_fail
+	li x2, 0x4d303ef9
+	csrrs x6, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xff8740e9
+	csrrc x6, 2944, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2944, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2944, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 2944, 0b11101
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 2944, 0b00101
+	li x2, 0x0000001d
+	bne x2, x6, csr_fail
+	csrrsi x6, 2944, 0b11010
+	li x2, 0x0000001d
+	bne x2, x6, csr_fail
+	csrrsi x6, 2944, 0b01101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2944, 0b00101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2944, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 2944, 0b11001
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# minstret
+	li x2, 0xa5a5a5a5
+	csrrw x6, 2818, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 2818, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x6, csr_fail
+	li x2, 0x351e3079
+	csrrw x6, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 2818, x2
+	li x2, 0x351e3079
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 2818, x2
+	li x2, 0xb5bfb5fd
+	bne x2, x6, csr_fail
+	li x2, 0x039aeab1
+	csrrs x6, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xf1843388
+	csrrc x6, 2818, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2818, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2818, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 2818, 0b01100
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 2818, 0b00101
+	li x2, 0x0000000c
+	bne x2, x6, csr_fail
+	csrrsi x6, 2818, 0b11010
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	csrrsi x6, 2818, 0b00100
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2818, 0b00101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2818, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 2818, 0b00100
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# minstreth
+	li x2, 0xa5a5a5a5
+	csrrw x6, 2946, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 2946, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x6, csr_fail
+	li x2, 0x881ccb13
+	csrrw x6, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 2946, x2
+	li x2, 0x881ccb13
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 2946, x2
+	li x2, 0xadbdefb7
+	bne x2, x6, csr_fail
+	li x2, 0x029f6b39
+	csrrs x6, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0x6badc5d9
+	csrrc x6, 2946, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2946, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 2946, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 2946, 0b01111
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 2946, 0b00101
+	li x2, 0x0000000f
+	bne x2, x6, csr_fail
+	csrrsi x6, 2946, 0b11010
+	li x2, 0x0000000f
+	bne x2, x6, csr_fail
+	csrrsi x6, 2946, 0b00011
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2946, 0b00101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 2946, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 2946, 0b00100
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mstatus
+	li x2, 0xa5a5a5a5
+	csrrw x6, 768, x2
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 768, x2
+	li x2, 0x00001880
+	bne x2, x6, csr_fail
+	li x2, 0x750b4706
+	csrrw x6, 768, x2
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 768, x2
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 768, x2
+	li x2, 0x00001880
+	bne x2, x6, csr_fail
+	li x2, 0x76e5e534
+	csrrs x6, 768, x2
+	li x2, 0x00001888
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 768, x2
+	li x2, 0x00001888
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 768, x2
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	li x2, 0xc5522492
+	csrrc x6, 768, x2
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	csrrwi x6, 768, 0b00101
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	csrrwi x6, 768, 0b11010
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	csrrwi x6, 768, 0b00011
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	csrrsi x6, 768, 0b00101
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	csrrsi x6, 768, 0b11010
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	csrrsi x6, 768, 0b11001
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	csrrci x6, 768, 0b00101
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	csrrci x6, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x6, csr_fail
+	csrrci x6, 768, 0b00100
+	li x2, 0x00001800
+	bne x2, x6, csr_fail
+	# misa
+	li x2, 0xa5a5a5a5
+	csrrw x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0x3f9e059e
+	csrrw x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0x691d060c
+	csrrs x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	li x2, 0xe458ff0a
+	csrrc x6, 769, x2
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrwi x6, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrwi x6, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrwi x6, 769, 0b10011
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrsi x6, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrsi x6, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrsi x6, 769, 0b11001
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrci x6, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrci x6, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	csrrci x6, 769, 0b01111
+	li x2, 0x40801104
+	bne x2, x6, csr_fail
+	# mie
+	li x2, 0xa5a5a5a5
+	csrrw x6, 772, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 772, x2
+	li x2, 0xa5a50080
+	bne x2, x6, csr_fail
+	li x2, 0xd0dd0d88
+	csrrw x6, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 772, x2
+	li x2, 0xd0dd0888
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 772, x2
+	li x2, 0xf5fd0888
+	bne x2, x6, csr_fail
+	li x2, 0xce09f02f
+	csrrs x6, 772, x2
+	li x2, 0xffff0888
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 772, x2
+	li x2, 0xffff0888
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x6, csr_fail
+	li x2, 0x6f0fed80
+	csrrc x6, 772, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 772, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 772, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 772, 0b00010
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrsi x6, 772, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 772, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 772, 0b00100
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrci x6, 772, 0b00101
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrci x6, 772, 0b11010
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrci x6, 772, 0b11100
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mtvec
+	li x2, 0xa5a5a5a5
+	csrrw x6, 773, x2
+	li x2, 0x00000001
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 773, x2
+	li x2, 0xa5a5a501
+	bne x2, x6, csr_fail
+	li x2, 0x0ec36594
+	csrrw x6, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 773, x2
+	li x2, 0x0ec36500
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 773, x2
+	li x2, 0xafe7e501
+	bne x2, x6, csr_fail
+	li x2, 0xc4098d59
+	csrrs x6, 773, x2
+	li x2, 0xffffff01
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 773, x2
+	li x2, 0xffffff01
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x6, csr_fail
+	li x2, 0x3acf510c
+	csrrc x6, 773, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 773, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x6, csr_fail
+	csrrwi x6, 773, 0b10000
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 773, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x6, csr_fail
+	csrrsi x6, 773, 0b01011
+	li x2, 0x00000001
+	bne x2, x6, csr_fail
+	csrrci x6, 773, 0b00101
+	li x2, 0x00000001
+	bne x2, x6, csr_fail
+	csrrci x6, 773, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 773, 0b00011
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mcountinhibit
+	li x2, 0xa5a5a5a5
+	csrrw x6, 800, x2
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 800, x2
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	li x2, 0x5e2261da
+	csrrw x6, 800, x2
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 800, x2
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 800, x2
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	li x2, 0xeee7b126
+	csrrs x6, 800, x2
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 800, x2
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 800, x2
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	li x2, 0xe7b07a67
+	csrrc x6, 800, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 800, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 800, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 800, 0b01110
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrsi x6, 800, 0b00101
+	li x2, 0x0000000c
+	bne x2, x6, csr_fail
+	csrrsi x6, 800, 0b11010
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	csrrsi x6, 800, 0b01101
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	csrrci x6, 800, 0b00101
+	li x2, 0x0000000d
+	bne x2, x6, csr_fail
+	csrrci x6, 800, 0b11010
+	li x2, 0x00000008
+	bne x2, x6, csr_fail
+	csrrci x6, 800, 0b10100
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mscratch
+	li x2, 0xa5a5a5a5
+	csrrw x6, 832, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 832, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x6, csr_fail
+	li x2, 0x58205bee
+	csrrw x6, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 832, x2
+	li x2, 0x58205bee
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 832, x2
+	li x2, 0xfda5ffef
+	bne x2, x6, csr_fail
+	li x2, 0xd91574e7
+	csrrs x6, 832, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 832, x2
+	li x2, 0xffffffff
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xb149b6be
+	csrrc x6, 832, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 832, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 832, 0b11010
+	li x2, 0x00000005
+	bne x2, x6, csr_fail
+	csrrwi x6, 832, 0b11100
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 832, 0b00101
+	li x2, 0x0000001c
+	bne x2, x6, csr_fail
+	csrrsi x6, 832, 0b11010
+	li x2, 0x0000001d
+	bne x2, x6, csr_fail
+	csrrsi x6, 832, 0b01111
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 832, 0b00101
+	li x2, 0x0000001f
+	bne x2, x6, csr_fail
+	csrrci x6, 832, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 832, 0b00110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mepc
+	li x2, 0xa5a5a5a5
+	csrrw x6, 833, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 833, x2
+	li x2, 0xa5a5a5a4
+	bne x2, x6, csr_fail
+	li x2, 0x2d699081
+	csrrw x6, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 833, x2
+	li x2, 0x2d699080
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 833, x2
+	li x2, 0xadedb5a4
+	bne x2, x6, csr_fail
+	li x2, 0x11592a86
+	csrrs x6, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x6, csr_fail
+	li x2, 0x07f62e97
+	csrrc x6, 833, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 833, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 833, 0b11010
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrwi x6, 833, 0b11011
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 833, 0b00101
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrsi x6, 833, 0b11010
+	li x2, 0x0000001e
+	bne x2, x6, csr_fail
+	csrrsi x6, 833, 0b00011
+	li x2, 0x0000001e
+	bne x2, x6, csr_fail
+	csrrci x6, 833, 0b00101
+	li x2, 0x0000001e
+	bne x2, x6, csr_fail
+	csrrci x6, 833, 0b11010
+	li x2, 0x0000001a
+	bne x2, x6, csr_fail
+	csrrci x6, 833, 0b10111
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mtval
+	li x2, 0xa5a5a5a5
+	csrrw x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xb044afb8
+	csrrw x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xd38a4c05
+	csrrs x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x52fc07fe
+	csrrc x6, 835, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 835, 0b01110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 835, 0b10000
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# mip
+	li x2, 0xa5a5a5a5
+	csrrw x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x1f6c4195
+	csrrw x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x9dec6f4c
+	csrrs x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xb93dbfa8
+	csrrc x6, 836, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 836, 0b10110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 836, 0b00011
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 836, 0b11000
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# tselect
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x84c74937
+	csrrw x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x37a99483
+	csrrs x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x1cd1238b
+	csrrc x6, 1952, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1952, 0b11011
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1952, 0b11100
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# tdata1
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0xf2b4a2a8
+	csrrw x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0x96b7fd8e
+	csrrs x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	li x2, 0xc1c59577
+	csrrc x6, 1953, x2
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrwi x6, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrwi x6, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrwi x6, 1953, 0b10111
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrsi x6, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrsi x6, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrsi x6, 1953, 0b10100
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrci x6, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrci x6, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	csrrci x6, 1953, 0b00000
+	li x2, 0x28001040
+	bne x2, x6, csr_fail
+	# tdata2
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x9a6afaec
+	csrrw x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x2bbfc243
+	csrrs x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xbcf72d35
+	csrrc x6, 1954, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1954, 0b10110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1954, 0b11011
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# tdata3
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x08a06202
+	csrrw x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x60ddd733
+	csrrs x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5263a307
+	csrrc x6, 1955, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1955, 0b11001
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1955, 0b10101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1955, 0b01011
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# tinfo
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0xc864b911
+	csrrw x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0xb291bdda
+	csrrs x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	li x2, 0x2f2fbe62
+	csrrc x6, 1956, x2
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrwi x6, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrwi x6, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrwi x6, 1956, 0b01111
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrsi x6, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrsi x6, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrsi x6, 1956, 0b01111
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrci x6, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrci x6, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	csrrci x6, 1956, 0b10110
+	li x2, 0x00000004
+	bne x2, x6, csr_fail
+	# mcontext
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x2bd58e6f
+	csrrw x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x368bb1c9
+	csrrs x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x19756289
+	csrrc x6, 1960, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1960, 0b10010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1960, 0b10000
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1960, 0b10110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	# scontext
+	li x2, 0xa5a5a5a5
+	csrrw x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x1e8b2d12
+	csrrw x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa27d6332
+	csrrs x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	li x2, 0xcd0c6f6e
+	csrrc x6, 1962, x2
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrwi x6, 1962, 0b10101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrsi x6, 1962, 0b11110
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrrci x6, 1962, 0b00111
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+	csrr x6, 1962
+	li x2, 0x00000000
+	bne x2, x6, csr_fail
+_end19:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x1, 0x0000000d
+	csrw 800,  x1 # set mcountinhibit to disable counting
+	li x1, 0x00000000
+	csrw 2816, x1 # reset cycle count
+	csrw 2944, x1
+	csrw 2818, x1 # reset instruction retired count
+	csrw 2946, x1
+	li x1, 0x00000001
+	csrw 773,  x1 # reset mtvec
+###############################################################################
+_start20:
+	# mcycle
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2816, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2816, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x51c60049
+	csrrw x12, 2816, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2816, x10
+	li x10, 0x51c60049
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2816, x10
+	li x10, 0xf5e7a5ed
+	bne x10, x12, csr_fail
+	li x10, 0xdcffb795
+	csrrs x12, 2816, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2816, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2816, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xc8f16251
+	csrrc x12, 2816, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2816, 0b01100
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b00101
+	li x10, 0x0000000c
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b11010
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrsi x12, 2816, 0b00011
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2816, 0b10011
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mcycleh
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2944, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2944, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x3b457b79
+	csrrw x12, 2944, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2944, x10
+	li x10, 0x3b457b79
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2944, x10
+	li x10, 0xbfe5fffd
+	bne x10, x12, csr_fail
+	li x10, 0x9bf7e112
+	csrrs x12, 2944, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2944, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2944, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xc718983b
+	csrrc x12, 2944, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2944, 0b10100
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b00101
+	li x10, 0x00000014
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b11010
+	li x10, 0x00000015
+	bne x10, x12, csr_fail
+	csrrsi x12, 2944, 0b00000
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2944, 0b01000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# minstret
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2818, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2818, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x3636d621
+	csrrw x12, 2818, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2818, x10
+	li x10, 0x3636d621
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2818, x10
+	li x10, 0xb7b7f7a5
+	bne x10, x12, csr_fail
+	li x10, 0x5e19882b
+	csrrs x12, 2818, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2818, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2818, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xed6432f6
+	csrrc x12, 2818, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2818, 0b01001
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b00101
+	li x10, 0x00000009
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b11010
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrsi x12, 2818, 0b10010
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2818, 0b10001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# minstreth
+	li x10, 0xa5a5a5a5
+	csrrw x12, 2946, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 2946, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0xb03582e7
+	csrrw x12, 2946, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 2946, x10
+	li x10, 0xb03582e7
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 2946, x10
+	li x10, 0xb5b5a7e7
+	bne x10, x12, csr_fail
+	li x10, 0x5153a8b1
+	csrrs x12, 2946, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 2946, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 2946, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x7762fc33
+	csrrc x12, 2946, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 2946, 0b00101
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b00101
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrsi x12, 2946, 0b10001
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 2946, 0b00111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mstatus
+	li x10, 0xa5a5a5a5
+	csrrw x12, 768, x10
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 768, x10
+	li x10, 0x00001880
+	bne x10, x12, csr_fail
+	li x10, 0xf9ae7874
+	csrrw x12, 768, x10
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 768, x10
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 768, x10
+	li x10, 0x00001880
+	bne x10, x12, csr_fail
+	li x10, 0x25e2d17c
+	csrrs x12, 768, x10
+	li x10, 0x00001888
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 768, x10
+	li x10, 0x00001888
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 768, x10
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	li x10, 0xacedb31b
+	csrrc x12, 768, x10
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b00101
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b11010
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	csrrwi x12, 768, 0b01000
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b00101
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b11010
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrsi x12, 768, 0b11111
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b00101
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x10, 0x00001808
+	bne x10, x12, csr_fail
+	csrrci x12, 768, 0b11010
+	li x10, 0x00001800
+	bne x10, x12, csr_fail
+	# misa
+	li x10, 0xa5a5a5a5
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0xb24d9293
+	csrrw x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x51d96c5d
+	csrrs x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	li x10, 0x59b564cf
+	csrrc x12, 769, x10
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrwi x12, 769, 0b01001
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrsi x12, 769, 0b11011
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b00101
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b11010
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	csrrci x12, 769, 0b00111
+	li x10, 0x40801104
+	bne x10, x12, csr_fail
+	# mie
+	li x10, 0xa5a5a5a5
+	csrrw x12, 772, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 772, x10
+	li x10, 0xa5a50080
+	bne x10, x12, csr_fail
+	li x10, 0xe8f76fac
+	csrrw x12, 772, x10
+	li x10, 0x5a5a0808
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 772, x10
+	li x10, 0xe8f70888
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 772, x10
+	li x10, 0xedf70888
+	bne x10, x12, csr_fail
+	li x10, 0xe16dc9a9
+	csrrs x12, 772, x10
+	li x10, 0xffff0888
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 772, x10
+	li x10, 0xffff0888
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 772, x10
+	li x10, 0x5a5a0808
+	bne x10, x12, csr_fail
+	li x10, 0xa339a581
+	csrrc x12, 772, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 772, 0b01111
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b00101
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b11010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 772, 0b01101
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b00101
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b11010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 772, 0b11101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mtvec
+	li x10, 0xa5a5a5a5
+	csrrw x12, 773, x10
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 773, x10
+	li x10, 0xa5a5a501
+	bne x10, x12, csr_fail
+	li x10, 0xe68854cc
+	csrrw x12, 773, x10
+	li x10, 0x5a5a5a00
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 773, x10
+	li x10, 0xe6885400
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 773, x10
+	li x10, 0xe7adf501
+	bne x10, x12, csr_fail
+	li x10, 0xe1ffd3fa
+	csrrs x12, 773, x10
+	li x10, 0xffffff01
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 773, x10
+	li x10, 0xffffff01
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 773, x10
+	li x10, 0x5a5a5a00
+	bne x10, x12, csr_fail
+	li x10, 0x8c40805c
+	csrrc x12, 773, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b11010
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrwi x12, 773, 0b11011
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b00101
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b11010
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrsi x12, 773, 0b00111
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b00101
+	li x10, 0x00000001
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 773, 0b10001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mcountinhibit
+	li x10, 0xa5a5a5a5
+	csrrw x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 800, x10
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	li x10, 0x659c29c5
+	csrrw x12, 800, x10
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 800, x10
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 800, x10
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	li x10, 0x027f7d91
+	csrrs x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 800, x10
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 800, x10
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	li x10, 0x69dc2dda
+	csrrc x12, 800, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 800, 0b01110
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b00101
+	li x10, 0x0000000c
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b11010
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrsi x12, 800, 0b10000
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b00101
+	li x10, 0x0000000d
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b11010
+	li x10, 0x00000008
+	bne x10, x12, csr_fail
+	csrrci x12, 800, 0b00111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mscratch
+	li x10, 0xa5a5a5a5
+	csrrw x12, 832, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 832, x10
+	li x10, 0xa5a5a5a5
+	bne x10, x12, csr_fail
+	li x10, 0x4309a2ae
+	csrrw x12, 832, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 832, x10
+	li x10, 0x4309a2ae
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 832, x10
+	li x10, 0xe7ada7af
+	bne x10, x12, csr_fail
+	li x10, 0x106b161a
+	csrrs x12, 832, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 832, x10
+	li x10, 0xffffffff
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 832, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0x58bec7cb
+	csrrc x12, 832, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b11010
+	li x10, 0x00000005
+	bne x10, x12, csr_fail
+	csrrwi x12, 832, 0b11011
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b00101
+	li x10, 0x0000001b
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b11010
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrsi x12, 832, 0b01100
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b00101
+	li x10, 0x0000001f
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 832, 0b10001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mepc
+	li x10, 0xa5a5a5a5
+	csrrw x12, 833, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 833, x10
+	li x10, 0xa5a5a5a4
+	bne x10, x12, csr_fail
+	li x10, 0x211734d3
+	csrrw x12, 833, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 833, x10
+	li x10, 0x211734d2
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 833, x10
+	li x10, 0xa5b7b5f6
+	bne x10, x12, csr_fail
+	li x10, 0x06ffc56a
+	csrrs x12, 833, x10
+	li x10, 0xfffffffe
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 833, x10
+	li x10, 0xfffffffe
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 833, x10
+	li x10, 0x5a5a5a5a
+	bne x10, x12, csr_fail
+	li x10, 0xcd7cb1fd
+	csrrc x12, 833, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 833, 0b01111
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b00101
+	li x10, 0x0000000e
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b11010
+	li x10, 0x0000000e
+	bne x10, x12, csr_fail
+	csrrsi x12, 833, 0b10000
+	li x10, 0x0000001e
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b00101
+	li x10, 0x0000001e
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b11010
+	li x10, 0x0000001a
+	bne x10, x12, csr_fail
+	csrrci x12, 833, 0b10011
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mtval
+	li x10, 0xa5a5a5a5
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8fd87d60
+	csrrw x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x57c0fa40
+	csrrs x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x04ced63f
+	csrrc x12, 835, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 835, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 835, 0b10001
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 835, 0b01111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# mip
+	li x10, 0xa5a5a5a5
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x9f9f3370
+	csrrw x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x0b4fab40
+	csrrs x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa8b4874f
+	csrrc x12, 836, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 836, 0b10110
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 836, 0b01010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 836, 0b10100
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tselect
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x51120c02
+	csrrw x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8e05e2b2
+	csrrs x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x07223e3c
+	csrrc x12, 1952, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1952, 0b10111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1952, 0b11111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tdata1
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x34fc8bc1
+	csrrw x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x8ff6025e
+	csrrs x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	li x10, 0xf5fe08e3
+	csrrc x12, 1953, x10
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrwi x12, 1953, 0b10111
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrsi x12, 1953, 0b00110
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b00101
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b11010
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	csrrci x12, 1953, 0b11110
+	li x10, 0x28001040
+	bne x10, x12, csr_fail
+	# tdata2
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa382ca24
+	csrrw x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xed8e7b9f
+	csrrs x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x93bed90a
+	csrrc x12, 1954, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1954, 0b01010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1954, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tdata3
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x07bb330f
+	csrrw x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x594caa3f
+	csrrs x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5bdcbbf1
+	csrrc x12, 1955, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1955, 0b11000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1955, 0b10011
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1955, 0b00000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# tinfo
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xdb4b7ead
+	csrrw x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xcd1f8cc1
+	csrrs x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	li x10, 0xfdb0e165
+	csrrc x12, 1956, x10
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrwi x12, 1956, 0b01111
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrsi x12, 1956, 0b00011
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b00101
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b11010
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	csrrci x12, 1956, 0b11001
+	li x10, 0x00000004
+	bne x10, x12, csr_fail
+	# mcontext
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8abd7261
+	csrrw x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8a7d91e4
+	csrrs x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8bd1c645
+	csrrc x12, 1960, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1960, 0b10000
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1960, 0b10111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1960, 0b11100
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	# scontext
+	li x10, 0xa5a5a5a5
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xd21f23a9
+	csrrw x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x8e38fbe8
+	csrrs x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xa5a5a5a5
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0x5a5a5a5a
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	li x10, 0xf5be1a87
+	csrrc x12, 1962, x10
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrwi x12, 1962, 0b01010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrsi x12, 1962, 0b00111
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b00101
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b11010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrrci x12, 1962, 0b00010
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+	csrr x12, 1962
+	li x10, 0x00000000
+	bne x10, x12, csr_fail
+_end20:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x2, 0x0000000d
+	csrw 800,  x2 # set mcountinhibit to disable counting
+	li x2, 0x00000000
+	csrw 2816, x2 # reset cycle count
+	csrw 2944, x2
+	csrw 2818, x2 # reset instruction retired count
+	csrw 2946, x2
+	li x2, 0x00000001
+	csrw 773,  x2 # reset mtvec
+###############################################################################
+_start21:
+	# mcycle
+	li x2, 0xa5a5a5a5
+	csrrw x5, 2816, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 2816, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x5, csr_fail
+	li x2, 0x872d49b1
+	csrrw x5, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 2816, x2
+	li x2, 0x872d49b1
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 2816, x2
+	li x2, 0xa7adedb5
+	bne x2, x5, csr_fail
+	li x2, 0x16928122
+	csrrs x5, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 2816, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 2816, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x31ca3a84
+	csrrc x5, 2816, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2816, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2816, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 2816, 0b10010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 2816, 0b00101
+	li x2, 0x00000012
+	bne x2, x5, csr_fail
+	csrrsi x5, 2816, 0b11010
+	li x2, 0x00000017
+	bne x2, x5, csr_fail
+	csrrsi x5, 2816, 0b11111
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2816, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2816, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 2816, 0b10110
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mcycleh
+	li x2, 0xa5a5a5a5
+	csrrw x5, 2944, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 2944, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x5, csr_fail
+	li x2, 0x05db5907
+	csrrw x5, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 2944, x2
+	li x2, 0x05db5907
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 2944, x2
+	li x2, 0xa5fffda7
+	bne x2, x5, csr_fail
+	li x2, 0xd6710d99
+	csrrs x5, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 2944, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 2944, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x0cf2444e
+	csrrc x5, 2944, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2944, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2944, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 2944, 0b01011
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 2944, 0b00101
+	li x2, 0x0000000b
+	bne x2, x5, csr_fail
+	csrrsi x5, 2944, 0b11010
+	li x2, 0x0000000f
+	bne x2, x5, csr_fail
+	csrrsi x5, 2944, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2944, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2944, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 2944, 0b10110
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# minstret
+	li x2, 0xa5a5a5a5
+	csrrw x5, 2818, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 2818, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x5, csr_fail
+	li x2, 0x9abc109b
+	csrrw x5, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 2818, x2
+	li x2, 0x9abc109b
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 2818, x2
+	li x2, 0xbfbdb5bf
+	bne x2, x5, csr_fail
+	li x2, 0x06670b5c
+	csrrs x5, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 2818, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 2818, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x5d3d7cc4
+	csrrc x5, 2818, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2818, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2818, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 2818, 0b00001
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 2818, 0b00101
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrsi x5, 2818, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrsi x5, 2818, 0b10000
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2818, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2818, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 2818, 0b00011
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# minstreth
+	li x2, 0xa5a5a5a5
+	csrrw x5, 2946, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 2946, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x5, csr_fail
+	li x2, 0xc245b117
+	csrrw x5, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 2946, x2
+	li x2, 0xc245b117
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 2946, x2
+	li x2, 0xe7e5b5b7
+	bne x2, x5, csr_fail
+	li x2, 0xc72f1444
+	csrrs x5, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 2946, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 2946, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x47481a92
+	csrrc x5, 2946, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2946, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 2946, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 2946, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 2946, 0b00101
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 2946, 0b11010
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrsi x5, 2946, 0b00111
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2946, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 2946, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 2946, 0b01010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mstatus
+	li x2, 0xa5a5a5a5
+	csrrw x5, 768, x2
+	li x2, 0x00001800
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 768, x2
+	li x2, 0x00001880
+	bne x2, x5, csr_fail
+	li x2, 0xfc0955c6
+	csrrw x5, 768, x2
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 768, x2
+	li x2, 0x00001880
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 768, x2
+	li x2, 0x00001880
+	bne x2, x5, csr_fail
+	li x2, 0x039b5889
+	csrrs x5, 768, x2
+	li x2, 0x00001888
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 768, x2
+	li x2, 0x00001888
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 768, x2
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	li x2, 0xe70a7e6d
+	csrrc x5, 768, x2
+	li x2, 0x00001800
+	bne x2, x5, csr_fail
+	csrrwi x5, 768, 0b00101
+	li x2, 0x00001800
+	bne x2, x5, csr_fail
+	csrrwi x5, 768, 0b11010
+	li x2, 0x00001800
+	bne x2, x5, csr_fail
+	csrrwi x5, 768, 0b11111
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrsi x5, 768, 0b00101
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrsi x5, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrsi x5, 768, 0b00100
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrci x5, 768, 0b00101
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrci x5, 768, 0b11010
+	li x2, 0x00001808
+	bne x2, x5, csr_fail
+	csrrci x5, 768, 0b10100
+	li x2, 0x00001800
+	bne x2, x5, csr_fail
+	# misa
+	li x2, 0xa5a5a5a5
+	csrrw x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x18154ec1
+	csrrw x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x1cc2958c
+	csrrs x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	li x2, 0x880f0978
+	csrrc x5, 769, x2
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrwi x5, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrwi x5, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrwi x5, 769, 0b10100
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrsi x5, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrsi x5, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrsi x5, 769, 0b00100
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrci x5, 769, 0b00101
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrci x5, 769, 0b11010
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	csrrci x5, 769, 0b00100
+	li x2, 0x40801104
+	bne x2, x5, csr_fail
+	# mie
+	li x2, 0xa5a5a5a5
+	csrrw x5, 772, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 772, x2
+	li x2, 0xa5a50080
+	bne x2, x5, csr_fail
+	li x2, 0xbc07263f
+	csrrw x5, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 772, x2
+	li x2, 0xbc070008
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 772, x2
+	li x2, 0xbda70088
+	bne x2, x5, csr_fail
+	li x2, 0x27778e93
+	csrrs x5, 772, x2
+	li x2, 0xffff0888
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 772, x2
+	li x2, 0xffff0888
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 772, x2
+	li x2, 0x5a5a0808
+	bne x2, x5, csr_fail
+	li x2, 0x472100c7
+	csrrc x5, 772, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 772, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 772, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 772, 0b10010
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrsi x5, 772, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 772, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 772, 0b01000
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrci x5, 772, 0b00101
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrci x5, 772, 0b11010
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrci x5, 772, 0b00111
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mtvec
+	li x2, 0xa5a5a5a5
+	csrrw x5, 773, x2
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 773, x2
+	li x2, 0xa5a5a501
+	bne x2, x5, csr_fail
+	li x2, 0x07f28a41
+	csrrw x5, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 773, x2
+	li x2, 0x07f28a01
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 773, x2
+	li x2, 0xa7f7af01
+	bne x2, x5, csr_fail
+	li x2, 0x829d407c
+	csrrs x5, 773, x2
+	li x2, 0xffffff01
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 773, x2
+	li x2, 0xffffff01
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 773, x2
+	li x2, 0x5a5a5a00
+	bne x2, x5, csr_fail
+	li x2, 0x2a76da21
+	csrrc x5, 773, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 773, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrwi x5, 773, 0b01110
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 773, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 773, 0b11010
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrsi x5, 773, 0b11011
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrci x5, 773, 0b00101
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrci x5, 773, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 773, 0b11111
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mcountinhibit
+	li x2, 0xa5a5a5a5
+	csrrw x5, 800, x2
+	li x2, 0x0000000d
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 800, x2
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	li x2, 0xc89f27d7
+	csrrw x5, 800, x2
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 800, x2
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 800, x2
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	li x2, 0x7059e3bd
+	csrrs x5, 800, x2
+	li x2, 0x0000000d
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 800, x2
+	li x2, 0x0000000d
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 800, x2
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	li x2, 0x0470410b
+	csrrc x5, 800, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 800, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 800, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 800, 0b10100
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrsi x5, 800, 0b00101
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrsi x5, 800, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrsi x5, 800, 0b01011
+	li x2, 0x0000000d
+	bne x2, x5, csr_fail
+	csrrci x5, 800, 0b00101
+	li x2, 0x0000000d
+	bne x2, x5, csr_fail
+	csrrci x5, 800, 0b11010
+	li x2, 0x00000008
+	bne x2, x5, csr_fail
+	csrrci x5, 800, 0b00000
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mscratch
+	li x2, 0xa5a5a5a5
+	csrrw x5, 832, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 832, x2
+	li x2, 0xa5a5a5a5
+	bne x2, x5, csr_fail
+	li x2, 0x67bf0648
+	csrrw x5, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 832, x2
+	li x2, 0x67bf0648
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 832, x2
+	li x2, 0xe7bfa7ed
+	bne x2, x5, csr_fail
+	li x2, 0x651be97d
+	csrrs x5, 832, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 832, x2
+	li x2, 0xffffffff
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 832, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x52e993f8
+	csrrc x5, 832, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 832, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 832, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrwi x5, 832, 0b00001
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 832, 0b00101
+	li x2, 0x00000001
+	bne x2, x5, csr_fail
+	csrrsi x5, 832, 0b11010
+	li x2, 0x00000005
+	bne x2, x5, csr_fail
+	csrrsi x5, 832, 0b01100
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 832, 0b00101
+	li x2, 0x0000001f
+	bne x2, x5, csr_fail
+	csrrci x5, 832, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 832, 0b01001
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mepc
+	li x2, 0xa5a5a5a5
+	csrrw x5, 833, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 833, x2
+	li x2, 0xa5a5a5a4
+	bne x2, x5, csr_fail
+	li x2, 0x8cb9fdc2
+	csrrw x5, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 833, x2
+	li x2, 0x8cb9fdc2
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 833, x2
+	li x2, 0xadbdfde6
+	bne x2, x5, csr_fail
+	li x2, 0xb4dd35f0
+	csrrs x5, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 833, x2
+	li x2, 0xfffffffe
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 833, x2
+	li x2, 0x5a5a5a5a
+	bne x2, x5, csr_fail
+	li x2, 0x4891cf83
+	csrrc x5, 833, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 833, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 833, 0b11010
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrwi x5, 833, 0b01100
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrsi x5, 833, 0b00101
+	li x2, 0x0000000c
+	bne x2, x5, csr_fail
+	csrrsi x5, 833, 0b11010
+	li x2, 0x0000000c
+	bne x2, x5, csr_fail
+	csrrsi x5, 833, 0b10101
+	li x2, 0x0000001e
+	bne x2, x5, csr_fail
+	csrrci x5, 833, 0b00101
+	li x2, 0x0000001e
+	bne x2, x5, csr_fail
+	csrrci x5, 833, 0b11010
+	li x2, 0x0000001a
+	bne x2, x5, csr_fail
+	csrrci x5, 833, 0b01110
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mtval
+	li x2, 0xa5a5a5a5
+	csrrw x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x19033f59
+	csrrw x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xe45be907
+	csrrs x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x88f7b912
+	csrrc x5, 835, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 835, 0b01001
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 835, 0b00111
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 835, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 835, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# mip
+	li x2, 0xa5a5a5a5
+	csrrw x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x80f675dd
+	csrrw x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x27a4756f
+	csrrs x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x7ce68e1a
+	csrrc x5, 836, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 836, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 836, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 836, 0b01011
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# tselect
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x96577675
+	csrrw x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x2c92abd7
+	csrrs x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xd571b952
+	csrrc x5, 1952, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1952, 0b10010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1952, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1952, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1952, 0b11111
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# tdata1
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0x5b22e017
+	csrrw x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0x23d4c077
+	csrrs x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	li x2, 0xb83e9b34
+	csrrc x5, 1953, x2
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrwi x5, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrwi x5, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrwi x5, 1953, 0b01110
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrsi x5, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrsi x5, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrsi x5, 1953, 0b10100
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrci x5, 1953, 0b00101
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrci x5, 1953, 0b11010
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	csrrci x5, 1953, 0b10101
+	li x2, 0x28001040
+	bne x2, x5, csr_fail
+	# tdata2
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x1658b614
+	csrrw x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa50690fa
+	csrrs x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x14569c58
+	csrrc x5, 1954, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1954, 0b00100
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1954, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1954, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1954, 0b00011
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# tdata3
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xe21ec0fc
+	csrrw x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x8398fca5
+	csrrs x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x2ef2ff5b
+	csrrc x5, 1955, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1955, 0b01010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1955, 0b01110
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1955, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1955, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1955, 0b01101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# tinfo
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0x67d3fa8e
+	csrrw x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0xd8684d6b
+	csrrs x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	li x2, 0x84059c40
+	csrrc x5, 1956, x2
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrwi x5, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrwi x5, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrwi x5, 1956, 0b01011
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrsi x5, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrsi x5, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrsi x5, 1956, 0b01110
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrci x5, 1956, 0b00101
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrci x5, 1956, 0b11010
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	csrrci x5, 1956, 0b10111
+	li x2, 0x00000004
+	bne x2, x5, csr_fail
+	# mcontext
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x85883c73
+	csrrw x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xe552840b
+	csrrs x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x74d6613d
+	csrrc x5, 1960, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1960, 0b00011
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1960, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1960, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1960, 0b01101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	# scontext
+	li x2, 0xa5a5a5a5
+	csrrw x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrw x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x2b6d0106
+	csrrw x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrs x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrs x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5fe7c21b
+	csrrs x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0xa5a5a5a5
+	csrrc x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x5a5a5a5a
+	csrrc x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	li x2, 0x66af98d3
+	csrrc x5, 1962, x2
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrwi x5, 1962, 0b01000
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrsi x5, 1962, 0b11111
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1962, 0b00101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1962, 0b11010
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrrci x5, 1962, 0b11101
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+	csrr x5, 1962
+	li x2, 0x00000000
+	bne x2, x5, csr_fail
+_end21:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x3, 0x0000000d
+	csrw 800,  x3 # set mcountinhibit to disable counting
+	li x3, 0x00000000
+	csrw 2816, x3 # reset cycle count
+	csrw 2944, x3
+	csrw 2818, x3 # reset instruction retired count
+	csrw 2946, x3
+	li x3, 0x00000001
+	csrw 773,  x3 # reset mtvec
+###############################################################################
+_start22:
+	# mcycle
+	li x9, 0xa5a5a5a5
+	csrrw x3, 2816, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 2816, x9
+	li x9, 0xa5a5a5a5
+	bne x9, x3, csr_fail
+	li x9, 0xdbc8aaec
+	csrrw x3, 2816, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 2816, x9
+	li x9, 0xdbc8aaec
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 2816, x9
+	li x9, 0xffedafed
+	bne x9, x3, csr_fail
+	li x9, 0xfe00520a
+	csrrs x3, 2816, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 2816, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 2816, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xc0c5998a
+	csrrc x3, 2816, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2816, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2816, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 2816, 0b10101
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 2816, 0b00101
+	li x9, 0x00000015
+	bne x9, x3, csr_fail
+	csrrsi x3, 2816, 0b11010
+	li x9, 0x00000015
+	bne x9, x3, csr_fail
+	csrrsi x3, 2816, 0b10100
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2816, 0b00101
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2816, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 2816, 0b10101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mcycleh
+	li x9, 0xa5a5a5a5
+	csrrw x3, 2944, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 2944, x9
+	li x9, 0xa5a5a5a5
+	bne x9, x3, csr_fail
+	li x9, 0x2cd259f9
+	csrrw x3, 2944, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 2944, x9
+	li x9, 0x2cd259f9
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 2944, x9
+	li x9, 0xadf7fdfd
+	bne x9, x3, csr_fail
+	li x9, 0x94923d6b
+	csrrs x3, 2944, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 2944, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 2944, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0x13971810
+	csrrc x3, 2944, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2944, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2944, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 2944, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 2944, 0b00101
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 2944, 0b11010
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrsi x3, 2944, 0b10010
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2944, 0b00101
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2944, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 2944, 0b00110
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# minstret
+	li x9, 0xa5a5a5a5
+	csrrw x3, 2818, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 2818, x9
+	li x9, 0xa5a5a5a5
+	bne x9, x3, csr_fail
+	li x9, 0xd0287ec0
+	csrrw x3, 2818, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 2818, x9
+	li x9, 0xd0287ec0
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 2818, x9
+	li x9, 0xf5adffe5
+	bne x9, x3, csr_fail
+	li x9, 0x6adc76fd
+	csrrs x3, 2818, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 2818, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 2818, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0x32da746d
+	csrrc x3, 2818, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2818, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2818, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 2818, 0b01101
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 2818, 0b00101
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrsi x3, 2818, 0b11010
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrsi x3, 2818, 0b11000
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2818, 0b00101
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2818, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 2818, 0b00010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# minstreth
+	li x9, 0xa5a5a5a5
+	csrrw x3, 2946, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 2946, x9
+	li x9, 0xa5a5a5a5
+	bne x9, x3, csr_fail
+	li x9, 0x8018d978
+	csrrw x3, 2946, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 2946, x9
+	li x9, 0x8018d978
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 2946, x9
+	li x9, 0xa5bdfdfd
+	bne x9, x3, csr_fail
+	li x9, 0x0a9ad4ee
+	csrrs x3, 2946, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 2946, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 2946, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0x7c7bd181
+	csrrc x3, 2946, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2946, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 2946, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 2946, 0b11011
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 2946, 0b00101
+	li x9, 0x0000001b
+	bne x9, x3, csr_fail
+	csrrsi x3, 2946, 0b11010
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrsi x3, 2946, 0b00110
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2946, 0b00101
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 2946, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 2946, 0b01010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mstatus
+	li x9, 0xa5a5a5a5
+	csrrw x3, 768, x9
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 768, x9
+	li x9, 0x00001880
+	bne x9, x3, csr_fail
+	li x9, 0xe9d662de
+	csrrw x3, 768, x9
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 768, x9
+	li x9, 0x00001888
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 768, x9
+	li x9, 0x00001888
+	bne x9, x3, csr_fail
+	li x9, 0xd225a1b6
+	csrrs x3, 768, x9
+	li x9, 0x00001888
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 768, x9
+	li x9, 0x00001888
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 768, x9
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	li x9, 0x01fe75a5
+	csrrc x3, 768, x9
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	csrrwi x3, 768, 0b00101
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	csrrwi x3, 768, 0b11010
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	csrrwi x3, 768, 0b10100
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	csrrsi x3, 768, 0b00101
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	csrrsi x3, 768, 0b11010
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	csrrsi x3, 768, 0b10111
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	csrrci x3, 768, 0b00101
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	csrrci x3, 768, 0b11010
+	li x9, 0x00001808
+	bne x9, x3, csr_fail
+	csrrci x3, 768, 0b11110
+	li x9, 0x00001800
+	bne x9, x3, csr_fail
+	# misa
+	li x9, 0xa5a5a5a5
+	csrrw x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0x6f3337dd
+	csrrw x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0x6f402148
+	csrrs x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	li x9, 0xe0f3dab6
+	csrrc x3, 769, x9
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrwi x3, 769, 0b00101
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrwi x3, 769, 0b11010
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrwi x3, 769, 0b11100
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrsi x3, 769, 0b00101
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrsi x3, 769, 0b11010
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrsi x3, 769, 0b11101
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrci x3, 769, 0b00101
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrci x3, 769, 0b11010
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	csrrci x3, 769, 0b00111
+	li x9, 0x40801104
+	bne x9, x3, csr_fail
+	# mie
+	li x9, 0xa5a5a5a5
+	csrrw x3, 772, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 772, x9
+	li x9, 0xa5a50080
+	bne x9, x3, csr_fail
+	li x9, 0x5bc393ab
+	csrrw x3, 772, x9
+	li x9, 0x5a5a0808
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 772, x9
+	li x9, 0x5bc30088
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 772, x9
+	li x9, 0xffe70088
+	bne x9, x3, csr_fail
+	li x9, 0x55e31042
+	csrrs x3, 772, x9
+	li x9, 0xffff0888
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 772, x9
+	li x9, 0xffff0888
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 772, x9
+	li x9, 0x5a5a0808
+	bne x9, x3, csr_fail
+	li x9, 0xdb305c6e
+	csrrc x3, 772, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 772, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 772, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 772, 0b11001
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrsi x3, 772, 0b00101
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrsi x3, 772, 0b11010
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrsi x3, 772, 0b01010
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrci x3, 772, 0b00101
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrci x3, 772, 0b11010
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrci x3, 772, 0b00100
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mtvec
+	li x9, 0xa5a5a5a5
+	csrrw x3, 773, x9
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 773, x9
+	li x9, 0xa5a5a501
+	bne x9, x3, csr_fail
+	li x9, 0x71e8385e
+	csrrw x3, 773, x9
+	li x9, 0x5a5a5a00
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 773, x9
+	li x9, 0x71e83800
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 773, x9
+	li x9, 0xf5edbd01
+	bne x9, x3, csr_fail
+	li x9, 0x616da7d7
+	csrrs x3, 773, x9
+	li x9, 0xffffff01
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 773, x9
+	li x9, 0xffffff01
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 773, x9
+	li x9, 0x5a5a5a00
+	bne x9, x3, csr_fail
+	li x9, 0x2fbcb294
+	csrrc x3, 773, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 773, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 773, 0b11010
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	csrrwi x3, 773, 0b01011
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 773, 0b00101
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	csrrsi x3, 773, 0b11010
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	csrrsi x3, 773, 0b00000
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	csrrci x3, 773, 0b00101
+	li x9, 0x00000001
+	bne x9, x3, csr_fail
+	csrrci x3, 773, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 773, 0b00000
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mcountinhibit
+	li x9, 0xa5a5a5a5
+	csrrw x3, 800, x9
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 800, x9
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	li x9, 0x8351ccd8
+	csrrw x3, 800, x9
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 800, x9
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 800, x9
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	li x9, 0xdfaf3a82
+	csrrs x3, 800, x9
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 800, x9
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 800, x9
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	li x9, 0x009bb85d
+	csrrc x3, 800, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 800, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 800, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 800, 0b01111
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrsi x3, 800, 0b00101
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrsi x3, 800, 0b11010
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrsi x3, 800, 0b11111
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrci x3, 800, 0b00101
+	li x9, 0x0000000d
+	bne x9, x3, csr_fail
+	csrrci x3, 800, 0b11010
+	li x9, 0x00000008
+	bne x9, x3, csr_fail
+	csrrci x3, 800, 0b11100
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mscratch
+	li x9, 0xa5a5a5a5
+	csrrw x3, 832, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 832, x9
+	li x9, 0xa5a5a5a5
+	bne x9, x3, csr_fail
+	li x9, 0x9839d463
+	csrrw x3, 832, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 832, x9
+	li x9, 0x9839d463
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 832, x9
+	li x9, 0xbdbdf5e7
+	bne x9, x3, csr_fail
+	li x9, 0x4bfa16dc
+	csrrs x3, 832, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 832, x9
+	li x9, 0xffffffff
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 832, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0x6b2e6866
+	csrrc x3, 832, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 832, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 832, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrwi x3, 832, 0b00101
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 832, 0b00101
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrsi x3, 832, 0b11010
+	li x9, 0x00000005
+	bne x9, x3, csr_fail
+	csrrsi x3, 832, 0b01000
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 832, 0b00101
+	li x9, 0x0000001f
+	bne x9, x3, csr_fail
+	csrrci x3, 832, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 832, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mepc
+	li x9, 0xa5a5a5a5
+	csrrw x3, 833, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 833, x9
+	li x9, 0xa5a5a5a4
+	bne x9, x3, csr_fail
+	li x9, 0x36cdce95
+	csrrw x3, 833, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 833, x9
+	li x9, 0x36cdce94
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 833, x9
+	li x9, 0xb7edefb4
+	bne x9, x3, csr_fail
+	li x9, 0xa13b6c05
+	csrrs x3, 833, x9
+	li x9, 0xfffffffe
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 833, x9
+	li x9, 0xfffffffe
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 833, x9
+	li x9, 0x5a5a5a5a
+	bne x9, x3, csr_fail
+	li x9, 0x6caf6074
+	csrrc x3, 833, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 833, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 833, 0b11010
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrwi x3, 833, 0b11100
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrsi x3, 833, 0b00101
+	li x9, 0x0000001c
+	bne x9, x3, csr_fail
+	csrrsi x3, 833, 0b11010
+	li x9, 0x0000001c
+	bne x9, x3, csr_fail
+	csrrsi x3, 833, 0b10110
+	li x9, 0x0000001e
+	bne x9, x3, csr_fail
+	csrrci x3, 833, 0b00101
+	li x9, 0x0000001e
+	bne x9, x3, csr_fail
+	csrrci x3, 833, 0b11010
+	li x9, 0x0000001a
+	bne x9, x3, csr_fail
+	csrrci x3, 833, 0b10000
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mtval
+	li x9, 0xa5a5a5a5
+	csrrw x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x14f388ad
+	csrrw x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x14fb1517
+	csrrs x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xd90a3adf
+	csrrc x3, 835, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 835, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 835, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 835, 0b11111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 835, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 835, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 835, 0b01001
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 835, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 835, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 835, 0b10010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# mip
+	li x9, 0xa5a5a5a5
+	csrrw x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x82add29a
+	csrrw x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xc03aa88a
+	csrrs x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x8878109b
+	csrrc x3, 836, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 836, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 836, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 836, 0b01111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 836, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 836, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 836, 0b10100
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 836, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 836, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 836, 0b00111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# tselect
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x0556b6cd
+	csrrw x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xf3d1c4ee
+	csrrs x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xb4eee12d
+	csrrc x3, 1952, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1952, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1952, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1952, 0b10011
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1952, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1952, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1952, 0b01111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1952, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1952, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1952, 0b00001
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# tdata1
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x73ffdf7b
+	csrrw x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x6d3204b8
+	csrrs x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	li x9, 0x594e04c7
+	csrrc x3, 1953, x9
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrwi x3, 1953, 0b00101
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrwi x3, 1953, 0b11010
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrwi x3, 1953, 0b01100
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrsi x3, 1953, 0b00101
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrsi x3, 1953, 0b11010
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrsi x3, 1953, 0b01100
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrci x3, 1953, 0b00101
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrci x3, 1953, 0b11010
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	csrrci x3, 1953, 0b01110
+	li x9, 0x28001040
+	bne x9, x3, csr_fail
+	# tdata2
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa95082e4
+	csrrw x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xbafa0aec
+	csrrs x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xd4a83024
+	csrrc x3, 1954, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1954, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1954, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1954, 0b01110
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1954, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1954, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1954, 0b01100
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1954, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1954, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1954, 0b11110
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# tdata3
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x6597e1fa
+	csrrw x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x6c0bdde7
+	csrrs x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x4d7460fc
+	csrrc x3, 1955, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1955, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1955, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1955, 0b11111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1955, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1955, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1955, 0b11110
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1955, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1955, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1955, 0b00001
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# tinfo
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0x3e749b89
+	csrrw x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0xf1050410
+	csrrs x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	li x9, 0xa65d9f30
+	csrrc x3, 1956, x9
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrwi x3, 1956, 0b00101
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrwi x3, 1956, 0b11010
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrwi x3, 1956, 0b10110
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrsi x3, 1956, 0b00101
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrsi x3, 1956, 0b11010
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrsi x3, 1956, 0b01111
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrci x3, 1956, 0b00101
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrci x3, 1956, 0b11010
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	csrrci x3, 1956, 0b01011
+	li x9, 0x00000004
+	bne x9, x3, csr_fail
+	# mcontext
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x1907e5ef
+	csrrw x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x48136a02
+	csrrs x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xbffeb9c5
+	csrrc x3, 1960, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1960, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1960, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1960, 0b10001
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1960, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1960, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1960, 0b10111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1960, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1960, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1960, 0b01001
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	# scontext
+	li x9, 0xa5a5a5a5
+	csrrw x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrw x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x46f765ad
+	csrrw x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrs x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrs x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xbf3714c4
+	csrrs x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xa5a5a5a5
+	csrrc x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0x5a5a5a5a
+	csrrc x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	li x9, 0xb942e577
+	csrrc x3, 1962, x9
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1962, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1962, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrwi x3, 1962, 0b00111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1962, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1962, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrsi x3, 1962, 0b01110
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1962, 0b00101
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1962, 0b11010
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrrci x3, 1962, 0b11111
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+	csrr x3, 1962
+	li x9, 0x00000000
+	bne x9, x3, csr_fail
+_end22:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x4, 0x0000000d
+	csrw 800,  x4 # set mcountinhibit to disable counting
+	li x4, 0x00000000
+	csrw 2816, x4 # reset cycle count
+	csrw 2944, x4
+	csrw 2818, x4 # reset instruction retired count
+	csrw 2946, x4
+	li x4, 0x00000001
+	csrw 773,  x4 # reset mtvec
+###############################################################################
+_start23:
+	# mcycle
+	li x5, 0xa5a5a5a5
+	csrrw x4, 2816, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 2816, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x4, csr_fail
+	li x5, 0x110c2624
+	csrrw x4, 2816, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 2816, x5
+	li x5, 0x110c2624
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 2816, x5
+	li x5, 0xb5ada7a5
+	bne x5, x4, csr_fail
+	li x5, 0xc54a426c
+	csrrs x4, 2816, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 2816, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 2816, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xbee39a3c
+	csrrc x4, 2816, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2816, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2816, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 2816, 0b01001
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 2816, 0b00101
+	li x5, 0x00000009
+	bne x5, x4, csr_fail
+	csrrsi x4, 2816, 0b11010
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	csrrsi x4, 2816, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2816, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2816, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 2816, 0b00100
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mcycleh
+	li x5, 0xa5a5a5a5
+	csrrw x4, 2944, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 2944, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x4, csr_fail
+	li x5, 0x236bd85a
+	csrrw x4, 2944, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 2944, x5
+	li x5, 0x236bd85a
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 2944, x5
+	li x5, 0xa7effdff
+	bne x5, x4, csr_fail
+	li x5, 0x8c84d165
+	csrrs x4, 2944, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 2944, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 2944, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0x33083892
+	csrrc x4, 2944, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2944, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2944, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 2944, 0b00111
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 2944, 0b00101
+	li x5, 0x00000007
+	bne x5, x4, csr_fail
+	csrrsi x4, 2944, 0b11010
+	li x5, 0x00000007
+	bne x5, x4, csr_fail
+	csrrsi x4, 2944, 0b01001
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2944, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2944, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 2944, 0b00000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# minstret
+	li x5, 0xa5a5a5a5
+	csrrw x4, 2818, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 2818, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x4, csr_fail
+	li x5, 0x27d77677
+	csrrw x4, 2818, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 2818, x5
+	li x5, 0x27d77677
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 2818, x5
+	li x5, 0xa7f7f7f7
+	bne x5, x4, csr_fail
+	li x5, 0xc04e06ca
+	csrrs x4, 2818, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 2818, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 2818, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0x020c97f3
+	csrrc x4, 2818, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2818, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2818, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 2818, 0b10000
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 2818, 0b00101
+	li x5, 0x00000010
+	bne x5, x4, csr_fail
+	csrrsi x4, 2818, 0b11010
+	li x5, 0x00000015
+	bne x5, x4, csr_fail
+	csrrsi x4, 2818, 0b10111
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2818, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2818, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 2818, 0b11011
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# minstreth
+	li x5, 0xa5a5a5a5
+	csrrw x4, 2946, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 2946, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x4, csr_fail
+	li x5, 0xe656307c
+	csrrw x4, 2946, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 2946, x5
+	li x5, 0xe656307c
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 2946, x5
+	li x5, 0xe7f7b5fd
+	bne x5, x4, csr_fail
+	li x5, 0x45b78add
+	csrrs x4, 2946, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 2946, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 2946, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xe1fabf24
+	csrrc x4, 2946, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2946, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 2946, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 2946, 0b00100
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 2946, 0b00101
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrsi x4, 2946, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrsi x4, 2946, 0b00001
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2946, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 2946, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 2946, 0b01010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mstatus
+	li x5, 0xa5a5a5a5
+	csrrw x4, 768, x5
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 768, x5
+	li x5, 0x00001880
+	bne x5, x4, csr_fail
+	li x5, 0x573b1953
+	csrrw x4, 768, x5
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 768, x5
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 768, x5
+	li x5, 0x00001880
+	bne x5, x4, csr_fail
+	li x5, 0x88b0531b
+	csrrs x4, 768, x5
+	li x5, 0x00001888
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 768, x5
+	li x5, 0x00001888
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 768, x5
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	li x5, 0x886425d0
+	csrrc x4, 768, x5
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	csrrwi x4, 768, 0b00101
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	csrrwi x4, 768, 0b11010
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	csrrwi x4, 768, 0b11000
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrsi x4, 768, 0b00101
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrsi x4, 768, 0b11010
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrsi x4, 768, 0b10000
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrci x4, 768, 0b00101
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrci x4, 768, 0b11010
+	li x5, 0x00001808
+	bne x5, x4, csr_fail
+	csrrci x4, 768, 0b01101
+	li x5, 0x00001800
+	bne x5, x4, csr_fail
+	# misa
+	li x5, 0xa5a5a5a5
+	csrrw x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x99c161c5
+	csrrw x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x29a6c102
+	csrrs x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	li x5, 0x4aeeb678
+	csrrc x4, 769, x5
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrwi x4, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrwi x4, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrwi x4, 769, 0b10000
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrsi x4, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrsi x4, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrsi x4, 769, 0b01111
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrci x4, 769, 0b00101
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrci x4, 769, 0b11010
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	csrrci x4, 769, 0b11110
+	li x5, 0x40801104
+	bne x5, x4, csr_fail
+	# mie
+	li x5, 0xa5a5a5a5
+	csrrw x4, 772, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 772, x5
+	li x5, 0xa5a50080
+	bne x5, x4, csr_fail
+	li x5, 0x30dd3980
+	csrrw x4, 772, x5
+	li x5, 0x5a5a0808
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 772, x5
+	li x5, 0x30dd0880
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 772, x5
+	li x5, 0xb5fd0880
+	bne x5, x4, csr_fail
+	li x5, 0x43acb624
+	csrrs x4, 772, x5
+	li x5, 0xffff0888
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 772, x5
+	li x5, 0xffff0888
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 772, x5
+	li x5, 0x5a5a0808
+	bne x5, x4, csr_fail
+	li x5, 0x5404364b
+	csrrc x4, 772, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 772, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 772, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 772, 0b01111
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrsi x4, 772, 0b00101
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrsi x4, 772, 0b11010
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrsi x4, 772, 0b11111
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrci x4, 772, 0b00101
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrci x4, 772, 0b11010
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrci x4, 772, 0b10100
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mtvec
+	li x5, 0xa5a5a5a5
+	csrrw x4, 773, x5
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 773, x5
+	li x5, 0xa5a5a501
+	bne x5, x4, csr_fail
+	li x5, 0xf4256da7
+	csrrw x4, 773, x5
+	li x5, 0x5a5a5a00
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 773, x5
+	li x5, 0xf4256d01
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 773, x5
+	li x5, 0xf5a5ed01
+	bne x5, x4, csr_fail
+	li x5, 0xc53b3b96
+	csrrs x4, 773, x5
+	li x5, 0xffffff01
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 773, x5
+	li x5, 0xffffff01
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 773, x5
+	li x5, 0x5a5a5a00
+	bne x5, x4, csr_fail
+	li x5, 0xa297e606
+	csrrc x4, 773, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 773, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 773, 0b11010
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	csrrwi x4, 773, 0b01111
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 773, 0b00101
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	csrrsi x4, 773, 0b11010
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	csrrsi x4, 773, 0b01010
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	csrrci x4, 773, 0b00101
+	li x5, 0x00000001
+	bne x5, x4, csr_fail
+	csrrci x4, 773, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 773, 0b10110
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mcountinhibit
+	li x5, 0xa5a5a5a5
+	csrrw x4, 800, x5
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 800, x5
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	li x5, 0xcc029a94
+	csrrw x4, 800, x5
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 800, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 800, x5
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	li x5, 0x135c9bfd
+	csrrs x4, 800, x5
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 800, x5
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 800, x5
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	li x5, 0x1a2f4561
+	csrrc x4, 800, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 800, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 800, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 800, 0b00010
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrsi x4, 800, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 800, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrsi x4, 800, 0b00011
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	csrrci x4, 800, 0b00101
+	li x5, 0x0000000d
+	bne x5, x4, csr_fail
+	csrrci x4, 800, 0b11010
+	li x5, 0x00000008
+	bne x5, x4, csr_fail
+	csrrci x4, 800, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mscratch
+	li x5, 0xa5a5a5a5
+	csrrw x4, 832, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 832, x5
+	li x5, 0xa5a5a5a5
+	bne x5, x4, csr_fail
+	li x5, 0xe1128e39
+	csrrw x4, 832, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 832, x5
+	li x5, 0xe1128e39
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 832, x5
+	li x5, 0xe5b7afbd
+	bne x5, x4, csr_fail
+	li x5, 0xbf53846f
+	csrrs x4, 832, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 832, x5
+	li x5, 0xffffffff
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 832, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0x4ff061f5
+	csrrc x4, 832, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 832, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 832, 0b11010
+	li x5, 0x00000005
+	bne x5, x4, csr_fail
+	csrrwi x4, 832, 0b11110
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 832, 0b00101
+	li x5, 0x0000001e
+	bne x5, x4, csr_fail
+	csrrsi x4, 832, 0b11010
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrsi x4, 832, 0b00111
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 832, 0b00101
+	li x5, 0x0000001f
+	bne x5, x4, csr_fail
+	csrrci x4, 832, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 832, 0b10010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mepc
+	li x5, 0xa5a5a5a5
+	csrrw x4, 833, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 833, x5
+	li x5, 0xa5a5a5a4
+	bne x5, x4, csr_fail
+	li x5, 0x6fcdc1ba
+	csrrw x4, 833, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 833, x5
+	li x5, 0x6fcdc1ba
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 833, x5
+	li x5, 0xefede5be
+	bne x5, x4, csr_fail
+	li x5, 0x3b388f97
+	csrrs x4, 833, x5
+	li x5, 0xfffffffe
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 833, x5
+	li x5, 0xfffffffe
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 833, x5
+	li x5, 0x5a5a5a5a
+	bne x5, x4, csr_fail
+	li x5, 0xb0987322
+	csrrc x4, 833, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 833, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 833, 0b11010
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrwi x4, 833, 0b10011
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrsi x4, 833, 0b00101
+	li x5, 0x00000012
+	bne x5, x4, csr_fail
+	csrrsi x4, 833, 0b11010
+	li x5, 0x00000016
+	bne x5, x4, csr_fail
+	csrrsi x4, 833, 0b10000
+	li x5, 0x0000001e
+	bne x5, x4, csr_fail
+	csrrci x4, 833, 0b00101
+	li x5, 0x0000001e
+	bne x5, x4, csr_fail
+	csrrci x4, 833, 0b11010
+	li x5, 0x0000001a
+	bne x5, x4, csr_fail
+	csrrci x4, 833, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mtval
+	li x5, 0xa5a5a5a5
+	csrrw x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xed2da0b5
+	csrrw x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xc19c204e
+	csrrs x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x1c43554d
+	csrrc x4, 835, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 835, 0b11101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 835, 0b10001
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 835, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 835, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 835, 0b01111
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# mip
+	li x5, 0xa5a5a5a5
+	csrrw x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x44104021
+	csrrw x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x739b1fd5
+	csrrs x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xcfdb1494
+	csrrc x4, 836, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 836, 0b10000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 836, 0b10000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 836, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 836, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 836, 0b00011
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# tselect
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xdaf6290c
+	csrrw x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x7ce32012
+	csrrs x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x500497bf
+	csrrc x4, 1952, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1952, 0b00111
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1952, 0b10101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1952, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1952, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1952, 0b01000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# tdata1
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0x2dcd9bc7
+	csrrw x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0xb7bb4e22
+	csrrs x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	li x5, 0x5bab5a3e
+	csrrc x4, 1953, x5
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrwi x4, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrwi x4, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrwi x4, 1953, 0b00110
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrsi x4, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrsi x4, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrsi x4, 1953, 0b10110
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrci x4, 1953, 0b00101
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrci x4, 1953, 0b11010
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	csrrci x4, 1953, 0b10000
+	li x5, 0x28001040
+	bne x5, x4, csr_fail
+	# tdata2
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xb9ed1256
+	csrrw x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x60b4b55f
+	csrrs x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x1b4c7bfd
+	csrrc x4, 1954, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1954, 0b00000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1954, 0b00110
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1954, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1954, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1954, 0b00010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# tdata3
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x6348ca57
+	csrrw x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x31f272c5
+	csrrs x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x730d24fa
+	csrrc x4, 1955, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1955, 0b00111
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1955, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1955, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1955, 0b00000
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# tinfo
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x37c3fdc6
+	csrrw x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x6106b623
+	csrrs x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	li x5, 0x3e252905
+	csrrc x4, 1956, x5
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrwi x4, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrwi x4, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrwi x4, 1956, 0b01110
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrsi x4, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrsi x4, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrsi x4, 1956, 0b11001
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrci x4, 1956, 0b00101
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrci x4, 1956, 0b11010
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	csrrci x4, 1956, 0b10011
+	li x5, 0x00000004
+	bne x5, x4, csr_fail
+	# mcontext
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x8b8b9969
+	csrrw x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xaa4f9528
+	csrrs x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x84353e2c
+	csrrc x4, 1960, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1960, 0b01010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1960, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1960, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1960, 0b00110
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	# scontext
+	li x5, 0xa5a5a5a5
+	csrrw x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrw x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a1ef70c
+	csrrw x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrs x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrs x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x798ee7d3
+	csrrs x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0xa5a5a5a5
+	csrrc x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x5a5a5a5a
+	csrrc x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	li x5, 0x576919a8
+	csrrc x4, 1962, x5
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrwi x4, 1962, 0b01110
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrsi x4, 1962, 0b11011
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1962, 0b00101
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1962, 0b11010
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrrci x4, 1962, 0b10111
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+	csrr x4, 1962
+	li x5, 0x00000000
+	bne x5, x4, csr_fail
+_end23:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x5, 0x0000000d
+	csrw 800,  x5 # set mcountinhibit to disable counting
+	li x5, 0x00000000
+	csrw 2816, x5 # reset cycle count
+	csrw 2944, x5
+	csrw 2818, x5 # reset instruction retired count
+	csrw 2946, x5
+	li x5, 0x00000001
+	csrw 773,  x5 # reset mtvec
+###############################################################################
+_start24:
+	# mcycle
+	li x7, 0xa5a5a5a5
+	csrrw x15, 2816, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 2816, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x15, csr_fail
+	li x7, 0x2d3d0799
+	csrrw x15, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 2816, x7
+	li x7, 0x2d3d0799
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 2816, x7
+	li x7, 0xadbda7bd
+	bne x7, x15, csr_fail
+	li x7, 0x33e28b41
+	csrrs x15, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x57c8262b
+	csrrc x15, 2816, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2816, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2816, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 2816, 0b00111
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 2816, 0b00101
+	li x7, 0x00000007
+	bne x7, x15, csr_fail
+	csrrsi x15, 2816, 0b11010
+	li x7, 0x00000007
+	bne x7, x15, csr_fail
+	csrrsi x15, 2816, 0b11011
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2816, 0b00101
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2816, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 2816, 0b11001
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mcycleh
+	li x7, 0xa5a5a5a5
+	csrrw x15, 2944, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 2944, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x15, csr_fail
+	li x7, 0x08af0aad
+	csrrw x15, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 2944, x7
+	li x7, 0x08af0aad
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 2944, x7
+	li x7, 0xadafafad
+	bne x7, x15, csr_fail
+	li x7, 0xbfc21974
+	csrrs x15, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x18475b4f
+	csrrc x15, 2944, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2944, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2944, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 2944, 0b00001
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 2944, 0b00101
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	csrrsi x15, 2944, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 2944, 0b10010
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2944, 0b00101
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2944, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 2944, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# minstret
+	li x7, 0xa5a5a5a5
+	csrrw x15, 2818, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 2818, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x15, csr_fail
+	li x7, 0xfcbc877c
+	csrrw x15, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 2818, x7
+	li x7, 0xfcbc877c
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 2818, x7
+	li x7, 0xfdbda7fd
+	bne x7, x15, csr_fail
+	li x7, 0x8334e898
+	csrrs x15, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x35b8967b
+	csrrc x15, 2818, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2818, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2818, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 2818, 0b00101
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 2818, 0b00101
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 2818, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 2818, 0b11000
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2818, 0b00101
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2818, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 2818, 0b01011
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# minstreth
+	li x7, 0xa5a5a5a5
+	csrrw x15, 2946, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 2946, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x15, csr_fail
+	li x7, 0xf97b2f5c
+	csrrw x15, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 2946, x7
+	li x7, 0xf97b2f5c
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 2946, x7
+	li x7, 0xfdffaffd
+	bne x7, x15, csr_fail
+	li x7, 0xd9d3768e
+	csrrs x15, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x7f6a71db
+	csrrc x15, 2946, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2946, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 2946, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 2946, 0b00100
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 2946, 0b00101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrsi x15, 2946, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 2946, 0b01100
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2946, 0b00101
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 2946, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 2946, 0b01100
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mstatus
+	li x7, 0xa5a5a5a5
+	csrrw x15, 768, x7
+	li x7, 0x00001800
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 768, x7
+	li x7, 0x00001880
+	bne x7, x15, csr_fail
+	li x7, 0x7d1c3f82
+	csrrw x15, 768, x7
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 768, x7
+	li x7, 0x00001880
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 768, x7
+	li x7, 0x00001880
+	bne x7, x15, csr_fail
+	li x7, 0xd6aa8f2d
+	csrrs x15, 768, x7
+	li x7, 0x00001888
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 768, x7
+	li x7, 0x00001888
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 768, x7
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	li x7, 0x0cb8549b
+	csrrc x15, 768, x7
+	li x7, 0x00001800
+	bne x7, x15, csr_fail
+	csrrwi x15, 768, 0b00101
+	li x7, 0x00001800
+	bne x7, x15, csr_fail
+	csrrwi x15, 768, 0b11010
+	li x7, 0x00001800
+	bne x7, x15, csr_fail
+	csrrwi x15, 768, 0b01010
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrsi x15, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrsi x15, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrsi x15, 768, 0b10011
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrci x15, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrci x15, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x15, csr_fail
+	csrrci x15, 768, 0b11011
+	li x7, 0x00001800
+	bne x7, x15, csr_fail
+	# misa
+	li x7, 0xa5a5a5a5
+	csrrw x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0xdefbba75
+	csrrw x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0xec1ddb52
+	csrrs x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	li x7, 0x3a42960d
+	csrrc x15, 769, x7
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrwi x15, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrwi x15, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrwi x15, 769, 0b10100
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrsi x15, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrsi x15, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrsi x15, 769, 0b11110
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrci x15, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrci x15, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	csrrci x15, 769, 0b01010
+	li x7, 0x40801104
+	bne x7, x15, csr_fail
+	# mie
+	li x7, 0xa5a5a5a5
+	csrrw x15, 772, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 772, x7
+	li x7, 0xa5a50080
+	bne x7, x15, csr_fail
+	li x7, 0x76e776a0
+	csrrw x15, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 772, x7
+	li x7, 0x76e70080
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 772, x7
+	li x7, 0xf7e70080
+	bne x7, x15, csr_fail
+	li x7, 0x03153e59
+	csrrs x15, 772, x7
+	li x7, 0xffff0888
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 772, x7
+	li x7, 0xffff0888
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x15, csr_fail
+	li x7, 0xc212c120
+	csrrc x15, 772, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 772, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 772, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 772, 0b00011
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrsi x15, 772, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 772, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 772, 0b11100
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrci x15, 772, 0b00101
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrci x15, 772, 0b11010
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrci x15, 772, 0b11000
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mtvec
+	li x7, 0xa5a5a5a5
+	csrrw x15, 773, x7
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 773, x7
+	li x7, 0xa5a5a501
+	bne x7, x15, csr_fail
+	li x7, 0xc000ee8e
+	csrrw x15, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 773, x7
+	li x7, 0xc000ee00
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 773, x7
+	li x7, 0xe5a5ef01
+	bne x7, x15, csr_fail
+	li x7, 0xd8364d5d
+	csrrs x15, 773, x7
+	li x7, 0xffffff01
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 773, x7
+	li x7, 0xffffff01
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x15, csr_fail
+	li x7, 0xbcfc88d8
+	csrrc x15, 773, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 773, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	csrrwi x15, 773, 0b10010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 773, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	csrrsi x15, 773, 0b01000
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	csrrci x15, 773, 0b00101
+	li x7, 0x00000001
+	bne x7, x15, csr_fail
+	csrrci x15, 773, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 773, 0b00110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mcountinhibit
+	li x7, 0xa5a5a5a5
+	csrrw x15, 800, x7
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 800, x7
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	li x7, 0x031d09cf
+	csrrw x15, 800, x7
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 800, x7
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 800, x7
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	li x7, 0x7ef42dc1
+	csrrs x15, 800, x7
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 800, x7
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 800, x7
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	li x7, 0x738b5aed
+	csrrc x15, 800, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 800, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 800, 0b10101
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrsi x15, 800, 0b00101
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrsi x15, 800, 0b00111
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	csrrci x15, 800, 0b00101
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	csrrci x15, 800, 0b11010
+	li x7, 0x00000008
+	bne x7, x15, csr_fail
+	csrrci x15, 800, 0b11000
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mscratch
+	li x7, 0xa5a5a5a5
+	csrrw x15, 832, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 832, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x15, csr_fail
+	li x7, 0xb817bdb3
+	csrrw x15, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 832, x7
+	li x7, 0xb817bdb3
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 832, x7
+	li x7, 0xbdb7bdb7
+	bne x7, x15, csr_fail
+	li x7, 0x445ae03c
+	csrrs x15, 832, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 832, x7
+	li x7, 0xffffffff
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x28064e33
+	csrrc x15, 832, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 832, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 832, 0b11010
+	li x7, 0x00000005
+	bne x7, x15, csr_fail
+	csrrwi x15, 832, 0b01101
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 832, 0b00101
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	csrrsi x15, 832, 0b11010
+	li x7, 0x0000000d
+	bne x7, x15, csr_fail
+	csrrsi x15, 832, 0b10000
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 832, 0b00101
+	li x7, 0x0000001f
+	bne x7, x15, csr_fail
+	csrrci x15, 832, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 832, 0b01110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mepc
+	li x7, 0xa5a5a5a5
+	csrrw x15, 833, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 833, x7
+	li x7, 0xa5a5a5a4
+	bne x7, x15, csr_fail
+	li x7, 0x3edd7c42
+	csrrw x15, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 833, x7
+	li x7, 0x3edd7c42
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 833, x7
+	li x7, 0xbffdfde6
+	bne x7, x15, csr_fail
+	li x7, 0x0f36642d
+	csrrs x15, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x15, csr_fail
+	li x7, 0x16763fa9
+	csrrc x15, 833, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 833, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 833, 0b11010
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrwi x15, 833, 0b00000
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrsi x15, 833, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 833, 0b11010
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrsi x15, 833, 0b11100
+	li x7, 0x0000001e
+	bne x7, x15, csr_fail
+	csrrci x15, 833, 0b00101
+	li x7, 0x0000001e
+	bne x7, x15, csr_fail
+	csrrci x15, 833, 0b11010
+	li x7, 0x0000001a
+	bne x7, x15, csr_fail
+	csrrci x15, 833, 0b10101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mtval
+	li x7, 0xa5a5a5a5
+	csrrw x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xafc38c38
+	csrrw x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x453f96ef
+	csrrs x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x95e6076c
+	csrrc x15, 835, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 835, 0b10110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 835, 0b11000
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 835, 0b10111
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# mip
+	li x7, 0xa5a5a5a5
+	csrrw x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5cb59335
+	csrrw x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xdac302a1
+	csrrs x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xc8b4f19f
+	csrrc x15, 836, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 836, 0b00110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 836, 0b10110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 836, 0b00011
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# tselect
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x8e296b48
+	csrrw x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xe951e77b
+	csrrs x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xc1b8fd9c
+	csrrc x15, 1952, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1952, 0b11100
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1952, 0b11101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1952, 0b11001
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# tdata1
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0xa42d1cd0
+	csrrw x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0x963bbff0
+	csrrs x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	li x7, 0xfe8f69d9
+	csrrc x15, 1953, x7
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrwi x15, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrwi x15, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrwi x15, 1953, 0b01100
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrsi x15, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrsi x15, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrsi x15, 1953, 0b01100
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrci x15, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrci x15, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	csrrci x15, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x15, csr_fail
+	# tdata2
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x913677c1
+	csrrw x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xc4c9ab77
+	csrrs x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5b16956a
+	csrrc x15, 1954, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1954, 0b00010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1954, 0b10100
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1954, 0b11101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# tdata3
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x718441e0
+	csrrw x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x20193b17
+	csrrs x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x92f07098
+	csrrc x15, 1955, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1955, 0b00100
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1955, 0b11110
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# tinfo
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0xa434ae13
+	csrrw x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0x1aeb90be
+	csrrs x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	li x7, 0xa1adb83d
+	csrrc x15, 1956, x7
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrwi x15, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrwi x15, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrwi x15, 1956, 0b10101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrsi x15, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrsi x15, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrsi x15, 1956, 0b01101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrci x15, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrci x15, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	csrrci x15, 1956, 0b00011
+	li x7, 0x00000004
+	bne x7, x15, csr_fail
+	# mcontext
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xb368a97a
+	csrrw x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x7fd8925f
+	csrrs x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x7fb761b3
+	csrrc x15, 1960, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1960, 0b01100
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1960, 0b00111
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1960, 0b01010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	# scontext
+	li x7, 0xa5a5a5a5
+	csrrw x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x89709024
+	csrrw x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x13b62821
+	csrrs x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	li x7, 0x1149f149
+	csrrc x15, 1962, x7
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrwi x15, 1962, 0b00001
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrsi x15, 1962, 0b01001
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrrci x15, 1962, 0b00111
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+	csrr x15, 1962
+	li x7, 0x00000000
+	bne x7, x15, csr_fail
+_end24:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x6, 0x0000000d
+	csrw 800,  x6 # set mcountinhibit to disable counting
+	li x6, 0x00000000
+	csrw 2816, x6 # reset cycle count
+	csrw 2944, x6
+	csrw 2818, x6 # reset instruction retired count
+	csrw 2946, x6
+	li x6, 0x00000001
+	csrw 773,  x6 # reset mtvec
+###############################################################################
+_start25:
+	# mcycle
+	li x7, 0xa5a5a5a5
+	csrrw x2, 2816, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 2816, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x2, csr_fail
+	li x7, 0x173d813e
+	csrrw x2, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 2816, x7
+	li x7, 0x173d813e
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 2816, x7
+	li x7, 0xb7bda5bf
+	bne x7, x2, csr_fail
+	li x7, 0x0cd4a418
+	csrrs x2, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 2816, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 2816, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xdf4fe740
+	csrrc x2, 2816, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2816, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2816, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 2816, 0b11001
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 2816, 0b00101
+	li x7, 0x00000019
+	bne x7, x2, csr_fail
+	csrrsi x2, 2816, 0b11010
+	li x7, 0x0000001d
+	bne x7, x2, csr_fail
+	csrrsi x2, 2816, 0b01000
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2816, 0b00101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2816, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 2816, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mcycleh
+	li x7, 0xa5a5a5a5
+	csrrw x2, 2944, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 2944, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x2, csr_fail
+	li x7, 0xc62b6006
+	csrrw x2, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 2944, x7
+	li x7, 0xc62b6006
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 2944, x7
+	li x7, 0xe7afe5a7
+	bne x7, x2, csr_fail
+	li x7, 0x08bd7660
+	csrrs x2, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 2944, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 2944, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xbb4a1db5
+	csrrc x2, 2944, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2944, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2944, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 2944, 0b10000
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 2944, 0b00101
+	li x7, 0x00000010
+	bne x7, x2, csr_fail
+	csrrsi x2, 2944, 0b11010
+	li x7, 0x00000015
+	bne x7, x2, csr_fail
+	csrrsi x2, 2944, 0b00000
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2944, 0b00101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2944, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 2944, 0b01110
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# minstret
+	li x7, 0xa5a5a5a5
+	csrrw x2, 2818, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 2818, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x2, csr_fail
+	li x7, 0x200b99b7
+	csrrw x2, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 2818, x7
+	li x7, 0x200b99b7
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 2818, x7
+	li x7, 0xa5afbdb7
+	bne x7, x2, csr_fail
+	li x7, 0x3deb6848
+	csrrs x2, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 2818, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 2818, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xb5d64149
+	csrrc x2, 2818, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2818, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2818, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 2818, 0b01101
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 2818, 0b00101
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	csrrsi x2, 2818, 0b11010
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	csrrsi x2, 2818, 0b11101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2818, 0b00101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2818, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 2818, 0b10111
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# minstreth
+	li x7, 0xa5a5a5a5
+	csrrw x2, 2946, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 2946, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x2, csr_fail
+	li x7, 0xffa61fa9
+	csrrw x2, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 2946, x7
+	li x7, 0xffa61fa9
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 2946, x7
+	li x7, 0xffa7bfad
+	bne x7, x2, csr_fail
+	li x7, 0xe15a1a49
+	csrrs x2, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 2946, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 2946, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0x99c6b960
+	csrrc x2, 2946, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2946, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 2946, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 2946, 0b01100
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 2946, 0b00101
+	li x7, 0x0000000c
+	bne x7, x2, csr_fail
+	csrrsi x2, 2946, 0b11010
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	csrrsi x2, 2946, 0b11101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2946, 0b00101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 2946, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 2946, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mstatus
+	li x7, 0xa5a5a5a5
+	csrrw x2, 768, x7
+	li x7, 0x00001800
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 768, x7
+	li x7, 0x00001880
+	bne x7, x2, csr_fail
+	li x7, 0x627c6f93
+	csrrw x2, 768, x7
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 768, x7
+	li x7, 0x00001880
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 768, x7
+	li x7, 0x00001880
+	bne x7, x2, csr_fail
+	li x7, 0x55ef2b06
+	csrrs x2, 768, x7
+	li x7, 0x00001888
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 768, x7
+	li x7, 0x00001888
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 768, x7
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	li x7, 0xf8cad51f
+	csrrc x2, 768, x7
+	li x7, 0x00001800
+	bne x7, x2, csr_fail
+	csrrwi x2, 768, 0b00101
+	li x7, 0x00001800
+	bne x7, x2, csr_fail
+	csrrwi x2, 768, 0b11010
+	li x7, 0x00001800
+	bne x7, x2, csr_fail
+	csrrwi x2, 768, 0b01111
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrsi x2, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrsi x2, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrsi x2, 768, 0b11001
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrci x2, 768, 0b00101
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrci x2, 768, 0b11010
+	li x7, 0x00001808
+	bne x7, x2, csr_fail
+	csrrci x2, 768, 0b00111
+	li x7, 0x00001800
+	bne x7, x2, csr_fail
+	# misa
+	li x7, 0xa5a5a5a5
+	csrrw x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0x02cbc261
+	csrrw x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0xca81cd94
+	csrrs x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	li x7, 0xee8c1734
+	csrrc x2, 769, x7
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrwi x2, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrwi x2, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrwi x2, 769, 0b00111
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrsi x2, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrsi x2, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrsi x2, 769, 0b10100
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrci x2, 769, 0b00101
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrci x2, 769, 0b11010
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	csrrci x2, 769, 0b01010
+	li x7, 0x40801104
+	bne x7, x2, csr_fail
+	# mie
+	li x7, 0xa5a5a5a5
+	csrrw x2, 772, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 772, x7
+	li x7, 0xa5a50080
+	bne x7, x2, csr_fail
+	li x7, 0x389691a4
+	csrrw x2, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 772, x7
+	li x7, 0x38960080
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 772, x7
+	li x7, 0xbdb70080
+	bne x7, x2, csr_fail
+	li x7, 0x4b5474b2
+	csrrs x2, 772, x7
+	li x7, 0xffff0888
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 772, x7
+	li x7, 0xffff0888
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 772, x7
+	li x7, 0x5a5a0808
+	bne x7, x2, csr_fail
+	li x7, 0x6fad7e5a
+	csrrc x2, 772, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 772, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 772, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 772, 0b01001
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrsi x2, 772, 0b00101
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrsi x2, 772, 0b11010
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrsi x2, 772, 0b00011
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrci x2, 772, 0b00101
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrci x2, 772, 0b11010
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrci x2, 772, 0b10001
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mtvec
+	li x7, 0xa5a5a5a5
+	csrrw x2, 773, x7
+	li x7, 0x00000001
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 773, x7
+	li x7, 0xa5a5a501
+	bne x7, x2, csr_fail
+	li x7, 0xadda308e
+	csrrw x2, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 773, x7
+	li x7, 0xadda3000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 773, x7
+	li x7, 0xadffb501
+	bne x7, x2, csr_fail
+	li x7, 0xeba981aa
+	csrrs x2, 773, x7
+	li x7, 0xffffff01
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 773, x7
+	li x7, 0xffffff01
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 773, x7
+	li x7, 0x5a5a5a00
+	bne x7, x2, csr_fail
+	li x7, 0x4aedc6a9
+	csrrc x2, 773, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 773, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x2, csr_fail
+	csrrwi x2, 773, 0b11000
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 773, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 773, 0b11010
+	li x7, 0x00000001
+	bne x7, x2, csr_fail
+	csrrsi x2, 773, 0b11000
+	li x7, 0x00000001
+	bne x7, x2, csr_fail
+	csrrci x2, 773, 0b00101
+	li x7, 0x00000001
+	bne x7, x2, csr_fail
+	csrrci x2, 773, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 773, 0b01011
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mcountinhibit
+	li x7, 0xa5a5a5a5
+	csrrw x2, 800, x7
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 800, x7
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	li x7, 0x7d8a7342
+	csrrw x2, 800, x7
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 800, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 800, x7
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	li x7, 0xfa42836c
+	csrrs x2, 800, x7
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 800, x7
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 800, x7
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	li x7, 0xe6222566
+	csrrc x2, 800, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 800, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 800, 0b00100
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrsi x2, 800, 0b00101
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrsi x2, 800, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrsi x2, 800, 0b01010
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	csrrci x2, 800, 0b00101
+	li x7, 0x0000000d
+	bne x7, x2, csr_fail
+	csrrci x2, 800, 0b11010
+	li x7, 0x00000008
+	bne x7, x2, csr_fail
+	csrrci x2, 800, 0b11100
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mscratch
+	li x7, 0xa5a5a5a5
+	csrrw x2, 832, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 832, x7
+	li x7, 0xa5a5a5a5
+	bne x7, x2, csr_fail
+	li x7, 0xbc695966
+	csrrw x2, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 832, x7
+	li x7, 0xbc695966
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 832, x7
+	li x7, 0xbdedfde7
+	bne x7, x2, csr_fail
+	li x7, 0xd05ca938
+	csrrs x2, 832, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 832, x7
+	li x7, 0xffffffff
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 832, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa8267d12
+	csrrc x2, 832, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 832, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 832, 0b11010
+	li x7, 0x00000005
+	bne x7, x2, csr_fail
+	csrrwi x2, 832, 0b10111
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 832, 0b00101
+	li x7, 0x00000017
+	bne x7, x2, csr_fail
+	csrrsi x2, 832, 0b11010
+	li x7, 0x00000017
+	bne x7, x2, csr_fail
+	csrrsi x2, 832, 0b11110
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 832, 0b00101
+	li x7, 0x0000001f
+	bne x7, x2, csr_fail
+	csrrci x2, 832, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 832, 0b00000
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mepc
+	li x7, 0xa5a5a5a5
+	csrrw x2, 833, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 833, x7
+	li x7, 0xa5a5a5a4
+	bne x7, x2, csr_fail
+	li x7, 0xb4cb87a6
+	csrrw x2, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 833, x7
+	li x7, 0xb4cb87a6
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 833, x7
+	li x7, 0xb5efa7a6
+	bne x7, x2, csr_fail
+	li x7, 0xfcfa3b6b
+	csrrs x2, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 833, x7
+	li x7, 0xfffffffe
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 833, x7
+	li x7, 0x5a5a5a5a
+	bne x7, x2, csr_fail
+	li x7, 0x49c6464d
+	csrrc x2, 833, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 833, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 833, 0b11010
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrwi x2, 833, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 833, 0b00101
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrsi x2, 833, 0b11010
+	li x7, 0x0000001e
+	bne x7, x2, csr_fail
+	csrrsi x2, 833, 0b11010
+	li x7, 0x0000001e
+	bne x7, x2, csr_fail
+	csrrci x2, 833, 0b00101
+	li x7, 0x0000001e
+	bne x7, x2, csr_fail
+	csrrci x2, 833, 0b11010
+	li x7, 0x0000001a
+	bne x7, x2, csr_fail
+	csrrci x2, 833, 0b01000
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mtval
+	li x7, 0xa5a5a5a5
+	csrrw x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x98557e7b
+	csrrw x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x830778e7
+	csrrs x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x74783c96
+	csrrc x2, 835, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 835, 0b10000
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 835, 0b01100
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 835, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 835, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 835, 0b00000
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# mip
+	li x7, 0xa5a5a5a5
+	csrrw x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x42d5c9ca
+	csrrw x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xe3abb48d
+	csrrs x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa6258426
+	csrrc x2, 836, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 836, 0b10110
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 836, 0b00011
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 836, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 836, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 836, 0b10001
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# tselect
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xfb541b53
+	csrrw x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x138272bb
+	csrrs x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x9a0ddcc2
+	csrrc x2, 1952, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1952, 0b00111
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1952, 0b00110
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1952, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1952, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1952, 0b10100
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# tdata1
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0xb9f96c1b
+	csrrw x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0xcbb3da9e
+	csrrs x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	li x7, 0x1b6e91cf
+	csrrc x2, 1953, x7
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrwi x2, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrwi x2, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrwi x2, 1953, 0b01100
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrsi x2, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrsi x2, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrsi x2, 1953, 0b01100
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrci x2, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrci x2, 1953, 0b11010
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	csrrci x2, 1953, 0b00101
+	li x7, 0x28001040
+	bne x7, x2, csr_fail
+	# tdata2
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x1ae28bbd
+	csrrw x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x6bf977bb
+	csrrs x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x64ef3c7b
+	csrrc x2, 1954, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1954, 0b11101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1954, 0b01001
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1954, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1954, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1954, 0b11011
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# tdata3
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x53f97535
+	csrrw x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa6baf290
+	csrrs x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xfcd35753
+	csrrc x2, 1955, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1955, 0b11011
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1955, 0b01001
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1955, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1955, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1955, 0b01010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# tinfo
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0xdf60f50c
+	csrrw x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0x950bf1c2
+	csrrs x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	li x7, 0x349c17ae
+	csrrc x2, 1956, x7
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrwi x2, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrwi x2, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrwi x2, 1956, 0b10001
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrsi x2, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrsi x2, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrsi x2, 1956, 0b00110
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrci x2, 1956, 0b00101
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrci x2, 1956, 0b11010
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	csrrci x2, 1956, 0b11011
+	li x7, 0x00000004
+	bne x7, x2, csr_fail
+	# mcontext
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x75dbcfd3
+	csrrw x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xd7853938
+	csrrs x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xcb3a5ff3
+	csrrc x2, 1960, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1960, 0b10110
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1960, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1960, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1960, 0b10011
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	# scontext
+	li x7, 0xa5a5a5a5
+	csrrw x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrw x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x67d54262
+	csrrw x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrs x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrs x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x48156497
+	csrrs x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0xa5a5a5a5
+	csrrc x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x5a5a5a5a
+	csrrc x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	li x7, 0x0627ba79
+	csrrc x2, 1962, x7
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrwi x2, 1962, 0b01010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrsi x2, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1962, 0b00101
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrrci x2, 1962, 0b11010
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+	csrr x2, 1962
+	li x7, 0x00000000
+	bne x7, x2, csr_fail
+_end25:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x7, 0x0000000d
+	csrw 800,  x7 # set mcountinhibit to disable counting
+	li x7, 0x00000000
+	csrw 2816, x7 # reset cycle count
+	csrw 2944, x7
+	csrw 2818, x7 # reset instruction retired count
+	csrw 2946, x7
+	li x7, 0x00000001
+	csrw 773,  x7 # reset mtvec
+###############################################################################
+_start26:
+	# mcycle
+	li x12, 0xa5a5a5a5
+	csrrw x15, 2816, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 2816, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x15, csr_fail
+	li x12, 0x559941cb
+	csrrw x15, 2816, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 2816, x12
+	li x12, 0x559941cb
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 2816, x12
+	li x12, 0xf5bde5ef
+	bne x12, x15, csr_fail
+	li x12, 0x5afc9079
+	csrrs x15, 2816, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 2816, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 2816, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0x693f7798
+	csrrc x15, 2816, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2816, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2816, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 2816, 0b00101
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 2816, 0b00101
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrsi x15, 2816, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrsi x15, 2816, 0b01111
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2816, 0b00101
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2816, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 2816, 0b01101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mcycleh
+	li x12, 0xa5a5a5a5
+	csrrw x15, 2944, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 2944, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x15, csr_fail
+	li x12, 0x764ddacd
+	csrrw x15, 2944, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 2944, x12
+	li x12, 0x764ddacd
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 2944, x12
+	li x12, 0xf7edffed
+	bne x12, x15, csr_fail
+	li x12, 0x3cb11a15
+	csrrs x15, 2944, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 2944, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 2944, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xd2aa33e9
+	csrrc x15, 2944, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2944, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2944, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 2944, 0b01111
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 2944, 0b00101
+	li x12, 0x0000000f
+	bne x12, x15, csr_fail
+	csrrsi x15, 2944, 0b11010
+	li x12, 0x0000000f
+	bne x12, x15, csr_fail
+	csrrsi x15, 2944, 0b01010
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2944, 0b00101
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2944, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 2944, 0b10100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# minstret
+	li x12, 0xa5a5a5a5
+	csrrw x15, 2818, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 2818, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x15, csr_fail
+	li x12, 0x08ecd4f9
+	csrrw x15, 2818, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 2818, x12
+	li x12, 0x08ecd4f9
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 2818, x12
+	li x12, 0xadedf5fd
+	bne x12, x15, csr_fail
+	li x12, 0x56fb6f64
+	csrrs x15, 2818, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 2818, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 2818, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xef72cbdd
+	csrrc x15, 2818, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2818, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2818, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 2818, 0b00011
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 2818, 0b00101
+	li x12, 0x00000003
+	bne x12, x15, csr_fail
+	csrrsi x15, 2818, 0b11010
+	li x12, 0x00000007
+	bne x12, x15, csr_fail
+	csrrsi x15, 2818, 0b10100
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2818, 0b00101
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2818, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 2818, 0b01111
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# minstreth
+	li x12, 0xa5a5a5a5
+	csrrw x15, 2946, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 2946, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x15, csr_fail
+	li x12, 0x3c579bb9
+	csrrw x15, 2946, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 2946, x12
+	li x12, 0x3c579bb9
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 2946, x12
+	li x12, 0xbdf7bfbd
+	bne x12, x15, csr_fail
+	li x12, 0x7cf1ddcd
+	csrrs x15, 2946, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 2946, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 2946, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0x5646cbaf
+	csrrc x15, 2946, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2946, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 2946, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 2946, 0b10001
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 2946, 0b00101
+	li x12, 0x00000011
+	bne x12, x15, csr_fail
+	csrrsi x15, 2946, 0b11010
+	li x12, 0x00000015
+	bne x12, x15, csr_fail
+	csrrsi x15, 2946, 0b01100
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2946, 0b00101
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 2946, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 2946, 0b10101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mstatus
+	li x12, 0xa5a5a5a5
+	csrrw x15, 768, x12
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 768, x12
+	li x12, 0x00001880
+	bne x12, x15, csr_fail
+	li x12, 0x8a0e612a
+	csrrw x15, 768, x12
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 768, x12
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 768, x12
+	li x12, 0x00001888
+	bne x12, x15, csr_fail
+	li x12, 0xc82366ed
+	csrrs x15, 768, x12
+	li x12, 0x00001888
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 768, x12
+	li x12, 0x00001888
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 768, x12
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	li x12, 0xdf9f73bc
+	csrrc x15, 768, x12
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	csrrwi x15, 768, 0b00101
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	csrrwi x15, 768, 0b11010
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	csrrwi x15, 768, 0b00001
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	csrrsi x15, 768, 0b00101
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	csrrsi x15, 768, 0b11010
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	csrrsi x15, 768, 0b11101
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	csrrci x15, 768, 0b00101
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	csrrci x15, 768, 0b11010
+	li x12, 0x00001808
+	bne x12, x15, csr_fail
+	csrrci x15, 768, 0b10011
+	li x12, 0x00001800
+	bne x12, x15, csr_fail
+	# misa
+	li x12, 0xa5a5a5a5
+	csrrw x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0x67af56e5
+	csrrw x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0xc659d97a
+	csrrs x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	li x12, 0x29719705
+	csrrc x15, 769, x12
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrwi x15, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrwi x15, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrwi x15, 769, 0b00111
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrsi x15, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrsi x15, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrsi x15, 769, 0b00100
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrci x15, 769, 0b00101
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrci x15, 769, 0b11010
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	csrrci x15, 769, 0b01001
+	li x12, 0x40801104
+	bne x12, x15, csr_fail
+	# mie
+	li x12, 0xa5a5a5a5
+	csrrw x15, 772, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 772, x12
+	li x12, 0xa5a50080
+	bne x12, x15, csr_fail
+	li x12, 0x61c07112
+	csrrw x15, 772, x12
+	li x12, 0x5a5a0808
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 772, x12
+	li x12, 0x61c00000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 772, x12
+	li x12, 0xe5e50080
+	bne x12, x15, csr_fail
+	li x12, 0x90334ca3
+	csrrs x15, 772, x12
+	li x12, 0xffff0888
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 772, x12
+	li x12, 0xffff0888
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 772, x12
+	li x12, 0x5a5a0808
+	bne x12, x15, csr_fail
+	li x12, 0x58a35db6
+	csrrc x15, 772, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 772, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 772, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 772, 0b01110
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrsi x15, 772, 0b00101
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrsi x15, 772, 0b11010
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrsi x15, 772, 0b10110
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrci x15, 772, 0b00101
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrci x15, 772, 0b11010
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrci x15, 772, 0b10100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mtvec
+	li x12, 0xa5a5a5a5
+	csrrw x15, 773, x12
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 773, x12
+	li x12, 0xa5a5a501
+	bne x12, x15, csr_fail
+	li x12, 0x7e5e3473
+	csrrw x15, 773, x12
+	li x12, 0x5a5a5a00
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 773, x12
+	li x12, 0x7e5e3401
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 773, x12
+	li x12, 0xffffb501
+	bne x12, x15, csr_fail
+	li x12, 0x6890546f
+	csrrs x15, 773, x12
+	li x12, 0xffffff01
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 773, x12
+	li x12, 0xffffff01
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 773, x12
+	li x12, 0x5a5a5a00
+	bne x12, x15, csr_fail
+	li x12, 0xb1856795
+	csrrc x15, 773, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 773, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 773, 0b11010
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	csrrwi x15, 773, 0b00011
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 773, 0b00101
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	csrrsi x15, 773, 0b11010
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	csrrsi x15, 773, 0b11001
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	csrrci x15, 773, 0b00101
+	li x12, 0x00000001
+	bne x12, x15, csr_fail
+	csrrci x15, 773, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 773, 0b11100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mcountinhibit
+	li x12, 0xa5a5a5a5
+	csrrw x15, 800, x12
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 800, x12
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	li x12, 0x577b091a
+	csrrw x15, 800, x12
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 800, x12
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 800, x12
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	li x12, 0x4a834990
+	csrrs x15, 800, x12
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 800, x12
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 800, x12
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	li x12, 0x0c265b0d
+	csrrc x15, 800, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 800, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 800, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 800, 0b10110
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrsi x15, 800, 0b00101
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrsi x15, 800, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrsi x15, 800, 0b01010
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	csrrci x15, 800, 0b00101
+	li x12, 0x0000000d
+	bne x12, x15, csr_fail
+	csrrci x15, 800, 0b11010
+	li x12, 0x00000008
+	bne x12, x15, csr_fail
+	csrrci x15, 800, 0b01000
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mscratch
+	li x12, 0xa5a5a5a5
+	csrrw x15, 832, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 832, x12
+	li x12, 0xa5a5a5a5
+	bne x12, x15, csr_fail
+	li x12, 0x6394b1a8
+	csrrw x15, 832, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 832, x12
+	li x12, 0x6394b1a8
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 832, x12
+	li x12, 0xe7b5b5ad
+	bne x12, x15, csr_fail
+	li x12, 0xfc5ff931
+	csrrs x15, 832, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 832, x12
+	li x12, 0xffffffff
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 832, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0x8115de32
+	csrrc x15, 832, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 832, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 832, 0b11010
+	li x12, 0x00000005
+	bne x12, x15, csr_fail
+	csrrwi x15, 832, 0b00011
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 832, 0b00101
+	li x12, 0x00000003
+	bne x12, x15, csr_fail
+	csrrsi x15, 832, 0b11010
+	li x12, 0x00000007
+	bne x12, x15, csr_fail
+	csrrsi x15, 832, 0b10001
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 832, 0b00101
+	li x12, 0x0000001f
+	bne x12, x15, csr_fail
+	csrrci x15, 832, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 832, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mepc
+	li x12, 0xa5a5a5a5
+	csrrw x15, 833, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 833, x12
+	li x12, 0xa5a5a5a4
+	bne x12, x15, csr_fail
+	li x12, 0x0b108053
+	csrrw x15, 833, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 833, x12
+	li x12, 0x0b108052
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 833, x12
+	li x12, 0xafb5a5f6
+	bne x12, x15, csr_fail
+	li x12, 0x3b6eccd4
+	csrrs x15, 833, x12
+	li x12, 0xfffffffe
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 833, x12
+	li x12, 0xfffffffe
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 833, x12
+	li x12, 0x5a5a5a5a
+	bne x12, x15, csr_fail
+	li x12, 0x0c51a1d7
+	csrrc x15, 833, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 833, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 833, 0b11010
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrwi x15, 833, 0b10111
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrsi x15, 833, 0b00101
+	li x12, 0x00000016
+	bne x12, x15, csr_fail
+	csrrsi x15, 833, 0b11010
+	li x12, 0x00000016
+	bne x12, x15, csr_fail
+	csrrsi x15, 833, 0b10110
+	li x12, 0x0000001e
+	bne x12, x15, csr_fail
+	csrrci x15, 833, 0b00101
+	li x12, 0x0000001e
+	bne x12, x15, csr_fail
+	csrrci x15, 833, 0b11010
+	li x12, 0x0000001a
+	bne x12, x15, csr_fail
+	csrrci x15, 833, 0b10011
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mtval
+	li x12, 0xa5a5a5a5
+	csrrw x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x6a74d189
+	csrrw x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x242f3afc
+	csrrs x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5581bddb
+	csrrc x15, 835, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 835, 0b01010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 835, 0b01100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 835, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 835, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 835, 0b11001
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# mip
+	li x12, 0xa5a5a5a5
+	csrrw x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x12863c9d
+	csrrw x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x59b85578
+	csrrs x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xeaa00b89
+	csrrc x15, 836, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 836, 0b10100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 836, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 836, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 836, 0b11001
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# tselect
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x24ca5fc9
+	csrrw x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x6561e3d4
+	csrrs x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x6f76af92
+	csrrc x15, 1952, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1952, 0b00010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1952, 0b01111
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1952, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1952, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1952, 0b00110
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# tdata1
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x72b8e35d
+	csrrw x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x7a26c3ef
+	csrrs x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	li x12, 0x48851c45
+	csrrc x15, 1953, x12
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrwi x15, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrwi x15, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrwi x15, 1953, 0b01000
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrsi x15, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrsi x15, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrsi x15, 1953, 0b10000
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrci x15, 1953, 0b00101
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrci x15, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	csrrci x15, 1953, 0b11010
+	li x12, 0x28001040
+	bne x12, x15, csr_fail
+	# tdata2
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xd1acd224
+	csrrw x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x78bafd1c
+	csrrs x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x1e938f27
+	csrrc x15, 1954, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1954, 0b01000
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1954, 0b11100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1954, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1954, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1954, 0b01100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# tdata3
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x40966130
+	csrrw x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xd07076ed
+	csrrs x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xfa27ec23
+	csrrc x15, 1955, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1955, 0b11011
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1955, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1955, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1955, 0b11011
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# tinfo
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x914da862
+	csrrw x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x5bc959ca
+	csrrs x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	li x12, 0x11503b76
+	csrrc x15, 1956, x12
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrwi x15, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrwi x15, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrwi x15, 1956, 0b10000
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrsi x15, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrsi x15, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrsi x15, 1956, 0b01011
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrci x15, 1956, 0b00101
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrci x15, 1956, 0b11010
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	csrrci x15, 1956, 0b11001
+	li x12, 0x00000004
+	bne x12, x15, csr_fail
+	# mcontext
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x546e2674
+	csrrw x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x2b76e255
+	csrrs x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa48f9456
+	csrrc x15, 1960, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1960, 0b11000
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1960, 0b00111
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1960, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1960, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1960, 0b10101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	# scontext
+	li x12, 0xa5a5a5a5
+	csrrw x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrw x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x8405bdd6
+	csrrw x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrs x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrs x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x945169bf
+	csrrs x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0xa5a5a5a5
+	csrrc x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x5a5a5a5a
+	csrrc x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	li x12, 0x1a1ad887
+	csrrc x15, 1962, x12
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrwi x15, 1962, 0b10100
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrsi x15, 1962, 0b00000
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1962, 0b00101
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1962, 0b11010
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrrci x15, 1962, 0b01110
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+	csrr x15, 1962
+	li x12, 0x00000000
+	bne x12, x15, csr_fail
+_end26:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x8, 0x0000000d
+	csrw 800,  x8 # set mcountinhibit to disable counting
+	li x8, 0x00000000
+	csrw 2816, x8 # reset cycle count
+	csrw 2944, x8
+	csrw 2818, x8 # reset instruction retired count
+	csrw 2946, x8
+	li x8, 0x00000001
+	csrw 773,  x8 # reset mtvec
+###############################################################################
+_start27:
+	# mcycle
+	li x4, 0xa5a5a5a5
+	csrrw x1, 2816, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 2816, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0x7c27933d
+	csrrw x1, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 2816, x4
+	li x4, 0x7c27933d
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 2816, x4
+	li x4, 0xfda7b7bd
+	bne x4, x1, csr_fail
+	li x4, 0x0f4aa4ed
+	csrrs x1, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0x22113ff9
+	csrrc x1, 2816, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2816, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2816, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 2816, 0b00100
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 2816, 0b00101
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrsi x1, 2816, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrsi x1, 2816, 0b11101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2816, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2816, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 2816, 0b10110
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mcycleh
+	li x4, 0xa5a5a5a5
+	csrrw x1, 2944, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 2944, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0xa4110521
+	csrrw x1, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 2944, x4
+	li x4, 0xa4110521
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 2944, x4
+	li x4, 0xa5b5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0x3e7af424
+	csrrs x1, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0x864fe8e1
+	csrrc x1, 2944, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2944, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2944, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 2944, 0b00010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 2944, 0b00101
+	li x4, 0x00000002
+	bne x4, x1, csr_fail
+	csrrsi x1, 2944, 0b11010
+	li x4, 0x00000007
+	bne x4, x1, csr_fail
+	csrrsi x1, 2944, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2944, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2944, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 2944, 0b01110
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# minstret
+	li x4, 0xa5a5a5a5
+	csrrw x1, 2818, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 2818, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0x7b5d30b5
+	csrrw x1, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 2818, x4
+	li x4, 0x7b5d30b5
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 2818, x4
+	li x4, 0xfffdb5b5
+	bne x4, x1, csr_fail
+	li x4, 0x0a7a17c0
+	csrrs x1, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0x4e6ffa8e
+	csrrc x1, 2818, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2818, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2818, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 2818, 0b01110
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 2818, 0b00101
+	li x4, 0x0000000e
+	bne x4, x1, csr_fail
+	csrrsi x1, 2818, 0b11010
+	li x4, 0x0000000f
+	bne x4, x1, csr_fail
+	csrrsi x1, 2818, 0b11000
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2818, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2818, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 2818, 0b01011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# minstreth
+	li x4, 0xa5a5a5a5
+	csrrw x1, 2946, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 2946, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0x31053264
+	csrrw x1, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 2946, x4
+	li x4, 0x31053264
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 2946, x4
+	li x4, 0xb5a5b7e5
+	bne x4, x1, csr_fail
+	li x4, 0x53d15471
+	csrrs x1, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0x3671419d
+	csrrc x1, 2946, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2946, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 2946, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 2946, 0b11110
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 2946, 0b00101
+	li x4, 0x0000001e
+	bne x4, x1, csr_fail
+	csrrsi x1, 2946, 0b11010
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrsi x1, 2946, 0b10001
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2946, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 2946, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 2946, 0b11011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mstatus
+	li x4, 0xa5a5a5a5
+	csrrw x1, 768, x4
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 768, x4
+	li x4, 0x00001880
+	bne x4, x1, csr_fail
+	li x4, 0x1e189333
+	csrrw x1, 768, x4
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 768, x4
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 768, x4
+	li x4, 0x00001880
+	bne x4, x1, csr_fail
+	li x4, 0x2b045e01
+	csrrs x1, 768, x4
+	li x4, 0x00001888
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 768, x4
+	li x4, 0x00001888
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 768, x4
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	li x4, 0x42ff4fc9
+	csrrc x1, 768, x4
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	csrrwi x1, 768, 0b00101
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	csrrwi x1, 768, 0b11010
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	csrrwi x1, 768, 0b11101
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrsi x1, 768, 0b00101
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrsi x1, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrsi x1, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrci x1, 768, 0b00101
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrci x1, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x1, csr_fail
+	csrrci x1, 768, 0b11111
+	li x4, 0x00001800
+	bne x4, x1, csr_fail
+	# misa
+	li x4, 0xa5a5a5a5
+	csrrw x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0xefae86ca
+	csrrw x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0x7374a3e4
+	csrrs x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	li x4, 0xb62b1e0b
+	csrrc x1, 769, x4
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrwi x1, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrwi x1, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrsi x1, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrsi x1, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrsi x1, 769, 0b00111
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrci x1, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrci x1, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	csrrci x1, 769, 0b10110
+	li x4, 0x40801104
+	bne x4, x1, csr_fail
+	# mie
+	li x4, 0xa5a5a5a5
+	csrrw x1, 772, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 772, x4
+	li x4, 0xa5a50080
+	bne x4, x1, csr_fail
+	li x4, 0xb4937038
+	csrrw x1, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 772, x4
+	li x4, 0xb4930008
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 772, x4
+	li x4, 0xb5b70088
+	bne x4, x1, csr_fail
+	li x4, 0x3eaaf5c9
+	csrrs x1, 772, x4
+	li x4, 0xffff0888
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 772, x4
+	li x4, 0xffff0888
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x1, csr_fail
+	li x4, 0x2c51d50a
+	csrrc x1, 772, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 772, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 772, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 772, 0b10110
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrsi x1, 772, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 772, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 772, 0b11111
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrci x1, 772, 0b00101
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrci x1, 772, 0b11010
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrci x1, 772, 0b01001
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mtvec
+	li x4, 0xa5a5a5a5
+	csrrw x1, 773, x4
+	li x4, 0x00000001
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 773, x4
+	li x4, 0xa5a5a501
+	bne x4, x1, csr_fail
+	li x4, 0x14736cb1
+	csrrw x1, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 773, x4
+	li x4, 0x14736c01
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 773, x4
+	li x4, 0xb5f7ed01
+	bne x4, x1, csr_fail
+	li x4, 0x8f0862af
+	csrrs x1, 773, x4
+	li x4, 0xffffff01
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 773, x4
+	li x4, 0xffffff01
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x1, csr_fail
+	li x4, 0x3db15f03
+	csrrc x1, 773, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 773, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x1, csr_fail
+	csrrwi x1, 773, 0b00100
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 773, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x1, csr_fail
+	csrrsi x1, 773, 0b01101
+	li x4, 0x00000001
+	bne x4, x1, csr_fail
+	csrrci x1, 773, 0b00101
+	li x4, 0x00000001
+	bne x4, x1, csr_fail
+	csrrci x1, 773, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 773, 0b10010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mcountinhibit
+	li x4, 0xa5a5a5a5
+	csrrw x1, 800, x4
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 800, x4
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	li x4, 0x39d963ee
+	csrrw x1, 800, x4
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 800, x4
+	li x4, 0x0000000c
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 800, x4
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	li x4, 0xf96559d2
+	csrrs x1, 800, x4
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 800, x4
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 800, x4
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	li x4, 0xa7140def
+	csrrc x1, 800, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 800, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 800, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 800, 0b00010
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrsi x1, 800, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 800, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrsi x1, 800, 0b01100
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	csrrci x1, 800, 0b00101
+	li x4, 0x0000000d
+	bne x4, x1, csr_fail
+	csrrci x1, 800, 0b11010
+	li x4, 0x00000008
+	bne x4, x1, csr_fail
+	csrrci x1, 800, 0b10111
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mscratch
+	li x4, 0xa5a5a5a5
+	csrrw x1, 832, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 832, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x1, csr_fail
+	li x4, 0x369955fc
+	csrrw x1, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 832, x4
+	li x4, 0x369955fc
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 832, x4
+	li x4, 0xb7bdf5fd
+	bne x4, x1, csr_fail
+	li x4, 0x3b52b08b
+	csrrs x1, 832, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 832, x4
+	li x4, 0xffffffff
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xb325c91d
+	csrrc x1, 832, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 832, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 832, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrwi x1, 832, 0b00100
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 832, 0b00101
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrsi x1, 832, 0b11010
+	li x4, 0x00000005
+	bne x4, x1, csr_fail
+	csrrsi x1, 832, 0b11010
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 832, 0b00101
+	li x4, 0x0000001f
+	bne x4, x1, csr_fail
+	csrrci x1, 832, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 832, 0b10001
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mepc
+	li x4, 0xa5a5a5a5
+	csrrw x1, 833, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 833, x4
+	li x4, 0xa5a5a5a4
+	bne x4, x1, csr_fail
+	li x4, 0xf9845d0e
+	csrrw x1, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 833, x4
+	li x4, 0xf9845d0e
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 833, x4
+	li x4, 0xfda5fdae
+	bne x4, x1, csr_fail
+	li x4, 0xe2244380
+	csrrs x1, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x1, csr_fail
+	li x4, 0xba8da6f0
+	csrrc x1, 833, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 833, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 833, 0b11010
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrwi x1, 833, 0b01111
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrsi x1, 833, 0b00101
+	li x4, 0x0000000e
+	bne x4, x1, csr_fail
+	csrrsi x1, 833, 0b11010
+	li x4, 0x0000000e
+	bne x4, x1, csr_fail
+	csrrsi x1, 833, 0b11011
+	li x4, 0x0000001e
+	bne x4, x1, csr_fail
+	csrrci x1, 833, 0b00101
+	li x4, 0x0000001e
+	bne x4, x1, csr_fail
+	csrrci x1, 833, 0b11010
+	li x4, 0x0000001a
+	bne x4, x1, csr_fail
+	csrrci x1, 833, 0b01100
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mtval
+	li x4, 0xa5a5a5a5
+	csrrw x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x17035797
+	csrrw x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x7ebd8bdb
+	csrrs x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x72a9010b
+	csrrc x1, 835, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 835, 0b00111
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 835, 0b01111
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 835, 0b01110
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# mip
+	li x4, 0xa5a5a5a5
+	csrrw x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5362cc29
+	csrrw x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x29175a7e
+	csrrs x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x02db757a
+	csrrc x1, 836, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 836, 0b10011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 836, 0b11000
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 836, 0b00111
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# tselect
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xf6c61dcd
+	csrrw x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x0ba9cb9a
+	csrrs x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5033d71a
+	csrrc x1, 1952, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1952, 0b01001
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1952, 0b11000
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1952, 0b10011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# tdata1
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0xf20e5aff
+	csrrw x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0x01bb6390
+	csrrs x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	li x4, 0xd61e04ed
+	csrrc x1, 1953, x4
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrwi x1, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrwi x1, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrwi x1, 1953, 0b11100
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrsi x1, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrsi x1, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrsi x1, 1953, 0b11101
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrci x1, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrci x1, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	csrrci x1, 1953, 0b01010
+	li x4, 0x28001040
+	bne x4, x1, csr_fail
+	# tdata2
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x9c81751e
+	csrrw x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x14a3c1d5
+	csrrs x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x00086e80
+	csrrc x1, 1954, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1954, 0b01100
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1954, 0b10100
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1954, 0b10001
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# tdata3
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x380ba2b5
+	csrrw x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x563c68be
+	csrrs x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xda32b21b
+	csrrc x1, 1955, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1955, 0b01110
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1955, 0b10000
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1955, 0b10011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# tinfo
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x31cf559d
+	csrrw x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x46264e6f
+	csrrs x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	li x4, 0x94f666b6
+	csrrc x1, 1956, x4
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrwi x1, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrwi x1, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrwi x1, 1956, 0b01011
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrsi x1, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrsi x1, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrsi x1, 1956, 0b01001
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrci x1, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrci x1, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	csrrci x1, 1956, 0b01000
+	li x4, 0x00000004
+	bne x4, x1, csr_fail
+	# mcontext
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x9636541f
+	csrrw x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xeb11eef2
+	csrrs x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x308cae8f
+	csrrc x1, 1960, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1960, 0b00000
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1960, 0b10010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1960, 0b10001
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	# scontext
+	li x4, 0xa5a5a5a5
+	csrrw x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xcf9a710c
+	csrrw x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x01211969
+	csrrs x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	li x4, 0xf19a0746
+	csrrc x1, 1962, x4
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrwi x1, 1962, 0b11011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrsi x1, 1962, 0b11011
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrrci x1, 1962, 0b01010
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+	csrr x1, 1962
+	li x4, 0x00000000
+	bne x4, x1, csr_fail
+_end27:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x9, 0x0000000d
+	csrw 800,  x9 # set mcountinhibit to disable counting
+	li x9, 0x00000000
+	csrw 2816, x9 # reset cycle count
+	csrw 2944, x9
+	csrw 2818, x9 # reset instruction retired count
+	csrw 2946, x9
+	li x9, 0x00000001
+	csrw 773,  x9 # reset mtvec
+###############################################################################
+_start28:
+	# mcycle
+	li x8, 0xa5a5a5a5
+	csrrw x9, 2816, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 2816, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x9, csr_fail
+	li x8, 0x2c843767
+	csrrw x9, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 2816, x8
+	li x8, 0x2c843767
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 2816, x8
+	li x8, 0xada5b7e7
+	bne x8, x9, csr_fail
+	li x8, 0x6c4534c9
+	csrrs x9, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xd293fe6d
+	csrrc x9, 2816, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2816, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2816, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 2816, 0b00011
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 2816, 0b00101
+	li x8, 0x00000003
+	bne x8, x9, csr_fail
+	csrrsi x9, 2816, 0b11010
+	li x8, 0x00000007
+	bne x8, x9, csr_fail
+	csrrsi x9, 2816, 0b01101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2816, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 2816, 0b01100
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mcycleh
+	li x8, 0xa5a5a5a5
+	csrrw x9, 2944, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 2944, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x9, csr_fail
+	li x8, 0x95073e6c
+	csrrw x9, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 2944, x8
+	li x8, 0x95073e6c
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 2944, x8
+	li x8, 0xb5a7bfed
+	bne x8, x9, csr_fail
+	li x8, 0x2bce457c
+	csrrs x9, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0x615f3ade
+	csrrc x9, 2944, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2944, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2944, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 2944, 0b01101
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 2944, 0b00101
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	csrrsi x9, 2944, 0b11010
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	csrrsi x9, 2944, 0b10100
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2944, 0b00101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2944, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 2944, 0b10111
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# minstret
+	li x8, 0xa5a5a5a5
+	csrrw x9, 2818, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 2818, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x9, csr_fail
+	li x8, 0x51996e16
+	csrrw x9, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 2818, x8
+	li x8, 0x51996e16
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 2818, x8
+	li x8, 0xf5bdefb7
+	bne x8, x9, csr_fail
+	li x8, 0x3abd4a27
+	csrrs x9, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xadb04d46
+	csrrc x9, 2818, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2818, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2818, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 2818, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 2818, 0b00101
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 2818, 0b11010
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrsi x9, 2818, 0b01100
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2818, 0b00101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2818, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 2818, 0b00100
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# minstreth
+	li x8, 0xa5a5a5a5
+	csrrw x9, 2946, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 2946, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x9, csr_fail
+	li x8, 0x5bebb4a0
+	csrrw x9, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 2946, x8
+	li x8, 0x5bebb4a0
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 2946, x8
+	li x8, 0xffefb5a5
+	bne x8, x9, csr_fail
+	li x8, 0x9b7f7070
+	csrrs x9, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0x47aefec1
+	csrrc x9, 2946, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2946, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 2946, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 2946, 0b00100
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 2946, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrsi x9, 2946, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrsi x9, 2946, 0b00001
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2946, 0b00101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 2946, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 2946, 0b11001
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mstatus
+	li x8, 0xa5a5a5a5
+	csrrw x9, 768, x8
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 768, x8
+	li x8, 0x00001880
+	bne x8, x9, csr_fail
+	li x8, 0xe09dcf14
+	csrrw x9, 768, x8
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 768, x8
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 768, x8
+	li x8, 0x00001880
+	bne x8, x9, csr_fail
+	li x8, 0x77d56a3f
+	csrrs x9, 768, x8
+	li x8, 0x00001888
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 768, x8
+	li x8, 0x00001888
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 768, x8
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	li x8, 0xb88d8aa4
+	csrrc x9, 768, x8
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	csrrwi x9, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	csrrwi x9, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	csrrwi x9, 768, 0b01100
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrsi x9, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrsi x9, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrsi x9, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrci x9, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrci x9, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x9, csr_fail
+	csrrci x9, 768, 0b11100
+	li x8, 0x00001800
+	bne x8, x9, csr_fail
+	# misa
+	li x8, 0xa5a5a5a5
+	csrrw x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x98fbc650
+	csrrw x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x242950e6
+	csrrs x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	li x8, 0x5067f627
+	csrrc x9, 769, x8
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrwi x9, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrwi x9, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrwi x9, 769, 0b10111
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrsi x9, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrsi x9, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrsi x9, 769, 0b00011
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrci x9, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrci x9, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	csrrci x9, 769, 0b00011
+	li x8, 0x40801104
+	bne x8, x9, csr_fail
+	# mie
+	li x8, 0xa5a5a5a5
+	csrrw x9, 772, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 772, x8
+	li x8, 0xa5a50080
+	bne x8, x9, csr_fail
+	li x8, 0x29e9d980
+	csrrw x9, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 772, x8
+	li x8, 0x29e90880
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 772, x8
+	li x8, 0xaded0880
+	bne x8, x9, csr_fail
+	li x8, 0x04b836e1
+	csrrs x9, 772, x8
+	li x8, 0xffff0888
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 772, x8
+	li x8, 0xffff0888
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x9, csr_fail
+	li x8, 0x21e60b71
+	csrrc x9, 772, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 772, 0b00001
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrsi x9, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 772, 0b00100
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrci x9, 772, 0b00101
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrci x9, 772, 0b11010
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrci x9, 772, 0b10110
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mtvec
+	li x8, 0xa5a5a5a5
+	csrrw x9, 773, x8
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 773, x8
+	li x8, 0xa5a5a501
+	bne x8, x9, csr_fail
+	li x8, 0x0594cd80
+	csrrw x9, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 773, x8
+	li x8, 0x0594cd00
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 773, x8
+	li x8, 0xa5b5ed01
+	bne x8, x9, csr_fail
+	li x8, 0x808a5fc3
+	csrrs x9, 773, x8
+	li x8, 0xffffff01
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 773, x8
+	li x8, 0xffffff01
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x9, csr_fail
+	li x8, 0x22fa344e
+	csrrc x9, 773, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	csrrwi x9, 773, 0b01001
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	csrrsi x9, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	csrrsi x9, 773, 0b01011
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	csrrci x9, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x9, csr_fail
+	csrrci x9, 773, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mcountinhibit
+	li x8, 0xa5a5a5a5
+	csrrw x9, 800, x8
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 800, x8
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	li x8, 0xbf69efce
+	csrrw x9, 800, x8
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 800, x8
+	li x8, 0x0000000c
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 800, x8
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	li x8, 0xf4caa7e9
+	csrrs x9, 800, x8
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 800, x8
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 800, x8
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	li x8, 0x0640c50e
+	csrrc x9, 800, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 800, 0b00100
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrsi x9, 800, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrsi x9, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrsi x9, 800, 0b01000
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	csrrci x9, 800, 0b00101
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	csrrci x9, 800, 0b11010
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrci x9, 800, 0b10110
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mscratch
+	li x8, 0xa5a5a5a5
+	csrrw x9, 832, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 832, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x9, csr_fail
+	li x8, 0xef8da646
+	csrrw x9, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 832, x8
+	li x8, 0xef8da646
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 832, x8
+	li x8, 0xefada7e7
+	bne x8, x9, csr_fail
+	li x8, 0x95b2c190
+	csrrs x9, 832, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 832, x8
+	li x8, 0xffffffff
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xad17f513
+	csrrc x9, 832, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 832, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 832, 0b11010
+	li x8, 0x00000005
+	bne x8, x9, csr_fail
+	csrrwi x9, 832, 0b01000
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 832, 0b00101
+	li x8, 0x00000008
+	bne x8, x9, csr_fail
+	csrrsi x9, 832, 0b11010
+	li x8, 0x0000000d
+	bne x8, x9, csr_fail
+	csrrsi x9, 832, 0b00010
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 832, 0b00101
+	li x8, 0x0000001f
+	bne x8, x9, csr_fail
+	csrrci x9, 832, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 832, 0b01110
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mepc
+	li x8, 0xa5a5a5a5
+	csrrw x9, 833, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 833, x8
+	li x8, 0xa5a5a5a4
+	bne x8, x9, csr_fail
+	li x8, 0x8757205e
+	csrrw x9, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 833, x8
+	li x8, 0x8757205e
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 833, x8
+	li x8, 0xa7f7a5fe
+	bne x8, x9, csr_fail
+	li x8, 0xb00802fb
+	csrrs x9, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x9, csr_fail
+	li x8, 0x7a44334e
+	csrrc x9, 833, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 833, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 833, 0b11010
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrwi x9, 833, 0b00110
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrsi x9, 833, 0b00101
+	li x8, 0x00000006
+	bne x8, x9, csr_fail
+	csrrsi x9, 833, 0b11010
+	li x8, 0x00000006
+	bne x8, x9, csr_fail
+	csrrsi x9, 833, 0b10110
+	li x8, 0x0000001e
+	bne x8, x9, csr_fail
+	csrrci x9, 833, 0b00101
+	li x8, 0x0000001e
+	bne x8, x9, csr_fail
+	csrrci x9, 833, 0b11010
+	li x8, 0x0000001a
+	bne x8, x9, csr_fail
+	csrrci x9, 833, 0b10110
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mtval
+	li x8, 0xa5a5a5a5
+	csrrw x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xea48fafc
+	csrrw x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa4726dc4
+	csrrs x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x63562eb3
+	csrrc x9, 835, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 835, 0b00010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 835, 0b01111
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 835, 0b10011
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# mip
+	li x8, 0xa5a5a5a5
+	csrrw x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xe80b4872
+	csrrw x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x933b402d
+	csrrs x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x9d93ab88
+	csrrc x9, 836, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 836, 0b11100
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 836, 0b10101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# tselect
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x45efdb7e
+	csrrw x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xe4184958
+	csrrs x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x06de31d9
+	csrrc x9, 1952, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1952, 0b01000
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1952, 0b11101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1952, 0b10010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# tdata1
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0xe30ba8e9
+	csrrw x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0xe0379149
+	csrrs x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	li x8, 0x8a876382
+	csrrc x9, 1953, x8
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrwi x9, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrwi x9, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrwi x9, 1953, 0b10001
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrsi x9, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrsi x9, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrsi x9, 1953, 0b01100
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrci x9, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrci x9, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	csrrci x9, 1953, 0b10000
+	li x8, 0x28001040
+	bne x8, x9, csr_fail
+	# tdata2
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xf28bc6e4
+	csrrw x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x70d6d87e
+	csrrs x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xcb731ff7
+	csrrc x9, 1954, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1954, 0b11001
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1954, 0b00011
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1954, 0b11000
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# tdata3
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x844e70e3
+	csrrw x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xd320e102
+	csrrs x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x05fd1d1f
+	csrrc x9, 1955, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1955, 0b10101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1955, 0b00001
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1955, 0b11110
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# tinfo
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0xdfd566f2
+	csrrw x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0x885cdd57
+	csrrs x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	li x8, 0x46c662e9
+	csrrc x9, 1956, x8
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrwi x9, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrwi x9, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrwi x9, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrsi x9, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrsi x9, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrsi x9, 1956, 0b00011
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrci x9, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrci x9, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	csrrci x9, 1956, 0b01110
+	li x8, 0x00000004
+	bne x8, x9, csr_fail
+	# mcontext
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa0fd4971
+	csrrw x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xbfaa3e91
+	csrrs x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x1a331872
+	csrrc x9, 1960, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1960, 0b00001
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1960, 0b10010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1960, 0b01100
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	# scontext
+	li x8, 0xa5a5a5a5
+	csrrw x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xee0aebf0
+	csrrw x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xd8474d1f
+	csrrs x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	li x8, 0xae5f7416
+	csrrc x9, 1962, x8
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrwi x9, 1962, 0b11100
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrsi x9, 1962, 0b00111
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrrci x9, 1962, 0b01000
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+	csrr x9, 1962
+	li x8, 0x00000000
+	bne x8, x9, csr_fail
+_end28:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x10, 0x0000000d
+	csrw 800,  x10 # set mcountinhibit to disable counting
+	li x10, 0x00000000
+	csrw 2816, x10 # reset cycle count
+	csrw 2944, x10
+	csrw 2818, x10 # reset instruction retired count
+	csrw 2946, x10
+	li x10, 0x00000001
+	csrw 773,  x10 # reset mtvec
+###############################################################################
+_start29:
+	# mcycle
+	li x4, 0xa5a5a5a5
+	csrrw x6, 2816, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 2816, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x6, csr_fail
+	li x4, 0xa59d8947
+	csrrw x6, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 2816, x4
+	li x4, 0xa59d8947
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 2816, x4
+	li x4, 0xa5bdade7
+	bne x4, x6, csr_fail
+	li x4, 0x4adfa4c9
+	csrrs x6, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xf3045063
+	csrrc x6, 2816, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2816, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2816, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 2816, 0b10110
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 2816, 0b00101
+	li x4, 0x00000016
+	bne x4, x6, csr_fail
+	csrrsi x6, 2816, 0b11010
+	li x4, 0x00000017
+	bne x4, x6, csr_fail
+	csrrsi x6, 2816, 0b11110
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2816, 0b00101
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2816, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 2816, 0b11011
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mcycleh
+	li x4, 0xa5a5a5a5
+	csrrw x6, 2944, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 2944, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x6, csr_fail
+	li x4, 0x22a39d7d
+	csrrw x6, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 2944, x4
+	li x4, 0x22a39d7d
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 2944, x4
+	li x4, 0xa7a7bdfd
+	bne x4, x6, csr_fail
+	li x4, 0x3f713b7c
+	csrrs x6, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0x6cedf051
+	csrrc x6, 2944, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2944, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2944, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 2944, 0b10010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 2944, 0b00101
+	li x4, 0x00000012
+	bne x4, x6, csr_fail
+	csrrsi x6, 2944, 0b11010
+	li x4, 0x00000017
+	bne x4, x6, csr_fail
+	csrrsi x6, 2944, 0b00011
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2944, 0b00101
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2944, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 2944, 0b00110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# minstret
+	li x4, 0xa5a5a5a5
+	csrrw x6, 2818, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 2818, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x6, csr_fail
+	li x4, 0x2a5fec76
+	csrrw x6, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 2818, x4
+	li x4, 0x2a5fec76
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 2818, x4
+	li x4, 0xafffedf7
+	bne x4, x6, csr_fail
+	li x4, 0xc21aa509
+	csrrs x6, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0x0d8bd63a
+	csrrc x6, 2818, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2818, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2818, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 2818, 0b01001
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 2818, 0b00101
+	li x4, 0x00000009
+	bne x4, x6, csr_fail
+	csrrsi x6, 2818, 0b11010
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	csrrsi x6, 2818, 0b11100
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2818, 0b00101
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2818, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 2818, 0b01101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# minstreth
+	li x4, 0xa5a5a5a5
+	csrrw x6, 2946, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 2946, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x6, csr_fail
+	li x4, 0x829cdea9
+	csrrw x6, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 2946, x4
+	li x4, 0x829cdea9
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 2946, x4
+	li x4, 0xa7bdffad
+	bne x4, x6, csr_fail
+	li x4, 0x3056072f
+	csrrs x6, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0x4b7d59b4
+	csrrc x6, 2946, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2946, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 2946, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 2946, 0b00001
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 2946, 0b00101
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	csrrsi x6, 2946, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrsi x6, 2946, 0b11000
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2946, 0b00101
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 2946, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 2946, 0b00010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mstatus
+	li x4, 0xa5a5a5a5
+	csrrw x6, 768, x4
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 768, x4
+	li x4, 0x00001880
+	bne x4, x6, csr_fail
+	li x4, 0x34168d30
+	csrrw x6, 768, x4
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 768, x4
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 768, x4
+	li x4, 0x00001880
+	bne x4, x6, csr_fail
+	li x4, 0x9b0e3263
+	csrrs x6, 768, x4
+	li x4, 0x00001888
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 768, x4
+	li x4, 0x00001888
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 768, x4
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	li x4, 0xa7ae12e7
+	csrrc x6, 768, x4
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	csrrwi x6, 768, 0b00101
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	csrrwi x6, 768, 0b11010
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	csrrwi x6, 768, 0b10010
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	csrrsi x6, 768, 0b00101
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	csrrsi x6, 768, 0b11010
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	csrrsi x6, 768, 0b11110
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	csrrci x6, 768, 0b00101
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	csrrci x6, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x6, csr_fail
+	csrrci x6, 768, 0b01001
+	li x4, 0x00001800
+	bne x4, x6, csr_fail
+	# misa
+	li x4, 0xa5a5a5a5
+	csrrw x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0xbaa2c70b
+	csrrw x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0xed26b809
+	csrrs x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	li x4, 0x495e8fbc
+	csrrc x6, 769, x4
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrwi x6, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrwi x6, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrwi x6, 769, 0b10111
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrsi x6, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrsi x6, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrsi x6, 769, 0b01101
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrci x6, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrci x6, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	csrrci x6, 769, 0b00100
+	li x4, 0x40801104
+	bne x4, x6, csr_fail
+	# mie
+	li x4, 0xa5a5a5a5
+	csrrw x6, 772, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 772, x4
+	li x4, 0xa5a50080
+	bne x4, x6, csr_fail
+	li x4, 0xfd5c3ffe
+	csrrw x6, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 772, x4
+	li x4, 0xfd5c0888
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 772, x4
+	li x4, 0xfdfd0888
+	bne x4, x6, csr_fail
+	li x4, 0x355f88c2
+	csrrs x6, 772, x4
+	li x4, 0xffff0888
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 772, x4
+	li x4, 0xffff0888
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x6, csr_fail
+	li x4, 0x515bd041
+	csrrc x6, 772, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 772, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 772, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 772, 0b01101
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrsi x6, 772, 0b00101
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrsi x6, 772, 0b11010
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrsi x6, 772, 0b00100
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrci x6, 772, 0b00101
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrci x6, 772, 0b11010
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrci x6, 772, 0b10110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mtvec
+	li x4, 0xa5a5a5a5
+	csrrw x6, 773, x4
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 773, x4
+	li x4, 0xa5a5a501
+	bne x4, x6, csr_fail
+	li x4, 0x6a15fd06
+	csrrw x6, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 773, x4
+	li x4, 0x6a15fd00
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 773, x4
+	li x4, 0xefb5fd01
+	bne x4, x6, csr_fail
+	li x4, 0xb97a5d82
+	csrrs x6, 773, x4
+	li x4, 0xffffff01
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 773, x4
+	li x4, 0xffffff01
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x6, csr_fail
+	li x4, 0xaa6fcffc
+	csrrc x6, 773, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 773, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	csrrwi x6, 773, 0b00110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 773, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	csrrsi x6, 773, 0b11100
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	csrrci x6, 773, 0b00101
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	csrrci x6, 773, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 773, 0b10111
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mcountinhibit
+	li x4, 0xa5a5a5a5
+	csrrw x6, 800, x4
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 800, x4
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	li x4, 0x4a36bc93
+	csrrw x6, 800, x4
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 800, x4
+	li x4, 0x00000001
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 800, x4
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	li x4, 0x4d85fd78
+	csrrs x6, 800, x4
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 800, x4
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 800, x4
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	li x4, 0x657c25de
+	csrrc x6, 800, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 800, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 800, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 800, 0b01011
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrsi x6, 800, 0b00101
+	li x4, 0x00000009
+	bne x4, x6, csr_fail
+	csrrsi x6, 800, 0b11010
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	csrrsi x6, 800, 0b00011
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	csrrci x6, 800, 0b00101
+	li x4, 0x0000000d
+	bne x4, x6, csr_fail
+	csrrci x6, 800, 0b11010
+	li x4, 0x00000008
+	bne x4, x6, csr_fail
+	csrrci x6, 800, 0b00111
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mscratch
+	li x4, 0xa5a5a5a5
+	csrrw x6, 832, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 832, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x6, csr_fail
+	li x4, 0x2ba34387
+	csrrw x6, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 832, x4
+	li x4, 0x2ba34387
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 832, x4
+	li x4, 0xafa7e7a7
+	bne x4, x6, csr_fail
+	li x4, 0xd9148588
+	csrrs x6, 832, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 832, x4
+	li x4, 0xffffffff
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0x9c309ba0
+	csrrc x6, 832, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 832, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 832, 0b11010
+	li x4, 0x00000005
+	bne x4, x6, csr_fail
+	csrrwi x6, 832, 0b00111
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 832, 0b00101
+	li x4, 0x00000007
+	bne x4, x6, csr_fail
+	csrrsi x6, 832, 0b11010
+	li x4, 0x00000007
+	bne x4, x6, csr_fail
+	csrrsi x6, 832, 0b00010
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 832, 0b00101
+	li x4, 0x0000001f
+	bne x4, x6, csr_fail
+	csrrci x6, 832, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 832, 0b10011
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mepc
+	li x4, 0xa5a5a5a5
+	csrrw x6, 833, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 833, x4
+	li x4, 0xa5a5a5a4
+	bne x4, x6, csr_fail
+	li x4, 0xcfc41067
+	csrrw x6, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 833, x4
+	li x4, 0xcfc41066
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 833, x4
+	li x4, 0xefe5b5e6
+	bne x4, x6, csr_fail
+	li x4, 0xcc20df4e
+	csrrs x6, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x6, csr_fail
+	li x4, 0x652b96b7
+	csrrc x6, 833, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 833, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 833, 0b11010
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrwi x6, 833, 0b00110
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrsi x6, 833, 0b00101
+	li x4, 0x00000006
+	bne x4, x6, csr_fail
+	csrrsi x6, 833, 0b11010
+	li x4, 0x00000006
+	bne x4, x6, csr_fail
+	csrrsi x6, 833, 0b10111
+	li x4, 0x0000001e
+	bne x4, x6, csr_fail
+	csrrci x6, 833, 0b00101
+	li x4, 0x0000001e
+	bne x4, x6, csr_fail
+	csrrci x6, 833, 0b11010
+	li x4, 0x0000001a
+	bne x4, x6, csr_fail
+	csrrci x6, 833, 0b10000
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mtval
+	li x4, 0xa5a5a5a5
+	csrrw x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x67f488da
+	csrrw x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x28d5f49c
+	csrrs x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x63a771c9
+	csrrc x6, 835, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 835, 0b00000
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 835, 0b00111
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 835, 0b11100
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# mip
+	li x4, 0xa5a5a5a5
+	csrrw x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xf3bd1aa2
+	csrrw x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x28d50c1b
+	csrrs x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x319fc417
+	csrrc x6, 836, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 836, 0b01001
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 836, 0b00111
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# tselect
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x57a5a035
+	csrrw x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x13ce102b
+	csrrs x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x70037af8
+	csrrc x6, 1952, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1952, 0b10100
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1952, 0b00001
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1952, 0b10111
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# tdata1
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0x5c4e12d6
+	csrrw x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0xae9e8f5f
+	csrrs x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	li x4, 0xaed90516
+	csrrc x6, 1953, x4
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrwi x6, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrwi x6, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrwi x6, 1953, 0b11011
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrsi x6, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrsi x6, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrsi x6, 1953, 0b00010
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrci x6, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrci x6, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	csrrci x6, 1953, 0b00000
+	li x4, 0x28001040
+	bne x4, x6, csr_fail
+	# tdata2
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x3b5471af
+	csrrw x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x147466fb
+	csrrs x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x2186c112
+	csrrc x6, 1954, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1954, 0b11110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1954, 0b01000
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1954, 0b10011
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# tdata3
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x091c3852
+	csrrw x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xe77b4aad
+	csrrs x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xbbcf1be6
+	csrrc x6, 1955, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1955, 0b01110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1955, 0b10110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# tinfo
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0x0cb239ae
+	csrrw x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0xd538fcd7
+	csrrs x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	li x4, 0x66a75586
+	csrrc x6, 1956, x4
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrwi x6, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrwi x6, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrwi x6, 1956, 0b11011
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrsi x6, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrsi x6, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrsi x6, 1956, 0b10010
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrci x6, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrci x6, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	csrrci x6, 1956, 0b11001
+	li x4, 0x00000004
+	bne x4, x6, csr_fail
+	# mcontext
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xde20209c
+	csrrw x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x4faa4a93
+	csrrs x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xc472a465
+	csrrc x6, 1960, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1960, 0b00010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1960, 0b10000
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1960, 0b11110
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	# scontext
+	li x4, 0xa5a5a5a5
+	csrrw x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x2424c117
+	csrrw x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa95f874c
+	csrrs x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	li x4, 0xd4daf004
+	csrrc x6, 1962, x4
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrwi x6, 1962, 0b00100
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrsi x6, 1962, 0b10011
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrrci x6, 1962, 0b00001
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+	csrr x6, 1962
+	li x4, 0x00000000
+	bne x4, x6, csr_fail
+_end29:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x11, 0x0000000d
+	csrw 800,  x11 # set mcountinhibit to disable counting
+	li x11, 0x00000000
+	csrw 2816, x11 # reset cycle count
+	csrw 2944, x11
+	csrw 2818, x11 # reset instruction retired count
+	csrw 2946, x11
+	li x11, 0x00000001
+	csrw 773,  x11 # reset mtvec
+###############################################################################
+_start30:
+	# mcycle
+	li x4, 0xa5a5a5a5
+	csrrw x10, 2816, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 2816, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x10, csr_fail
+	li x4, 0x4097dc6c
+	csrrw x10, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 2816, x4
+	li x4, 0x4097dc6c
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 2816, x4
+	li x4, 0xe5b7fded
+	bne x4, x10, csr_fail
+	li x4, 0x78548b2e
+	csrrs x10, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 2816, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 2816, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xf5f0338d
+	csrrc x10, 2816, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2816, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2816, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 2816, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 2816, 0b00101
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 2816, 0b11010
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrsi x10, 2816, 0b10000
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2816, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2816, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 2816, 0b00001
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mcycleh
+	li x4, 0xa5a5a5a5
+	csrrw x10, 2944, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 2944, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x10, csr_fail
+	li x4, 0x72b90d38
+	csrrw x10, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 2944, x4
+	li x4, 0x72b90d38
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 2944, x4
+	li x4, 0xf7bdadbd
+	bne x4, x10, csr_fail
+	li x4, 0x5042113d
+	csrrs x10, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 2944, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 2944, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xe95e578f
+	csrrc x10, 2944, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2944, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2944, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 2944, 0b10110
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 2944, 0b00101
+	li x4, 0x00000016
+	bne x4, x10, csr_fail
+	csrrsi x10, 2944, 0b11010
+	li x4, 0x00000017
+	bne x4, x10, csr_fail
+	csrrsi x10, 2944, 0b00111
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2944, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2944, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 2944, 0b10111
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# minstret
+	li x4, 0xa5a5a5a5
+	csrrw x10, 2818, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 2818, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x10, csr_fail
+	li x4, 0x3fb8c413
+	csrrw x10, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 2818, x4
+	li x4, 0x3fb8c413
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 2818, x4
+	li x4, 0xbfbde5b7
+	bne x4, x10, csr_fail
+	li x4, 0x8b6dec1c
+	csrrs x10, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 2818, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 2818, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xdf0edabc
+	csrrc x10, 2818, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2818, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2818, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 2818, 0b11111
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 2818, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrsi x10, 2818, 0b11010
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrsi x10, 2818, 0b00111
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2818, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2818, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 2818, 0b10010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# minstreth
+	li x4, 0xa5a5a5a5
+	csrrw x10, 2946, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 2946, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x10, csr_fail
+	li x4, 0xa4c6725d
+	csrrw x10, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 2946, x4
+	li x4, 0xa4c6725d
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 2946, x4
+	li x4, 0xa5e7f7fd
+	bne x4, x10, csr_fail
+	li x4, 0x43aa1062
+	csrrs x10, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 2946, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 2946, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0x9b8c3655
+	csrrc x10, 2946, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2946, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 2946, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 2946, 0b01110
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 2946, 0b00101
+	li x4, 0x0000000e
+	bne x4, x10, csr_fail
+	csrrsi x10, 2946, 0b11010
+	li x4, 0x0000000f
+	bne x4, x10, csr_fail
+	csrrsi x10, 2946, 0b11001
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2946, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 2946, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 2946, 0b10110
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mstatus
+	li x4, 0xa5a5a5a5
+	csrrw x10, 768, x4
+	li x4, 0x00001800
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 768, x4
+	li x4, 0x00001880
+	bne x4, x10, csr_fail
+	li x4, 0xa6705d8b
+	csrrw x10, 768, x4
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 768, x4
+	li x4, 0x00001888
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 768, x4
+	li x4, 0x00001888
+	bne x4, x10, csr_fail
+	li x4, 0x3fbb2441
+	csrrs x10, 768, x4
+	li x4, 0x00001888
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 768, x4
+	li x4, 0x00001888
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 768, x4
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	li x4, 0xd9ee192e
+	csrrc x10, 768, x4
+	li x4, 0x00001800
+	bne x4, x10, csr_fail
+	csrrwi x10, 768, 0b00101
+	li x4, 0x00001800
+	bne x4, x10, csr_fail
+	csrrwi x10, 768, 0b11010
+	li x4, 0x00001800
+	bne x4, x10, csr_fail
+	csrrwi x10, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrsi x10, 768, 0b00101
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrsi x10, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrsi x10, 768, 0b00111
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrci x10, 768, 0b00101
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrci x10, 768, 0b11010
+	li x4, 0x00001808
+	bne x4, x10, csr_fail
+	csrrci x10, 768, 0b00010
+	li x4, 0x00001800
+	bne x4, x10, csr_fail
+	# misa
+	li x4, 0xa5a5a5a5
+	csrrw x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0xfc05e0ba
+	csrrw x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0x22f978d8
+	csrrs x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	li x4, 0x234602f7
+	csrrc x10, 769, x4
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrwi x10, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrwi x10, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrwi x10, 769, 0b11001
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrsi x10, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrsi x10, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrsi x10, 769, 0b10101
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrci x10, 769, 0b00101
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrci x10, 769, 0b11010
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	csrrci x10, 769, 0b10110
+	li x4, 0x40801104
+	bne x4, x10, csr_fail
+	# mie
+	li x4, 0xa5a5a5a5
+	csrrw x10, 772, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 772, x4
+	li x4, 0xa5a50080
+	bne x4, x10, csr_fail
+	li x4, 0x0db5528e
+	csrrw x10, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 772, x4
+	li x4, 0x0db50088
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 772, x4
+	li x4, 0xadb50088
+	bne x4, x10, csr_fail
+	li x4, 0x72fc30dd
+	csrrs x10, 772, x4
+	li x4, 0xffff0888
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 772, x4
+	li x4, 0xffff0888
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 772, x4
+	li x4, 0x5a5a0808
+	bne x4, x10, csr_fail
+	li x4, 0x9a3de244
+	csrrc x10, 772, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 772, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 772, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 772, 0b00011
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrsi x10, 772, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 772, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 772, 0b10001
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrci x10, 772, 0b00101
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrci x10, 772, 0b11010
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrci x10, 772, 0b00110
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mtvec
+	li x4, 0xa5a5a5a5
+	csrrw x10, 773, x4
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 773, x4
+	li x4, 0xa5a5a501
+	bne x4, x10, csr_fail
+	li x4, 0x67d14b51
+	csrrw x10, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 773, x4
+	li x4, 0x67d14b01
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 773, x4
+	li x4, 0xe7f5ef01
+	bne x4, x10, csr_fail
+	li x4, 0x77a1ce61
+	csrrs x10, 773, x4
+	li x4, 0xffffff01
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 773, x4
+	li x4, 0xffffff01
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 773, x4
+	li x4, 0x5a5a5a00
+	bne x4, x10, csr_fail
+	li x4, 0x14fccb28
+	csrrc x10, 773, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 773, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	csrrwi x10, 773, 0b00001
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 773, 0b00101
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	csrrsi x10, 773, 0b11010
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	csrrsi x10, 773, 0b11100
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	csrrci x10, 773, 0b00101
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	csrrci x10, 773, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 773, 0b00110
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mcountinhibit
+	li x4, 0xa5a5a5a5
+	csrrw x10, 800, x4
+	li x4, 0x0000000d
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 800, x4
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	li x4, 0x91fb0af1
+	csrrw x10, 800, x4
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 800, x4
+	li x4, 0x00000001
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 800, x4
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	li x4, 0x18f61e1e
+	csrrs x10, 800, x4
+	li x4, 0x0000000d
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 800, x4
+	li x4, 0x0000000d
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 800, x4
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	li x4, 0x73ac721a
+	csrrc x10, 800, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 800, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 800, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 800, 0b00110
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrsi x10, 800, 0b00101
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrsi x10, 800, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrsi x10, 800, 0b11101
+	li x4, 0x0000000d
+	bne x4, x10, csr_fail
+	csrrci x10, 800, 0b00101
+	li x4, 0x0000000d
+	bne x4, x10, csr_fail
+	csrrci x10, 800, 0b11010
+	li x4, 0x00000008
+	bne x4, x10, csr_fail
+	csrrci x10, 800, 0b11011
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mscratch
+	li x4, 0xa5a5a5a5
+	csrrw x10, 832, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 832, x4
+	li x4, 0xa5a5a5a5
+	bne x4, x10, csr_fail
+	li x4, 0x60448a00
+	csrrw x10, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 832, x4
+	li x4, 0x60448a00
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 832, x4
+	li x4, 0xe5e5afa5
+	bne x4, x10, csr_fail
+	li x4, 0xc8376dcf
+	csrrs x10, 832, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 832, x4
+	li x4, 0xffffffff
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 832, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xdacbd3f6
+	csrrc x10, 832, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 832, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 832, 0b11010
+	li x4, 0x00000005
+	bne x4, x10, csr_fail
+	csrrwi x10, 832, 0b10101
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 832, 0b00101
+	li x4, 0x00000015
+	bne x4, x10, csr_fail
+	csrrsi x10, 832, 0b11010
+	li x4, 0x00000015
+	bne x4, x10, csr_fail
+	csrrsi x10, 832, 0b01001
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 832, 0b00101
+	li x4, 0x0000001f
+	bne x4, x10, csr_fail
+	csrrci x10, 832, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 832, 0b01100
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mepc
+	li x4, 0xa5a5a5a5
+	csrrw x10, 833, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 833, x4
+	li x4, 0xa5a5a5a4
+	bne x4, x10, csr_fail
+	li x4, 0x122e9fb2
+	csrrw x10, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 833, x4
+	li x4, 0x122e9fb2
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 833, x4
+	li x4, 0xb7afbfb6
+	bne x4, x10, csr_fail
+	li x4, 0xa132a0e9
+	csrrs x10, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 833, x4
+	li x4, 0xfffffffe
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 833, x4
+	li x4, 0x5a5a5a5a
+	bne x4, x10, csr_fail
+	li x4, 0xde85ae50
+	csrrc x10, 833, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 833, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 833, 0b11010
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrwi x10, 833, 0b10010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrsi x10, 833, 0b00101
+	li x4, 0x00000012
+	bne x4, x10, csr_fail
+	csrrsi x10, 833, 0b11010
+	li x4, 0x00000016
+	bne x4, x10, csr_fail
+	csrrsi x10, 833, 0b01111
+	li x4, 0x0000001e
+	bne x4, x10, csr_fail
+	csrrci x10, 833, 0b00101
+	li x4, 0x0000001e
+	bne x4, x10, csr_fail
+	csrrci x10, 833, 0b11010
+	li x4, 0x0000001a
+	bne x4, x10, csr_fail
+	csrrci x10, 833, 0b10101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mtval
+	li x4, 0xa5a5a5a5
+	csrrw x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xace46d5a
+	csrrw x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5029198f
+	csrrs x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x0627beb9
+	csrrc x10, 835, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 835, 0b00110
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 835, 0b11101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 835, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 835, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 835, 0b11011
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# mip
+	li x4, 0xa5a5a5a5
+	csrrw x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x75d66da5
+	csrrw x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x17b2e751
+	csrrs x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xb8c706af
+	csrrc x10, 836, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 836, 0b11101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 836, 0b10000
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 836, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 836, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 836, 0b10001
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# tselect
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x75862401
+	csrrw x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x26f3f622
+	csrrs x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xe9baa824
+	csrrc x10, 1952, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1952, 0b00100
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1952, 0b11000
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1952, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1952, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1952, 0b01011
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# tdata1
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0xf0d548bf
+	csrrw x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0x80e3c105
+	csrrs x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	li x4, 0x7a0330b2
+	csrrc x10, 1953, x4
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrwi x10, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrwi x10, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrwi x10, 1953, 0b00010
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrsi x10, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrsi x10, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrsi x10, 1953, 0b01110
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrci x10, 1953, 0b00101
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrci x10, 1953, 0b11010
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	csrrci x10, 1953, 0b11001
+	li x4, 0x28001040
+	bne x4, x10, csr_fail
+	# tdata2
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x9a5f3060
+	csrrw x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x08318bfc
+	csrrs x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x3cea6f58
+	csrrc x10, 1954, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1954, 0b00000
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1954, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1954, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1954, 0b10101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# tdata3
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xf9e55def
+	csrrw x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x8a940dab
+	csrrs x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x49b3911c
+	csrrc x10, 1955, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1955, 0b01011
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1955, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1955, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1955, 0b00111
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# tinfo
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0xf8eb265a
+	csrrw x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0x1eba7a1f
+	csrrs x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	li x4, 0xea16db3a
+	csrrc x10, 1956, x4
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrwi x10, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrwi x10, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrwi x10, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrsi x10, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrsi x10, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrsi x10, 1956, 0b10101
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrci x10, 1956, 0b00101
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrci x10, 1956, 0b11010
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	csrrci x10, 1956, 0b00111
+	li x4, 0x00000004
+	bne x4, x10, csr_fail
+	# mcontext
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x4b988bfb
+	csrrw x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x4add331d
+	csrrs x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x7dccf5d9
+	csrrc x10, 1960, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1960, 0b10110
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1960, 0b00001
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1960, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1960, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1960, 0b01101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	# scontext
+	li x4, 0xa5a5a5a5
+	csrrw x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrw x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x761ed0f7
+	csrrw x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrs x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrs x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x06976165
+	csrrs x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0xa5a5a5a5
+	csrrc x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x5a5a5a5a
+	csrrc x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	li x4, 0x29b3af1c
+	csrrc x10, 1962, x4
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrwi x10, 1962, 0b10111
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrsi x10, 1962, 0b01000
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1962, 0b00101
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1962, 0b11010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrrci x10, 1962, 0b00010
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+	csrr x10, 1962
+	li x4, 0x00000000
+	bne x4, x10, csr_fail
+_end30:
+###############################################################################
+# Manually added code to inhibit mcycle(h) and minstret(h).
+	li x12, 0x0000000d
+	csrw 800,  x12 # set mcountinhibit to disable counting
+	li x12, 0x00000000
+	csrw 2816, x12 # reset cycle count
+	csrw 2944, x12
+	csrw 2818, x12 # reset instruction retired count
+	csrw 2946, x12
+	li x12, 0x00000001
+	csrw 773,  x12 # reset mtvec
+###############################################################################
+_start31:
+	# mcycle
+	li x8, 0xa5a5a5a5
+	csrrw x14, 2816, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 2816, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x14, csr_fail
+	li x8, 0x64cb71da
+	csrrw x14, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 2816, x8
+	li x8, 0x64cb71da
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 2816, x8
+	li x8, 0xe5eff5ff
+	bne x8, x14, csr_fail
+	li x8, 0x9ac8c9e9
+	csrrs x14, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 2816, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 2816, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0x68a7b73b
+	csrrc x14, 2816, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2816, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2816, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 2816, 0b11111
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrsi x14, 2816, 0b11010
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrsi x14, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2816, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2816, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 2816, 0b10101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mcycleh
+	li x8, 0xa5a5a5a5
+	csrrw x14, 2944, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 2944, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x14, csr_fail
+	li x8, 0x501e2f15
+	csrrw x14, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 2944, x8
+	li x8, 0x501e2f15
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 2944, x8
+	li x8, 0xf5bfafb5
+	bne x8, x14, csr_fail
+	li x8, 0xc89b471f
+	csrrs x14, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 2944, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 2944, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xd42d7c8c
+	csrrc x14, 2944, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2944, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2944, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 2944, 0b11100
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 2944, 0b00101
+	li x8, 0x0000001c
+	bne x8, x14, csr_fail
+	csrrsi x14, 2944, 0b11010
+	li x8, 0x0000001d
+	bne x8, x14, csr_fail
+	csrrsi x14, 2944, 0b00100
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2944, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2944, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 2944, 0b01011
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# minstret
+	li x8, 0xa5a5a5a5
+	csrrw x14, 2818, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 2818, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x14, csr_fail
+	li x8, 0xb9a23f1a
+	csrrw x14, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 2818, x8
+	li x8, 0xb9a23f1a
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 2818, x8
+	li x8, 0xbda7bfbf
+	bne x8, x14, csr_fail
+	li x8, 0xe68e021a
+	csrrs x14, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 2818, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 2818, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0x3792a28b
+	csrrc x14, 2818, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2818, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2818, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 2818, 0b00010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 2818, 0b00101
+	li x8, 0x00000002
+	bne x8, x14, csr_fail
+	csrrsi x14, 2818, 0b11010
+	li x8, 0x00000007
+	bne x8, x14, csr_fail
+	csrrsi x14, 2818, 0b00001
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2818, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2818, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 2818, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# minstreth
+	li x8, 0xa5a5a5a5
+	csrrw x14, 2946, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 2946, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x14, csr_fail
+	li x8, 0xd7f504b6
+	csrrw x14, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 2946, x8
+	li x8, 0xd7f504b6
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 2946, x8
+	li x8, 0xf7f5a5b7
+	bne x8, x14, csr_fail
+	li x8, 0x515ab875
+	csrrs x14, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 2946, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 2946, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0x332f339a
+	csrrc x14, 2946, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2946, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 2946, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 2946, 0b00110
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 2946, 0b00101
+	li x8, 0x00000006
+	bne x8, x14, csr_fail
+	csrrsi x14, 2946, 0b11010
+	li x8, 0x00000007
+	bne x8, x14, csr_fail
+	csrrsi x14, 2946, 0b01100
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2946, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 2946, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 2946, 0b11110
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mstatus
+	li x8, 0xa5a5a5a5
+	csrrw x14, 768, x8
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 768, x8
+	li x8, 0x00001880
+	bne x8, x14, csr_fail
+	li x8, 0x32245727
+	csrrw x14, 768, x8
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 768, x8
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 768, x8
+	li x8, 0x00001880
+	bne x8, x14, csr_fail
+	li x8, 0x7ddc0d5e
+	csrrs x14, 768, x8
+	li x8, 0x00001888
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 768, x8
+	li x8, 0x00001888
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 768, x8
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	li x8, 0x3ec76a76
+	csrrc x14, 768, x8
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	csrrwi x14, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	csrrwi x14, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	csrrwi x14, 768, 0b00001
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	csrrsi x14, 768, 0b00101
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	csrrsi x14, 768, 0b11010
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	csrrsi x14, 768, 0b11101
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	csrrci x14, 768, 0b00101
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	csrrci x14, 768, 0b11010
+	li x8, 0x00001808
+	bne x8, x14, csr_fail
+	csrrci x14, 768, 0b01111
+	li x8, 0x00001800
+	bne x8, x14, csr_fail
+	# misa
+	li x8, 0xa5a5a5a5
+	csrrw x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0x31f652b4
+	csrrw x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0xc1f98bcd
+	csrrs x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	li x8, 0x51e94d91
+	csrrc x14, 769, x8
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrwi x14, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrwi x14, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrwi x14, 769, 0b00001
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrsi x14, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrsi x14, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrsi x14, 769, 0b01110
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrci x14, 769, 0b00101
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrci x14, 769, 0b11010
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	csrrci x14, 769, 0b10001
+	li x8, 0x40801104
+	bne x8, x14, csr_fail
+	# mie
+	li x8, 0xa5a5a5a5
+	csrrw x14, 772, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 772, x8
+	li x8, 0xa5a50080
+	bne x8, x14, csr_fail
+	li x8, 0x927a5e45
+	csrrw x14, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 772, x8
+	li x8, 0x927a0800
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 772, x8
+	li x8, 0xb7ff0880
+	bne x8, x14, csr_fail
+	li x8, 0x815e9f0b
+	csrrs x14, 772, x8
+	li x8, 0xffff0888
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 772, x8
+	li x8, 0xffff0888
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 772, x8
+	li x8, 0x5a5a0808
+	bne x8, x14, csr_fail
+	li x8, 0x01b7390c
+	csrrc x14, 772, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 772, 0b10101
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrsi x14, 772, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 772, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 772, 0b00100
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrci x14, 772, 0b00101
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrci x14, 772, 0b11010
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrci x14, 772, 0b01000
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mtvec
+	li x8, 0xa5a5a5a5
+	csrrw x14, 773, x8
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 773, x8
+	li x8, 0xa5a5a501
+	bne x8, x14, csr_fail
+	li x8, 0xbb08381e
+	csrrw x14, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 773, x8
+	li x8, 0xbb083800
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 773, x8
+	li x8, 0xbfadbd01
+	bne x8, x14, csr_fail
+	li x8, 0xbff736ed
+	csrrs x14, 773, x8
+	li x8, 0xffffff01
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 773, x8
+	li x8, 0xffffff01
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 773, x8
+	li x8, 0x5a5a5a00
+	bne x8, x14, csr_fail
+	li x8, 0x8236f49d
+	csrrc x14, 773, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 773, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	csrrwi x14, 773, 0b00111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	csrrsi x14, 773, 0b11010
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	csrrsi x14, 773, 0b00010
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	csrrci x14, 773, 0b00101
+	li x8, 0x00000001
+	bne x8, x14, csr_fail
+	csrrci x14, 773, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 773, 0b01010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mcountinhibit
+	li x8, 0xa5a5a5a5
+	csrrw x14, 800, x8
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 800, x8
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	li x8, 0x2059d93b
+	csrrw x14, 800, x8
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 800, x8
+	li x8, 0x00000009
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 800, x8
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	li x8, 0xd5c2a4c5
+	csrrs x14, 800, x8
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 800, x8
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 800, x8
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	li x8, 0x5dedfe96
+	csrrc x14, 800, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 800, 0b10101
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrsi x14, 800, 0b00101
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrsi x14, 800, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrsi x14, 800, 0b01111
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	csrrci x14, 800, 0b00101
+	li x8, 0x0000000d
+	bne x8, x14, csr_fail
+	csrrci x14, 800, 0b11010
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrci x14, 800, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mscratch
+	li x8, 0xa5a5a5a5
+	csrrw x14, 832, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 832, x8
+	li x8, 0xa5a5a5a5
+	bne x8, x14, csr_fail
+	li x8, 0xefd904b8
+	csrrw x14, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 832, x8
+	li x8, 0xefd904b8
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 832, x8
+	li x8, 0xeffda5bd
+	bne x8, x14, csr_fail
+	li x8, 0x66aaf816
+	csrrs x14, 832, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 832, x8
+	li x8, 0xffffffff
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 832, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xbc5abc96
+	csrrc x14, 832, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 832, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 832, 0b11010
+	li x8, 0x00000005
+	bne x8, x14, csr_fail
+	csrrwi x14, 832, 0b00011
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 832, 0b00101
+	li x8, 0x00000003
+	bne x8, x14, csr_fail
+	csrrsi x14, 832, 0b11010
+	li x8, 0x00000007
+	bne x8, x14, csr_fail
+	csrrsi x14, 832, 0b10100
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 832, 0b00101
+	li x8, 0x0000001f
+	bne x8, x14, csr_fail
+	csrrci x14, 832, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 832, 0b01010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mepc
+	li x8, 0xa5a5a5a5
+	csrrw x14, 833, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 833, x8
+	li x8, 0xa5a5a5a4
+	bne x8, x14, csr_fail
+	li x8, 0x30075736
+	csrrw x14, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 833, x8
+	li x8, 0x30075736
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 833, x8
+	li x8, 0xb5a7f7b6
+	bne x8, x14, csr_fail
+	li x8, 0xc8d9d79f
+	csrrs x14, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 833, x8
+	li x8, 0xfffffffe
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 833, x8
+	li x8, 0x5a5a5a5a
+	bne x8, x14, csr_fail
+	li x8, 0x656fe2d4
+	csrrc x14, 833, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 833, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 833, 0b11010
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrwi x14, 833, 0b01000
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrsi x14, 833, 0b00101
+	li x8, 0x00000008
+	bne x8, x14, csr_fail
+	csrrsi x14, 833, 0b11010
+	li x8, 0x0000000c
+	bne x8, x14, csr_fail
+	csrrsi x14, 833, 0b01111
+	li x8, 0x0000001e
+	bne x8, x14, csr_fail
+	csrrci x14, 833, 0b00101
+	li x8, 0x0000001e
+	bne x8, x14, csr_fail
+	csrrci x14, 833, 0b11010
+	li x8, 0x0000001a
+	bne x8, x14, csr_fail
+	csrrci x14, 833, 0b10010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mtval
+	li x8, 0xa5a5a5a5
+	csrrw x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x1efb7a9f
+	csrrw x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x0da526da
+	csrrs x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x05223d2a
+	csrrc x14, 835, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 835, 0b10010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 835, 0b10011
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 835, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 835, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 835, 0b10010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# mip
+	li x8, 0xa5a5a5a5
+	csrrw x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x2ec6cba4
+	csrrw x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xbfc31c1a
+	csrrs x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x47f4db8b
+	csrrc x14, 836, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 836, 0b10100
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 836, 0b01101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 836, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 836, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 836, 0b11101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# tselect
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5673b28c
+	csrrw x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xab5ac4f4
+	csrrs x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xf946f104
+	csrrc x14, 1952, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1952, 0b11111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1952, 0b10101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1952, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1952, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1952, 0b10000
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# tdata1
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0x11fa095e
+	csrrw x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0xe72a80a6
+	csrrs x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	li x8, 0xec835456
+	csrrc x14, 1953, x8
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrwi x14, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrwi x14, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrwi x14, 1953, 0b10010
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrsi x14, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrsi x14, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrsi x14, 1953, 0b01110
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrci x14, 1953, 0b00101
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrci x14, 1953, 0b11010
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	csrrci x14, 1953, 0b00010
+	li x8, 0x28001040
+	bne x8, x14, csr_fail
+	# tdata2
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x0cd6edaa
+	csrrw x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x42cbcd20
+	csrrs x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x7463762d
+	csrrc x14, 1954, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1954, 0b11111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1954, 0b11001
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1954, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1954, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1954, 0b11100
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# tdata3
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x29074a09
+	csrrw x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x838231a5
+	csrrs x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xe77c54ea
+	csrrc x14, 1955, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1955, 0b01111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1955, 0b01010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1955, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1955, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1955, 0b10011
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# tinfo
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0x33ebef97
+	csrrw x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0x08e7d938
+	csrrs x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	li x8, 0xd458e070
+	csrrc x14, 1956, x8
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrwi x14, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrwi x14, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrwi x14, 1956, 0b10001
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrsi x14, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrsi x14, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrsi x14, 1956, 0b01101
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrci x14, 1956, 0b00101
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrci x14, 1956, 0b11010
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	csrrci x14, 1956, 0b11111
+	li x8, 0x00000004
+	bne x8, x14, csr_fail
+	# mcontext
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x91ee3ce4
+	csrrw x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x0bccb869
+	csrrs x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x6aa25ba0
+	csrrc x14, 1960, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1960, 0b01011
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1960, 0b10100
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1960, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1960, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1960, 0b11111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	# scontext
+	li x8, 0xa5a5a5a5
+	csrrw x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrw x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x7b5d1cca
+	csrrw x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrs x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrs x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x15729470
+	csrrs x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0xa5a5a5a5
+	csrrc x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x5a5a5a5a
+	csrrc x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	li x8, 0x52ef4492
+	csrrc x14, 1962, x8
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrwi x14, 1962, 0b00100
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrsi x14, 1962, 0b10111
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1962, 0b00101
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1962, 0b11010
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrrci x14, 1962, 0b11100
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+	csrr x14, 1962
+	li x8, 0x00000000
+	bne x8, x14, csr_fail
+_end31:
 
 ################################################################################
 #


### PR DESCRIPTION
Bigger version of the CSR access test.  Doesn't test the access modes of the CSRs any better, but it uses all available GPRs to do it, so it should produce a small bump in ISA Fcov.