### PR TITLE
Mike ins cross

### DIFF
--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -1558,7 +1558,7 @@ class uvme_rv32isa_covg extends uvm_component;
       cp_ins_prev : coverpoint (ins_prev.asm) {
          option.weight = 0;
       }
-      cr_ins_prev_x_ins: cross (cp_ins_prev, cp_ins ) {
+      cr_ins_prev_x_ins: cross cp_ins_prev, cp_ins {
          option.weight = 1;
          option.comment = "Cross previous with current instruction";
       }

--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -1546,12 +1546,24 @@ class uvme_rv32isa_covg extends uvm_component;
         }
     endgroup
 
-   // Every instruction has been followed by every
-   // other instruction
+   // Every instruction has been followed by every other instruction
+`ifdef DSIM
+   // dsim handling of per_instance coverage
    covergroup instr_cg with function sample(ins_t ins);
-    `ifndef DSIM
+      cp_ins : coverpoint (ins.asm) {
+         type_option.weight = 0;
+      }
+      cp_ins_prev : coverpoint (ins_prev.asm) {
+         type_option.weight = 0;
+      }
+      cr_ins_prev_x_ins: cross cp_ins_prev, cp_ins {
+         type_option.weight = 1;
+         type_option.comment = "Cross previous with current instruction";
+      }
+   endgroup // instr_cg
+`else
+   covergroup instr_cg with function sample(ins_t ins);
       option.per_instance = 1;
-    `endif
       cp_ins : coverpoint (ins.asm) {
          option.weight = 0;
       }
@@ -1563,6 +1575,7 @@ class uvme_rv32isa_covg extends uvm_component;
          option.comment = "Cross previous with current instruction";
       }
    endgroup // instr_cg
+`endif // DSIM
 
     `uvm_component_utils(uvme_rv32isa_covg)
 

--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -1541,8 +1541,6 @@ class uvme_rv32isa_covg extends uvm_component;
         }
     endgroup
 
-// TODO : only counting occurrence, ignoring when not called.
-// FIXME: DONE
     covergroup c_ebreak_cg   with function sample(ins_t ins);
         option.per_instance = 1;
         cp_asm   : coverpoint (ins.asm) {
@@ -1553,13 +1551,17 @@ class uvme_rv32isa_covg extends uvm_component;
    // Every instruction has been followed by every
    // other instruction
    covergroup instr_cg with function sample(ins_t ins);
-      option.per_instance = 1;
-      cp_ins : coverpoint ins.asm{
-      option.weight = 0;}
-      cp_ins_prev : coverpoint ins_prev.asm{
-      option.weight = 0;}
-      cr_ins_prev_x_ins: cross cp_ins_prev, cp_ins{
-      option.comment = "Cross previous with current instruction";}
+      //option.per_instance = 1;
+      cp_ins : coverpoint (ins.asm) {
+         option.weight = 0;
+      }
+      cp_ins_prev : coverpoint (ins_prev.asm) {
+         option.weight = 0;
+      }
+      cr_ins_prev_x_ins: cross (cp_ins_prev, cp_ins ) {
+         option.weight = 1;
+         option.comment = "Cross previous with current instruction";
+      }
    endgroup // instr_cg
 
     `uvm_component_utils(uvme_rv32isa_covg)
@@ -1962,12 +1964,13 @@ class uvme_rv32isa_covg extends uvm_component;
                                            ins.ins_str))                    
                 end
             endcase
-        end
+        end // else branch of if (ins.compressed)
        
         // Do not call sample until ins_prev is assigned otherwise
         // get a hit on bin [ADD][1st instruction]
         if (ins_prev.ins_str != "") 
           instr_cg.sample(ins);
+
         ins_prev = ins; // Save instruction as previous
 
         // Send instruction to analysis port

--- a/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
+++ b/cv32/env/uvme_cv32/cov/uvme_rv32isa_covg.sv
@@ -1349,16 +1349,14 @@ class uvme_rv32isa_covg extends uvm_component;
         }
     endgroup
 
-// TODO : missing coverage of all immediate values and destination registers.
-// FIXME: DONE
     covergroup c_lui_cg      with function sample(ins_t ins);
         option.per_instance = 1;
         cp_rd    : coverpoint get_gpr_name(ins.ops[0].val, ins.ops[0].key, "c.lui") {
-            bins gprval[] = {ra,[gp:a5]};
+            bins gprval[] = {ra,[gp:t6]}; // invalid when rd = x2 (sp)
         }
         cp_imm6   : coverpoint get_imm(ins.ops[1].val,"c.lui" ) {    
             bins neg  = {[$:-1]};
-            bins zero = {0};
+            // invalid when imm = 0
             bins pos  = {[1:$]};
         }
     endgroup
@@ -1551,7 +1549,9 @@ class uvme_rv32isa_covg extends uvm_component;
    // Every instruction has been followed by every
    // other instruction
    covergroup instr_cg with function sample(ins_t ins);
-      //option.per_instance = 1;
+    `ifndef DSIM
+      option.per_instance = 1;
+    `endif
       cp_ins : coverpoint (ins.asm) {
          option.weight = 0;
       }
@@ -1566,7 +1566,7 @@ class uvme_rv32isa_covg extends uvm_component;
 
     `uvm_component_utils(uvme_rv32isa_covg)
 
-// TODO : review by 20-July-2020
+// TODO : need review
     function new(string name="rv32isa_covg", uvm_component parent=null);
         super.new(name, parent);
         add_cg        = new();


### PR DESCRIPTION
Hi @GTumbush, this is a minor tweak to your #320.  For reasons that are not clear to me, the `per_instance` option to covergroups causes dsim generate duplicated results.  I am working that out with them, in the meantime, this kludge should ensure both xrun and dsim regressions produce good results.

I've tweaked the c.liu covergroup as I noticed it was not binning x16..x31 and had coverage for imm=0 which is not correct.