### PR TITLE
Improvements to metrics-regress script

### DIFF
--- a/bin/metrics-regress
+++ b/bin/metrics-regress
@@ -70,19 +70,19 @@ reqParams = {}
 reqParams['regressionName'] = args.regressionName
 
 # Determine the git reference to pass to Metrics. For PRs, the reference
-# is of the format /refs/pull/<PR-number>/merge
+# is of the format refs/pull/<PR-number>/merge
 if str(os.environ['GITHUB_EVENT_NAME']) == 'pull_request_target':
-    reqParams['branch'] = '/refs/pull/' + str(os.environ['PR_NUMBER']) + '/merge'
+    reqParams['branch'] = 'refs/pull/' + str(os.environ['PR_NUMBER']) + '/merge'
 else:
     reqParams['branch'] = str(os.environ['GITHUB_REF'])
 params = json.dumps(reqParams)
 
-response, regressionData = make_http_request('POST', postRegression, params) 
+response, regressionData = make_http_request('POST', postRegression, params)
 
 ## Check response
-if response.status is not 201:
+if response.status != 201:
     print('Error, regression was not started. Response: ' + str(response.status) + ':' \
-          + str(response.reason))
+          + str(response.reason) + ' ' + str(regressionData))
     print('Exit with code 1')
     exit(1)
 else:
@@ -94,7 +94,7 @@ regressionRunId = regressionData['id']
 while True:
     time.sleep(10)
     response, regressionData = make_http_request('GET', getRegressionRunInfo+regressionRunId)
-    if response.status is 200:
+    if response.status == 200:
         if 'complete' in regressionData['status']:
             print('Regression complete')
             break
@@ -118,7 +118,7 @@ print('\n')
 while True:
     time.sleep(10)
     response, regressionData = make_http_request('GET', getRegressionRunInfo+regressionRunId)
-    if response.status is 200:
+    if response.status == 200:
         if regressionData['functionalCoverage'] is not None :
             break
 
@@ -143,4 +143,3 @@ if regressionData['testRuns']['failed'] > 0 or \
 else:
     print('All tests have passed. Exit with code 0.')
     exit(0)
-


### PR DESCRIPTION
- Better error reporting when a Metrics regression is not started
- Fixed lint errors: used value comparison operators instead of reference compare operators
- Fixed typo on line 75: GitHub references do not start with a leading /