### PR TITLE
Fixes to reenable debug_test in ci_check

### DIFF
--- a/cv32e40x/regress/cv32e40x_ci_check.yaml
+++ b/cv32e40x/regress/cv32e40x_ci_check.yaml
@@ -37,11 +37,10 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test COREV=YES TEST=illegal
 
-  # FIXME:strichmo:Should file an issue to fix this ASAP
-  # debug_test:
-  #   build: uvmt_cv32e40x
-  #   dir: cv32e40x/sim/uvmt
-  #   cmd: make test COREV=YES TEST=debug_test
+  debug_test:
+    build: uvmt_cv32e40x
+    dir: cv32e40x/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test
 
   csr_instructions:
     build: uvmt_cv32e40x

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -176,6 +176,7 @@ module uvmt_cv32e40x_dut_wrap #(// DUT (riscv_core) parameters.
          .instr_rvalid_i         ( instr_rvalid                   ),
          .instr_addr_o           ( instr_addr                     ),
          .instr_rdata_i          ( instr_rdata                    ),
+         .instr_err_i            ( '0                             ), //TODO: Temp tie off to get "debug_test" to pass
 
          .data_req_o             ( data_req                       ),
          .data_gnt_i             ( data_gnt                       ),


### PR DESCRIPTION
Quick fix to get debug_test to pass until we have verification of bus errors in place.

Signed-off-by: Marton Teilgard <mateilga@silabs.com>