### PR TITLE
Core v verif multi, update Riviera-PRO makefile

### DIFF
--- a/lib/corev-dv/manifest.f
+++ b/lib/corev-dv/manifest.f
@@ -26,6 +26,5 @@ ${RISCV_DV_ROOT}/test/riscv_instr_test_pkg.sv
 ${COREV_DV_ROOT}/corev_instr_test_pkg.sv
 
 // Core-specific CORE-V-VERIF
-${CV_CORE_COREV_DV_ROOT}/"${CV_CORE_LC}"_instr_test_pkg.sv
-${CV_CORE_COREV_DV_ROOT}/"${CV_CORE_LC}"_instr_gen_tb_top.sv
-
+${CV_CORE_COREV_DV_ROOT}/${CV_CORE_LC}_instr_test_pkg.sv
+${CV_CORE_COREV_DV_ROOT}/${CV_CORE_LC}_instr_gen_tb_top.sv

--- a/lib/corev-dv/manifest.f
+++ b/lib/corev-dv/manifest.f
@@ -26,5 +26,6 @@ ${RISCV_DV_ROOT}/test/riscv_instr_test_pkg.sv
 ${COREV_DV_ROOT}/corev_instr_test_pkg.sv
 
 // Core-specific CORE-V-VERIF
-${CV_CORE_COREV_DV_ROOT}/${CV_CORE_LC}_instr_test_pkg.sv
-${CV_CORE_COREV_DV_ROOT}/${CV_CORE_LC}_instr_gen_tb_top.sv
+${CV_CORE_COREV_DV_ROOT}/"${CV_CORE_LC}"_instr_test_pkg.sv
+${CV_CORE_COREV_DV_ROOT}/"${CV_CORE_LC}"_instr_gen_tb_top.sv
+


### PR DESCRIPTION
Hey!
In this PR I update makefile for Riviera-PRO due issue #461.
```
make test SIMULATOR=riviera TEST=hello-world
```
works
```
$ make corev-dv CV_CORE=cv32e40p SIMULATOR=riviera
$ make gen_corev-dv test TEST=corev_rand_interrupt SIMULATOR=riviera
```
works, also I check
```
make compliance_regression RISCV_ISA=rv32imc
```
and works too