### PR TITLE
fix compliance issues

### DIFF
--- a/bin/templates/metrics.json.j2
+++ b/bin/templates/metrics.json.j2
@@ -38,8 +38,13 @@
         "build": "{{t.build}}",
         "cmd": "cd {{t.dir}}; {{t.cmd}} CV_CORE={{project}} CFG={{cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RNDSEED=<seed> {{common_dsim_make_vars}} {{makeargs}}",
         "wavesCmd": "cd {{t.dir}}; {{t.cmd}} CV_CORE={{project}} CFG={{cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RNDSEED=<seed> {{common_dsim_make_vars_waves}} {{makeargs}}",
+{% if t.results %}
+        "metricsFile": "{{cfg}}/{{t.results}}{{test_suffix}}/metrics.db",
+        "wavesFile": "{{cfg}}/{{t.results}}{{test_suffix}}/{{t.name}}{{test_suffix}}.vcd",
+{% else %}
         "metricsFile": "{{cfg}}/{{t.name}}{{test_suffix}}/metrics.db",
         "wavesFile": "{{cfg}}/{{t.name}}{{test_suffix}}/{{t.name}}{{test_suffix}}.vcd",
+{% endif %}
         "seed" : "random",
         "iterations": {{t.num}},
         "isPass": "{{t.simulation_passed}}",

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -87,18 +87,29 @@ popd > /dev/null
 
 {% endif %}
 {% for run_index in range(t.num|int) %}
-{% set test_cmd = t.cmd|replace('<RUN_INDEX>', run_index) %}
-{% set test_log = t.log|replace('<RUN_INDEX>', run_index) %}
+{% set test_cmd = t.cmd %}
+{% set test_log = t.log %}
 # --> Test (Index: {{run_index}}): {{t.cmd}} : {{t.description}}
 {% set cmd = test_cmd + ' CV_CORE=' + project + ' CFG=' + cfg + ' SIMULATOR=' + t.simulator + ' COMP=0 USE_ISS=' + regress_macros.yesorno(t.iss) + ' COV=' + regress_macros.yesorno(t.cov) + ' SEED=random GEN_START_INDEX=' + run_index|string + ' RUN_INDEX=' + run_index|string + makeargs %}
 echo "{{session}}: Running test [cd {{t.abs_dir}} && {{cmd}}]"
 pushd {{t.abs_dir}} > /dev/null
 {{cmd}} >& /dev/null;
 popd > /dev/null
+
 {# Determine log location #}
+{% if t.results %}
+log={{t.abs_dir}}/{{t.simulator}}_results/{{cfg}}/{{t.results}}_{{run_index}}/{{t.simulator}}-{{test_log}}.log
+{% else %}
 log={{t.abs_dir}}/{{t.simulator}}_results/{{cfg}}/{{test_log}}_{{run_index}}/{{t.simulator}}-{{test_log}}.log
+{% endif %}
+
+{# Compliance signature check #}
 {% if 'compliance' in t.cmd %}
-compliance_diff_log={{t.abs_dir}}/{{t.simulator}}_results/{{cfg}}/{{test_log}}/diff_signatures.log
+{% if t.results %}
+compliance_diff_log={{t.abs_dir}}/{{t.simulator}}_results/{{cfg}}/{{t.results}}_{{run_index}}/diff_signatures.log
+{% else %}
+compliance_diff_log={{t.abs_dir}}/{{t.simulator}}_results/{{cfg}}/{{test_log}}_{{run_index}}/diff_signatures.log
+{% endif %}
 {% endif %}
 
 failed=0

--- a/cv32e40p/regress/cv32e40p_compliance.yaml
+++ b/cv32e40p/regress/cv32e40p_compliance.yaml
@@ -24,150 +24,175 @@ tests:
     description: RISCV_COMPLIANCE_C-ADD
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-ADD
+    results: rv32imc/C-ADD
 
   C-ADDI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-ADDI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-ADDI
+    results: rv32imc/C-ADDI
 
   C-ADDI16SP:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-ADDI16SP
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-ADDI16SP
+    results: rv32imc/C-ADDI16SP
 
   C-ADDI4SPN:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-ADDI4SPN
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-ADDI4SPN
+    results: rv32imc/C-ADDI4SPN
 
   C-AND:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-AND
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-AND
+    results: rv32imc/C-AND
 
   C-ANDI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-ANDI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-ANDI
+    results: rv32imc/C-ANDI
 
   C-BEQZ:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-BEQZ
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-BEQZ
+    results: rv32imc/C-BEQZ
 
   C-BNEZ:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-BNEZ
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-BNEZ
+    results: rv32imc/C-BNEZ
 
   C-J:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-J
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-J
+    results: rv32imc/C-J
 
   C-JAL:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-JAL
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-JAL
+    results: rv32imc/C-JAL
 
   C-JALR:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-JALR
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-JALR
-
+    results: rv32imc/C-JALR
+    
   C-JR:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-JR
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-JR
+    results: rv32imc/C-JR
 
   C-LI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-LI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-LI
+    results: rv32imc/C-LI
 
   C-LUI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-LUI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-LUI
+    results: rv32imc/C-LUI
 
   C-LW:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-LW
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-LW
+    results: rv32imc/C-LW
 
   C-LWSP:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-LWSP
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-LWSP
+    results: rv32imc/C-LWSP
 
   C-MV:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-MV
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-MV
+    results: rv32imc/C-MV
 
   C-OR:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-OR
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-OR
+    results: rv32imc/C-OR
 
   C-SLLI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SLLI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SLLI
+    results: rv32imc/C-SLLI
 
   C-SRAI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SRAI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SRAI
+    results: rv32imc/C-SRAI
 
   C-SRLI:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SRLI
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SRLI
+    results: rv32imc/C-SRLI
 
   C-SUB:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SUB
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SUB
+    results: rv32imc/C-SUB
 
   C-SW:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SW
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SW
+    results: rv32imc/C-SW
 
   C-SWSP:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-SWSP
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-SWSP
+    results: rv32imc/C-SWSP
 
   C-XOR:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_C-XOR
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32imc COMPLIANCE_PROG=C-XOR
+    results: rv32imc/C-XOR
 
   # -------------------------------------------------------------------------
   # RV32IMC tests
@@ -178,72 +203,84 @@ tests:
     description: RISCV_COMPLIANCE_I-ADD-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-ADD-01
+    results: rv32i/I-ADD-01
 
   I-ADDI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-ADDI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-ADDI-01
+    results: rv32i/I-ADDI-01
 
   I-AND-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-AND-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-AND-01
+    results: rv32i/I-AND-01
 
   I-ANDI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-ANDI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-ANDI-01
+    results: rv32i/I-ANDI-01
 
   I-AUIPC-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-AUIPC-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-AUIPC-01
+    results: rv32i/I-AUIPC-01
 
   I-BEQ-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BEQ-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BEQ-01
-
+    results: rv32i/I-BEQ-01
+  
   I-BGE-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BGE-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BGE-01
+    results: rv32i/I-BGE-01
 
   I-BGEU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BGEU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BGEU-01
+    results: rv32i/I-BGEU-01
 
   I-BLT-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BLT-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BLT-01
+    results: rv32i/I-BLT-01
 
   I-BLTU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BLTU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BLTU-01
-
+    results: rv32i/I-BLTU-01
+    
   I-BNE-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-BNE-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-BNE-01
+    results: rv32i/I-BNE-01
 
   I-DELAY_SLOTS-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-DELAY_SLOTS-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-DELAY_SLOTS-01
+    results: rv32i/I-DELAY_SLOTS-01
 
   # Not running for cv32e40p
   # I-EBREAK-01:
@@ -264,60 +301,70 @@ tests:
     description: RISCV_COMPLIANCE_I-ENDIANESS-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-ENDIANESS-01
+    results: rv32i/I-ENDIANESS-01
 
   I-IO-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-IO-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-IO-01
+    results: rv32i/I-IO-01
 
   I-JAL-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-JAL-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-JAL-01
-
+    results: rv32i/I-JAL-01
+  
   I-JALR-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-JALR-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-JALR-01
+    results: rv32i/I-JALR-01
 
   I-LB-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LB-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LB-01
+    results: rv32i/I-LB-01
 
   I-LBU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LBU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LBU-01
+    results: rv32i/I-LBU-01
 
   I-LH-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LH-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LH-01
+    results: rv32i/I-LH-01
 
   I-LHU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LHU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LHU-01
+    results: rv32i/I-LHU-01
 
   I-LUI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LUI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LUI-01
+    results: rv32i/I-LUI-01
 
   I-LW-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-LW-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-LW-01
+    results: rv32i/I-LW-01
 
   # Not running for cv32e40p
   # I-MISALIGN_JMP-01:
@@ -338,126 +385,147 @@ tests:
     description: RISCV_COMPLIANCE_I-OR-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-OR-01
+    results: rv32i/I-OR-01
 
   I-ORI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-ORI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-ORI-01
+    results: rv32i/I-ORI-01
 
   I-RF_size-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-RF_size-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-RF_size-01
+    results: rv32i/I-RF_size-01
 
   I-RF_width-01:
     build: uvmt_cv32e40p_compliance_build
-    description: RISCV_COMPLcIANCE_I-RF_width-01
+    description: RISCV_COMPLIANCE_I-RF_width-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-RF_width-01
+    results: rv32i/I-RF_width-01
 
   I-RF_x0-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-RF_x0-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-RF_x0-01
+    results: rv32i/I-RF_x0-01
 
   I-SB-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SB-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SB-01
+    results: rv32i/I-SB-01
 
   I-SH-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SH-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SH-01
+    results: rv32i/I-SH-01
 
   I-SLL-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLL-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLL-01
+    results: rv32i/I-SLL-01
 
   I-SLLI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLLI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLLI-01
+    results: rv32i/I-SLLI-01
 
   I-SLT-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLT-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLT-01
+    results: rv32i/I-SLT-01
 
   I-SLTI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLTI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLTI-01
+    results: rv32i/I-SLTI-01
 
   I-SLTIU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLTIU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLTIU-01
+    results: rv32i/I-SLTIU-01
 
   I-SLTU-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SLTU-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SLTU-01
+    results: rv32i/I-SLTU-01
 
   I-SRA-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SRA-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SRA-01
+    results: rv32i/I-SRA-01
 
   I-SRAI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SRAI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SRAI-01
+    results: rv32i/I-SRAI-01
 
   I-SRL-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SRL-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SRL-01
+    results: rv32i/I-SRL-01
 
   I-SRLI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SRLI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SRLI-01
+    results: rv32i/I-SRLI-01
 
   I-SUB-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SUB-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SUB-01
+    results: rv32i/I-SUB-01
 
   I-SW-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-SW-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-SW-01
+    results: rv32i/I-SW-01
 
   I-XOR-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-XOR-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-XOR-01
+    results: rv32i/I-XOR-01
 
   I-XORI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-XORI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32i COMPLIANCE_PROG=I-XORI-01
+    results: rv32i/I-XORI-01
 
   # -------------------------------------------------------------------------
   # RV32IM tests
@@ -467,48 +535,56 @@ tests:
     description: RISCV_COMPLIANCE_MUL
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=MUL
+    results: rv32im/MUL
 
   MULH:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_MULH
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=MULH
+    results: rv32im/MULH
 
   MULHSU:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_MULHSU
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=MULHSU
+    results: rv32im/MULHSU
 
   MULHU:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_MULHU
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=MULHU
+    results: rv32im/MULHU
 
   REM:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_REM
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=REM
+    results: rv32im/REM
 
   REMU:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_REMU
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=REMU
+    results: rv32im/REMU
 
   DIV:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_DIV
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=DIV
+    results: rv32im/DIV
 
   DIVU:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_DIVU
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32im COMPLIANCE_PROG=DIVU
+    results: rv32im/DIVU
 
   # -------------------------------------------------------------------------
   # RV32ZICSR tests
@@ -518,36 +594,42 @@ tests:
     description: RISCV_COMPLIANCE_I-CSRRC-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRC-01
+    results: rv32Zicsr/I-CSRRC-01
 
   I-CSRRCI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-CSRRCI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRCI-01
+    results: rv32Zicsr/I-CSRRCI-01
 
   I-CSRRS-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-CSRRS-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRS-01
+    results: rv32Zicsr/I-CSRRS-01
 
   I-CSRRSI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-CSRRSI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRSI-01
+    results: rv32Zicsr/I-CSRRSI-01
 
   I-CSRRW-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-CSRRW-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRW-01
+    results: rv32Zicsr/I-CSRRW-01
 
   I-CSRRWI-01:
     build: uvmt_cv32e40p_compliance_build
     description: RISCV_COMPLIANCE_I-CSRRWI-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zicsr COMPLIANCE_PROG=I-CSRRWI-01
+    results: rv32Zicsr/I-CSRRWI-01
 
   # -------------------------------------------------------------------------
   # RV32ZIFENCEI tests
@@ -557,4 +639,5 @@ tests:
     description: RISCV_COMPLIANCE_I-FENCE.I-01
     dir: cv32e40p/sim/uvmt
     cmd: make compliance_check_sig RISCV_ISA=rv32Zifencei COMPLIANCE_PROG=I-FENCE.I-01
+    results: rv32Zifencei/I-FENCE.I-01
 

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -51,6 +51,7 @@ endif
 DATE           = $(shell date +%F)
 CV_CORE_LC     = $(shell echo $(CV_CORE) | tr A-Z a-z)
 CV_CORE_UC     = $(shell echo $(CV_CORE) | tr a-z A-Z)
+SIMULATOR_UC   = $(shell echo $(SIMULATOR) | tr a-z A-Z)
 export CV_CORE_LC
 export CV_CORE_UC
 .DEFAULT_GOAL := no_rule 
@@ -209,6 +210,7 @@ all_compliance: $(COMPLIANCE_PKG)
 	make build_compliance RISCV_ISA=rv32Zifencei
 
 # "compliance" is a simulator-specific target defined in <sim>.mk
+COMPLIANCE_RESULTS = $($(SIMULATOR_UC)_RESULTS)
 
 compliance_check_sig: compliance
 	@echo "Checking Compliance Signature for $(RISCV_ISA)/$(COMPLIANCE_PROG)"
@@ -218,15 +220,15 @@ compliance_check_sig: compliance
 	export REF=$(REF) && export SIG=$(SIG) && export COMPL_PROG=$(COMPLIANCE_PROG) && \
 	export RISCV_TARGET=${RISCV_TARGET} && export RISCV_DEVICE=${RISCV_DEVICE} && \
 	export RISCV_ISA=${RISCV_ISA} export SIG_ROOT=${SIG_ROOT} && \
-	$(CORE_V_VERIF)/bin/diff_signatures.sh | tee $(SIMULATOR)_results/$(CFG)/$(RISCV_ISA)/$(COMPLIANCE_PROG)/diff_signatures.log
+	$(CORE_V_VERIF)/bin/diff_signatures.sh | tee $(COMPLIANCE_RESULTS)/$(CFG)/$(RISCV_ISA)/$(COMPLIANCE_PROG)_$(RUN_INDEX)/diff_signatures.log
 
 compliance_check_all_sigs:
-	@$(MKDIR_P) $(SIMULATOR)_results/$(CFG)/$(RISCV_ISA)
+	@$(MKDIR_P) $(COMPLIANCE_RESULTS)/$(CFG)/$(RISCV_ISA)
 	@echo "Checking Compliance Signature for all tests in $(CFG)/$(RISCV_ISA)"
 	@export SUITEDIR=$(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscv/riscv-compliance/riscv-test-suite/$(RISCV_ISA) && \
 	export RISCV_TARGET=${RISCV_TARGET} && export RISCV_DEVICE=${RISCV_DEVICE} && \
 	export RISCV_ISA=${RISCV_ISA} export SIG_ROOT=${SIG_ROOT} && \
-	$(CORE_V_VERIF)/bin/diff_signatures.sh $(RISCV_ISA) | tee $(SIMULATOR)_results/$(CFG)/$(RISCV_ISA)/diff_signatures.log
+	$(CORE_V_VERIF)/bin/diff_signatures.sh $(RISCV_ISA) | tee $(COMPLIANCE_RESULTS)/$(CFG)/$(RISCV_ISA)/diff_signatures.log
 
 #	export REF=$(REF) && export SIG=$(SIG) && export COMPL_PROG=$(COMPLIANCE_PROG) && \
 


### PR DESCRIPTION
cv32e40p_compliance regression working again
functional coverage working in Metrics with compliance regression

should be able to deprecate the static_compliance regression after this PR

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>