### PR TITLE
No stalls on instruction fetch bus

### DIFF
--- a/cv32/tests/programs/custom/perf_counters_instructions/test.yaml
+++ b/cv32/tests/programs/custom/perf_counters_instructions/test.yaml
@@ -2,3 +2,5 @@ name: perf_counters_instructions
 uvm_test: uvmt_cv32_firmware_test_c
 description: >
     Performance Counters Basic Test
+plusargs: >
+    +max_data_zero_instr_stall


### PR DESCRIPTION
The `IMISS` event (cycles waiting for instruction fetches, excluding jumps and branches) routinely fails when random stalls on the instruction fetch bus are enabled.  That test will never be sophisticated enough to predict proper counting of IMISS events in the presence of stalls, so I have disabled them.

If we need to, we can split off the IMISS test into its own testcase so that the remaining perf counts can be tested in the presence of instruction fetch stalls.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>