### PR TITLE
OBI unrequested gnt coverage fix

### DIFF
--- a/cv32e40p/tb/core/mm_ram.sv
+++ b/cv32e40p/tb/core/mm_ram.sv
@@ -696,13 +696,13 @@ module mm_ram
   always_comb
   begin
     ram_instr_req    = instr_req_i;
-    ram_instr_addr   = instr_addr_remap;
-    ram_instr_gnt    = instr_req_i;
+    ram_instr_addr   = instr_addr_remap;    
+    ram_instr_gnt    = instr_req_i ? 1'b1 : $urandom;
     core_instr_rdata = ram_instr_rdata;
 
     ram_data_req     = data_req_dec;
     ram_data_addr    = data_addr_dec;
-    ram_data_gnt     = data_req_i;
+    ram_data_gnt     = data_req_i ? 1'b1 : $urandom;
     core_data_rdata  = ram_data_rdata;
     ram_data_wdata   = data_wdata_dec;
     ram_data_we      = data_we_dec;

--- a/cv32e40p/tb/core/tb_riscv/riscv_gnt_stall.sv
+++ b/cv32e40p/tb/core/tb_riscv/riscv_gnt_stall.sv
@@ -112,9 +112,9 @@ always @(posedge clk_i or negedge rst_ni) begin
     #(100ps);
 `endif
 
-    // When request is removed, remove grant
+    // When request is removed, randomize gnt
     if (!req_core_i) begin
-      grant_core_o <= 1'b0;
+      grant_core_o <= $urandom;
     end
 
     // New request coming in

--- a/lib/uvm_agents/uvma_obi/uvma_obi_assert.sv
+++ b/lib/uvm_agents/uvma_obi/uvma_obi_assert.sv
@@ -130,4 +130,10 @@ module uvma_obi_assert
   else
     `uvm_error(info_tag, $sformatf("be of 0x%01x not consistent with addr 0x%08x", $sampled(be), $sampled(addr)));
 
+  // Cover that grant is asserted when unrequested
+  property p_unrequested_gnt;
+    !req ##0 gnt;
+  endproperty : p_unrequested_gnt
+  c_unrequested_gnt: cover property(p_unrequested_gnt);
+
 endmodule : uvma_obi_assert


### PR DESCRIPTION
in both stall and non-stall randomization modes, add around gnt assertion for both I and D busses even if not requested

add cover property to obi assert to ensure coverage

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>