### PR TITLE
add CV_CORE_PATH for optionally having rtl repo dir symlinked locally

### DIFF
--- a/cv32e40x/sim/README.md
+++ b/cv32e40x/sim/README.md
@@ -3,7 +3,10 @@ The directories from which you should launch your interactive simulations and
 regressions are the `core` and `uvmt_cv32` directories located here.
 
 ### Cloning the RTL
-The Makefiles will automatically clone the required RTL to `../../core-v-cores/cv32e40x`.
+The Makefiles will automatically clone the required RTL to `../../core-v-cores/cv32e40x`,
+unless the CV_CORE_PATH parameter is set.
+If the CV_CORE_PATH is set, a symlink to this path will be created in `../../core-v-cores/` instead of cloning the repo.
+This allows for working on the RTL in a separate environment.
 <br><br>
 There are user variables
 in `./Common.mk` that control the URL, branch and hash of the cloned code - see

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -76,22 +76,26 @@ $(error Must define a COMPLIANCE_REPO to use the common makefile)
 endif
 
 ###############################################################################
-# Generate command to clone the core RTL
-ifeq ($(CV_CORE_BRANCH), master)
-  TMP = git clone $(CV_CORE_REPO) $(CV_CORE_PKG)
-else
-  TMP = git clone -b $(CV_CORE_BRANCH) --single-branch $(CV_CORE_REPO) $(CV_CORE_PKG)
-endif
-
-# If a TAG is specified, the HASH is not considered
-ifeq ($(CV_CORE_TAG), none)
-  ifeq ($(CV_CORE_HASH), head)
-    CLONE_CV_CORE_CMD = $(TMP)
+# Generate command to clone or symlink the core RTL
+ifeq ($(CV_CORE_PATH), "")
+  ifeq ($(CV_CORE_BRANCH), master)
+    TMP = git clone $(CV_CORE_REPO) $(CV_CORE_PKG)
   else
-    CLONE_CV_CORE_CMD = $(TMP); cd $(CV_CORE_PKG); git checkout $(CV_CORE_HASH)
+    TMP = git clone -b $(CV_CORE_BRANCH) --single-branch $(CV_CORE_REPO) $(CV_CORE_PKG)
+  endif
+
+  # If a TAG is specified, the HASH is not considered
+  ifeq ($(CV_CORE_TAG), none)
+    ifeq ($(CV_CORE_HASH), head)
+      CLONE_CV_CORE_CMD = $(TMP)
+    else
+      CLONE_CV_CORE_CMD = $(TMP); cd $(CV_CORE_PKG); git checkout $(CV_CORE_HASH)
+    endif
+  else
+    CLONE_CV_CORE_CMD = $(TMP); cd $(CV_CORE_PKG); git checkout tags/$(CV_CORE_TAG)
   endif
 else
-  CLONE_CV_CORE_CMD = $(TMP); cd $(CV_CORE_PKG); git checkout tags/$(CV_CORE_TAG)
+  CLONE_CV_CORE_CMD = ln -s $(CV_CORE_PATH) $(CV_CORE_PKG)
 endif
 
 ###############################################################################


### PR DESCRIPTION
This PR adds the possibility to point a core directory in `core-v-cores` to a local directory via symlink. This is instead of cloning.
The benefit is that one doesn't have to be afraid of some `make clean` or other scripts accidentally wiping the core directory.
Hence one can safely work on a core's RTL and run ci_check, clean-build core-v-verif, etc.

(This is something we had locally, intermediately before the "multi-design" core-v-verif repo was ready. I am merely porting it over to the github repo now.)