### PR TITLE
isa_fcov_holes requires COREV toolchain

### DIFF
--- a/cv32/regress/cv32_full.yaml
+++ b/cv32/regress/cv32_full.yaml
@@ -243,7 +243,7 @@ tests:
     build: uvmt_cv32
     description: ISA function coverage test
     dir: cv32/sim/uvmt_cv32
-    cmd: make test TEST=isa_fcov_holes
+    cmd: make test COREV=YES TEST=isa_fcov_holes
 
   cv32e40p_csr_access_test:
     build: uvmt_cv32

--- a/cv32/regress/cv32_full_covg_no_pulp.yaml
+++ b/cv32/regress/cv32_full_covg_no_pulp.yaml
@@ -294,4 +294,4 @@ tests:
     build: uvmt_cv32
     description: ISA function coverage test
     dir: cv32/sim/uvmt_cv32
-    cmd: make test TEST=isa_fcov_holes
+    cmd: make test COREV=YES TEST=isa_fcov_holes


### PR DESCRIPTION
Noticed that the `isa_fcov_holes` test-program was not set to use the COREV toolchain in regression, which it needs to compile properly.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>