### PR TITLE
Add scripts to create a GitHub action that launches a Metrics regression

### DIFF
--- a/.github/workflows/metrics-regress.yml
+++ b/.github/workflows/metrics-regress.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: ./bin/metrics-regress.py $METRICS_REGRESSION_NAME $METRICS_PROJECT_ID
+      - run: ./bin/metrics-regress $METRICS_REGRESSION_NAME $METRICS_PROJECT_ID
         env:
           METRICS_CI_TOKEN: ${{ secrets.METRICS_CI_TOKEN }}
           METRICS_REGRESSION_NAME: cv32_ci_check_regression

--- a/.github/workflows/metrics-regress.yml
+++ b/.github/workflows/metrics-regress.yml
@@ -8,8 +8,8 @@ name: metrics-regress
 on:
   push:
     branches: [ master ]
-  pull_request_target:
-    branches: [ master ]
+#  pull_request_target:
+#    branches: [ master ]
 
 # If you fork this repository, you must create a new Metrics project for your fork
 # and set the environment variable $METRICS_PROJECT_ID accordingly

--- a/.github/workflows/metrics-regress.yml
+++ b/.github/workflows/metrics-regress.yml
@@ -1,0 +1,28 @@
+# This workflow initiates a regression on the Metrics platform and waits
+# for the result of the regression. If all tests pass, the action succeeds.
+
+name: metrics-regress
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request_target:
+    branches: [ master ]
+
+# If you fork this repository, you must create a new Metrics project for your fork
+# and set the environment variable $METRICS_PROJECT_ID accordingly
+jobs:
+  metrics-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ./bin/metrics-regress.py $METRICS_REGRESSION_NAME $METRICS_PROJECT_ID
+        env:
+          METRICS_CI_TOKEN: ${{ secrets.METRICS_CI_TOKEN }}
+          METRICS_REGRESSION_NAME: cv32_ci_check_regression
+          METRICS_PROJECT_ID: ${{ secrets.METRICS_PROJECT_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+

--- a/bin/metrics-regress
+++ b/bin/metrics-regress
@@ -42,7 +42,7 @@ reqParams['regressionName'] = args.regressionName
 
 # Determine the git reference to pass to Metrics. For PRs, the reference
 # is of the format /refs/pull/<PR-number>/merge
-if str(os.environ['GITHUB_EVENT_NAME']) is 'pull_request_target':
+if str(os.environ['GITHUB_EVENT_NAME']) == 'pull_request_target':
     reqParams['branch'] = '/refs/pull/' + str(os.environ['PR_NUMBER']) + '/merge'
 else:
     reqParams['branch'] = str(os.environ['GITHUB_REF'])

--- a/bin/metrics-regress.py
+++ b/bin/metrics-regress.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+
+import json
+import http.client
+import argparse
+import os
+import time
+import math
+
+def make_http_request( req_type, endpoint, params=None ):
+    headers = { 'Content-Type': 'application/json',
+                'Private-Token': str(os.environ['METRICS_CI_TOKEN'])
+               }
+    
+    conn = http.client.HTTPSConnection(server)
+    conn.request(req_type, endpoint, params, headers)
+    response = conn.getresponse()
+    data = response.read()
+    regressionData = json.loads(data.decode('utf-8'))
+    conn.close()
+
+    return response, regressionData
+
+
+## Parse arguments to get regression name and project ID
+parser = argparse.ArgumentParser(prog='metrics-regress',
+                                 description='Launch a regression on the Metrics platform and query results')
+parser.add_argument('regressionName', help='The name of the regression to run')
+parser.add_argument('projectId',      help='The ID of the Metrics project')
+args = parser.parse_args()
+
+## Server
+server =  'openhwgroup.metrics.ca:443'
+
+## API Endpoints
+postRegression = '/api/v1/projects/'+args.projectId+'/regressionRuns'
+getRegressionRunInfo = '/api/v1/projects/'+args.projectId+'/regressionRuns/'
+
+## Start regression
+reqParams = {}
+reqParams['regressionName'] = args.regressionName
+
+# Determine the git reference to pass to Metrics. For PRs, the reference
+# is of the format /refs/pull/<PR-number>/merge
+if str(os.environ['GITHUB_EVENT_NAME']) is 'pull_request_target':
+    reqParams['branch'] = '/refs/pull/' + str(os.environ['PR_NUMBER']) + '/merge'
+else:
+    reqParams['branch'] = str(os.environ['GITHUB_REF'])
+params = json.dumps(reqParams)
+
+response, regressionData = make_http_request('POST', postRegression, params) 
+
+## Check response
+if response.status is not 201:
+    print('Error, regression was not started. Response: ' + str(response.status) + ':' \
+          + str(response.reason))
+    print('Exit with code 1')
+    exit(1)
+else:
+    print('Regression started. Id = ' + regressionData['id'])
+
+## Start polling regression status
+regressionRunId = regressionData['id']
+
+while True:
+    time.sleep(10)
+    response, regressionData = make_http_request('GET', getRegressionRunInfo+regressionRunId)
+    if response.status is 200:
+        if 'complete' in regressionData['status']:
+            print('Regression complete')
+            break
+        if 'buildFailed' in regressionData['status']:
+            print('A build has failed. No tests will be run')
+            print('Debug at: https://openhwgroup.metrics.ca/' + args.projectId + \
+                  '/results/regressionRuns/' + regressionRunId)
+            exit(1)
+
+## Print test status
+print('\n')
+print('Regression results')
+print('==================')
+print('Total number of tests: ' + str(regressionData['testRuns']['total']))
+print('Passed tests: ' + str(regressionData['testRuns']['passed']))
+print('Failed tests: ' + str(regressionData['testRuns']['failed']))
+print('Incomplete tests: ' + str(regressionData['testRuns']['incomplete']))
+print('\n')
+
+## Poll for coverage data
+while True:
+    time.sleep(10)
+    response, regressionData = make_http_request('GET', getRegressionRunInfo+regressionRunId)
+    if response.status is 200:
+        if regressionData['functionalCoverage'] is not None :
+            break
+
+## Print functional coverage
+print('Coverage results')
+print('================')
+print('Functional: ' + str(math.trunc(regressionData['functionalCoverage']*100)/100))
+if regressionData['assertionCoverage'] is not None:
+    print('Assertion: ' + str(math.trunc(regressionData['assertionCoverage']*100) /100))
+if regressionData['lineCoverage'] is not None:
+    print('Code (block): ' + str(math.trunc(regressionData['lineCoverage']*100) /100))
+print('\n')
+
+print('Full results at: https://openhwgroup.metrics.ca/' + args.projectId + \
+      '/results/regressionRuns/' + regressionRunId)
+      
+## Set the exit code to be used by github action
+if regressionData['testRuns']['failed'] > 0 or \
+   regressionData['testRuns']['incomplete'] > 0:
+    print('One or more tests has failed/is incomplete. Exit with code 1.')
+    exit(1)
+else:
+    print('All tests have passed. Exit with code 0.')
+    exit(0)
+
+    
+                                                 
+
+                                                 
+                        


### PR DESCRIPTION
Using the scripts added in this PR, a regression will be launched on the Metrics platform in response to a push or pull request operation on the master branch of the core-v-verif repository. Additional customization of this GitHub action is possible.

Signed-off-by: Aimee Sutton <aimee.sutton@metrics.ca>