### PR TITLE
Bugfix uvma_isacov GUI=1

### DIFF
--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -27,7 +27,9 @@ class uvma_isacov_mon_c extends uvm_monitor;
   extern function new(string name = "uvma_isacov_mon", uvm_component parent = null);
   extern virtual function void build_phase(uvm_phase phase);
   extern virtual task run_phase(uvm_phase phase);
+  `ifdef DPI_DASM
   extern task sample_instr();
+  `endif
 
 endclass : uvma_isacov_mon_c
 
@@ -78,6 +80,7 @@ task uvma_isacov_mon_c::run_phase(uvm_phase phase);
 endtask : run_phase
 
 
+`ifdef DPI_DASM
 task uvma_isacov_mon_c::sample_instr();
 
   uvma_isacov_mon_trn_c mon_trn;
@@ -124,3 +127,4 @@ task uvma_isacov_mon_c::sample_instr();
   ap.write(mon_trn);
 
 endtask : sample_instr
+`endif


### PR DESCRIPTION
The [PR about integrating a disassembler](https://github.com/openhwgroup/core-v-verif/pull/554) broke runs with GUI=1.
Sorry I was not aware of this until I tried GUI=1 just now.

Explanation:
The use of DPI includes a shared object file (.so).
By default this .so is not built and included in simulations.
It is ok to run without the .so and still have references to it in the code, as long as one don't attempt to call it.
Hence, I used ifdef to make such usage optional.
But running in gui (xrun) treats this differently and complained about the missing symbol linkage even when it would not get called.

Solution:
Ifdef the entire function that refers to the dpi function.
(As opposed to ifdef on only _the call to the function_ that refers to the dpi function).