### PR TITLE
Support for multiple GCC toolchains

### DIFF
--- a/cv32/bsp/Makefile
+++ b/cv32/bsp/Makefile
@@ -21,3 +21,12 @@ $(LIBCV-VERIF): $(OBJ)
 
 clean:
 	rm -f $(OBJ) $(LIBCV-VERIF)
+
+
+vars:
+	@echo "make bsp variables:"
+	@echo "   CV_SW_TOOLCHAIN  = $(CV_SW_TOOLCHAIN)"
+	@echo "   RISCV            = $(RISCV)"
+	@echo "   RISCV_EXE_PREFIX = $(RISCV_EXE_PREFIX)"
+	@echo "   RISCV_GCC        = $(RISCV_GCC)"
+

--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -178,8 +178,9 @@ PULP_SW_TOOLCHAIN   ?= /opt/pulp
 PULP_MARCH          ?= unknown
 
 CV_SW_TOOLCHAIN  ?= /opt/riscv
+CV_SW_MARCH      ?= unknown
 RISCV            ?= $(CV_SW_TOOLCHAIN)
-RISCV_PREFIX     ?= riscv32-unknown-elf-
+RISCV_PREFIX     ?= riscv32-$(CV_SW_MARCH)-elf-
 RISCV_EXE_PREFIX ?= $(RISCV)/bin/$(RISCV_PREFIX)
 
 ifeq ($(call IS_YES,$(GNU)),YES)
@@ -342,7 +343,10 @@ endif
 	$(RISCV_EXE_PREFIX)objdump -D -S $*.elf > $*.objdump
 
 bsp:
-	make -C $(BSP)
+	make -C $(BSP) RISCV=$(RISCV) RISCV_PREFIX=$(RISCV_PREFIX) RISCV_EXE_PREFIX=$(RISCV_EXE_PREFIX)
+
+vars-bsp:
+	make vars -C $(BSP) RISCV=$(RISCV) RISCV_PREFIX=$(RISCV_PREFIX) RISCV_EXE_PREFIX=$(RISCV_EXE_PREFIX)
 
 clean-bsp:
 	make clean -C $(BSP)


### PR DESCRIPTION
Hi @strichmo, this is a high-urgency PR, please review as soon as you get a chance.

To mimic what we'll have on the MetricsCI system, I have installed the PULP toolchain at **/opt/riscv** and the [COREV toolchain](https://www.embecosm.com/resources/tool-chain-downloads/#corev) (from Embecosm) at **/opt/corev** on my local machine.  With these updates I can use the COREV variable to select the COREV toolchain for any testcase.   For example, the following does what you'd expect:
```
$ make test TEST=interrupt_test COREV=YES
```
Note that using the PULP toolchain, the `interrupt_test` test-program does not compile.

So, this all works for me locally.   I want to ensure that it doesn't break anything you have.   I'd also like to know why its necessary to pass variables explicitly to the `bsp` Makefile.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>