### PR TITLE
Update to latest RTL and remove FPNEW dependencies

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -68,22 +68,10 @@ BANNER=*************************************************************************
 
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= 68bb847
-
-FPNEW_REPO      ?= https://github.com/pulp-platform/fpnew
-FPNEW_BRANCH    ?= master
-#2020-10-05
-FPNEW_HASH      ?= 5b2a9d4
-#2020-09-23
-#FPNEW_HASH      ?= a0c021c360abcc94e434d41974a52bdcbf14d156
+CV32E40P_HASH   ?= 8dfe6f0
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
-#RISCVDV_REPO    ?= https://github.com/MikeOpenHWGroup/riscv-dv
 RISCVDV_BRANCH  ?= master
-# May 2 version of riscv-dv.  Later versions have had known randomization errors
-#RISCVDV_HASH    ?= c37c5f3f57ac61991aa5abd614badb367c5d025d
-# July 8 version.  Randomization errors have significantly improved.
-#                  Generation of riscv_pmp_test fails (we do not care for CV32E40P).
 RISCVDV_HASH    ?= 10fd4fa8b7d0808732ecf656c213866cae37045a
 
 COMPLIANCE_REPO   ?= https://github.com/riscv/riscv-compliance
@@ -102,19 +90,6 @@ ifeq ($(CV32E40P_HASH), head)
   CLONE_CV32E40P_CMD = $(TMP)
 else
   CLONE_CV32E40P_CMD = $(TMP); cd $(CV32E40P_PKG); git checkout $(CV32E40P_HASH)
-endif
-
-# Generate command to clone the FPNEW RTL
-ifeq ($(FPNEW_BRANCH), master)
-  TMP2 = git clone $(FPNEW_REPO) --recurse $(FPNEW_PKG)
-else
-  TMP2 = git clone -b $(FPNEW_BRANCH) --single-branch $(FPNEW_REPO) --recurse $(FPNEW_PKG)
-endif
-
-ifeq ($(FPNEW_HASH), head)
-  CLONE_FPNEW_CMD = $(TMP2)
-else
-  CLONE_FPNEW_CMD = $(TMP2); cd $(FPNEW_PKG); git checkout $(FPNEW_HASH)
 endif
 # RTL repo vars end
 
@@ -144,6 +119,7 @@ ifeq ($(COMPLIANCE_HASH), head)
 else
   CLONE_COMPLIANCE_CMD = $(TMP4); cd $(COMPLIANCE_PKG); git checkout $(COMPLIANCE_HASH)
 endif
+# RISCV Compliance repo var end
 
 ###############################################################################
 # Imperas Instruction Set Simulator

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -155,15 +155,11 @@ include $(MAKE_PATH)/../Common.mk
 clone_cv32e40p_rtl:
 	$(CLONE_CV32E40P_CMD)
 
-clone_fpnew_rtl: clone_cv32e40p_rtl
-	$(CLONE_FPNEW_CMD)
-
 clone_riscv-dv:
 	$(CLONE_RISCVDV_CMD)
 
 $(CV32E40P_PKG):
 	$(CLONE_CV32E40P_CMD)
-	$(CLONE_FPNEW_CMD)
 
 $(RISCVDV_PKG):
 	$(CLONE_RISCVDV_CMD)	

--- a/cv32/sim/uvmt_cv32/dsim.mk
+++ b/cv32/sim/uvmt_cv32/dsim.mk
@@ -95,7 +95,6 @@ mk_results:
 
 ################################################################################
 # DSIM compile target
-#      - TODO: cd $(DSIM_RESULTS) - incompatible with pkg file
 comp: mk_results $(CV32E40P_PKG) $(OVP_MODEL_DPI)
 	$(DSIM) \
 		$(DSIM_CMP_FLAGS) \


### PR DESCRIPTION
Hi @strichmo.  This PR is in response to [cv32e40p pr #560](https://github.com/openhwgroup/cv32e40p/pull/560).  This PR removes the Makefile's cloning of fpnew, as this is now part of cv32e40p.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>