### PR TITLE
New test load_store_rs1_zero covers loads and stores with rs1=zero

### DIFF
--- a/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
+++ b/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
@@ -45,33 +45,33 @@ _start_main:
     li a1, 0x12345678
     sw a1, 2044(zero)
     lw a2, 2044(zero)
-    bne a2, a1, csr_fail
+    bne a2, a1, test_fail
 
     # write/read mem[2047]=0x9A with sb and lb (lb does sign extend)
     li a3, 0x9A
     sb a3, 2047(zero)
     li a3, 0xFFFFFF9A # Sign extended expected value
     lb a4, 2047(zero)
-    bne a4, a3, csr_fail
+    bne a4, a3, test_fail
         
     # write/read mem[2047]=0xBC with sb and lbu (lbu does not sign extend)
     li a5, 0xBC
     sb a5, 2047(zero)
     lbu a6, 2047(zero)
-    bne a5, a6, csr_fail
+    bne a5, a6, test_fail
 
     # write/read mem[2047]=0xDE & mem[2046]=0xF0 with sh and lh (lh does sign extend)
     li a7, 0xDEF0
     sh a7, 2046(zero)
     li a7, 0xFFFFDEF0 # Sign extended expected value
     lh a0, 2046(zero)
-    bne a7, a0, csr_fail
+    bne a7, a0, test_fail
         
     # write/read mem[2047]=0x81 & mem[2046]=0x23 with sh and lhu (lhu does not sign extend)
     li a1, 0x8123
     sh a1, 2046(zero)
     lhu a2, 2046(zero)
-    bne a1, a2, csr_fail
+    bne a1, a2, test_fail
         
 test_done:
     lui a0,print_port>>12
@@ -99,13 +99,13 @@ test_done:
     sw a1,0(a0)
     sw a1,0(a0)
 
-csr_pass:
+test_pass:
     li x18, 123456789
     li x17, 0x20000000
     sw x18,0(x17)
     wfi
 
-csr_fail:
+test_fail:
     lui a0,print_port>>12
     addi a1,zero,'\n'
     sw a1,0(a0)

--- a/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
+++ b/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
@@ -1,0 +1,127 @@
+################################################################################
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+# - Addresses coverage hole in which load and store instructions are not
+#   generated for which operand rs1=ZERO.
+# - THIS TEST IS SELF CHECKING but should be run against a
+#   reference model to check results.
+# - This test can be abandoned and corev_rand_instr_test should produce
+#   this combination when https://github.com/google/riscv-dv/issues/752
+#   is addressed.
+################################################################################
+.include "user_define.h"
+.section .text.start
+.globl _start
+.section .text
+.type _start, @function
+
+_start:
+    j _start_main
+
+.globl _start_main
+.section .text
+_start_main:
+
+# Verify uncompressed load and store
+    # Write/read mem[2044]=12, mem[2045]=34, mem[2046]=56, mem[2047]=78
+    li a1, 0x12345678
+    sw a1, 2044(zero)
+    lw a2, 2044(zero)
+    bne a2, a1, csr_fail
+
+    # write/read mem[2047]=9A with sb and lb (lbu does sign extend)
+    li a3, 0x9A
+    sb a3, 2047(zero)
+    li a3, 0xFFFFFF9A # Expected value
+    lb a4, 2047(zero)
+    bne a4, a3, csr_fail
+        
+    # write/read mem[2047]=BC with sb and lbu (lbu does not sign extend)
+    li a5, 0xBC
+    sb a5, 2047(zero)
+    lbu a6, 2047(zero)
+    bne a5, a6, csr_fail
+        
+test_done:
+    lui a0,print_port>>12
+    addi a1,zero,'\n'
+    sw a1,0(a0)
+    addi a1,zero,'C'
+    sw a1,0(a0)
+    addi a1,zero,'V'
+    sw a1,0(a0)
+    addi a1,zero,'3'
+    sw a1,0(a0)
+    addi a1,zero,'2'
+    sw a1,0(a0)
+    addi a1,zero,' '
+    sw a1,0(a0)
+    addi a1,zero,'D'
+    sw a1,0(a0)
+    addi a1,zero,'O'
+    sw a1,0(a0)
+    addi a1,zero,'N'
+    sw a1,0(a0)
+    addi a1,zero,'E'
+    sw a1,0(a0)
+    addi a1,zero,'\n'
+    sw a1,0(a0)
+    sw a1,0(a0)
+
+csr_pass:
+    li x18, 123456789
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi
+
+csr_fail:
+    lui a0,print_port>>12
+    addi a1,zero,'\n'
+    sw a1,0(a0)
+    addi a1,zero,'C'
+    sw a1,0(a0)
+    addi a1,zero,'V'
+    sw a1,0(a0)
+    addi a1,zero,'3'
+    sw a1,0(a0)
+    addi a1,zero,'2'
+    sw a1,0(a0)
+    addi a1,zero,' '
+    sw a1,0(a0)
+    addi a1,zero,'F'
+    sw a1,0(a0)
+    addi a1,zero,'A'
+    sw a1,0(a0)
+    addi a1,zero,'I'
+    sw a1,0(a0)
+    addi a1,zero,'L'
+    sw a1,0(a0)
+    addi a1,zero,'\n'
+    sw a1,0(a0)
+    sw a1,0(a0)
+
+    li x18, 1
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi
+#
+# end
+#

--- a/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
+++ b/cv32/tests/programs/custom/load_store_rs1_zero/load_store_rs1_zero.S
@@ -41,24 +41,37 @@ _start:
 _start_main:
 
 # Verify uncompressed load and store
-    # Write/read mem[2044]=12, mem[2045]=34, mem[2046]=56, mem[2047]=78
+    # Write/read mem[2047]=12, mem[2046]=34, mem[2045]=56, mem[2044]=78
     li a1, 0x12345678
     sw a1, 2044(zero)
     lw a2, 2044(zero)
     bne a2, a1, csr_fail
 
-    # write/read mem[2047]=9A with sb and lb (lbu does sign extend)
+    # write/read mem[2047]=0x9A with sb and lb (lb does sign extend)
     li a3, 0x9A
     sb a3, 2047(zero)
-    li a3, 0xFFFFFF9A # Expected value
+    li a3, 0xFFFFFF9A # Sign extended expected value
     lb a4, 2047(zero)
     bne a4, a3, csr_fail
         
-    # write/read mem[2047]=BC with sb and lbu (lbu does not sign extend)
+    # write/read mem[2047]=0xBC with sb and lbu (lbu does not sign extend)
     li a5, 0xBC
     sb a5, 2047(zero)
     lbu a6, 2047(zero)
     bne a5, a6, csr_fail
+
+    # write/read mem[2047]=0xDE & mem[2046]=0xF0 with sh and lh (lh does sign extend)
+    li a7, 0xDEF0
+    sh a7, 2046(zero)
+    li a7, 0xFFFFDEF0 # Sign extended expected value
+    lh a0, 2046(zero)
+    bne a7, a0, csr_fail
+        
+    # write/read mem[2047]=0x81 & mem[2046]=0x23 with sh and lhu (lhu does not sign extend)
+    li a1, 0x8123
+    sh a1, 2046(zero)
+    lhu a2, 2046(zero)
+    bne a1, a2, csr_fail
         
 test_done:
     lui a0,print_port>>12

--- a/cv32/tests/programs/custom/load_store_rs1_zero/test.yaml
+++ b/cv32/tests/programs/custom/load_store_rs1_zero/test.yaml
@@ -1,0 +1,4 @@
+name: load_store_rs1_zero
+uvm_test: uvmt_cv32_firmware_test_c
+description: >
+    load and store with rs1=zero


### PR DESCRIPTION
From Steve Richmond spreadsheet cv32e40p_201115_cov_holes.xlsx

![image](https://user-images.githubusercontent.com/54555114/99452912-6a3bf900-28e1-11eb-9950-5d55ffca99c8.png)
![image](https://user-images.githubusercontent.com/54555114/99452586-f26dce80-28e0-11eb-94ec-f329a81f8271.png)

To address missing coverage created test load_store_rs1_zero which covers the following instructions with operand rs1=zero:
lw, lb, lbu, lh, lhu
sw, sb, sh

Coverage has been verified.

Test is self-checking but can still run with the RM.
