### PR TITLE
define default SHELL interpreter

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -68,6 +68,8 @@ BANNER=*************************************************************************
 #      *_TAG:    Not yet supported (TODO).
 #                
 
+export SHELL = /bin/bash
+
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
 CV32E40P_HASH   ?= 6c858bc


### PR DESCRIPTION
This pull request defines the default SHELL interpreter in make as /bin/bash
the standard default is /bin/sh
unfortunately ubuntu uses a symbolic link from /bin/sh -> /bin/dash
The dash shell is not compatible at running some of the interpreter commands in the Makefiles
