### PR TITLE
Integrate RTL hash a26b194

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -68,13 +68,17 @@ BANNER=*************************************************************************
 
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
+#2020-10-14
+CV32E40P_HASH   ?= a26b194
 #2020-10-08
-CV32E40P_HASH   ?= f6196bf
+#CV32E40P_HASH   ?= f6196bf
 
 FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
 FPNEW_BRANCH    ?= master
+#2020-10-05
+FPNEW_HASH      ?= 5b2a9d4
 #2020-09-23
-FPNEW_HASH      ?= a0c021c360abcc94e434d41974a52bdcbf14d156
+#FPNEW_HASH      ?= a0c021c360abcc94e434d41974a52bdcbf14d156
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 #RISCVDV_REPO    ?= https://github.com/MikeOpenHWGroup/riscv-dv

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -152,7 +152,12 @@ module uvmt_cv32_tb;
     assign debug_cov_assert_if.mcountinhibit_q = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mcountinhibit_q;
     assign debug_cov_assert_if.mcycle = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmcounter_q[0];
     assign debug_cov_assert_if.minstret = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmcounter_q[2];
-    assign debug_cov_assert_if.inst_ret = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.inst_ret;
+
+    // TODO: review this change from CV32E40P_HASH f6196bf to a26b194. It should be logically equivalent.
+    //assign debug_cov_assert_if.inst_ret = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.inst_ret;
+    assign debug_cov_assert_if.inst_ret = (dut_wrap.cv32e40p_wrapper_i.core_i.id_valid &
+                                           dut_wrap.cv32e40p_wrapper_i.core_i.is_decoding);
+
     assign debug_cov_assert_if.csr_access = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.csr_access;
     assign debug_cov_assert_if.csr_op = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.csr_op;
     assign debug_cov_assert_if.csr_addr = dut_wrap.cv32e40p_wrapper_i.core_i.csr_addr;

--- a/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
+++ b/cv32/tb/uvmt_cv32/uvmt_cv32_tb.sv
@@ -155,8 +155,13 @@ module uvmt_cv32_tb;
 
     // TODO: review this change from CV32E40P_HASH f6196bf to a26b194. It should be logically equivalent.
     //assign debug_cov_assert_if.inst_ret = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.inst_ret;
-    assign debug_cov_assert_if.inst_ret = (dut_wrap.cv32e40p_wrapper_i.core_i.id_valid &
-                                           dut_wrap.cv32e40p_wrapper_i.core_i.is_decoding);
+    // First attempt: this causes unexpected failures of a_minstret_count
+    //assign debug_cov_assert_if.inst_ret = (dut_wrap.cv32e40p_wrapper_i.core_i.id_valid &
+    //                                       dut_wrap.cv32e40p_wrapper_i.core_i.is_decoding);
+    // Second attempt: (based on OK input).  This passes, but maybe only because p_minstret_count
+    //                                       is the only property sensitive to inst_ret. Will
+    //                                       this work in the general case?
+    assign debug_cov_assert_if.inst_ret = dut_wrap.cv32e40p_wrapper_i.core_i.cs_registers_i.mhpmevent_minstret_i;
 
     assign debug_cov_assert_if.csr_access = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.csr_access;
     assign debug_cov_assert_if.csr_op = dut_wrap.cv32e40p_wrapper_i.core_i.id_stage_i.csr_op;


### PR DESCRIPTION
Hi @silabs-oysteink and @strichmo.  Here is my attempt to update the environment to point to the latest RTL (hash a26b194).  In the past week there have been some surprisingly large updates to the RTL and this had a big impact on the `debug_cov_assert_if` in the tb.  The `inst_ret` signal in the cs_registers module is gone, but fortunately the `id_valid` and `is_decoding` signals generated in the core module are still there so I created a logically equivalent signal that you'll spot right away.

This compiles and runs a ci_check regression without issue.  However, I am not in a position to understand if that `inst_ret` signal is still doing what the debug assertions assume it is doing.  @silabs-oysteink, you'll need to drill into that.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>