### PR TITLE
improve error log reporting when embench fails

### DIFF
--- a/cv32e40x/tests/.gitignore
+++ b/cv32e40x/tests/.gitignore
@@ -14,3 +14,4 @@ csrc
 inter.vpd
 ucli.key
 vc_hdrs.h
+emb_*/

--- a/cv32e40x/vendor_lib/.gitignore
+++ b/cv32e40x/vendor_lib/.gitignore
@@ -1,0 +1,2 @@
+embench/
+

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -287,13 +287,19 @@ sanity: hello-world
 ###############################################################################
 # Read YAML test specifications
 
+ifeq ($(VERBOSE),1)
+YAML2MAKE_DEBUG = --debug
+else
+YAML2MAKE_DEBUG =
+endif
+
 # If the gen_corev-dv target is defined then read in a test specification file
 YAML2MAKE = $(CORE_V_VERIF)/bin/yaml2make
 ifneq ($(filter gen_corev-dv,$(MAKECMDGOALS)),)
 ifeq ($(TEST),)
 $(error ERROR must specify a TEST variable with gen_corev-dv target)
 endif
-GEN_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=corev-dv.yaml --debug --prefix=GEN --core=$(CV_CORE))
+GEN_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=corev-dv.yaml $(YAML2MAKE_DEBUG) --prefix=GEN --core=$(CV_CORE))
 ifeq ($(GEN_FLAGS_MAKE),)
 $(error ERROR Could not find corev-dv.yaml for test: $(TEST))
 endif
@@ -306,7 +312,7 @@ ifneq ($(filter $(TEST_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifeq ($(TEST),)
 $(error ERROR must specify a TEST variable)
 endif
-TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml --debug --run-index=$(RUN_INDEX) --prefix=TEST --core=$(CV_CORE))
+TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(RUN_INDEX) --prefix=TEST --core=$(CV_CORE))
 ifeq ($(TEST_FLAGS_MAKE),)
 $(error ERROR Could not find test.yaml for test: $(TEST))
 endif
@@ -319,7 +325,7 @@ CFGYAML2MAKE = $(CORE_V_VERIF)/bin/cfgyaml2make
 CFG_YAML_PARSE_TARGETS=comp test
 ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(CFG),)
-CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml --debug --prefix=CFG --core=$(CV_CORE))
+CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml $(YAML2MAKE_DEBUG) --prefix=CFG --core=$(CV_CORE))
 ifeq ($(CFG_FLAGS_MAKE),)
 $(error ERROR Error finding or parsing configuration: $(CFG).yaml)
 endif

--- a/mk/uvmt/unsim.mk
+++ b/mk/uvmt/unsim.mk
@@ -24,6 +24,8 @@ no_rule:
 	@echo 'no SIMULATOR and rule/target specified.'
 	@echo 'Usage: make SIMULATOR=<simulator> <target>'
 	@echo 'e.g: make SIMULATOR=xrun hello-world'
+	@exit 1
 
 %::
 	@echo '$(SIMULATOR): unknown simulator'
+	@exit 1


### PR DESCRIPTION
No real change to embench flow except to emit log location so user can debug failures in benchmarks
add gitignores for embench in e40x
reduce default verbosity of yaml2make to clean up log messages (re-enable with VERBOSE=1 to make)
