### PR TITLE
Fix REPO, BRANCH and HASH variables

### DIFF
--- a/bin/ci_check
+++ b/bin/ci_check
@@ -288,11 +288,11 @@ if (uvm):
                 if (build_cmd != ''):
                     build_cmd = build_cmd.replace('dsim', svtool)
                     if (args.repo):
-                        build_cmd = build_cmd + ' {}_REPO='.format(args.core.upper()) + args.repo
+                        build_cmd = build_cmd + ' CV_CORE_REPO=' + args.repo
                     if (args.branch):
-                        build_cmd = build_cmd + ' {}_BRANCH='.format(args.core.upper()) + args.branch
+                        build_cmd = build_cmd + ' CV_CORE_BRANCH=' + args.branch
                     if (args.hash):
-                        build_cmd = build_cmd + ' {}_HASH='.format(args.core.upper()) + args.hash
+                        build_cmd = build_cmd + ' CV_CORE_HASH=' + args.hash
                     if (prcmd or debug):
                         print(build_cmd)
                     else:


### PR DESCRIPTION
`ci_check` incorrectly builds the Makefile variables for cloning the RTL repo in the case where the user wants to override what's in `/<core>/sim/Common.mk`.  I stumbled across this one while testing [576](https://github.com/openhwgroup/core-v-verif/pull/576).  The fix is trivial.

This is something we'll want to propagate the dev branch for all cores.  I'm deliberately pushing this onto the master, as it gives us an opportunity to see how that will work.

Signed-off-by: MikeOpenHWGroup <mike@openhwgroup.org>