### PR TITLE
Embench deployment to Core-v-verif for cv32e40p

### DIFF
--- a/bin/run_embench.py
+++ b/bin/run_embench.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+#
+# run_embench : python script to fetch, set up, build and run EMBench 
+#               benchmarking suite on the present cores
+#
+# Author: Marton Teilgård
+#  email: mateilga@silabs.com
+#
+# Written with Python 3.6.5 on RHEL 7.7.  Your python mileage may vary.
+#
+# Restriction:
+#
+#
+################################################################################
+
+import argparse
+import logging
+import os
+import sys
+import subprocess
+import jinja2
+import re
+
+
+
+def main():
+
+  check_python_version(3,6)
+
+  parser = build_parser()
+  args = parser.parse_args()
+  paths = build_paths(args.core)
+
+  if args.debug == 'YES':
+    log_level = logging.DEBUG
+  else:
+    log_level = logging.WARNING
+
+  logging.basicConfig(level=log_level, format='%(levelname)s: %(message)s')
+
+
+  if args.core == 'notset':
+    print('Must specify a core to benchmark')
+    sys.exit(1)
+
+  if args.ccomp == 'notset':
+    print('Must specify a c compiler to benchmark')
+    sys.exit(1)
+
+  if args.type != 'speed' and args.type != 'size':
+    print(f"Invalid type selected: {args.type}, must be 'speed' or 'size'")
+    sys.exit(1)
+
+  if args.build_only == 'YES':
+    build_only = True
+  elif args.build_only == 'NO':
+    build_only = False
+  else:
+    print(f"Invalid 'build_only' option: {args.build_only}, must be 'YES' or 'NO'")
+    sys.exit(1)
+
+  print("Starting EMBench for core-v-verif")
+  print(f"Benchmarking core: {args.core}")
+  print(f"Type of benchmark to run: {args.type}\n\n")
+
+
+  # checking if there are existing configuration files
+  if os.path.exists(paths['emcfg']):
+    logging.info("EMBench repository checked out previously. \n Cleaning results and skipping cfg copy")
+    prebuilt = True
+    # deleting existing build results
+    try:
+      subprocess.run(
+        ['find', '.', '!', '-path', '.', '!', '-path', './README.md', '-delete'],
+        cwd=paths['testsem']
+      )
+    except:
+      logging.fatal('Failed to delete old build results')
+  else:
+    prebuilt = False
+
+  
+  print("Building Benchmark files")
+
+
+  if not prebuilt:
+    # copy core-native config
+    logging.info(f"Copying EMBench config from {paths['libcfg']} to {paths['emcfg']}")
+    try:
+      subprocess.run(
+        ['cp', '-R', paths['libcfg'], paths['emcfg']]
+      )
+    except:
+      logging.fatal('EMBench config copy failed')
+
+    # copy source files from bsp
+    # Only done when testing speed, size benchmark is built without support
+    # to matchEMBench baseline
+    if args.type == 'speed':
+      logging.info(f"Copying files from {paths['bsp']} to {paths['embrd']}")
+      for file in os.listdir(paths['bsp']):
+        if file.endswith('.S') or file.endswith('.c'):
+          logging.info(f"Copying {file}")
+          try:
+            subprocess.run(['cp', paths['bsp']+'/'+file, paths['embrd']])
+          except:
+            logging.fatal(f"EMBench bsp copy of file {file} failed")
+
+    # copy python module
+    logging.info(f"Copying {paths['libpy']}/run_corev32.py to {paths['empy']}/run_corev32.py")
+    try:
+      subprocess.run(
+        ['cp', f"{paths['libpy']}/run_corev32.py", f"{paths['empy']}/run_corev32.py"]
+      )
+    except:
+      logging.fatal('EMBench python module copy failed')
+
+
+
+  # build EMBench library
+  logging.info(f"Calling build script")
+  try: 
+    res = subprocess.run(
+      ['build_all.py', '--arch=corev32', '--board=corev32', f"--chip={args.type}", f"--cc={args.ccomp}", f"--ldflags=-T{paths['bsp']}/link.ld", '--clean'],
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      cwd=paths['embench']
+    )
+  except:
+    logging.fatal('EMBench build failed')
+
+  if build_passed(res.stdout.decode('utf-8')):
+    print(f"EMBench for {args.type} built successfully")
+  else:
+    logging.fatal('EMBench build failed')
+    sys.exit(1)
+
+  # build test directory, copy and rename the executable test files, and generate yaml files
+  # This is not done if the built files are for the size benchmark, as these are not able to run
+  if args.type == 'speed':
+    for folder in os.listdir(paths['emres']):
+      # create test directory
+      folder_ext = f"emb_{folder}"
+      
+      logging.info(f"Creating folder {paths['testsem']}/{folder_ext}")
+      try:
+        subprocess.run(['mkdir', f"{paths['testsem']}/{folder_ext}"])
+      except:
+        logging.fatal(f"Failed to generate folder {paths['testsem']}/{folder_ext}")
+        sys.exit(1)
+
+      # copy test file from 
+      for file in os.listdir(f"{paths['emres']}/{folder}"):
+        if not file.endswith('.o'):
+          logging.info(f"Copying file {file}")
+          try:
+            subprocess.run(['cp', f"{paths['emres']}/{folder}/{file}", f"{paths['testsem']}/{folder_ext}/emb_{file}.elf"])
+          except:
+            logging.fatal(f"Copying file {file} to {paths['emres']}/{folder_ext}/ failed")
+            sys.exit(1)
+          
+          break
+      
+      # generate test.yaml
+      logging.info(f"Rendering template: test.yaml.j2 for test: {folder_ext}")
+      generate_test_yaml(f"{paths['testsem']}/{folder_ext}", folder_ext)
+
+
+  if build_only: 
+    print("Build only selected, exiting")
+    sys.exit()
+
+  # run benchmark script
+  print(f"Starting benchmarking of {args.type}")
+
+  if args.type == 'speed':
+    arglist = ['benchmark_speed.py', '--target-module=run_corev32', '--timeout=1200', f"--cpu-mhz={args.cpu_mhz}", f"--make-path={paths['make']}", f"--simulator={args.simulator}"]
+  else:
+    arglist = ['benchmark_size.py']
+
+    
+  try:
+    res = subprocess.run(
+      arglist,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      universal_newlines=True,
+      cwd=paths['embench'],
+      )
+
+  except:
+      logging.fatal(f"EMBench script benchmark_{args.type}.py failed")
+      sys.exit(1)
+
+
+  #Check if benchmark run succeeded
+  if not run_passed(res.stdout, args.type):
+    logging.fatal(f"EMBench benchmark run failed")
+
+
+  if check_result(res.stdout, args.target, args.type) and args.target != 0:
+    print(f"Benchmark run met target")
+  elif args.target != 0:
+    print(f"Benchmark run failed to meet the target: {args.target}")
+
+
+
+
+###############################################################################
+# End of Main  
+
+def build_parser():
+  """Build a parser for all the arguments"""
+  parser = argparse.ArgumentParser(description='Clone and run EMBench', formatter_class=argparse.RawTextHelpFormatter)
+
+  parser.add_argument(
+    '-c',
+    '--core',
+    default='notset',
+    help='Core to benchmark'
+  )
+
+  parser.add_argument(
+    '-cc',
+    '--ccomp',
+    default='notset',
+    help='C compiler for benchmark'
+  )
+
+  parser.add_argument(
+    '-t',
+    '--type',
+    default='speed',
+    help=(
+      'What benchmark to run. Valid options: speed, size\n'+
+      'Default option: speed \n'+
+      'NOTE: type affects build configuration!\n'+
+      'makefile alias: EMB_TYPE'
+    )
+  )
+
+  parser.add_argument(
+    '-b',
+    '--build-only',
+    default='NO',
+    help=(
+      'Set this option to "YES" to only build the benchmarks.\n'+
+      'Type option is still honored\n'+
+      'makefile alias: EMB_BUILD_ONLY'
+    )
+  )
+
+  parser.add_argument(
+    '-tgt',
+    '--target',
+    type=float,
+    default=0,
+    help=(
+      'Set a target for your EMBench score\n'+
+      'Benchmark run will fail if target is not met\n'+
+      'If no target is set, no checking is done\n'+
+      'makefile alias: EMB_TARGET'
+    )
+  )
+
+  parser.add_argument(
+    '-f',
+    '--cpu-mhz',
+    default=1,
+    help=(
+      'Set the core frequency in MHz.\n'+
+      'Default is 1 MHz\n'+
+      'makefile alias: EMB_CPU_MHZ'
+    )
+  )
+
+  parser.add_argument(
+    '-sim',
+    '--simulator',
+    default='xrun',
+    help=(
+      'Simulator to run the benchmarks\n'+
+      'makefile alias: SIMULATOR'
+    )
+  )
+
+  parser.add_argument(
+    '-d',
+    '--debug',
+    default='NO',
+    help=(
+      'Set this option to "YES" to increase verbosity of the script\n'+
+      'makefile alias: EMB_DEBUG'
+    )
+  )
+  
+  return parser
+
+def build_paths(core):
+  """map out necessary paths"""
+  paths = dict()
+  paths['cver'] = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+  paths['core'] = paths['cver'] + '/' + core
+  paths['libcfg'] = paths['core'] + '/tests/embench/config/corev32'
+  paths['libpy'] = paths['core'] + '/tests/embench/pylib'
+  paths['vlib'] = paths['core'] + '/vendor_lib'
+  paths['make'] = paths['core'] + '/sim/uvmt'
+  paths['embench'] = paths['vlib'] + '/embench'
+  paths['emcfg'] = paths['embench'] + '/config/corev32'
+  paths['empy'] = paths['embench'] + '/pylib'
+  paths['embrd'] = paths['emcfg'] + '/boards/corev32'
+  paths['emres'] = paths['embench'] + '/bd/src'
+  paths['bsp'] = paths['core'] + '/bsp'
+  paths['testsem'] = paths['core'] + '/tests/programs/embench'
+
+  return paths
+
+def generate_test_yaml(folder, test_name):
+  env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__),                                                         
+                                                        'templates')), trim_blocks=True)
+  template = env.get_template('embench_test.yaml.j2')
+  
+  out = open(f"{folder}/test.yaml", 'w')
+  out.write(template.render(name=test_name))
+  out.close()
+    
+def build_passed(stdout_str):
+  if re.search('All benchmarks built successfully', stdout_str, re.S):
+    return True
+  else:
+    return False
+
+def run_passed(stdout_str, type):
+  if type == 'speed':
+    if re.search('All benchmarks run successfully', stdout_str, re.S):
+      return True
+    else:
+      return False
+  else: #size
+    if re.search('All benchmarks sized successfully', stdout_str, re.S):
+      return True
+    else:
+      return False
+
+def check_result(stdout_str, tgt, type):
+  #print results to screen
+  print(stdout_str)
+  
+  #find result in numeric value and compare to target
+  rcstr = re.search('Geometric mean *(\d+)[.](\d+)', stdout_str, re.S)
+  result = int(rcstr.group(1)) + (int(rcstr.group(2)) * 0.01)
+
+  if type == 'speed':
+    if (tgt == 0) or (result >= tgt):
+      return True
+    else:
+      return False
+  else:
+    if (tgt == 0) or (result <= tgt):
+      return True
+    else:
+      return False
+
+
+# Make sure we have new enough python
+def check_python_version(major, minor):
+    """Check the python version is at least {major}.{minor}."""
+    if ((sys.version_info[0] < major)
+        or ((sys.version_info[0] == major) and (sys.version_info[1] < minor))):
+        log.error('ERROR: Requires Python {mjr}.{mnr} or later'.format(mjr=major, mnr=minor))
+        sys.exit(1)
+
+
+#run main
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/templates/embench_test.yaml.j2
+++ b/bin/templates/embench_test.yaml.j2
@@ -1,0 +1,28 @@
+{#
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+# test-yaml.j2: Jinja2 template for rendering test.yaml files for run_embench
+
+#}
+
+name: {{name}}
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    test is part of EMBench benchmarking suite

--- a/bin/yaml2make
+++ b/bin/yaml2make
@@ -52,6 +52,7 @@ CFG_PATH = (
             )
 TEST_PATHS = (
             '<CV_CORE>/tests/programs/corev-dv/',
+            '<CV_CORE>/tests/programs/embench/',
             '<CV_CORE>/tests/programs/custom',
             )
 try:

--- a/cv32e40p/sim/Common.mk
+++ b/cv32e40p/sim/Common.mk
@@ -23,6 +23,10 @@ RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master
 RISCVDV_HASH		?= 0b625258549e733082c12e5dc749f05aefb07d5a
 
+EMBENCH_REPO    ?= https://github.com/embench/embench-iot.git
+EMBENCH_BRANCH  ?= master
+EMBENCH_HASH		?= 6934ddd1ff445245ee032d4258fdeb9828b72af4
+
 COMPLIANCE_REPO   ?= https://github.com/riscv/riscv-compliance
 COMPLIANCE_BRANCH ?= master
 # 2020-08-19

--- a/cv32e40p/tests/.gitignore
+++ b/cv32e40p/tests/.gitignore
@@ -14,3 +14,4 @@ csrc
 inter.vpd
 ucli.key
 vc_hdrs.h
+emb_*/

--- a/cv32e40p/tests/embench/README.md
+++ b/cv32e40p/tests/embench/README.md
@@ -1,0 +1,108 @@
+# EMBench for Core-V-Verif
+
+[EMBench](https://github.com/embench/embench-iot) has been integrated into Core-V-Verif to allow easy benchmarking of the RISC-V cores supported by 
+Core-V-Verif. This document explains the usage and implementation of the EMBench scripts and their integration
+into the makefile environment of Core-V-Verif.<br><br>
+
+
+## Quick start guide
+
+For a core that already has the supporting configuration files, running the EMBench Benchmarks can be achieved
+in the following manner:<br>
+from path:
+>/core-v-verif/\[core\]/sim/uvmt
+
+run the following shell command:
+>% make embench SIMULATOR=\[available simulator\]
+
+This will run the EMBench default benchmark \(speed\) on the core in the path, with the simulator given in the options.
+**Note** that runtime here can be several hours. If you are uncertain if the simulations are running as they
+should, the tests can be run outside of the benchmarking script, see [this](#simulate-an-embench-test-outside-of-the-script) section for details.
+
+If you want to set a target score for you benchmark, you can set the option EMB_TARGET, like this:
+>% make embench SIMULATOR=\[sim\] EMB_TARGET=\[float\]
+
+The EMBench script will determine if the target has been met, for either a speed or size benchmark, and report 
+the result.
+
+To run a size benchmark, set the EMB_TYPE option to *size*:
+>% make embench EMB_TYPE=size
+
+**Note** that SIMULATOR is not set when running size, as no simulation is necessary. Also note that when building the tests for the size benchmark, they are built without support files and libraries to match EMBench baseline, so any simulation with these files will fail. <br><br>
+
+ 
+## Relevant files and directories
+
+- **core-v-verif/bin/run_embench.py**<br>
+Main script that builds, runs and evaluates EMBench Benchmarks on the selected core.
+
+- **/core-v-verif/\[core\]/tests/embench/config/**<br>
+Core specific configuration required by EMBench
+
+- **/core-v-verif/\[core\]/tests/embench/pylib/run_corev32.py**<br>
+Core specific python module required by EMBench
+
+- **/core-v-verif/\[core\]/tests/programs/embench/**<br>
+Test directory that is populated by the EMBench script with files necessary to run the EMBench tests
+with the *make test ..* method.
+
+- **/core-v-verif/\[core\]/vendor_lib/embench/**<br>
+Directory where the EMBench repo is cloned when the script runs<br><br>
+
+## Script options from make environment
+The following table lists the available options, their default values and their function. 
+**Note** that only options unique to the EMBench scripts are included here, other dependencies, like the 
+SIMULATOR option, are omitted.
+
+| Option         | Default    | Description                                                                                                                            |
+|----------------|------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| EMB_TYPE       | speed      | What benchmark to run. Valid options: speed, size<br>NOTE: type affects build configuration!                                           |
+| EMB_BUILD_ONLY | NO         | Set this option to "YES" to only build the benchmarks                                                                                  |
+| EMB_TARGET     | 0(not set) | Set a target(float) for your EMBench score<br>Benchmark run will fail if target is not met<br>If no target is set, no checking is done |
+| EMB_CPU_MHZ    | 1          | Set the core frequency in MHz \*                                                                                                       |
+| EMB_DEBUG      | NO         | Set this option to "YES" to increase verbosity of the script                                                                           |
+
+<br>
+* This value is used for calculation in EMBench only. Measurement is done by cycle count, so this does not 
+have to match simulation, but can be used to predict results for a system running the core at a 
+specific frequency.<br><br>
+
+## Simulate an EMBench test outside of the scripted environment
+As the EMBench integration utilizes the *make test* calls already present in Core-V-Verif, the tests can be
+simulated separately from the benchmark environment. To accomplish this, complete the following steps:
+
+1. Run the EMBench script with the "EMB_BUILD_ONLY=YES" option. Type must be *speed*, but can be left out as this is the default.
+   >% make embench EMB_BUILD_ONLY=YES
+2. Run *make test* in the following manner:
+   >% make test TEST=emb_\[testname\] SIMULATOR=\[sim\] USE_ISS=NO
+
+This will simulate as any other test. Note that step 1 can be omitted if there has been a previously run 
+speed benchmark, and the repository has not been cleaned. At the time of writing, ISS must be disabled
+as the accesses to the cycle counter in the mm_ram causes step and compare mismatches. Simulating with ISS 
+will also cause a significant increase in runtime.<br><br>
+
+## Extend EMBench integration to a new core
+As new core designs are added to Core-V-Verif, we will want to run the Benchmarks on these. This section 
+describes the necessary steps to accomplish this. *Note* that this description only includes EMBench 
+unique files, dependencies in the core specific makefiles also exist.
+
+Copy the embench configuration directory from cv32e40p to the new core:
+>/core-v-verif/\[core\]/tests/embench
+
+Copy over the embench directory under *programs*. This should be empty except for a readme file.
+>/core-v-verif/\[core\]/tests/programs/embench
+
+If there are no differences in configuration necessary compared to the cv32e40p, you are now done, and can
+run the EMBench scripts in the manner described above. However, if there are notable differences, 
+a quick description on what to check follows. For full details, please check the EMBench [documentation](https://github.com/embench/embench-iot/blob/master/doc/README.md).<br>
+
+For compiler flags, linker flags or library dependencies, check the follwing files:
+>/core-v-verif/\[core\]/tests/embench/config/corev32/chips/size/chip.cfg<br>
+>/core-v-verif/\[core\]/tests/embench/config/corev32/chips/speed/chip.cfg
+
+For changes to how the test files communicates with the testbench:
+>/core-v-verif/\[core\]/tests/embench/config/corev32/chips/\[type\]/chipsupport.c<br>
+>/core-v-verif/\[core\]/tests/embench/config/corev32/chips/\[type\]/chipsupport.h
+
+If the new core has specific requirements to it's *make test* call, check this file:
+>/core-v-verif/\[core\]/tests/embench/pylib/run_corev32.py

--- a/cv32e40p/tests/embench/config/corev32/arch.cfg
+++ b/cv32e40p/tests/embench/config/corev32/arch.cfg
@@ -1,0 +1,67 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+
+# This is a python setting of parameters for the architecture.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.

--- a/cv32e40p/tests/embench/config/corev32/boards/corev32/board.cfg
+++ b/cv32e40p/tests/embench/config/corev32/boards/corev32/board.cfg
@@ -1,0 +1,69 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+
+# This is a python setting of parameters for the board.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+cpu_mhz = 1

--- a/cv32e40p/tests/embench/config/corev32/boards/corev32/boardsupport.c
+++ b/cv32e40p/tests/embench/config/corev32/boards/corev32/boardsupport.c
@@ -1,0 +1,21 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#include "boardsupport.h"
+

--- a/cv32e40p/tests/embench/config/corev32/boards/corev32/boardsupport.h
+++ b/cv32e40p/tests/embench/config/corev32/boards/corev32/boardsupport.h
@@ -1,0 +1,21 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+
+

--- a/cv32e40p/tests/embench/config/corev32/chips/size/chip.cfg
+++ b/cv32e40p/tests/embench/config/corev32/chips/size/chip.cfg
@@ -1,0 +1,86 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+
+# This is a python setting of parameters for the chip.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+# This is the generic framework for compilers, where the only common set up
+# is:
+
+# '-c' is used to specify generation of object files when compiling a
+
+# each global data and function is put in its own section
+
+# - we garbage collect unused sections on linking
+
+cflags = [
+  '-c', '-Os', '-ffunction-sections', '-mabi=ilp32', '-march=rv32imc'
+]
+
+ldflags = [
+    '-Wl,-gc-sections', '-Wl,-A,elf32lriscv', '-nostartfiles', '-nostdlib', '-mabi=ilp32', '-march=rv32imc'
+]
+
+dummy_libs = ['crt0', 'libm', 'libc', 'libgcc']

--- a/cv32e40p/tests/embench/config/corev32/chips/size/chipsupport.c
+++ b/cv32e40p/tests/embench/config/corev32/chips/size/chipsupport.c
@@ -1,0 +1,44 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#include <support.h>
+#include <stdint.h>
+#include "chipsupport.h"
+
+void
+initialise_board ()
+{
+  printf("Initialize board corev32 \n");
+  __asm__ volatile ("li a0, 0" : : : "memory");
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+ 
+  
+  __asm__ volatile ("li a0, 0" : : : "memory");
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+  
+}
+ 

--- a/cv32e40p/tests/embench/config/corev32/chips/size/chipsupport.h
+++ b/cv32e40p/tests/embench/config/corev32/chips/size/chipsupport.h
@@ -1,0 +1,27 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+#define CPU_MHZ 1
+
+#define TICKS_ADDR (*((volatile uint32_t*)0x15001004))
+
+#endif

--- a/cv32e40p/tests/embench/config/corev32/chips/speed/chip.cfg
+++ b/cv32e40p/tests/embench/config/corev32/chips/speed/chip.cfg
@@ -1,0 +1,87 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+
+# This is a python setting of parameters for the chip.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+# This is the generic framework for compilers, where the only common set up
+# is:
+
+# '-c' is used to specify generation of object files when compiling a
+
+# each global data and function is put in its own section
+
+# - we garbage collect unused sections on linking
+
+cflags = [
+  '-c', '-O2', '-ffunction-sections', '-mabi=ilp32', '-march=rv32im'
+]
+
+ldflags = [
+    '-Wl,-gc-sections', '-Wl,-A,elf32lriscv', '-nostartfiles', '-mabi=ilp32', '-march=rv32im'
+]
+user_libs  = ['-lm']
+
+#dummy_libs = ['libm']

--- a/cv32e40p/tests/embench/config/corev32/chips/speed/chipsupport.c
+++ b/cv32e40p/tests/embench/config/corev32/chips/speed/chipsupport.c
@@ -1,0 +1,51 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#include <support.h>
+#include <stdint.h>
+#include "chipsupport.h"
+
+void
+initialise_board ()
+{
+  printf("Initialize board corev32 \n");
+  __asm__ volatile ("li a0, 0" : : : "memory");
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+  printf("start of test \n");
+  //reset cycle counter
+  TICKS_ADDR = 0;
+  
+  __asm__ volatile ("li a0, 0" : : : "memory");
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+  uint32_t cycle_cnt = TICKS_ADDR;
+  printf("end of test \n");
+  printf("Result is given in CPU cycles \n");
+  printf("RES: %d \n", cycle_cnt);
+
+  _exit(0);
+}
+ 

--- a/cv32e40p/tests/embench/config/corev32/chips/speed/chipsupport.h
+++ b/cv32e40p/tests/embench/config/corev32/chips/speed/chipsupport.h
@@ -1,0 +1,27 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+#define CPU_MHZ 1
+
+#define TICKS_ADDR (*((volatile uint32_t*)0x15001004))
+
+#endif

--- a/cv32e40p/tests/embench/pylib/run_corev32.py
+++ b/cv32e40p/tests/embench/pylib/run_corev32.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+################################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+#
+# run_corev32 : python module provided to EMBench to allow the run script to 
+#               run simulations in core-v-verif
+#
+# Author: Marton Teilgård
+#  email: mateilga@silabs.com
+#
+#
+# Restriction:
+#
+#
+# TODO:
+################################################################################
+
+"""
+Embench module to run benchmark programs.
+
+This version is part of core-v-verif integration to EMBench.
+"""
+
+__all__ = [
+    'get_target_args',
+    'build_benchmark_cmd',
+    'decode_results',
+]
+
+import argparse
+import re
+
+from embench_core import log
+
+
+def get_target_args(remnant):
+    """Parse left over arguments"""
+    parser = argparse.ArgumentParser(description='Get target specific args')
+
+    parser.add_argument(
+        '--cpu-mhz',
+        type=int,
+        default=1,
+        help='Processor clock speed in MHz'
+    )
+
+    parser.add_argument(
+        '--make-path',
+        type=str,
+        required=True,
+        help='The path to run make test from'
+    )
+
+    parser.add_argument(
+        '--simulator',
+        type=str,
+        required=True,
+        help='Simulator to run the benchmarks'
+    )
+
+    return parser.parse_args(remnant)
+
+
+def build_benchmark_cmd(bench, args):
+    """Construct the command to run the benchmark.  "args" is a
+       namespace with target specific arguments"""
+
+    #CPU period
+    global cpu_per 
+    cpu_per = float(1/(args.cpu_mhz*1_000_000))
+    
+    #Utilize "make test" environment in core-v-verif
+    return ['make', '-C', args.make_path, 'test', f"TEST=emb_{bench}", f"SIMULATOR={args.simulator}", 'USE_ISS=NO']
+
+
+def decode_results(stdout_str, stderr_str):
+    """Extract the results from the output string of the run. Return the
+       elapsed time in milliseconds or zero if the run failed."""
+  
+
+    global cpu_per
+
+    #check that simulation returned successfully
+    if not re.search('SIMULATION PASSED', stdout_str, re.S):
+        log.debug('Warning: Simulation reporting error')
+        return 0.0
+
+    # Match "RES: <cycles>"
+    rcstr = re.search('RES: (\d+)', stdout_str, re.S)
+    if not rcstr:
+        log.debug('Warning: Failed to find result')
+        return 0.0
+
+    time = float(int(rcstr.group(1))*cpu_per)
+    time_ms = time * 1000
+    
+
+    return time_ms
+
+    # We must have failed to find a time
+    log.debug('Warning: Failed to find timing')
+    return 0.0

--- a/cv32e40p/tests/programs/embench/README.md
+++ b/cv32e40p/tests/programs/embench/README.md
@@ -1,0 +1,4 @@
+EMBench generated tests
+==================================
+
+This directory is populated with generated tests when running EMBench speed benchmark

--- a/cv32e40p/vendor_lib/.gitignore
+++ b/cv32e40p/vendor_lib/.gitignore
@@ -1,0 +1,1 @@
+embench/

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -67,6 +67,10 @@ ifndef RISCVDV_REPO
 $(error Must define a RISCVDV_REPO to use the common makefile)
 endif
 
+ifndef EMBENCH_REPO
+$(warning Must define a EMBENCH_REPO to use the common makefile)
+endif
+
 ifndef COMPLIANCE_REPO
 $(error Must define a COMPLIANCE_REPO to use the common makefile)
 endif
@@ -120,6 +124,20 @@ else
 endif
 # RISCV Compliance repo var end
 
+###############################################################################
+# Generate command to clone EMBench (Embedded Benchmarking suite)
+ifeq ($(EMBENCH_BRANCH), master)
+  TMP5 = git clone $(EMBENCH_REPO) --recurse $(EMBENCH_PKG)
+else
+  TMP5 = git clone -b $(EMBENCH_BRANCH) --single-branch $(EMBENCH_REPO) --recurse $(EMBENCH_PKG)
+endif
+
+ifeq ($(EMBENCH_HASH), head)
+  CLONE_EMBENCH_CMD = $(TMP5)
+else
+  CLONE_EMBENCH_CMD = $(TMP5); cd $(EMBENCH_PKG); git checkout $(EMBENCH_HASH)
+endif
+# RISCV-DV repo var end
 ###############################################################################
 # Imperas Instruction Set Simulator
 

--- a/mk/uvmt/riviera.mk
+++ b/mk/uvmt/riviera.mk
@@ -331,5 +331,5 @@ clean:
 	rm -rf $(VSIM_RESULTS) library.cfg $(VWORK)
 
 # All generated files plus the clone of the RTL
-clean_all: clean clean_riscv-dv clean_test_programs clean-bsp clean_compliance
+clean_all: clean clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench
 	rm -rf $(CV_CORE_PKG)

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -350,5 +350,5 @@ clean_eclipse:
 	rm  -rf workspace
 
 # All generated files plus the clone of the RTL
-clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance
+clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench
 	rm -rf $(CV_CORE_PKG)

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -457,5 +457,5 @@ clean:
 	rm -rf $(VSIM_RESULTS)
 
 # All generated files plus the clone of the RTL
-clean_all: clean clean_riscv-dv clean_test_programs clean-bsp clean_compliance
+clean_all: clean clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench
 	rm -rf $(CV_CORE_PKG)

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -348,6 +348,8 @@ compliance: $(XRUN_COMPLIANCE_PREREQ)
 		+firmware=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).hex \
 		+elf_file=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).elf
 
+
+
 ###############################################################################
 # Use Google instruction stream generator (RISCV-DV) to create new test-programs
 comp_corev-dv: $(RISCVDV_PKG)
@@ -430,5 +432,5 @@ clean_eclipse:
 	rm  -rf workspace
 
 # All generated files plus the clone of the RTL
-clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance
+clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench
 	rm -rf $(CV_CORE_PKG)


### PR DESCRIPTION
Signedoff-by: Marton Teilgard <mateilga@silabs.com>
This is the deployment of EMBench support for Core-v-verif, as described in issue #495 .

The commit includes:

- EMBench integration via make environment
- The ability to build and run benchmarks for speed and size
- Option for setting target score that pass/fails the benchmark run
- Test artifacts than can be simulated through "make test"

Details can be found in the readme file:
core-v-verif/cv32e40p/tests/embench/README.md