### PR TITLE
Updated Riscv-dv to latest hash

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_asm_program_gen.sv
@@ -86,7 +86,8 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
         // Jump to commmon interrupt handling routine
         intr_handler = {intr_handler,
                         $sformatf("j %0s%0smode_intr_handler", hart_prefix(hart), mode),
-                        "1: j test_done"};
+                        $sformatf("1: la x%0d, test_done", cfg.scratch_reg),
+                        $sformatf("jalr x%0d, 0", cfg.scratch_reg)};
       end
 
       gen_section(get_label($sformatf("%0smode_intr_vector_%0d", mode, i), hart), intr_handler);
@@ -108,9 +109,6 @@ class cv32e40p_asm_program_gen extends corev_asm_program_gen;
     end
     mode_name = cfg.init_privileged_mode.name();
     instr.push_back($sformatf("csrw mepc, x%0d", cfg.gpr[0]));
-    if (!riscv_instr_pkg::support_pmp) begin
-      instr.push_back($sformatf("jal ra, %0sinit_%0s", hart_prefix(hart), mode_name.tolower()));
-    end
     gen_section(get_label("mepc_setup", hart), instr);
   endfunction
 

--- a/cv32e40p/env/corev-dv/cv32e40p_privileged_common_seq.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_privileged_common_seq.sv
@@ -20,7 +20,7 @@
 //-----------------------------------------------------------------------------------------
 // CORE-V privileged mode sequence customizations
 //
-// Overrides enter_privileged_mode()
+// Overrides setup_mmode_reg()
 //-----------------------------------------------------------------------------------------
 
 class cv32e40p_privileged_common_seq extends riscv_privileged_common_seq;
@@ -31,36 +31,66 @@ class cv32e40p_privileged_common_seq extends riscv_privileged_common_seq;
         super.new(name);
     endfunction
 
-    // Override this function to use "ret" instead of "mret" to exit the function
-    // in the assembly.
-    // When initializing a mode this section can enable interrupts, which would blow away
-    // any value in *epc register.  Therefore a manual j->mret calling routine does not work
-    // and can cause infinite loop.
-    // Therefore the calling section will use jal and expect a ret to return (using x1)
-    virtual function void enter_privileged_mode(input privileged_mode_t mode,
-                                                output string instrs[$]);
-        string label = format_string({$sformatf("%0sinit_%0s:",
-                                    hart_prefix(hart), mode.name())}, LABEL_STR_LEN);
-        string ret_instr[] = {"ret"};
-        riscv_privil_reg regs[$];
-        label = label.tolower();
-        setup_mmode_reg(mode, regs);
-        if(mode == SUPERVISOR_MODE) begin
-            setup_smode_reg(mode, regs);
+    // Override this function to avoid setting MIE before mret call to prevent
+    // infinite loop
+    virtual function void setup_mmode_reg(privileged_mode_t mode, ref riscv_privil_reg regs[$]);
+      mstatus = riscv_privil_reg::type_id::create("mstatus");
+      mstatus.init_reg(MSTATUS);
+      if (cfg.randomize_csr) begin
+        mstatus.set_val(cfg.mstatus);
+      end
+      mstatus.set_field("MPRV", cfg.mstatus_mprv);
+      mstatus.set_field("MXR", cfg.mstatus_mxr);
+      mstatus.set_field("SUM", cfg.mstatus_sum);
+      mstatus.set_field("TVM", cfg.mstatus_tvm);
+      mstatus.set_field("TW", cfg.set_mstatus_tw);
+      mstatus.set_field("FS", cfg.mstatus_fs);
+      mstatus.set_field("VS", cfg.mstatus_vs);
+      if (!(SUPERVISOR_MODE inside {supported_privileged_mode}) && (XLEN != 32)) begin
+        mstatus.set_field("SXL", 2'b00);
+      end else if (XLEN == 64) begin
+        mstatus.set_field("SXL", 2'b10);
+      end
+      if (!(USER_MODE inside {supported_privileged_mode}) && (XLEN != 32)) begin
+        mstatus.set_field("UXL", 2'b00);
+      end else if (XLEN == 64) begin
+        mstatus.set_field("UXL", 2'b10);
+      end
+      mstatus.set_field("XS", 0);
+      mstatus.set_field("SD", 0);
+      mstatus.set_field("UIE", 0);
+      // Set the previous privileged mode as the target mode
+      mstatus.set_field("MPP", mode);
+      mstatus.set_field("SPP", 0);
+      // Enable interrupt
+      mstatus.set_field("MPIE", cfg.enable_interrupt);
+      // MIE will be set by mret, avoid trapping before returning from this
+      // setup function
+      mstatus.set_field("MIE", 0);
+      mstatus.set_field("SPIE", cfg.enable_interrupt);
+      mstatus.set_field("SIE",  cfg.enable_interrupt);
+      mstatus.set_field("UPIE", cfg.enable_interrupt);
+      mstatus.set_field("UIE", riscv_instr_pkg::support_umode_trap);
+      `uvm_info(`gfn, $sformatf("mstatus_val: 0x%0x", mstatus.get_val()), UVM_LOW)
+      regs.push_back(mstatus);
+      // Enable external and timer interrupt
+      if (MIE inside {implemented_csr}) begin
+        mie = riscv_privil_reg::type_id::create("mie");
+        mie.init_reg(MIE);
+        if (cfg.randomize_csr) begin
+          mie.set_val(cfg.mie);
         end
-        if(mode == USER_MODE) begin
-            setup_umode_reg(mode, regs);
-        end
-        if(cfg.virtual_addr_translation_on) begin
-            setup_satp(instrs);
-        end
-        gen_csr_instr(regs, instrs);
-        // Use mret/sret to switch to the target privileged mode
-        instrs.push_back(ret_instr[0]);
-        foreach(instrs[i]) begin
-            instrs[i] = {indent, instrs[i]};
-        end
-        instrs.push_front(label);
-    endfunction : enter_privileged_mode
+        mie.set_field("UEIE", cfg.enable_interrupt);
+        mie.set_field("SEIE", cfg.enable_interrupt);
+        mie.set_field("MEIE", cfg.enable_interrupt);
+        mie.set_field("USIE", cfg.enable_interrupt);
+        mie.set_field("SSIE", cfg.enable_interrupt);
+        mie.set_field("MSIE", cfg.enable_interrupt);
+        mie.set_field("MTIE", cfg.enable_interrupt & cfg.enable_timer_irq);
+        mie.set_field("STIE", cfg.enable_interrupt & cfg.enable_timer_irq);
+        mie.set_field("UTIE", cfg.enable_interrupt & cfg.enable_timer_irq);
+        regs.push_back(mie);
+      end
+    endfunction : setup_mmode_reg
 
 endclass : cv32e40p_privileged_common_seq

--- a/cv32e40p/env/corev-dv/target/cv32e40p/riscv_core_setting.sv
+++ b/cv32e40p/env/corev-dv/target/cv32e40p/riscv_core_setting.sv
@@ -117,6 +117,13 @@ const privileged_reg_t implemented_csr[] = {
     MIP         // Machine interrupt pending
 };
 
+`ifdef DSIM
+  bit [11:0] custom_csr[] = {
+`else
+  const bit [11:0] custom_csr[] = {
+`endif
+};
+
 // ----------------------------------------------------------------------------
 // Supported interrupt/exception setting, used for functional coverage
 // ----------------------------------------------------------------------------

--- a/cv32e40p/sim/Common.mk
+++ b/cv32e40p/sim/Common.mk
@@ -21,7 +21,7 @@ CV_CORE_TAG    ?= cv32e40p_v1.0.0
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master
-RISCVDV_HASH    ?= 10fd4fa8b7d0808732ecf656c213866cae37045a
+RISCVDV_HASH		?= 0b625258549e733082c12e5dc749f05aefb07d5a
 
 COMPLIANCE_REPO   ?= https://github.com/riscv/riscv-compliance
 COMPLIANCE_BRANCH ?= master


### PR DESCRIPTION
Summary of changes:


        - Removed jump to init_machine_mode (function location inlined
          by Google, no longer needed).

        - Reverted previous mret->ret change to init_machine_mode
          generator function to avoid an infinite loop.

        - Changed setup_mmode_reg to not enable MIE bit.
          This is instead done by mret at the end of code section
          by copying MPIE->MIE. (cf. riscv priv. spec.)
          This prevents an infinite loop if an interrupt request is
          present prior to init_machine_mode completion.

        - Updated common interrupt handler jump for increased robustness
          with large programs. (Ports over change from RISCV-DV
          upstream).

        - Added empty custom csr definitions for compatibility with
          latest Riscv-dv.

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>