### PR TITLE
Add instr x instr coverage

### DIFF
--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -38,7 +38,9 @@ class uvme_rv32isa_covg extends uvm_component;
 
     uvme_cv32_cntxt_c  cntxt;
     
-    uvm_analysis_port#(uvme_rv32isa_covg_trn_c) ap;    
+    uvm_analysis_port#(uvme_rv32isa_covg_trn_c) ap;  
+
+    ins_t ins_prev; // Previous instruction  
 
     // The following CSR ABI names are not currently included:
     // fp, pc
@@ -1548,6 +1550,18 @@ class uvme_rv32isa_covg extends uvm_component;
         }
     endgroup
 
+   // Every instruction has been followed by every
+   // other instruction
+   covergroup instr_cg with function sample(ins_t ins);
+      option.per_instance = 1;
+      cp_ins : coverpoint ins.asm{
+      option.weight = 0;}
+      cp_ins_prev : coverpoint ins_prev.asm{
+      option.weight = 0;}
+      cr_ins_prev_x_ins: cross cp_ins_prev, cp_ins{
+      option.comment = "Cross previous with current instruction";}
+   endgroup // instr_cg
+
     `uvm_component_utils(uvme_rv32isa_covg)
 
 // TODO : review by 20-July-2020
@@ -1639,6 +1653,8 @@ class uvme_rv32isa_covg extends uvm_component;
         c_ebreak_cg   = new();
         c_beqz_cg     = new();
         c_bnez_cg     = new();
+
+        instr_cg      = new();
 
         ap = new("ap", this);
     endfunction: new
@@ -1947,6 +1963,8 @@ class uvme_rv32isa_covg extends uvm_component;
                 end
             endcase
         end
+        instr_cg.sample(ins);
+        ins_prev = ins; // Save instruction as previous
 
         // Send instruction to analysis port
         begin             

--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -1963,7 +1963,11 @@ class uvme_rv32isa_covg extends uvm_component;
                 end
             endcase
         end
-        instr_cg.sample(ins);
+       
+        // Do not call sample until ins_prev is assigned otherwise
+        // get a hit on bin [ADD][1st instruction]
+        if (ins_prev.ins_str != "") 
+          instr_cg.sample(ins);
         ins_prev = ins; // Save instruction as previous
 
         // Send instruction to analysis port


### PR DESCRIPTION
Added covergroup instr_cg for cross of every instruction covered by every other instruction.  Individual coverpoints used to create cross are weighted with 0.  Verified with short 8-instruction test case which produced the expected 7 bins in cross coverage.

For the following instruction sequence:
![image](https://user-images.githubusercontent.com/54555114/97761989-e60a0900-1acc-11eb-8148-7f1567637cd6.png)

Collected the following cross coverage:
![image](https://user-images.githubusercontent.com/54555114/97762109-2cf7fe80-1acd-11eb-8028-13bb547fc9fc.png)
