### PR TITLE
Remove RUN_INDEX from single tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ cva6/tests/riscv-compliance/
 cva6/tests/riscv-tests/
 tools/
 uvm/riscv-dv/
+riviera_results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,16 @@
 # Contributing
-Contributors are encouraged to be a [member](https://www.openhwgroup.org/membership/) of the OpenHW Group.  New members are always welcome.  Have a look at [README](https://github.com/openhwgroup/core-v-verif/blob/master/README.md), especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started) section.
+New Contributors are always welecome.  Contributors are encouraged, but not required, to be a [member](https://www.openhwgroup.org/membership/) of the OpenHW Group. Have a look at [README](https://github.com/openhwgroup/core-v-verif/blob/master/README.md), especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started) section.
+
+## Contributor Agreement
+Contributors must be covered by the terms of the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) (for individuals) or the [Eclipse Member Committer and Contributor Agreement](https://www.eclipse.org/legal/committer_process/EclipseMemberCommitterAgreement.pdf) (for employees of Member companies). The ECA/MCCA is an agreement covering a Contributor's role in making technical contributions to the OpenHW Group, and it provides the legal framework for granting copyright on code and/or documents merged into OpenHW Group repositories.
+<br>
+All pull-requests to OpenHW Group git repositories must be signed-off using the `--signoff` (or `-s`) option to the git commit command (see below).
 
 ## The Mechanics
 1. [Fork](https://help.github.com/articles/fork-a-repo/) the [core-v-verif](https://github.com/openhwgroup/core-v-verif) repository
 2. Clone repository: `git clone https://github.com/[your_github_username]/core-v-verif`
 3. Create your feature branch: `git checkout -b <my_branch>.`<br> Please uniquify your branch name.  See the [Git Cheats](https://github.com/openhwgroup/core-v-verif/blob/master/GitCheats.md) for a useful nominclature.
 4. Test your changes with the [ci_check](https://github.com/openhwgroup/core-v-verif/blob/regression_test/ci/ci_check) script.
-5. Commit your changes: `git commit -m 'Add some feature' -s`<br>...take note of that **-s**, it's important!
+5. Commit your changes: `git commit -m 'Add some feature' --signoff`<br>...take note of that **--signoff**, it's important!
 6. Push feature branch: `git push origin <my_branch>`
 7. Submit a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,21 @@
 # Contributing
-New Contributors are always welcome. Start by having a look at the **README**, especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started) section.
+New Contributors are always welcome. Start by having a look at the **README**,
+especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started)
+section.
 
 ## Contributor Agreement
-Contributors are encouraged, but not required, to be a [member](https://www.openhwgroup.org/membership/) of the OpenHW Group.
-Contributors must be covered by the terms of the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) (for individuals) or the [Eclipse Member Committer and Contributor Agreement](https://www.eclipse.org/legal/committer_process/EclipseMemberCommitterAgreement.pdf) (for employees of Member companies). The ECA/MCCA is an agreement covering a Contributor's role in making technical contributions to the OpenHW Group, and it provides the legal framework for granting copyright on code and/or documents merged into OpenHW Group repositories.
+Most Contributors are [members](https://www.openhwgroup.org/membership/) of the
+OpenHW Group and participate in one or more [Technical Task Groups](https://www.openhwgroup.org/working-groups/).
+Membership is strongly encouraged, but not required.  Contributors must be
+covered by the terms of the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
+(for individuals) **or** the [Eclipse Member Committer and Contributor Agreement](https://www.eclipse.org/legal/committer_process/EclipseMemberCommitterAgreement.pdf)
+(for employees of Member companies). The ECA/MCCA provides a legal
+framework for a Contributor's technical contributions to the OpenHW Group,
+including provisions for grant of copyright license and a Developer
+Certificate of Origin on contributions merged into OpenHW Group repositories.
 <br><br>
-All pull-requests to OpenHW Group git repositories must be signed-off using the `--signoff` (or `-s`) option to the git commit command (see below).
+All pull-requests to OpenHW Group git repositories must be signed-off using the
+`--signoff` (or `-s`) option to the git commit command (see below).
 
 ## The Mechanics
 1. [Fork](https://help.github.com/articles/fork-a-repo/) the [core-v-verif](https://github.com/openhwgroup/core-v-verif) repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,10 @@
 # Contributing
-New Contributors are always welecome.  Contributors are encouraged, but not required, to be a [member](https://www.openhwgroup.org/membership/) of the OpenHW Group. Have a look at [README](https://github.com/openhwgroup/core-v-verif/blob/master/README.md), especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started) section.
+New Contributors are always welcome. Start by having a look at the **README**, especially the [getting started](https://github.com/openhwgroup/core-v-verif#getting-started) section.
 
 ## Contributor Agreement
+Contributors are encouraged, but not required, to be a [member](https://www.openhwgroup.org/membership/) of the OpenHW Group.
 Contributors must be covered by the terms of the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) (for individuals) or the [Eclipse Member Committer and Contributor Agreement](https://www.eclipse.org/legal/committer_process/EclipseMemberCommitterAgreement.pdf) (for employees of Member companies). The ECA/MCCA is an agreement covering a Contributor's role in making technical contributions to the OpenHW Group, and it provides the legal framework for granting copyright on code and/or documents merged into OpenHW Group repositories.
-<br>
+<br><br>
 All pull-requests to OpenHW Group git repositories must be signed-off using the `--signoff` (or `-s`) option to the git commit command (see below).
 
 ## The Mechanics

--- a/cv32/regress/cv32_debug.yaml
+++ b/cv32/regress/cv32_debug.yaml
@@ -1,8 +1,8 @@
 # YAML file to specify a regression testlist
 ---
 # Header
-name: cv32_interrupt
-description: Directed and random interrupt tests for CV32E40P
+name: cv32_debug_regression
+description: Directed and random debug tests for CV32E40P
 
 # List of builds
 builds:

--- a/cv32/tests/programs/custom/debug_test/test.yaml
+++ b/cv32/tests/programs/custom/debug_test/test.yaml
@@ -1,7 +1,7 @@
 # Test definition YAML for test
 
 # Debug directed test
-name: debug_test_<RUN_INDEX>
+name: debug_test
 uvm_test: uvmt_cv32_firmware_test_c
 program: debug_test
 description: >

--- a/cv32/tests/programs/custom/debug_test_boot_set/test.yaml
+++ b/cv32/tests/programs/custom/debug_test_boot_set/test.yaml
@@ -1,7 +1,7 @@
 # Test definition YAML for test
 
 # Debug directed test for debug request at reset
-name: debug_test_boot_set_<RUN_INDEX>
+name: debug_test_boot_set
 uvm_test: uvmt_cv32_firmware_test_c
 program: debug_test_reset
 description: >

--- a/cv32/tests/programs/custom/debug_test_known_miscompares/test.yaml
+++ b/cv32/tests/programs/custom/debug_test_known_miscompares/test.yaml
@@ -2,7 +2,7 @@
 
 # Debug trigger directed test
 # Asserts debug_req_i  while processing an illegal insn
-name: debug_test_known_miscompares_<RUN_INDEX>
+name: debug_test_known_miscompares
 uvm_test: uvmt_cv32_firmware_test_c
 program: debug_test_known_miscompares
 description: >


### PR DESCRIPTION
This is a fix for #447.

The `test.yaml` for a couple of the directed debug tests had a TEST_INDEX post-fix in their name.  I cannot understand why, but this only affects Riviera-PRO.  This fix cleans things up and works with dsim and xrun.  In order to  test that the problem goes away using Riviera-PRO I needed to stub out the simulator, but I can confirm that the original issue reported in #447 shows up using these stubs and goes away with the update on this branch.