### PR TITLE
Fix signature check

### DIFF
--- a/cv32/sim/tools/gtk/cv32e40p_core_IO.gtkw
+++ b/cv32/sim/tools/gtk/cv32e40p_core_IO.gtkw
@@ -1,78 +1,101 @@
 [*]
-[*] GTKWave Analyzer v3.3.104 (w)1999-2020 BSI
-[*] Tue Jul 28 17:14:14 2020
+[*] GTKWave Analyzer v3.3.107 (w)1999-2020 BSI
+[*] Mon Nov 23 19:03:40 2020
 [*]
-[dumpfile] "/data/mike/GitHubRepos/openhwgroup/core-v-verif/master/cv32/sim/uvmt_cv32/dsim_results/corev_arithmetic_base_test_0/dsim.fst"
-[dumpfile_mtime] "Mon Jul 27 20:32:31 2020"
-[dumpfile_size] 5859591
-[savefile] "/data/mike/GitHubRepos/openhwgroup/core-v-verif/master/cv32/sim/tools/gtk/cv32e40p_core_IO.gtkw"
-[timestart] 0
-[size] 1900 940
-[pos] -1 -338
-*-13.000000 12000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
-[treeopen] uvmt_cv32_tb.
-[treeopen] uvmt_cv32_tb.dut_wrap.
-[treeopen] uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.
-[treeopen] uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.
+[dumpfile] "/data/mike/GitHubRepos/MikeOpenHWGroup/core-v-verif/pipeline_hazards/cv32/sim/uvmt_cv32/dsim_results/hello-world/dsim.fst"
+[dumpfile_mtime] "Mon Nov 23 18:49:40 2020"
+[dumpfile_size] 4020478
+[savefile] "/data/mike/GitHubRepos/MikeOpenHWGroup/core-v-verif/pipeline_hazards/cv32/sim/tools/gtk/cv32e40p_core_IO.gtkw"
+[timestart] 58070
+[size] 1920 936
+[pos] -915 -334
+*-13.000000 2040 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] $root.
+[treeopen] $root.uvmt_cv32_tb.
+[treeopen] $root.uvmt_cv32_tb.dut_wrap.
+[treeopen] $root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.
 [sst_width] 434
 [signals_width] 346
 [sst_expanded] 1
-[sst_vpaned_height] 276
+[sst_vpaned_height] 175
+@200
+-Clock and Reset
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.clk_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.rst_ni
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.clk_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.rst_ni
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.scan_cg_en_i
+@200
+-Configuration Inputs
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.boot_addr_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.hart_id_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_halt_addr_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_exception_addr_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.mtvec_addr_i[31:0]
-@29
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.fetch_enable_i
-@28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_req_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.pulp_clock_en_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.scan_cg_en_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.core_sleep_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.boot_addr_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.mtvec_addr_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_exception_addr_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_halt_addr_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.hart_id_i[31:0]
+@200
+-Aux Processor Unit I/O
+@23
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_flags_i[4:0]
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_addr_o[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_be_o[3:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_flags_o[14:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_gnt_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_gnt_i
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rdata_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_op_o[5:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_operands_o[95:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_req_o
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rvalid_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_req_o
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_wdata_o[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_result_i[31:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_we_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_rvalid_i
+@200
+-Special Control Signals
+@28
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.core_sleep_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.pulp_clock_en_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.fetch_enable_i
+@200
+-Data Memory Interface
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_addr_o[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_addr_o[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_be_o[3:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_gnt_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_gnt_i
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rdata_i[31:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rdata_i[31:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_req_o
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rvalid_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_ack_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_req_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rvalid_i
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_id_o[4:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_wdata_o[31:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_valid_i
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_gnt_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_we_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_halted_o
+@200
+-Debug Module Interface
+@28
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_havereset_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_req_i
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_running_o
+@200
+-Instruction Memory Interface
 @22
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_result_i[31:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_flags_i[4:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_flags_o[14:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_op_o[5:0]
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_operands_o[95:0]
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_addr_o[31:0]
 @28
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_ready_o
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_req_o
-uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_master_type_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_gnt_i
+@22
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rdata_i[31:0]
+@28
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_req_o
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rvalid_i
+@200
+-Interrupts
+@22
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_i[31:0]
+@28
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_ack_o
+@22
+$root.uvmt_cv32_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_id_o[4:0]
 [pattern_trace] 1
 [pattern_trace] 0

--- a/cv32/sim/uvmt_cv32/Makefile
+++ b/cv32/sim/uvmt_cv32/Makefile
@@ -184,13 +184,14 @@ clr_compliance:
 	make clean -C $(PROJ_ROOT_DIR)/vendor_lib/riscv/riscv-compliance
 
 build_compliance: clone_compliance
-	make -i -C $(PROJ_ROOT_DIR)/vendor_lib/riscv/riscv-compliance \
+	make simulate -i -C $(PROJ_ROOT_DIR)/vendor_lib/riscv/riscv-compliance \
 		RISCV_TARGET=OpenHW \
 		RISCV_DEVICE=cv32e40p \
 		PATH=$(RISCV)/bin:$(PATH) \
 		RISCV_PREFIX=$(RISCV_PREFIX) \
 		NOTRAPS=1 \
 		RISCV_ISA=$(RISCV_ISA)
+#		VERBOSE=1
 
 all_compliance: clone_compliance
 	make build_compliance RISCV_ISA=rv32i        && \


### PR DESCRIPTION
Fix the make invocation so that there is no generation of a test signature until the test-program actually runs in the UVM environment.   Fix for #253.