### PR TITLE
Move to latest RTL

### DIFF
--- a/cv32/sim/Common.mk
+++ b/cv32/sim/Common.mk
@@ -72,7 +72,7 @@ export SHELL = /bin/bash
 
 CV32E40P_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV32E40P_BRANCH ?= master
-CV32E40P_HASH   ?= edfe222
+CV32E40P_HASH   ?= 3c8f422223ed72e514f424fbe23b27267c405b0b
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master


### PR DESCRIPTION
Moving to the latest RTL

By the way: @MikeOpenHWGroup, maybe as a side effect of the previous RTL commit  (that added the names to generated blocks) the issues mentioned in https://github.com/openhwgroup/cv32e40p/issues/572 have been solved (as I had to rewrite the blocks mentioned by the dsim warnings). I have no way to check with dsim myself though.

Signed-off-by: Arjan Bink <Arjan.Bink@silabs.com>