### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Functional verification project for the CORE-V family of RISC-V cores.
 
 ## NEWS UPDATES:
 **2020-12-16**: The [cv32e40p_v1.0.0](https://github.com/openhwgroup/core-v-verif/releases/tag/22dc5fc) of core-v-verif is released.
-This tag clones the v1.0.0 release of the CV32E40P CORE-V core and will allow you to reproduce the verification environment as it existed at `RTl Freeze`.
+This tag clones the v1.0.0 release of the CV32E40P CORE-V core and will allow you to reproduce the verification environment as it existed at `RTL Freeze`.
 <br>
 More news is available in the [archive](https://github.com/openhwgroup/core-v-verif/blob/master/NEWS_ARCHIVE.md).
 


### PR DESCRIPTION
Fixed a simple typo in the README.

Signed-off-by: MikeOpenHWGroup <mike@openhwgroup.org>