### PR TITLE
point to latest core with generate block naming fixes

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -72,7 +72,7 @@ export SHELL = /bin/bash
 
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= 6c858bc
+CV32E40P_HASH   ?= edfe222
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master


### PR DESCRIPTION
Brings in core updates to improve coverage collection and closure
Locally ran with ci_check in Xcelium
