### PR TITLE
Removed magic numbers for mm_ram addresses and added a cycle counter

### DIFF
--- a/cv32e40p/tb/core/mm_ram.sv
+++ b/cv32e40p/tb/core/mm_ram.sv
@@ -88,6 +88,10 @@ module mm_ram
     localparam int                        MMADDR_RNDNUM     = 32'h1500_1000;
     localparam int                        MMADDR_TICKS      = 32'h1500_1004;
 
+    // UVM info tags
+    localparam string                     MM_RAM_TAG = "MM_RAM";
+    localparam string                     RNDSTALL_TAG = "RNDSTALL";
+
     // mux for read and writes
     enum logic [2:0]{RAM, MM, RND_STALL, ERR, RND_NUM, TICKS} select_rdata_d, select_rdata_q;
 
@@ -193,7 +197,7 @@ module mm_ram
 `ifndef VERILATOR
         if (!$test$plusargs("rand_stall_obi_disable")) begin
             if ($test$plusargs("max_data_zero_instr_stall")) begin
-                `uvm_info("RNDSTALL", "Max data stall, zero instruction stall configuration", UVM_LOW)
+                `uvm_info(RNDSTALL_TAG, "Max data stall, zero instruction stall configuration", UVM_LOW)
                 // This "knob" creates maximum stalls on data loads/stores, and
                 // no stalls on instruction fetches.  Used for fence.i testing. 
                 rnd_stall_regs[RND_STALL_DATA_EN]     = 1;
@@ -233,16 +237,16 @@ module mm_ram
             end
         end
 
-        `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall enable: %0d", rnd_stall_regs[RND_STALL_INSTR_EN]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall mode:   %0d", rnd_stall_regs[RND_STALL_INSTR_MODE]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall gnt:    %0d", rnd_stall_regs[RND_STALL_INSTR_GNT]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall valid:  %0d", rnd_stall_regs[RND_STALL_INSTR_VALID]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("INSTR OBI stall max:    %0d", rnd_stall_regs[RND_STALL_INSTR_MAX]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("DATA  OBI stall enable: %0d", rnd_stall_regs[RND_STALL_DATA_EN]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("DATA  OBI stall mode:   %0d", rnd_stall_regs[RND_STALL_DATA_MODE]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("DATA  OBI stall gnt:    %0d", rnd_stall_regs[RND_STALL_DATA_GNT]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("DATA  OBI stall valid:  %0d", rnd_stall_regs[RND_STALL_DATA_VALID]), UVM_LOW)
-        `uvm_info("RNDSTALL", $sformatf("DATA  OBI stall max:    %0d", rnd_stall_regs[RND_STALL_DATA_MAX]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("INSTR OBI stall enable: %0d", rnd_stall_regs[RND_STALL_INSTR_EN]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("INSTR OBI stall mode:   %0d", rnd_stall_regs[RND_STALL_INSTR_MODE]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("INSTR OBI stall gnt:    %0d", rnd_stall_regs[RND_STALL_INSTR_GNT]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("INSTR OBI stall valid:  %0d", rnd_stall_regs[RND_STALL_INSTR_VALID]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("INSTR OBI stall max:    %0d", rnd_stall_regs[RND_STALL_INSTR_MAX]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("DATA  OBI stall enable: %0d", rnd_stall_regs[RND_STALL_DATA_EN]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("DATA  OBI stall mode:   %0d", rnd_stall_regs[RND_STALL_DATA_MODE]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("DATA  OBI stall gnt:    %0d", rnd_stall_regs[RND_STALL_DATA_GNT]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("DATA  OBI stall valid:  %0d", rnd_stall_regs[RND_STALL_DATA_VALID]), UVM_LOW)
+        `uvm_info(RNDSTALL_TAG, $sformatf("DATA  OBI stall max:    %0d", rnd_stall_regs[RND_STALL_DATA_MAX]), UVM_LOW)
 `endif
     end : configure_stalls
 
@@ -331,7 +335,7 @@ module mm_ram
                         sig_fd = $fopen(sig_file, "w");
                         if (sig_fd == 0) begin
                             errno = $ferror(sig_fd, error_str);
-                            `uvm_error("MM_RAM", $sformatf("Cannot open signature file %s for writing (error_str: %s).", sig_file, error_str))
+                            `uvm_error(MM_RAM_TAG, $sformatf("Cannot open signature file %s for writing (error_str: %s).", sig_file, error_str))
                             use_sig_file = 1'b0;
                         end else begin
                             use_sig_file = 1'b1;
@@ -347,7 +351,7 @@ module mm_ram
                                                           dp_ram_i.mem[addr+1], dp_ram_i.mem[addr+0]);
                         end
                     end
-                    `uvm_info("MM_RAM", $sformatf("Dumping signature:\n%s", sig_string), UVM_LOW)
+                    `uvm_info(MM_RAM_TAG, $sformatf("Dumping signature:\n%s", sig_string), UVM_LOW)
 `else
                     if ($value$plusargs("signature=%s", sig_file)) begin
                         sig_fd = $fopen(sig_file, "w");
@@ -454,7 +458,7 @@ module mm_ram
          || data_addr_i == MMADDR_SIGDUMP
          || data_addr_i == MMADDR_TICKS
          || data_addr_i[31:16] == MMADDR_RNDSTALL))
-           else `uvm_fatal("MM_RAM", $sformatf("out of bounds write to %08x with %08x", data_addr_i, data_wdata_i))
+           else `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds write to %08x with %08x", data_addr_i, data_wdata_i))
 `endif
 
     logic[31:0] data_rdata_mux;
@@ -469,8 +473,7 @@ module mm_ram
 `ifndef VERILATOR
             data_rdata_mux = rnd_stall_rdata;
 `else
-            $display("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i);
-            $fatal(2);
+            `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i));
 `endif
         
         end else if (select_rdata_q == RND_NUM) begin
@@ -479,11 +482,10 @@ module mm_ram
             data_rdata_mux = cycle_count_q;
 
             if (cycle_count_overflow_q) begin
-                $fatal(1, "cycle counter read after overflow");
+                `uvm_fatal(MM_RAM_TAG, "cycle counter read after overflow");
             end
         end else if (select_rdata_q == ERR) begin
-            $display("out of bounds read from %08x", data_addr_i);
-            $fatal(2);
+            `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds read from %08x", data_addr_i));
         end
     end
 

--- a/cv32e40p/tb/core/mm_ram.sv
+++ b/cv32e40p/tb/core/mm_ram.sv
@@ -75,8 +75,21 @@ module mm_ram
 
     localparam int                        RND_IRQ_ID     = 31;    
 
+    localparam int                        MMADDR_PRINT      = 32'h1000_0000;
+    localparam int                        MMADDR_TESTSTATUS = 32'h2000_0000;
+    localparam int                        MMADDR_EXIT       = 32'h2000_0004;
+    localparam int                        MMADDR_SIGBEGIN   = 32'h2000_0008;
+    localparam int                        MMADDR_SIGEND     = 32'h2000_000C;
+    localparam int                        MMADDR_SIGDUMP    = 32'h2000_0010;
+    localparam int                        MMADDR_TIMERREG   = 32'h1500_0000;
+    localparam int                        MMADDR_TIMERVAL   = 32'h1500_0004;
+    localparam int                        MMADDR_DBG        = 32'h1500_0008;
+    localparam int                        MMADDR_RNDSTALL   = 16'h1600;
+    localparam int                        MMADDR_RNDNUM     = 32'h1500_1000;
+    localparam int                        MMADDR_TICKS      = 32'h1500_1004;
+
     // mux for read and writes
-    enum logic [2:0]{RAM, MM, RND_STALL, ERR, RND_NUM} select_rdata_d, select_rdata_q;
+    enum logic [2:0]{RAM, MM, RND_STALL, ERR, RND_NUM, TICKS} select_rdata_d, select_rdata_q;
 
     enum logic {T_RAM, T_PER} transaction;
 
@@ -129,6 +142,11 @@ module mm_ram
     logic                          timer_reg_valid;
     logic                          timer_val_valid;
     logic [31:0]                   timer_wdata;
+
+            // cycle counting
+    logic [31:0]                   cycle_count_q;
+    logic                          cycle_count_overflow_q;
+    logic                          cycle_count_clear;
 
     // debugger control signals
     logic [31:0]                   debugger_wdata;
@@ -260,6 +278,7 @@ module mm_ram
         rnd_stall_wdata     = '0;
         rnd_stall_we        = '0;
         rnd_num_req         = '0;
+        cycle_count_clear   = '0;
         select_rdata_d      = RAM;
         transaction         = T_PER;
 
@@ -283,29 +302,29 @@ module mm_ram
                     data_we_dec    = data_we_i;
                     data_be_dec    = data_be_i;
                     transaction    = T_RAM;
-                end else if (data_addr_i == 32'h1000_0000) begin
+                end else if (data_addr_i == MMADDR_PRINT) begin
                     print_wdata = data_wdata_i;
                     print_valid = '1;
 
-                end else if (data_addr_i == 32'h2000_0000) begin
+                end else if (data_addr_i == MMADDR_TESTSTATUS) begin
                     if (data_wdata_i == 123456789)
                         tests_passed_o = '1;
                     else if (data_wdata_i == 1)
                         tests_failed_o = '1;
 
-                end else if (data_addr_i == 32'h2000_0004) begin
+                end else if (data_addr_i == MMADDR_EXIT) begin
                     exit_valid_o = '1;
                     exit_value_o = data_wdata_i;
 
-                end else if (data_addr_i == 32'h2000_0008) begin
+                end else if (data_addr_i == MMADDR_SIGBEGIN) begin
                     // sets signature begin
                     sig_begin_d = data_wdata_i;
 
-                end else if (data_addr_i == 32'h2000_000C) begin
+                end else if (data_addr_i == MMADDR_SIGEND) begin
                     // sets signature end
                     sig_end_d = data_wdata_i;
 
-                end else if (data_addr_i == 32'h2000_0010) begin
+                end else if (data_addr_i == MMADDR_SIGDUMP) begin
                     // dump signature and halt
 `ifndef VERILATOR
                     if ($value$plusargs("signature=%s", sig_file)) begin
@@ -353,23 +372,25 @@ module mm_ram
                     exit_valid_o = '1; // signal halt to testbench
                     exit_value_o = '0;
 
-                end else if (data_addr_i == 32'h1500_0000) begin
+                end else if (data_addr_i == MMADDR_TIMERREG) begin
                     timer_wdata = data_wdata_i;
                     timer_reg_valid = '1;
 
-                end else if (data_addr_i == 32'h1500_0004) begin
+                end else if (data_addr_i == MMADDR_TIMERVAL) begin
                     timer_wdata = data_wdata_i;
                     timer_val_valid = '1;
 
-                end else if (data_addr_i == 32'h1500_0008) begin
+                end else if (data_addr_i == MMADDR_DBG) begin
                     debugger_wdata = data_wdata_i;
                     debugger_valid = '1;
 
-                end else if (data_addr_i[31:16] == 16'h1600) begin
+                end else if (data_addr_i[31:16] == MMADDR_RNDSTALL) begin
                     rnd_stall_req   = data_req_i;
                     rnd_stall_wdata = data_wdata_i;
                     rnd_stall_addr  = data_addr_i;
                     rnd_stall_we    = data_we_i;
+                end else if (data_addr_i == MMADDR_TICKS) begin
+                    cycle_count_clear = 1;
                 end else begin
                     // out of bounds write
                 end
@@ -395,16 +416,18 @@ module mm_ram
                     data_we_dec    = data_we_i;
                     data_be_dec    = data_be_i;
                     transaction    = T_RAM;
-                end else if (data_addr_i[31:16] == 16'h1600) begin
+                end else if (data_addr_i[31:16] == MMADDR_RNDSTALL) begin
                     select_rdata_d = RND_STALL;
 
                     rnd_stall_req      = data_req_i;
                     rnd_stall_wdata    = data_wdata_i;
                     rnd_stall_addr     = data_addr_i;
                     rnd_stall_we       = data_we_i;
-                end else if (data_addr_i[31:0] == 32'h1500_1000) begin
+                end else if (data_addr_i[31:0] == MMADDR_RNDNUM) begin
                     rnd_num_req = 1'b1;
                     select_rdata_d = RND_NUM;
+                end else if (data_addr_i == MMADDR_TICKS) begin
+                    select_rdata_d = TICKS;
                 end else
                     select_rdata_d = ERR;
 
@@ -420,17 +443,18 @@ module mm_ram
       || ( (data_addr_i >= dm_halt_addr_i) &&
            (data_addr_i < (dm_halt_addr_i + (2 ** DBG_ADDR_WIDTH)) )
          )
-      || data_addr_i == 32'h1000_0000
-      || data_addr_i == 32'h1500_0000
-      || data_addr_i == 32'h1500_0004
-      || data_addr_i == 32'h1500_0008
-      || data_addr_i == 32'h2000_0000
-      || data_addr_i == 32'h2000_0004
-      || data_addr_i == 32'h2000_0008
-      || data_addr_i == 32'h2000_000c
-      || data_addr_i == 32'h2000_0010
-      || data_addr_i[31:16] == 16'h1600))
-        else `uvm_fatal("MM_RAM", $sformatf("out of bounds write to %08x with %08x", data_addr_i, data_wdata_i))
+         || data_addr_i == MMADDR_PRINT
+         || data_addr_i == MMADDR_TIMERREG
+         || data_addr_i == MMADDR_TIMERVAL
+         || data_addr_i == MMADDR_DBG
+         || data_addr_i == MMADDR_TESTSTATUS
+         || data_addr_i == MMADDR_EXIT
+         || data_addr_i == MMADDR_SIGBEGIN
+         || data_addr_i == MMADDR_SIGEND
+         || data_addr_i == MMADDR_SIGDUMP
+         || data_addr_i == MMADDR_TICKS
+         || data_addr_i[31:16] == MMADDR_RNDSTALL))
+           else `uvm_fatal("MM_RAM", $sformatf("out of bounds write to %08x with %08x", data_addr_i, data_wdata_i))
 `endif
 
     logic[31:0] data_rdata_mux;
@@ -451,6 +475,12 @@ module mm_ram
         
         end else if (select_rdata_q == RND_NUM) begin
             data_rdata_mux = rnd_num;    
+        end else if (select_rdata_q == TICKS) begin
+            data_rdata_mux = cycle_count_q;
+
+            if (cycle_count_overflow_q) begin
+                $fatal(1, "cycle counter read after overflow");
+            end
         end else if (select_rdata_q == ERR) begin
             $display("out of bounds read from %08x", data_addr_i);
             $fatal(2);
@@ -504,6 +534,23 @@ module mm_ram
         end // else: !if(~rst_ni)
     end // block: tb_irq_timer
 
+    // Count cycles
+    always_ff @(posedge clk_i, negedge rst_ni) begin: tb_cycle_counter
+        if (~rst_ni) begin
+            cycle_count_q <= '0;
+            cycle_count_overflow_q <= 0;
+        end else begin
+            if (cycle_count_clear) begin
+                cycle_count_q <= '0;
+            end else begin
+                cycle_count_q <= cycle_count_q + 1;
+            end
+
+            if (cycle_count_q + 1 == 0) begin
+                cycle_count_overflow_q <= 1;
+            end
+        end
+    end
 
     // Update random stall control
     always @(posedge clk_i, negedge rst_ni) begin: tb_stall


### PR DESCRIPTION
Signed-off-by: Marton Teilgard <mateilga@silabs.com>

The magic numbers used to signify the mm_ram addresses have been made in to parameters for readability.

A cycle counter has been added to mm_ram. The motivation for this is to enable benchmarks running on the core to access and record the cycle count for a given testcase, which will be necessary for implementing EMBench and Coremark in core-v-verif.

This PR is relevant to issues #494 and #495.