### PR TITLE
add ebreaks in general program to hit missing coverage

### DIFF
--- a/cv32/tests/programs/corev-dv/corev_rand_debug_ebreak/corev-dv.yaml
+++ b/cv32/tests/programs/corev-dv/corev_rand_debug_ebreak/corev-dv.yaml
@@ -12,8 +12,8 @@ plusargs: >
     +boot_mode=m
     +no_csr_instr=1
     +no_wfi=0
-    +no_ebreak=1
-    +no_dret=1
+    +no_ebreak=0
+    +no_dret=0
     +enable_misaligned_instr=1
     +enable_ebreak_in_debug_rom=1
     +set_dcsr_ebreak=1


### PR DESCRIPTION
Thanks @silabs-oysteink for the tip!

Note that this addition while necessary does make the test susceptible to failure from the known ISS/exception/debug request issue.

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>