### PR TITLE
Improved randomization control

### DIFF
--- a/cv32/sim/uvmt_cv32/dsim.mk
+++ b/cv32/sim/uvmt_cv32/dsim.mk
@@ -42,8 +42,25 @@ ifeq ($(USE_ISS),YES)
 #    DSIM_USER_COMPILE_ARGS += "+define+CV32E40P_ASSERT_ON+ISS+CV32E40P_TRACE_EXECUTION"
 #    DSIM_RUN_FLAGS         += +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
 endif
+
+# Seed management for constrained-random sims. This is an intentional repeat
+# of the root Makefile: dsim regressions use random seeds by default.
+DSIM_SEED    ?= random
+DSIM_RNDSEED ?= 
+
+ifeq ($(DSIM_SEED),random)
+DSIM_RNDSEED = $(shell date +%N)
+else
+ifeq ($(DSIM_SEED),)
+# Empty DSIM_SEED variable selects a random value
+DSIM_RNDSEED = 1
+else
+DSIM_RNDSEED = $(DSIM_SEED)
+endif
+endif
+
 DSIM_RUN_FLAGS         += $(USER_RUN_FLAGS)
-DSIM_RUN_FLAGS         += -sv_seed $(RNDSEED)
+DSIM_RUN_FLAGS         += -sv_seed $(DSIM_RNDSEED)
 
 # Variables to control wave dumping from command the line
 # Humans _always_ forget the "S", so you can have it both ways...
@@ -295,7 +312,7 @@ gen_corev-dv:
 		idx=$$((idx + 1)); \
 	done
 	cd  $(DSIM_COREVDV_RESULTS)/$(TEST) && \
-	dsim  -sv_seed $(RNDSEED) \
+	dsim  -sv_seed $(DSIM_RNDSEED) \
 		-sv_lib $(UVM_HOME)/src/dpi/libuvm_dpi.so \
 		+acc+rwb \
 		-image image \

--- a/cv32/tb/core/mm_ram.sv
+++ b/cv32/tb/core/mm_ram.sv
@@ -167,35 +167,51 @@ module mm_ram
 `ifndef VERILATOR
         #1ns;
         if (!$test$plusargs("rand_stall_obi_disable")) begin
-            randcase
-                2: begin
-                    // No delays
-                end
-                1: begin
-                    // Create RAM stall delays
-                    rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
-                    rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
-                    rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
-                    rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
-                    rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
-                end
-            endcase
-        end
+            if ($test$plusargs("max_data_zero_instr_stall")) begin
+                // used for fence.i
+                rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
+                rnd_stall_regs[RND_STALL_DATA_MODE]   = 2;
+                rnd_stall_regs[RND_STALL_DATA_GNT]    = 2;
+                rnd_stall_regs[RND_STALL_DATA_VALID]  = 2;
+                rnd_stall_regs[RND_STALL_DATA_MAX]    = 3;
+            end
+            else begin
+                randcase
+                    1: begin
+                        // No delays
+                    end
+                    1: begin
+                        // Only INSTRUCTION RAM stalls
+                        rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
+                        rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
+                        rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
+                        rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
+                        rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
+                    end
+                    1: begin
+                        // Only DATA RAM stalls
+                        rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
+                        rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
+                        rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
+                        rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
+                        rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
+                    end
+                    7: begin
+                        // Both INSTRUCTION and DATA RAM stalls
+                        rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
+                        rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
+                        rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
+                        rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
+                        rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
 
-        if (!$test$plusargs("rand_stall_obi_disable")) begin
-            randcase
-                2: begin
-                    // No delays
-                end
-                1: begin
-                    // Create RAM stall delays
-                    rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
-                    rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
-                    rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
-                    rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
-                    rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
-                end
-            endcase
+                        rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
+                        rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
+                        rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
+                        rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
+                        rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
+                    end
+                endcase
+            end
         end
 
         `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall enable: %0d", rnd_stall_regs[RND_STALL_INSTR_EN]), UVM_LOW)

--- a/cv32/tb/core/mm_ram.sv
+++ b/cv32/tb/core/mm_ram.sv
@@ -168,7 +168,9 @@ module mm_ram
         #1ns;
         if (!$test$plusargs("rand_stall_obi_disable")) begin
             if ($test$plusargs("max_data_zero_instr_stall")) begin
-                // used for fence.i
+                `uvm_info("RNDSTALL", "Max data stall, zero instruction stall configuration", UVM_LOW)
+                // This "knob" creates maximum stalls on data loads/stores, and
+                // no stalls on instruction fetches.  Used for fence.i testing. 
                 rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
                 rnd_stall_regs[RND_STALL_DATA_MODE]   = 2;
                 rnd_stall_regs[RND_STALL_DATA_GNT]    = 2;
@@ -177,33 +179,25 @@ module mm_ram
             end
             else begin
                 randcase
-                    1: begin
+                    2: begin
                         // No delays
                     end
                     1: begin
-                        // Only INSTRUCTION RAM stalls
+                        // Create RAM stall delays
                         rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
                         rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
                         rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
                         rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
                         rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
+                    end
+                endcase
+
+                randcase
+                    2: begin
+                        // No delays
                     end
                     1: begin
-                        // Only DATA RAM stalls
-                        rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
-                        rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
-                        rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);
-                        rnd_stall_regs[RND_STALL_DATA_VALID]  = $urandom_range(2,0);
-                        rnd_stall_regs[RND_STALL_DATA_MAX]    = $urandom_range(3,0);
-                    end
-                    7: begin
-                        // Both INSTRUCTION and DATA RAM stalls
-                        rnd_stall_regs[RND_STALL_INSTR_EN]    = 1;
-                        rnd_stall_regs[RND_STALL_INSTR_MODE]  = $urandom_range(2,1);
-                        rnd_stall_regs[RND_STALL_INSTR_GNT]   = $urandom_range(3,0);
-                        rnd_stall_regs[RND_STALL_INSTR_VALID] = $urandom_range(3,0);
-                        rnd_stall_regs[RND_STALL_INSTR_MAX]   = $urandom_range(3,0);
-
+                        // Create RAM stall delays
                         rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
                         rnd_stall_regs[RND_STALL_DATA_MODE]   = $urandom_range(2,1);
                         rnd_stall_regs[RND_STALL_DATA_GNT]    = $urandom_range(2,0);


### PR DESCRIPTION
Changes up the randomization of the memory stalls a little bit and updates the dsim makefile to run with random seeds by default.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>