### PR TITLE
make imperas iss ovpsim selectable at run-time

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -8,26 +8,26 @@
       {
         "name":     "uvmt_cv32e40p",
         "image":    "cv32-simulation-tools:20200720.11.0-19102020",
-        "cmd":      "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
-        "wavesCmd": "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
+        "cmd":      "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40p_compliance_build",
         "image":    "cv32-simulation-tools:20200720.11.0-19102020",
-        "cmd":      "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
-        "wavesCmd": "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
+        "cmd":      "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x",
         "image":    "cv32-simulation-tools:20200720.11.0-19102020",
-        "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
-        "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
+        "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_compliance_build",
         "image":    "cv32-simulation-tools:20200720.11.0-19102020",
-        "cmd":      "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
-        "wavesCmd": "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim USE_ISS=YES DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
+        "cmd":      "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       }
     ]
   },

--- a/.metrics.json
+++ b/.metrics.json
@@ -145,6 +145,17 @@
       }
     },
     {
+      "name":        "cv32e40x_ci_check_dev_no_iss",
+      "description": "Commit sanity for CV32E40X using dynamic test generation",
+      "verbose":     "true",
+      "tests": {
+        "resultsDir": "/mux-flow/build/results",
+        "builds":    ["uvmt_cv32e40x"],
+        "listCmd":   "/mux-flow/build/repo/bin/cv_regress --iss=0 --core=cv32e40x --cfg=default --file=cv32e40x_ci_check --metrics --outfile=/mux-flow/build/repo/cv32e40x_ci_check.json",
+        "listFile":  "/mux-flow/build/repo/cv32e40x_ci_check.json"
+      }
+    },
+    {
       "name":        "cv32e40x_rel_check_release",
       "description": "Release branch check for CV32E40X using dynamic test generation",
       "verbose":     "true",

--- a/bin/README.md
+++ b/bin/README.md
@@ -44,9 +44,13 @@ simulator for the purposes of ensuring a pull-request can be safely made.  Note 
 be able to be executed in any directory where previously it required the user to *cd* to ci/.  Please 
 refer to *ci_check*'s help utility for more details on options
 
+If required, the step and compare ISS can be disabled for this regression by setting _--iss=0_
+
 *Examples:*
 > \# Run CI sanity regression on Xcelium<br>
 % ci_check -s xrun<br>
+> \# Run CI sanity regression on Xcelium with the ISS disabled<br>
+% ci_check -s xrun --iss=0<br>
 > \# Get help of all available options<br>
 % ci_check --help
 

--- a/bin/cfgyaml2make
+++ b/bin/cfgyaml2make
@@ -79,7 +79,13 @@ def read_file(file):
 
     stream = open(matches[0], 'r')
     logger.debug('Reading cfg specification: {}'.format(matches[0]))
-    cfg_spec = yaml.load(stream)
+    # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
+    # Older PyYAMLs will not support the Loader argument
+    # So try the new way first, then catch to the old way
+    try:
+        cfg_spec = yaml.load(stream, Loader=yaml.FullLoader)
+    except AttributeError:
+        cfg_spec = yaml.load(stream)
     stream.close()
 
     # Validation

--- a/bin/ci_check
+++ b/bin/ci_check
@@ -79,6 +79,7 @@ parser.add_argument("-c", "--check_only",    help="Check previosu results (do no
 parser.add_argument("-k", "--keep",          help="Keep previous cloned or generated files",          action="store_true")
 parser.add_argument("-v", "--verilator",     help="Run Verilator on the CORE testbench",              action="store_true")
 parser.add_argument("-u", "--no_uvm",        help="DO NOT run CI regression on the UVM testbench",    action="store_true")
+parser.add_argument('--iss',                 help='Force USE_ISS flag to each test run (use 0 or 1), default: Enabled')
 parser.add_argument("--repo",                help="Use this repo for the RTL, not one in Makefile",   type=str)
 parser.add_argument("--branch",              help="Use this branch for the RTL, not one in Makefile", type=str)
 parser.add_argument("--hash",                help="Use this hash for the RTL, not one in Makefile",   type=str)
@@ -183,7 +184,13 @@ def load_regress_yaml(regression):
     '''Load the regression yaml and return the dictionary'''
     full_regression = os.path.join(topdir, '{}/regress'.format(args.core.lower()), regression + '.yaml')
     fh = open(full_regression, 'r')
-    dict = yaml.load(fh)
+    # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
+    # Older PyYAMLs will not support the Loader argument
+    # So try the new way first, then catch to the old way
+    try:
+        dict = yaml.load(fh, Loader=yaml.FullLoader)
+    except AttributeError:
+        dict = yaml.load(fh)
     fh.close()
 
     return dict
@@ -339,10 +346,16 @@ if (uvm):
                     except KeyError:
                         num = 1
 
-                    try:                    
-                        iss = key['iss']
-                    except KeyError:
-                        iss = 1
+                    # The iss command-line switch takes precedence,
+                    # Otherwise use what is in the regression yaml if defined
+                    # Otherwise set to 1                    
+                    if args.iss != None:
+                        iss = int(args.iss)
+                    else:
+                        try:                    
+                            iss = key['iss']
+                        except KeyError:
+                            iss = 1
 
                     for n in range(num):                    
                         # Add directory

--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -80,6 +80,9 @@ def is_test_indexed(project, name):
     for t in test_dirs:
         test_yaml = os.path.join(t, name, 'test.yaml')
         if os.path.exists(test_yaml):
+            # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
+            # Older PyYAMLs will not support the Loader argument
+            # So try the new way first, then catch to the old way
             try:
                 test_spec = yaml.load(open(test_yaml), Loader=yaml.FullLoader)
             except AttributeError:
@@ -109,6 +112,9 @@ def read_file(args, file):
     full_regress_file = os.path.join(get_regress_path(args.project), file)
     stream = open(full_regress_file, 'r')
     logger.info('Reading regression: {}'.format(full_regress_file))    
+    # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
+    # Older PyYAMLs will not support the Loader argument
+    # So try the new way first, then catch to the old way
     try:
         testlist = yaml.load(stream, Loader=yaml.FullLoader)
     except AttributeError:

--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -80,7 +80,11 @@ def is_test_indexed(project, name):
     for t in test_dirs:
         test_yaml = os.path.join(t, name, 'test.yaml')
         if os.path.exists(test_yaml):
-            test_spec = yaml.load(open(test_yaml))            
+            try:
+                test_spec = yaml.load(open(test_yaml), Loader=yaml.FullLoader)
+            except AttributeError:
+                test_spec = yaml.load(open(test_yaml))
+
             if '<RUN_INDEX>' in test_spec['name']:
                 return True
             else:
@@ -104,8 +108,11 @@ def read_file(args, file):
     '''Read a YAML definition filelist'''
     full_regress_file = os.path.join(get_regress_path(args.project), file)
     stream = open(full_regress_file, 'r')
-    logger.info('Reading regression: {}'.format(full_regress_file))
-    testlist = yaml.load(stream)
+    logger.info('Reading regression: {}'.format(full_regress_file))    
+    try:
+        testlist = yaml.load(stream, Loader=yaml.FullLoader)
+    except AttributeError:
+        testlist = yaml.load(stream)
     stream.close()
     pp = pprint.PrettyPrinter()
     logger.debug('Read YAML:')
@@ -152,6 +159,8 @@ def read_file(args, file):
             test.set_cov()
         if args.make:
             test.sub_make(args.make)
+        if args.iss != None:            
+            test.iss = args.iss
 
         # Determine if a test is valid, skip for compliance tests
         # Since it is not possible to determine apriori if a compliance test is valid
@@ -185,6 +194,7 @@ parser.add_argument('-d', '--debug', help='Emit debug messages from logger', act
 parser.add_argument('-s', '--simulator', help='Select simulator', choices=VALID_SIMULATORS, default=DEFAULT_SIMULATOR)
 parser.add_argument('-c', '--cov', help='Enable coverage', action='store_true')
 parser.add_argument('--cfg', default=DEFAULT_CFG, help='Test configuration to test')
+parser.add_argument('--iss', default=None, help='Force USE_ISS flag to each test run')
 parser.add_argument('-m', '--metrics', help='Select Metrics waves output', action='store_true')
 parser.add_argument('-n', '--num', help='Force number of iterations for tests with multiple iteration')
 parser.add_argument('--lsf', help='If applicable for output format, set LSF args to dispatch jobs')

--- a/bin/templates/metrics.json.j2
+++ b/bin/templates/metrics.json.j2
@@ -24,8 +24,8 @@
 
 {% import 'regress_macros.j2' as regress_macros %}
 
-{% set common_dsim_make_vars = "CV_CORE=" + project + " DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results" %}
-{% set common_dsim_make_vars_waves = "CV_CORE=" + project + " DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1" %}
+{% set common_dsim_make_vars = "CV_CORE=" + project + " COMP=0 DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results" %}
+{% set common_dsim_make_vars_waves = "CV_CORE=" + project + " COMP=0 DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1" %}
 [
 {% for r in regressions %}
 {% for t in r.tests.values()|sort(attribute='name') %}

--- a/bin/templates/regress_macros.j2
+++ b/bin/templates/regress_macros.j2
@@ -1,3 +1,3 @@
 {%- macro yesorno(val) -%}
-{%- if val -%}YES{%- else -%}NO{%- endif -%}
+{%- if val == '0' -%}NO{%- elif val == '1' -%}YES{%- else -%}{{val}}{%- endif -%}
 {%- endmacro -%}

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -62,7 +62,7 @@ incr_test_counts () {
 
 {% for b in unique_builds.values() %}
 # Build:{{b.name}} {{b.description}}
-{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + cfg + ' SIMULATOR=' + b.simulator + ' USE_ISS=' + regress_macros.yesorno(b.iss) + ' COV=' + regress_macros.yesorno(b.cov) + makeargs %}
+{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + cfg + ' SIMULATOR=' + b.simulator + ' COV=' + regress_macros.yesorno(b.cov) + makeargs %}
 echo "{{session}}: Running build: [cd {{b.abs_dir}} && {{cmd}}]"
 pushd {{b.abs_dir}} > /dev/null
 {{cmd}}

--- a/bin/templates/regress_vsif.j2
+++ b/bin/templates/regress_vsif.j2
@@ -39,7 +39,7 @@ group cv32e40p {
 {% endif %}
 {% for b in unique_builds.values() %}
     // Build:{{b.name}} {{b.description}}    
-    pre_group_script: 'cd {{b.abs_dir}} && {{b.cmd}} CV_CORE={{project}} CFG={{cfg}} CV_SIM_PREFIX= SIMULATOR={{b.simulator}} USE_ISS={{b.iss}} COV={{regress_macros.yesorno(b.cov)}} {{makeargs}}';
+    pre_group_script: 'cd {{b.abs_dir}} && {{b.cmd}} CV_CORE={{project}} CFG={{cfg}} CV_SIM_PREFIX= SIMULATOR={{b.simulator}} COV={{regress_macros.yesorno(b.cov)}} {{makeargs}}';
 
 {% endfor %}
 {% for r in regressions %}

--- a/bin/yaml2make
+++ b/bin/yaml2make
@@ -85,7 +85,13 @@ def read_file(test, type, run_index):
 
     stream = open(matches[0], 'r')
     logger.debug('Reading test specification: {}'.format(matches[0]))
-    test_spec = yaml.load(stream)
+    # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
+    # Older PyYAMLs will not support the Loader argument
+    # So try the new way first, then catch to the old way
+    try:
+        test_spec = yaml.load(stream, Loader=yaml.FullLoader)
+    except AttributeError:
+        test_spec = yaml.load(stream)
     stream.close()
     test_spec['test_dir'] = os.path.dirname(matches[0])
 
@@ -123,12 +129,12 @@ def emit_make(test_spec, prefix):
 # Command-line arguments
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-t', '--test', help='Test to look for')
-parser.add_argument('-d', '--debug', action='store_true', help='Display debug messages')
-parser.add_argument('--yaml', choices=VALID_YAMLS, help='Name of YAML test specification to find')
-parser.add_argument('--prefix', help='Prefix to add to make variables generated')
+parser.add_argument('-t', '--test', help='Required: Test to look for')
+parser.add_argument('--yaml', choices=VALID_YAMLS, help='Required: Name of YAML test specification to find')
 parser.add_argument('--core', default=DEFAULT_CORE, help='Default core to test')
+parser.add_argument('--prefix', help='Prefix to add to make variables generated')
 parser.add_argument('--run-index', default='0', help='Add a run index to append to test specifications')
+parser.add_argument('-d', '--debug', action='store_true', help='Display debug messages')
 args = parser.parse_args()
 
 if args.debug:

--- a/cv32e40x/regress/cv32e40x_interrupt.yaml
+++ b/cv32e40x/regress/cv32e40x_interrupt.yaml
@@ -15,7 +15,6 @@ builds:
     # required: the make command to create the build
     cmd: make comp
     dir: cv32e40x/sim/uvmt    
-    iss: 1
 
 # List of tests
 tests:

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -17,7 +17,7 @@ export SHELL = /bin/bash
 CV_CORE_REPO   ?= https://github.com/strichmo/cv32e40x.git
 CV_CORE_BRANCH ?= master
 #CV_CORE_HASH   ?= 79aa234b4ee7a67d07c8ee0cd27d81a7db89bb2f
-CV_CORE_HASH   ?= 9a53e533c3e1bf38c470f5784facc1e1abd179c7
+CV_CORE_HASH   ?= 9b0d8ce382fa072c423b3caa6d348c0bd537ea33
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -13,9 +13,11 @@
 
 export SHELL = /bin/bash
 
-CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
+#CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
+CV_CORE_REPO   ?= https://github.com/strichmo/cv32e40x.git
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 79aa234b4ee7a67d07c8ee0cd27d81a7db89bb2f
+#CV_CORE_HASH   ?= 79aa234b4ee7a67d07c8ee0cd27d81a7db89bb2f
+CV_CORE_HASH   ?= 9a53e533c3e1bf38c470f5784facc1e1abd179c7
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
@@ -26,3 +28,4 @@ COMPLIANCE_REPO   ?= https://github.com/strichmo/riscv-arch-test.git
 COMPLIANCE_BRANCH ?= strichmo/pr/cv32e40x_initial_old_compliance
 # 2020-08-19
 COMPLIANCE_HASH   ?= cf29051b177ba61b8c39de91c33d20d202697423
+

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -13,11 +13,9 @@
 
 export SHELL = /bin/bash
 
-#CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
-CV_CORE_REPO   ?= https://github.com/strichmo/cv32e40x.git
+CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-#CV_CORE_HASH   ?= 79aa234b4ee7a67d07c8ee0cd27d81a7db89bb2f
-CV_CORE_HASH   ?= 9b0d8ce382fa072c423b3caa6d348c0bd537ea33
+CV_CORE_HASH   ?= b62250f81acc8505556b43e341c19668b4f8a5d8
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -122,16 +122,17 @@ module uvmt_cv32e40x_dut_wrap #(// DUT (riscv_core) parameters.
                  fill_cnt++;
                 rnd_byte = $random();
                 uvmt_cv32e40x_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
-                `ifdef ISS
-                uvmt_cv32e40x_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
-                `endif
+                if ($test$plusargs("USE_ISS")) begin
+                  uvmt_cv32e40x_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                end                
              end
           end
-          `ifdef ISS
+          if ($test$plusargs("USE_ISS")) begin
              `uvm_info("DUT_WRAP", $sformatf("Filled 0d%0d RTL and ISS memory bytes with random values", fill_cnt), UVM_LOW)
-          `else
+          end
+          else begin
              `uvm_info("DUT_WRAP", $sformatf("Filled 0d%0d RTL memory bytes with random values", fill_cnt), UVM_LOW)
-          `endif
+          end
         end
         else begin
           `uvm_error("DUT_WRAP", "No firmware specified!")

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_step_compare.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_step_compare.sv
@@ -161,7 +161,7 @@ module uvmt_cv32e40x_step_compare
       end
 
       // Compare CSR's
-      `ifdef ISS
+      if (use_iss) begin
         foreach(`CV32E40X_RM_RVVI_STATE.csr[index]) begin
            step_compare_if.num_csr_checks++;
            ignore = 0;
@@ -228,9 +228,8 @@ module uvmt_cv32e40x_step_compare
            if (!ignore)
              check_32bit(.compared(index), .expected(`CV32E40X_RM_RVVI_STATE.csr[index]), .actual(csr_val));
 
-        end // foreach (ovp.cpu.csr[index])
-        
-      `endif      
+        end // foreach (ovp.cpu.csr[index])        
+      end // if (use_iss)
     endfunction // compare
     
     // RTL->RM CSR : mcycle, minstret, mcycleh, minstreth

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_step_compare.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_step_compare.sv
@@ -73,6 +73,7 @@ module uvmt_cv32e40x_step_compare
    bit  miscompare;
    bit  is_stall_sim = 0;
    bit  ignore_dpc_check = 0;
+   bit  use_iss = 0;
 
   // FIXME:strichmo:when running random interrupts and random debug requests it is possible to enter debug mode 
   // (while also acking an interrupt) when the debug program counter may or may not yet be pointing to the interrupt
@@ -88,6 +89,11 @@ module uvmt_cv32e40x_step_compare
     end
   end
 
+  initial begin
+    if ($test$plusargs("USE_ISS"))
+      use_iss = 1;
+  end
+  
   // Set the is_stall_sim flag if random stalls are enabled
   // This will turn off some unpredictable checks:
   // - CSR wire checks
@@ -270,86 +276,88 @@ module uvmt_cv32e40x_step_compare
    initial state <= IDLE; // cause an event for always @*
    
    always @(*) begin
-      case (state)
-        IDLE: begin
-            state <= RTL_STEP;
-        end
-        
-        RTL_STEP: begin
-            clknrst_if.start_clk();
-            fork
-                begin
-                    @step_compare_if.riscv_retire;
-                    clknrst_if.stop_clk();
-                    state <= RTL_VALID;
-                end
-                begin
-                    @step_compare_if.riscv_trap;
-                    state <= RTL_TRAP;
-                end
-                begin
-                    @step_compare_if.riscv_halt;
-                    state <= RTL_HALT;
-                end
-            join_any
-            disable fork;
-        end
+      if (use_iss) begin
+        case (state)
+          IDLE: begin
+              state <= RTL_STEP;
+          end
+          
+          RTL_STEP: begin
+              clknrst_if.start_clk();
+              fork
+                  begin
+                      @step_compare_if.riscv_retire;
+                      clknrst_if.stop_clk();
+                      state <= RTL_VALID;
+                  end
+                  begin
+                      @step_compare_if.riscv_trap;
+                      state <= RTL_TRAP;
+                  end
+                  begin
+                      @step_compare_if.riscv_halt;
+                      state <= RTL_HALT;
+                  end
+              join_any
+              disable fork;
+          end
 
-        RTL_VALID: begin
-            state <= RM_STEP;
-        end
-        
-        RTL_TRAP: begin
-            //state <= RM_STEP; // TODO: RTL/RVVI needs additional work
-            state <= RTL_STEP;
-        end
-        
-        RTL_HALT: begin
-            state <= RTL_STEP;
-        end
+          RTL_VALID: begin
+              state <= RM_STEP;
+          end
+          
+          RTL_TRAP: begin
+              //state <= RM_STEP; // TODO: RTL/RVVI needs additional work
+              state <= RTL_STEP;
+          end
+          
+          RTL_HALT: begin
+              state <= RTL_STEP;
+          end
 
-        RM_STEP: begin
-            pushRTL2RM("ret_rtl");
-            `CV32E40X_RM_RVVI_CONTROL.stepi();
-            fork
-                begin
-                    @step_compare_if.ovp_cpu_valid;
-                    ->`CV32E40X_TRACER.ovp_retire;
-                    state <= RM_VALID;
-                end
-                begin
-                    @step_compare_if.ovp_cpu_trap;
-                    state <= RM_TRAP;
-                end
-                begin
-                    @step_compare_if.ovp_cpu_halt;
-                    state <= RM_HALT;
-                end
-            join_any
-            disable fork;
-        end
+          RM_STEP: begin
+              pushRTL2RM("ret_rtl");
+              `CV32E40X_RM_RVVI_CONTROL.stepi();
+              fork
+                  begin
+                      @step_compare_if.ovp_cpu_valid;
+                      ->`CV32E40X_TRACER.ovp_retire;
+                      state <= RM_VALID;
+                  end
+                  begin
+                      @step_compare_if.ovp_cpu_trap;
+                      state <= RM_TRAP;
+                  end
+                  begin
+                      @step_compare_if.ovp_cpu_halt;
+                      state <= RM_HALT;
+                  end
+              join_any
+              disable fork;
+          end
 
-        RM_VALID: begin
-            state <= CMP;
-        end
-        
-        RM_TRAP: begin
-            //state <= CMP; // TODO: needs enabling after RTL/RVVI fix
-            state <= RM_STEP;
-        end
-        
-        RM_HALT: begin
-            state <= RM_STEP;
-        end
+          RM_VALID: begin
+              state <= CMP;
+          end
+          
+          RM_TRAP: begin
+              //state <= CMP; // TODO: needs enabling after RTL/RVVI fix
+              state <= RM_STEP;
+          end
+          
+          RM_HALT: begin
+              state <= RM_STEP;
+          end
 
-        CMP: begin 
-             compare();
-             ->ev_compare;
-             instruction_count += 1;           
-             //state <= RTL_STEP;
-             state <= IDLE;
-        end
-      endcase // case (state)
+          CMP: begin 
+              compare();
+              ->ev_compare;
+              instruction_count += 1;           
+              //state <= RTL_STEP;
+              state <= IDLE;
+          end
+        endcase // case (state)
+      end
    end
 
    always @(instruction_count) begin

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -252,10 +252,9 @@ bind cv32e40x_wrapper
 
     uvmt_cv32e40x_debug_assert u_debug_assert(.cov_assert_if(debug_cov_assert_if));
 
-  /**
-   * ISS WRAPPER instance:
-   */
-   `ifdef ISS
+    /**
+    * ISS WRAPPER instance:
+    */   
       uvmt_cv32e40x_iss_wrap  #(
                                 .ID (0)
                                )
@@ -473,7 +472,6 @@ bind cv32e40x_wrapper
             endcase
         end
       end
-    `endif // ISS
 
    /**
     * Test bench entry point.

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
@@ -177,16 +177,14 @@ interface uvmt_cv32e40x_core_cntrl_if (
     hart_id           = 32'h0000_0000;
 
     // If a override is provided via plusarg then set bootstrap pins and adjust ISS model
-    if ($value$plusargs("mtvec_addr=0x%x", mtvec_addr)) begin
+    if ($value$plusargs("mtvec_addr=0x%x", mtvec_addr) && $test$plusargs("USE_ISS")) begin
       string override;
       int fh;
 
-`ifdef ISS
       override = $sformatf("--override root/cpu/mtvec=0x%08x", {mtvec_addr[31:8], 8'h01});
       fh = $fopen("ovpsim.ic", "a");      
       $fwrite(fh, " %s\n", override);
-      $fclose(fh);
-`endif
+      $fclose(fh);      
     end
 
     qsc_stat_str =                $sformatf("\tpulp_clock_en     = %0d\n", pulp_clock_en);

--- a/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
+++ b/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
@@ -332,12 +332,10 @@ function void uvmt_cv32e40x_base_test_c::phase_ended(uvm_phase phase);
      // then mark test as failed
      if (!tp && !evalid && !tf) `uvm_error("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to flag test passed and failed to signal exit value.")   
 
-     // Report on number of ISS step and compare checks if the ISS is used
-     `ifdef ISS      
+     // Report on number of ISS step and compare checks if the ISS is used     
      if ($test$plusargs("USE_ISS")) begin
        step_compare_vif.report_step_compare(); 
-     end
-     `endif
+     end     
 
      print_banner("test finished");
    end

--- a/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
+++ b/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
@@ -333,7 +333,11 @@ function void uvmt_cv32e40x_base_test_c::phase_ended(uvm_phase phase);
      if (!tp && !evalid && !tf) `uvm_error("END_OF_TEST", "DUT WRAPPER virtual peripheral failed to flag test passed and failed to signal exit value.")   
 
      // Report on number of ISS step and compare checks if the ISS is used
-     `ifdef ISS step_compare_vif.report_step_compare(); `endif
+     `ifdef ISS      
+     if ($test$plusargs("USE_ISS")) begin
+       step_compare_vif.report_step_compare(); 
+     end
+     `endif
 
      print_banner("test finished");
    end

--- a/cv32e40x/vendor_lib/imperas/riscv_CV32E40X_OVPsim/sv/riscv_CV32E40P.sv
+++ b/cv32e40x/vendor_lib/imperas/riscv_CV32E40X_OVPsim/sv/riscv_CV32E40P.sv
@@ -569,12 +569,14 @@ module CPU
     endfunction
     
     initial begin
-        ovpcfg_load();
-        elf_load();
-        ovpEntry(ovpcfg, elf_file);
-        `ifndef UVM
-        $finish;
-        `endif
+        if ($test$plusargs("USE_ISS")) begin            
+            ovpcfg_load();
+            elf_load();
+            ovpEntry(ovpcfg, elf_file);
+            `ifndef UVM
+            $finish;
+            `endif
+        end
     end
     
     `ifndef UVM

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_mon.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_mon.sv
@@ -137,23 +137,23 @@ task uvma_interrupt_mon_c::monitor_irq();
 endtask : monitor_irq
 
 task uvma_interrupt_mon_c::monitor_irq_iss();
-`ifdef ISS
-   while(1) begin
-      @(cntxt.vif.mon_cb);
+   if ($test$plusargs("USE_ISS")) begin   
+      while(1) begin
+         @(cntxt.vif.mon_cb);
 
-      if (cntxt.vif.mon_cb.irq_ack) begin         
-         uvma_interrupt_mon_trn_c mon_trn = uvma_interrupt_mon_trn_c::type_id::create("mon_irq_trn");
-         mon_trn.action = UVMA_INTERRUPT_MON_ACTION_IRQ;
-         mon_trn.id = cntxt.vif.mon_cb.irq_id;
+         if (cntxt.vif.mon_cb.irq_ack) begin         
+            uvma_interrupt_mon_trn_c mon_trn = uvma_interrupt_mon_trn_c::type_id::create("mon_irq_trn");
+            mon_trn.action = UVMA_INTERRUPT_MON_ACTION_IRQ;
+            mon_trn.id = cntxt.vif.mon_cb.irq_id;
 
-         // Wait for the ISS to enter
-         wait (cntxt.vif.deferint == 1'b0);
-         wait (cntxt.vif.ovp_cpu_state_stepi == 1'b1);
+            // Wait for the ISS to enter
+            wait (cntxt.vif.deferint == 1'b0);
+            wait (cntxt.vif.ovp_cpu_state_stepi == 1'b1);
 
-         ap_iss.write(mon_trn);
+            ap_iss.write(mon_trn);
+         end
       end
    end
-`endif
 endtask : monitor_irq_iss
 
 

--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -36,12 +36,10 @@ DSIM_CODE_COV_SCOPE    ?= $(MAKE_PATH)/../tools/dsim/ccov_scopes.txt
 DSIM_USE_ISS           ?= YES
 
 DSIM_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
+DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
+DSIM_USER_COMPILE_ARGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
 ifeq ($(USE_ISS),YES)
-    DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
-    DSIM_USER_COMPILE_ARGS += "+define+ISS+$(CV_CORE_UC)_TRACE_EXECUTION"
-	DSIM_RUN_FLAGS         += +USE_ISS
-#    DSIM_USER_COMPILE_ARGS += "+define+CV32E40P_ASSERT_ON+ISS+CV32E40P_TRACE_EXECUTION"
-#    DSIM_RUN_FLAGS         += +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
+	DSIM_RUN_FLAGS     += +USE_ISS
 endif
 
 # Seed management for constrained-random sims. This is an intentional repeat

--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -39,6 +39,7 @@ DSIM_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 ifeq ($(USE_ISS),YES)
     DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
     DSIM_USER_COMPILE_ARGS += "+define+ISS+$(CV_CORE_UC)_TRACE_EXECUTION"
+	DSIM_RUN_FLAGS         += +USE_ISS
 #    DSIM_USER_COMPILE_ARGS += "+define+CV32E40P_ASSERT_ON+ISS+CV32E40P_TRACE_EXECUTION"
 #    DSIM_RUN_FLAGS         += +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
 endif

--- a/mk/uvmt/riviera.mk
+++ b/mk/uvmt/riviera.mk
@@ -75,11 +75,9 @@ VLOG_DEBUG_FLAGS ?= -dbg
 VLOG_FLAGS += $(DPILIB_VLOG_OPT)
 
 # Add the ISS to compilation
-ifeq ($(call IS_YES,$(USE_ISS)),YES)
 VLOG_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
-VLOG_FLAGS += "+define+ISS+$(CV_CORE_UC)_TRACE_EXECUTION"
+VLOG_FLAGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
 VLOG_FLAGS += -dpilib
-endif
 
 ###############################################################################
 # VSIM (Simulaion)

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -130,9 +130,9 @@ endif
 ################################################################################
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
+VCS_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
+VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
-    VCS_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
-    VCS_USER_COMPILE_ARGS += "+define+ISS +define+$(CV_CORE_UC)_TRACE_EXECUTION"
     VCS_PLUSARGS +="+USE_ISS"
 endif
 

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -88,10 +88,8 @@ VLOG_FILE_LIST = -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 VLOG_FLAGS += $(DPILIB_VLOG_OPT)
 
 # Add the ISS to compilation
-ifeq ($(call IS_YES,$(USE_ISS)),YES)
 VLOG_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
-VLOG_FLAGS += "+define+ISS+$(CV_CORE_UC)_TRACE_EXECUTION"
-endif
+VLOG_FLAGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
 
 ###############################################################################
 # VOPT (Optimization)

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -145,13 +145,10 @@ endif
 XRUN_UVM_MACROS_INC_FILE = $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC)_uvm_macros_inc.sv
 
 XRUN_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
+XRUN_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
+XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
-    XRUN_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
-    XRUN_USER_COMPILE_ARGS += +define+ISS+$(CV_CORE_UC)_TRACE_EXECUTION
     XRUN_PLUSARGS +="+USE_ISS"
-#     XRUN_PLUSARGS += +USE_ISS +ovpcfg="--controlfile $(OVP_CTRL_FILE)"
-else
-	XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 endif
 
 # Simulate using latest elab


### PR DESCRIPTION
Remove all compile-time defines for Imperas ISS (USE_ISS)
Instead create run-time option (+USE_ISS).
Requires a PR to E40X to make tracer handoff with OVP ISS also run-time selectable.  Note that this PR points to a local fork which does this.  I will PR that update as well when we review/approve this PR.
Note that due to design of step-and-compare testcases will not repeat between running with and without ISS.

@MikeOpenHWGroup Will discuss this tomorrow morning.
