### PR TITLE
Hotfix: xrun debug

### DIFF
--- a/cv32e40p/sim/tools/xrun/probe.tcl
+++ b/cv32e40p/sim/tools/xrun/probe.tcl
@@ -1,5 +1,5 @@
 database -open waves -default -incsize 2G
-probe -create uvmt_cv32_tb -depth all -database waves
+probe -create uvmt_cv32e40p_tb -depth all -database waves
 
 run
 exit


### PR DESCRIPTION
Fixes issues with tcl script that prevents xrun debugging with WAVES=1

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>