### PR TITLE
Correct path to library in riviera makefile

### DIFF
--- a/mk/uvmt/riviera.mk
+++ b/mk/uvmt/riviera.mk
@@ -284,7 +284,7 @@ run: $(VSIM_RUN_PREREQ) gen_ovpsim_ic
 			$(VSIM_FLAGS) \
 			${DPILIB_VSIM_OPT} \
 			-l vsim-$(VSIM_TEST).log \
-			-lib $(VSIM_RESULTS)/work \
+			-lib $(VSIM_RESULTS)/$(CFG)/work \
 			+UVM_TESTNAME=$(TEST_UVM_TEST)\
 			$(RTLSRC_VLOG_TB_TOP) \
 			$(TEST_PLUSARGS) \


### PR DESCRIPTION
Hey!
In this pull request I added `$(CFG)` on path to library in simulation command
Signed-off-by: Dawid Zimonczyk <dawidz@aldec.com.pl>