### PR TITLE
mm_ram Cycle counter update

### DIFF
--- a/cv32e40x/tb/core/mm_ram.sv
+++ b/cv32e40x/tb/core/mm_ram.sv
@@ -75,18 +75,19 @@ module mm_ram
 
     localparam int                        RND_IRQ_ID     = 31;    
 
-    localparam int                        MMADDR_PRINT      = 32'h1000_0000;
-    localparam int                        MMADDR_TESTSTATUS = 32'h2000_0000;
-    localparam int                        MMADDR_EXIT       = 32'h2000_0004;
-    localparam int                        MMADDR_SIGBEGIN   = 32'h2000_0008;
-    localparam int                        MMADDR_SIGEND     = 32'h2000_000C;
-    localparam int                        MMADDR_SIGDUMP    = 32'h2000_0010;
-    localparam int                        MMADDR_TIMERREG   = 32'h1500_0000;
-    localparam int                        MMADDR_TIMERVAL   = 32'h1500_0004;
-    localparam int                        MMADDR_DBG        = 32'h1500_0008;
-    localparam int                        MMADDR_RNDSTALL   = 16'h1600;
-    localparam int                        MMADDR_RNDNUM     = 32'h1500_1000;
-    localparam int                        MMADDR_TICKS      = 32'h1500_1004;
+    localparam int                        MMADDR_PRINT          = 32'h1000_0000;
+    localparam int                        MMADDR_TESTSTATUS     = 32'h2000_0000;
+    localparam int                        MMADDR_EXIT           = 32'h2000_0004;
+    localparam int                        MMADDR_SIGBEGIN       = 32'h2000_0008;
+    localparam int                        MMADDR_SIGEND         = 32'h2000_000C;
+    localparam int                        MMADDR_SIGDUMP        = 32'h2000_0010;
+    localparam int                        MMADDR_TIMERREG       = 32'h1500_0000;
+    localparam int                        MMADDR_TIMERVAL       = 32'h1500_0004;
+    localparam int                        MMADDR_DBG            = 32'h1500_0008;
+    localparam int                        MMADDR_RNDSTALL       = 16'h1600;
+    localparam int                        MMADDR_RNDNUM         = 32'h1500_1000;
+    localparam int                        MMADDR_TICKS          = 32'h1500_1004;
+    localparam int                        MMADDR_TICKS_PRINT    = 32'h1500_1008;
 
     // UVM info tags
     localparam string                     MM_RAM_TAG = "MM_RAM";
@@ -151,6 +152,7 @@ module mm_ram
     logic [31:0]                   cycle_count_q;
     logic                          cycle_count_overflow_q;
     logic                          cycle_count_clear;
+    logic                          cycle_count_print;
 
     // debugger control signals
     logic [31:0]                   debugger_wdata;
@@ -283,6 +285,7 @@ module mm_ram
         rnd_stall_we        = '0;
         rnd_num_req         = '0;
         cycle_count_clear   = '0;
+        cycle_count_print   = '0;
         select_rdata_d      = RAM;
         transaction         = T_PER;
 
@@ -395,6 +398,9 @@ module mm_ram
                     rnd_stall_we    = data_we_i;
                 end else if (data_addr_i == MMADDR_TICKS) begin
                     cycle_count_clear = 1;
+                end else if (data_addr_i == MMADDR_TICKS_PRINT) begin
+                    cycle_count_print = 1;
+                    //`uvm_info(MM_RAM_TAG, $sformatf("Cycle count is %0d", cycle_count_q), UVM_LOW);
                 end else begin
                     // out of bounds write
                 end
@@ -457,6 +463,7 @@ module mm_ram
          || data_addr_i == MMADDR_SIGEND
          || data_addr_i == MMADDR_SIGDUMP
          || data_addr_i == MMADDR_TICKS
+         || data_addr_i == MMADDR_TICKS_PRINT
          || data_addr_i[31:16] == MMADDR_RNDSTALL))
            else `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds write to %08x with %08x", data_addr_i, data_wdata_i))
 `endif
@@ -541,6 +548,15 @@ module mm_ram
             cycle_count_q <= '0;
             cycle_count_overflow_q <= 0;
         end else begin
+
+            if (cycle_count_print) begin
+`ifndef VERILATOR
+                `uvm_info(MM_RAM_TAG, $sformatf("Cycle count is %0d", cycle_count_q), UVM_LOW);
+`else
+                $display("MM_RAM: Cycle count is %0d", cycle_count_q);
+`endif
+            end
+
             if (cycle_count_clear) begin
                 cycle_count_q <= '0;
             end else begin

--- a/cv32e40x/tests/programs/custom/dhrystone/dhrystone.c
+++ b/cv32e40x/tests/programs/custom/dhrystone/dhrystone.c
@@ -367,6 +367,7 @@
 
 // mm_ram cycle counter address 
 #define TICKS_ADDR (*((volatile uint32_t*)0x15001004))
+#define TICKS_PRINT_ADDR (*((volatile uint32_t*)0x15001008))
 
 #define Mic_secs_Per_Second     1000000.0
                 /* Berkeley UNIX C returns process times in seconds/HZ */
@@ -696,8 +697,8 @@ int main (int argc, char *argv[])
 
   } /* loop "for Run_Index" */
 
-  //record cycle counter
-  uint32_t cycle_cnt = TICKS_ADDR;
+  //print cycle counter
+  TICKS_PRINT_ADDR = 0;
 
   printf ("Execution ends%c", '\n');
   printf (" %c", '\n');
@@ -751,7 +752,6 @@ int main (int argc, char *argv[])
   printf ("Str_2_Loc:           %s\n", Str_2_Loc);
   printf ("        should be:   DHRYSTONE PROGRAM, 2'ND STRING%c", '\n');
 
-  printf ("Cycle count is %d \n", cycle_cnt);
 
 
 


### PR DESCRIPTION
I've added a print feature to the cycle counter in mm_ram that allows a test program to initiate a print of the cycle counter without having to know the value. The motivation for this is to allow benchmarks like Dhrystone to run with ISS, as a read of the counter causes a step-and-compare error today.