### PR TITLE
Restore CORE testbench

### DIFF
--- a/NEWS_ARCHIVE.md
+++ b/NEWS_ARCHIVE.md
@@ -1,0 +1,15 @@
+### NEWS UPDATES (going back to early 2020):
+**2020-12-10**: OpenHW formally decalres [RTL Freeze for CV32E40P](https://www.openhwgroup.org/news/2020/12/10/core-v-cve4-rtl-freeze-milestone-achieved/)
+<br>
+**2020-10-15**: Aldec's Riviera-PRO SystemVerilog simulator is now supported by core-v-verif.  Check out the README in [mk/uvmt](https://github.com/openhwgroup/core-v-verif/tree/master/mk/uvmt#running-the-environment-with-aldec-riviera-pro-riviera) for more information.
+<br>
+**2020-09-04**: a new (and _much_ better) method of specifying and organizating test-programs and simulations is now merged in.  See slide "_Test Specification Updates_" in the [2020-08-31 CV32E40P project update](https://github.com/openhwgroup/core-v-docs/blob/master/verif/MeetingPresentations/20200831-CV32E40P-ProjectScheduleUpdate.pptx).
+<br>
+**2020-06-12**: a new "Board Support Package" for CV32E40P simulations is installed at `cv32/bsp`.  This BSP should be used to compile/assemble your [test-programs](https://core-v-docs-verif-strat.readthedocs.io/en/latest/test_program_environment.html).  The Makefiles for both the CORE testbench and UVM verification environment have been updated to use this BSP.
+<br>
+**2020-06-02:** The [Imperas OVPsim Instruction Set Generator](http://www.ovpworld.org/) has been integrated into the UVM environment as the Referenece Model for the CV32E40(P).  You will need to obtain a license from Imperas to use it.
+<br>
+**2020-02-28:** The OpenHW Group CV32E40P is now live!<br>This repository no longer contains a local copy of the RTL.  The RTL is cloned from the appropriate [core-v-cores](https://github.com/openhwgroup/core-v-cores) repository as needed.  The specific branch and hash of the RTL is controlled by a set of variables in `cv32e40p/sim/Common.mk`.
+<br>
+**2020-02-10:** The core-v-verif repository now supports multiple cores.  The previously named cv32 directory is now cv32e40p to represent the testbench for the CV32E40P core.  Future cores will be verified in respectively named directories in core-v-verif as siblings to cva6 and cv32e40p.
+

--- a/README.md
+++ b/README.md
@@ -1,25 +1,18 @@
 # core-v-verif
-Functional verification project for the CORE-V family of RISC-V cores. This project is under active development.
+Functional verification project for the CORE-V family of RISC-V cores.
 
 ## NEWS UPDATES:
-**2020-10-15**: Aldec's Riviera-PRO SystemVerilog simulator is now supported by core-v-verif.  Check out the README in [mk/uvmt](https://github.com/openhwgroup/core-v-verif/tree/master/mk/uvmt#running-the-environment-with-aldec-riviera-pro-riviera) for more information.
+**2020-12-16**: The [cv32e40p_v1.0.0](https://github.com/openhwgroup/core-v-verif/releases/tag/22dc5fc) of core-v-verif is released.
+This tag clones the v1.0.0 release of the CV32E40P CORE-V core and will allow you to reproduce the verification environment as it existed at `RTl Freeze`.
 <br>
-**2020-09-04**: a new (and _much_ better) method of specifying and organizating test-programs and simulations is now merged in.  See slide "_Test Specification Updates_" in the [2020-08-31 CV32E40P project update](https://github.com/openhwgroup/core-v-docs/blob/master/verif/MeetingPresentations/20200831-CV32E40P-ProjectScheduleUpdate.pptx).
-<br>
-**2020-06-12**: a new "Board Support Package" for CV32E40P simulations is installed at `cv32/bsp`.  This BSP should be used to compile/assemble your [test-programs](https://core-v-docs-verif-strat.readthedocs.io/en/latest/test_program_environment.html).  The Makefiles for both the CORE testbench and UVM verification environment have been updated to use this BSP.
-<br>
-**2020-06-02:** The [Imperas OVPsim Instruction Set Generator](http://www.ovpworld.org/) has been integrated into the UVM environment as the Referenece Model for the CV32E40(P).  You will need to obtain a license from Imperas to use it.
-<br>
-**2020-02-28:** The OpenHW Group CV32E40P is now live!<br>This repository no longer contains a local copy of the RTL.  The RTL is cloned from the appropriate [core-v-cores](https://github.com/openhwgroup/core-v-cores) repository as needed.  The specific branch and hash of the RTL is controlled by a set of variables in `cv32e40p/sim/Common.mk`.
-<br>
-**2021-02-10:** The core-v-verif repository now supports multiple cores.  The previously named cv32 directory is now cv32e40p to represent the testbench for the CV32E40P core.  Future cores will be verified in respectively named directories in core-v-verif as siblings to cva6 and cv32e40p.
+More news is available in the [archive](https://github.com/openhwgroup/core-v-verif/blob/master/NEWS_ARCHIVE.md).
 
 ## Getting Started
 First, have a look at the [OpenHW Group's website](https://www.openhwgroup.org) to learn a bit more about who we are and what we are doing.  
+<br>
+Reading the [Verification Strategy](https://core-v-docs-verif-strat.readthedocs.io/en/latest/) is strongly recommended.
 
-The design and verification documentation for the various CORE-V cores is located in the [OpenHW Group's CORE-V documentation repo](https://github.com/openhwgroup/core-v-docs).  Reading the [Verification Strategy](https://core-v-docs-verif-strat.readthedocs.io/en/latest/) is strongly recommended.
-
-### With CV32E40P
+### Getting started with CV32E40P
 If you want to run a simulation there are two options:
 1. To run the CORE testbench, go to `cv32e40p/sim/core` and read the README.
 2. To run the CV32E40P UVM environment, go to `cv32e40p/sim/uvmt` and read the README.
@@ -27,7 +20,7 @@ If you want to run a simulation there are two options:
 #### CV32E40P coverage data
 The most recently published coverage report for the CV32E40P can be found [here](https://openhwgroup.github.io/core-v-verif/).
 
-### With CVA6
+### Getting started with CVA6
 To run CVA6 testbench, go to [cva6](cva6) directory and read the README.
 
 ## Directory Structure of this Repo
@@ -44,7 +37,8 @@ Verification Environments, testbenches, testcases and simulation Makefiles for t
 Verification Environments, testbenches, testcases and simulation Makefiles for the CVA6 cores.
 
 ### docs
-Source for GitHub Pages.  Contains a pointers to the [Verification Strategy document](https://core-v-docs-verif-strat.readthedocs.io/en/latest/), the [CORE-V-DOCS](https://github.com/openhwgroup/core-v-docs) repository, and available coverage reports.
+Source for GitHub Pages.
+Contains a pointers to the [Verification Strategy document](https://core-v-docs-verif-strat.readthedocs.io/en/latest/), the [CORE-V-DOCS](https://github.com/openhwgroup/core-v-docs) repository, and available coverage reports.
 
 ### mk
 Common simulation Makefiles that support testbenches for all CORE-V cores.
@@ -62,7 +56,7 @@ within a project are defined as [issues](https://github.com/openhwgroup/core-v-v
 <br><br>To ease our work of reviewing your contributions, please:
 
 * Review [CONTRIBUTING](https://github.com/openhwgroup/core-v-verif/blob/master/CONTRIBUTING.md).
-* Split large contributions into smaller commits addressing individual changes or bug fixes. Do not mix unrelated changes
-into the same commit!
+* Split large contributions into smaller commits addressing individual changes or bug fixes.
+Do not mix unrelated changes into the same commit!
 * Write meaningful commit messages.
 * If asked to modify your changes, do fixup your commits and rebase your branch to maintain a clean history.

--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -1,26 +1,26 @@
 ###############################################################################
 #
 # Copyright 2020 OpenHW Group
-# 
+#
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://solderpad.org/licenses/
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 ###############################################################################
 #
 # Makefile for the CV_CORE "core" testbench.  Substantially modified from the
 # Makefile original for the RI5CY testbench.
 #
 ###############################################################################
-# 
+#
 # Copyright 2019 Claire Wolf
 # Copyright 2019 Robert Balas
 #
@@ -54,7 +54,14 @@ CV_CORE_LC     = $(shell echo $(CV_CORE) | tr A-Z a-z)
 CV_CORE_UC     = $(shell echo $(CV_CORE) | tr a-z A-Z)
 
 # Compile compile flags for all simulators
-SV_CMP_FLAGS = 
+SV_CMP_FLAGS =
+
+###############################################################################
+# Common Makefiles:
+#  -Variables for RTL and other dependencies (e.g. RISCV-DV)
+include ../Common.mk
+#  -Core Firmware and the RISCV GCC Toolchain (SDK)
+include $(CORE_V_VERIF)/mk/Common.mk
 
 # vsim configuration
 VVERSION  = "10.7b"
@@ -183,7 +190,7 @@ export DESIGN_RTL_DIR = $(CV_CORE_PKG)/rtl
 CUSTOM_PROG  ?= requested_csr_por
 
 # Shorthand rules for convience
-CV_CORE_pkg: $(CV_CORE_PKG)
+CV_CORE_pkg: clone_$(CV_CORE_LC)_rtl
 
 tbsrc_pkg: $(TBSRC_PKG)
 
@@ -219,13 +226,6 @@ unit-test: $(SIMULATOR)-unit-test
 
 .PHONY: unit-test-gui
 unit-test-gui: $(SIMULATOR)-unit-test-gui
-
-###############################################################################
-# Common Makefile:
-#    - Core Firmware and the RISCV GCC Toolchain (SDK)
-#    - Variables for RTL dependencies
-include ../Common.mk
-include $(CORE_V_VERIF)/mk/Common.mk
 
 # assume verilator if no target chosen
 .DEFAULT_GOAL := sanity-veri-run
@@ -462,7 +462,7 @@ verilate: testbench_verilator
 sanity-veri-run:
 	make custom CUSTOM_PROG=hello-world
 
-testbench_verilator: $(CV_CORE_PKG) $(TBSRC_VERI) $(TBSRC_PKG)
+testbench_verilator: CV_CORE_pkg $(TBSRC_VERI) $(TBSRC_PKG)
 	@echo "$(BANNER)"
 	@echo "* Compiling CORE TB and CV32E40P with Verilator"
 	@echo "$(BANNER)"
@@ -472,7 +472,7 @@ testbench_verilator: $(CV_CORE_PKG) $(TBSRC_VERI) $(TBSRC_PKG)
 		--Wno-MODDUP --top-module \
 		tb_top_verilator $(TBSRC_VERI) \
 		-f $(CV_CORE_MANIFEST) \
-		$(CV_CORE_PKG)/bhv/CV_CORE_core_log.sv \
+		$(CV_CORE_PKG)/bhv/$(CV_CORE_LC)_core_log.sv \
 		$(TBSRC_CORE)/tb_top_verilator.cpp --Mdir $(VERI_OBJ_DIR) \
 		-CFLAGS "-std=gnu++11 $(VERI_CFLAGS)" \
 		$(VERI_COMPILE_FLAGS)

--- a/cv32e40p/sim/tools/gtk/cv32e40p_core_IO.fst.gtkw
+++ b/cv32e40p/sim/tools/gtk/cv32e40p_core_IO.fst.gtkw
@@ -1,0 +1,100 @@
+[*]
+[*] GTKWave Analyzer v3.3.108 (w)1999-2020 BSI
+[*] Mon Feb 22 21:01:23 2021
+[*]
+[dumpfile] "/home/mike/GitHubRepos/MikeOpenHWGroup/core-v-verif/master/cv32e40p/sim/uvmt/dsim_results/interrupt_test/dsim.fst"
+[dumpfile_mtime] "Mon Feb 22 20:48:54 2021"
+[dumpfile_size] 72678013
+[savefile] "/home/mike/GitHubRepos/MikeOpenHWGroup/core-v-verif/master/cv32e40p/sim/tools/gtk/cv32e40p_core_IO.fst.gtkw"
+[timestart] 35610
+[size] 1920 948
+[pos] -47 -47
+*-13.000000 2040 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] $root.
+[treeopen] $root.uvmt_cv32e40p_tb.
+[treeopen] $root.uvmt_cv32e40p_tb.clknrst_if_iss.
+[treeopen] $root.uvmt_cv32e40p_tb.dut_wrap.
+[treeopen] $root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.
+[sst_width] 434
+[signals_width] 346
+[sst_expanded] 1
+[sst_vpaned_height] 175
+@200
+-Clock and Reset
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.clk_i
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.rst_ni
+@200
+-Configuration Inputs
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.boot_addr_i[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_exception_addr_i[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.dm_halt_addr_i[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.hart_id_i[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.mtvec_addr_i[31:0]
+@200
+-Aux Processor Unit I/O
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_flags_i[4:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_flags_o[14:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_gnt_i
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_op_o[5:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_operands_o[95:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_req_o
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_result_i[31:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.apu_rvalid_i
+@200
+-Special Control Signals
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.fetch_enable_i
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.core_sleep_o
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.pulp_clock_en_i
+@29
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.scan_cg_en_i
+@200
+-Data Memory Interface
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_addr_o[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_be_o[3:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_gnt_i
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rdata_i[31:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_req_o
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_rvalid_i
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_wdata_o[31:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.data_we_o
+@200
+-Debug Module Interface
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_halted_o
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_havereset_o
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.debug_req_i
+@200
+-Instruction Memory Interface
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_addr_o[31:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_gnt_i
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rdata_i[31:0]
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_req_o
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.instr_rvalid_i
+@200
+-Interrupts
+@28
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_ack_o
+@22
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_i[31:0]
+$root.uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.irq_id_o[4:0]
+[pattern_trace] 1
+[pattern_trace] 0

--- a/cv32e40p/tb/core/cv32e40p_tb_wrapper.sv
+++ b/cv32e40p/tb/core/cv32e40p_tb_wrapper.sv
@@ -68,21 +68,22 @@ module cv32e40p_tb_wrapper
     // interrupts (only timer for now)
     assign irq_sec     = '0;
 
-	// core log reports parameter usage and illegal instructions to the logfile
-    cv32e40p_core_log
-     #(
-          .PULP_XPULP            ( PULP_XPULP            ),
-          .PULP_CLUSTER          ( PULP_CLUSTER          ),
-          .FPU                   ( FPU                   ),
-          .PULP_ZFINX            ( PULP_ZFINX            ),
-          .NUM_MHPMCOUNTERS      ( NUM_MHPMCOUNTERS      ))
-    core_log_i(
-          .clk_i              ( cv32e40p_core_i.id_stage_i.clk              ),
-          .is_decoding_i      ( cv32e40p_core_i.id_stage_i.is_decoding_o    ),
-          .illegal_insn_dec_i ( cv32e40p_core_i.id_stage_i.illegal_insn_dec ),
-          .hart_id_i          ( cv32e40p_core_i.hart_id_i                   ),
-          .pc_id_i            ( cv32e40p_core_i.pc_id                       )
-      );
+//    // core log reports parameter usage and illegal instructions to the logfile
+//    // MIKET: commenting out as the cv32e40p RTL wrapper does this as well.
+//    cv32e40p_core_log
+//     #(
+//          .PULP_XPULP            ( PULP_XPULP            ),
+//          .PULP_CLUSTER          ( PULP_CLUSTER          ),
+//          .FPU                   ( FPU                   ),
+//          .PULP_ZFINX            ( PULP_ZFINX            ),
+//          .NUM_MHPMCOUNTERS      ( NUM_MHPMCOUNTERS      ))
+//    core_log_i(
+//          .clk_i              ( cv32e40p_core_i.id_stage_i.clk              ),
+//          .is_decoding_i      ( cv32e40p_core_i.id_stage_i.is_decoding_o    ),
+//          .illegal_insn_dec_i ( cv32e40p_core_i.id_stage_i.illegal_insn_dec ),
+//          .hart_id_i          ( cv32e40p_core_i.hart_id_i                   ),
+//          .pc_id_i            ( cv32e40p_core_i.pc_id                       )
+//      );
 
     // instantiate the core
     cv32e40p_core #(

--- a/mk/README.md
+++ b/mk/README.md
@@ -1,4 +1,4 @@
-This directory contains the _Common_ makefile which is included by all core testbenches to perform common functionality: <br>
+This directory contains the _Common_ makefiles for the UVM and Core testbenches to perform common functionality: <br>
 - Cloning third party repositories (Core RTL, libraries, ISGs, RISC-V compliance library, etc.)
 - Invoking the toolchain to compile directed and/or random test programs into machine code for simulation
 - Invoking the toolchain to compile compliance test programs for simulation

--- a/mk/core/core.mk
+++ b/mk/core/core.mk
@@ -1,0 +1,241 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+#
+# Makefile for the CORE testbench for multiple OpenHW-verified cores.
+#
+###############################################################################
+
+# Variable checks
+ifndef CV_CORE
+$(error Must set CV_CORE to a valid core)
+endif
+
+# "Constants"
+DATE           = $(shell date +%F)
+CV_CORE_LC     = $(shell echo $(CV_CORE) | tr A-Z a-z)
+CV_CORE_UC     = $(shell echo $(CV_CORE) | tr a-z A-Z)
+export CV_CORE_LC
+export CV_CORE_UC
+.DEFAULT_GOAL := no_rule 
+
+# Useful commands
+MKDIR_P = mkdir -p
+
+# Compile compile flags for all simulators (careful!)
+WAVES        ?= 0
+SV_CMP_FLAGS ?= "+define+$(CV_CORE_UC)_ASSERT_ON"
+TIMESCALE    ?= -timescale 1ns/1ps
+UVM_PLUSARGS ?=
+
+# User selectable SystemVerilog simulator targets/rules
+CV_SIMULATOR ?= unsim
+SIMULATOR    ?= $(CV_SIMULATOR)
+
+# Optionally exclude the OVPsim (not recommended)
+USE_ISS      ?= YES
+
+# Common configuration variables
+CFG             ?= default
+
+# Common Generation variables
+GEN_START_INDEX ?= 0
+GEN_NUM_TESTS   ?= 1
+
+# Commont test variables
+RUN_INDEX       ?= 0
+
+# UVM Environment
+export DV_UVMT_PATH           = $(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt
+export DV_UVME_PATH           = $(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme
+export DV_UVML_HRTBT_PATH     = $(CORE_V_VERIF)/lib/uvm_libs/uvml_hrtbt
+export DV_UVMA_CLKNRST_PATH   = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clknrst
+export DV_UVMA_INTERRUPT_PATH = $(CORE_V_VERIF)/lib/uvm_agents/uvma_interrupt
+export DV_UVMA_DEBUG_PATH     = $(CORE_V_VERIF)/lib/uvm_agents/uvma_debug
+export DV_UVMA_OBI_PATH       = $(CORE_V_VERIF)/lib/uvm_agents/uvma_obi
+export DV_UVML_TRN_PATH       = $(CORE_V_VERIF)/lib/uvm_libs/uvml_trn
+export DV_UVML_LOGS_PATH      = $(CORE_V_VERIF)/lib/uvm_libs/uvml_logs
+export DV_UVML_SB_PATH        = $(CORE_V_VERIF)/lib/uvm_libs/uvml_sb
+
+export DV_OVPM_HOME           = $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/imperas
+export DV_OVPM_MODEL          = $(DV_OVPM_HOME)/riscv_$(CV_CORE_UC)_OVPsim
+export DV_OVPM_DESIGN         = $(DV_OVPM_HOME)/design
+
+DV_UVMT_SRCS                  = $(wildcard $(DV_UVMT_PATH)/*.sv))
+
+# Testcase name: must be the CLASS name of the testcase (not the filename).
+# Look in ../../tests/uvmt
+UVM_TESTNAME ?= uvmt_$(CV_CORE_LC)_firmware_test_c
+
+# Google's random instruction generator
+RISCVDV_PKG         := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/google/riscv-dv
+COREVDV_PKG         := $(CORE_V_VERIF)/lib/corev-dv
+CV_CORE_COREVDV_PKG := $(CORE_V_VERIF)/$(CV_CORE_LC)/env/corev-dv
+export RISCV_DV_ROOT         = $(RISCVDV_PKG)
+export COREV_DV_ROOT         = $(COREVDV_PKG)
+export CV_CORE_COREV_DV_ROOT = $(CV_CORE_COREVDV_PKG)
+
+# RISC-V Foundation's RISC-V Compliance Test-suite
+COMPLIANCE_PKG   := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance
+
+# TB source files for the CV32E core
+TBSRC_TOP   := $(TBSRC_HOME)/uvmt/uvmt_$(CV_CORE_LC)_tb.sv
+TBSRC_HOME  := $(CORE_V_VERIF)/$(CV_CORE_LC)/tb
+export TBSRC_HOME = $(CORE_V_VERIF)/$(CV_CORE_LC)/tb
+
+SIM_LIBS    := $(CORE_V_VERIF)/lib/sim_libs
+
+RTLSRC_VLOG_TB_TOP	:= $(basename $(notdir $(TBSRC_TOP)))
+RTLSRC_VOPT_TB_TOP	:= $(addsuffix _vopt, $(RTLSRC_VLOG_TB_TOP))
+
+# RTL source files for the CV32E core
+# DESIGN_RTL_DIR is used by CV32E40P_MANIFEST file
+CV_CORE_PKG          := $(CORE_V_VERIF)/core-v-cores/$(CV_CORE_LC)
+CV_CORE_MANIFEST     := $(CV_CORE_PKG)/$(CV_CORE_LC)_manifest.flist
+export DESIGN_RTL_DIR = $(CV_CORE_PKG)/rtl
+
+RTLSRC_HOME   := $(CV_CORE_PKG)/rtl
+RTLSRC_INCDIR := $(RTLSRC_HOME)/include
+
+###############################################################################
+# Seed management for constrained-random sims
+SEED    ?= 1
+RNDSEED ?= 
+
+ifeq ($(SEED),random)
+RNDSEED = $(shell date +%N)
+else
+ifeq ($(SEED),)
+# Empty SEED variable selects 1
+RNDSEED = 1
+else
+RNDSEED = $(SEED)
+endif
+endif
+
+###############################################################################
+# Common Makefile:
+#    - Core Firmware and the RISCV GCC Toolchain (SDK)
+#    - Variables for RTL dependencies
+include $(CORE_V_VERIF)/mk/Common.mk
+###############################################################################
+# Clone core RTL and DV dependencies
+clone_cv_core_rtl:
+	$(CLONE_CV_CORE_CMD)
+
+clone_riscv-dv:
+	$(CLONE_RISCVDV_CMD)
+
+$(CV_CORE_PKG):
+	echo "Cloning"
+	$(CLONE_CV_CORE_CMD)
+
+$(COMPLIANCE_PKG):
+	$(CLONE_COMPLIANCE_CMD)
+
+###############################################################################
+# RISC-V Compliance Test-suite
+#     As much as possible, the test suite is used "out-of-the-box".  The
+#     "build_compliance" target below uses the Makefile supplied by the suite
+#     to compile all the individual test-programs in the suite to generate the
+#     elf and hex files used in simulation.  Each <sim>.mk is assumed to have a
+#     target to run the compiled test-program.
+
+# RISCV_ISA='rv32i|rv32im|rv32imc|rv32Zicsr|rv32Zifencei'
+RISCV_ISA    ?= rv32i
+RISCV_TARGET ?= OpenHW
+RISCV_DEVICE ?= $(CV_CORE_LC)
+
+clone_compliance:
+	$(CLONE_COMPLIANCE_CMD)
+
+clr_compliance:
+	make clean -C $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance
+
+build_compliance: $(COMPLIANCE_PKG)
+	make simulate -i -C $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance \
+		RISCV_TARGET=${RISCV_TARGET} \
+		RISCV_DEVICE=${RISCV_DEVICE} \
+		PATH=$(RISCV)/bin:$(PATH) \
+		RISCV_PREFIX=$(RISCV_PREFIX) \
+		NOTRAPS=1 \
+		RISCV_ISA=$(RISCV_ISA)
+#		VERBOSE=1
+
+all_compliance: $(COMPLIANCE_PKG)
+	make build_compliance RISCV_ISA=rv32i        && \
+	make build_compliance RISCV_ISA=rv32im       && \
+	make build_compliance RISCV_ISA=rv32imc      && \
+	make build_compliance RISCV_ISA=rv32Zicsr    && \
+	make build_compliance RISCV_ISA=rv32Zifencei
+
+# "compliance" is a simulator-specific target defined in <sim>.mk
+
+compliance_check_sig: compliance
+	@echo "Checking Compliance Signature for $(RISCV_ISA)/$(COMPLIANCE_PROG)"
+	@echo "Reference: $(REF)"
+	@echo "Signature: $(SIG)"
+	@export SUITEDIR=$(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance/riscv-test-suite/$(RISCV_ISA) && \
+	export REF=$(REF) && export SIG=$(SIG) && export COMPL_PROG=$(COMPLIANCE_PROG) && \
+	export RISCV_TARGET=${RISCV_TARGET} && export RISCV_DEVICE=${RISCV_DEVICE} && \
+	export RISCV_ISA=${RISCV_ISA} export SIG_ROOT=${SIG_ROOT} && \
+	$(CORE_V_VERIF)/bin/diff_signatures.sh | tee $(SIMULATOR)_results/$(COMPLIANCE_PROG)/diff_signatures.log
+
+compliance_check_all_sigs:
+	@$(MKDIR_P) $(SIMULATOR)_results/$(RISCV_ISA)
+	@echo "Checking Compliance Signature for all tests in $(RISCV_ISA)"
+	@export SUITEDIR=$(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance/riscv-test-suite/$(RISCV_ISA) && \
+	export RISCV_TARGET=${RISCV_TARGET} && export RISCV_DEVICE=${RISCV_DEVICE} && \
+	export RISCV_ISA=${RISCV_ISA} export SIG_ROOT=${SIG_ROOT} && \
+	$(CORE_V_VERIF)/bin/diff_signatures.sh $(RISCV_ISA) | tee $(SIMULATOR)_results/$(RISCV_ISA)/diff_signatures.log
+
+#	export REF=$(REF) && export SIG=$(SIG) && export COMPL_PROG=$(COMPLIANCE_PROG) && \
+
+compliance_regression:
+	make build_compliance RISCV_ISA=$(RISCV_ISA)
+	@export SIM_DIR=$(CORE_V_VERIF)/$(CV_CORE_LC)/sim/uvmt && \
+	$(CORE_V_VERIF)/bin/run_compliance.sh $(RISCV_ISA)
+	make compliance_check_all_sigs RISCV_ISA=$(RISCV_ISA)
+
+dah:
+	@export SIM_DIR=$(CORE_V_VERIF)/cv32/sim/uvmt && \
+	$(CORE_V_VERIF)/bin/run_compliance.sh $(RISCV_ISA)
+
+###############################################################################
+# Clean up your mess!
+#   1. Clean all generated files of the C and assembler tests
+#   2. Simulator-specific clean targets are in ./<simulator>.mk
+#   3. clean-bsp target is specified in ../Common.mk
+clean_test_programs: clean-bsp
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.o       -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.hex     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.elf     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.map     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.readelf -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.objdump -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.o       -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.hex     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.elf     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.map     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.readelf -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name *.objdump -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs -name corev_*.S -exec rm {} \;
+
+clean_compliance:
+	rm -rf $(COMPLIANCE_PKG)


### PR DESCRIPTION
This get the core testbench working again in the new "core-v-verif multi" structure.  Tested with Verilator and dsim.

Signed-off-by: MikeOpenHWGroup <mike@openhwgroup.org>