### PR TITLE
add in support for IO memory updating the RM memeory view

### DIFF
--- a/cv32e40p/tb/core/mm_ram.sv
+++ b/cv32e40p/tb/core/mm_ram.sv
@@ -471,13 +471,17 @@ module mm_ram
             data_rdata_mux = core_data_rdata;
         end else if(select_rdata_q == RND_STALL) begin
             data_rdata_mux = rnd_stall_rdata;
+            uvmt_cv32e40p_tb.iss_wrap.ram.RND_STALL = data_rdata_mux;
 `ifndef VERILATOR
             `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i));
 `endif
         end else if (select_rdata_q == RND_NUM) begin
             data_rdata_mux = rnd_num;
+            uvmt_cv32e40p_tb.iss_wrap.ram.RND_NUM = data_rdata_mux;
+
         end else if (select_rdata_q == TICKS) begin
             data_rdata_mux = cycle_count_q;
+            uvmt_cv32e40p_tb.iss_wrap.ram.TICKS = data_rdata_mux;
 `ifndef VERILATOR
             if (cycle_count_overflow_q) begin
                 `uvm_fatal(MM_RAM_TAG, "cycle counter read after overflow");

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
@@ -234,7 +234,7 @@ module uvmt_cv32e40p_step_compare
     endfunction // compare
     
     int cycles = 0;
-    always @(posedge uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.clk) begin
+    always @(posedge `CV32E40P_CORE.clk) begin
         cycles++;
     end
 

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
@@ -233,6 +233,11 @@ module uvmt_cv32e40p_step_compare
       `endif      
     endfunction // compare
     
+    int cycles = 0;
+    always @(posedge uvmt_cv32e40p_tb.dut_wrap.cv32e40p_wrapper_i.core_i.clk) begin
+        cycles++;
+    end
+
     // RTL->RM CSR : mcycle, minstret, mcycleh, minstreth
     function automatic void pushRTL2RM(string message);
         logic [ 5:0] gpr_addr;
@@ -243,6 +248,9 @@ module uvmt_cv32e40p_step_compare
           gpr_value = `CV32E40P_TRACER.insn_regs_write[0].value;
           `CV32E40P_RM.GPR_rtl[gpr_addr] = gpr_value;
         end
+        // Pass cycles and reset
+        `CV32E40P_RM.cycles = cycles;
+        cycles = 0;
     endfunction // pushRTL2RM
     
     /*

--- a/cv32e40p/vendor_lib/imperas/design/ram.sv
+++ b/cv32e40p/vendor_lib/imperas/design/ram.sv
@@ -35,10 +35,14 @@ module RAM
 
     // Sparse memory supported by all RTL simulators
     reg [31:0] mem [bit[29:0]];
+    
+    reg [31:0] TICKS;
+    reg [31:0] RND_NUM;
+    reg [31:0] RND_STALL;
 
     Uns32 daddr4, iaddr4;
     Uns32 value;
-    bit isROM, isRAM;
+    bit   isROM, isRAM, isIO, isDBG;
     Uns32 loROM, hiROM;
     Uns32 loRAM, hiRAM;
     
@@ -59,12 +63,24 @@ module RAM
     endfunction
     
     always @(posedge SysBus.Clk) begin
+        //
+        // MEM  0x0000_0000 +0x0400_0000
+        // IO   0x1000_0000
+        // IO   0x1500_0000 +8
+        // IO   0x1500_1000 +8
+        // IO   0x1600_1000 +0x0010_0000
+        // DBG  0x1A11_0800 +0x0000_1000
+        // IO   0x2000_1000 +16
+        //
+        
         isROM = (SysBus.IAddr>=loROM && SysBus.IAddr<=hiROM);
         isRAM = (SysBus.DAddr>=loRAM && SysBus.DAddr<=hiRAM);
         
+        isIO  = (SysBus.DAddr>='h10000000 && SysBus.DAddr<='h20000010);
+        
         daddr4 = SysBus.DAddr >> 2;
         iaddr4 = SysBus.IAddr >> 2;
-        
+
         // Uninitialized Memory
         if (!mem.exists(daddr4)) mem[daddr4] = 'h0;
         if (!mem.exists(iaddr4)) mem[iaddr4] = 'h0;
@@ -73,7 +89,6 @@ module RAM
         if (isROM || isRAM) begin
             if (SysBus.Drd==1) begin
                 SysBus.DData = mem[daddr4] & byte2bit(SysBus.Dbe);
-                //$display("Load  %08x <= [%08X]", SysBus.DData, daddr4);
             end
         end
         if (SysBus.Drd == 1 && SysBus.DAddr==32'h1500_1000) begin
@@ -85,8 +100,6 @@ module RAM
             if (SysBus.Dwr==1) begin
                 value = mem[daddr4] & ~(byte2bit(SysBus.Dbe));
                 mem[daddr4] = value | (SysBus.DData & byte2bit(SysBus.Dbe));
-                //$display("Store %08x <= %08X", daddr4, mem[daddr4]);
-                
             end
         end
         
@@ -94,23 +107,89 @@ module RAM
         if (isROM) begin
             if (SysBus.Ird==1) begin
                 SysBus.IData = mem[iaddr4] & byte2bit(SysBus.Ibe);
-                //$display("Fetch %08x <= [%08X]", SysBus.IData, iaddr4);
+            end
+        end
+        
+        if (isIO) begin
+            if (SysBus.Dwr==1) begin
+                if (SysBus.DAddr == 'h10000000) begin 
+                    // $display("IOWR [%08X]<=%08X : Printer", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000000) begin 
+                    // $display("IOWR [%08X]<=%08X : timer_irg_mask", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000004) begin 
+                    // $display("IOWR [%08X]<=%08X : Interrupt Timer Control", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000008) begin 
+                    // $display("IOWR [%08X]<=%08X : Debug Control", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15001000) begin 
+                    // $display("IOWR [%08X]<=%08X : Random Number Generator", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15001004) begin 
+                    $display("IOWR [%08X]<=%08X : Timer", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000000) begin 
+                    // $display("IOWR [%08X]<=%08X : Status Flags, Assert", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000004) begin 
+                    // $display("IOWR [%08X]<=%08X : Status Flags, Assert", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000008) begin 
+                    // $display("IOWR [%08X]<=%08X : Status Flags, Signature Start", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h2000000C) begin 
+                    // $display("IOWR [%08X]<=%08X : Status Flags, Signature End", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000010) begin 
+                    // $display("IOWR [%08X]<=%08X : Status Flags, Signature Write", SysBus.DAddr, SysBus.DData);
+                end else if ((SysBus.DAddr>>16) == 'h1600) begin 
+                    // $display("IOWR [%08X]<=%08X : Stall Control", SysBus.DAddr, SysBus.DData);
+                end else begin
+                    //$display("Error IOWR [%08X]<=%08X : Unknown", SysBus.DAddr, SysBus.DData);
+                    //$finish;
+                end
+            end
+            if (SysBus.Drd==1) begin
+                if (SysBus.DAddr == 'h10000000) begin 
+                    // $display("IORD [%08X]=>%08X : Printer", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000000) begin 
+                    // $display("IORD [%08X]=>%08X : timer_irg_mask", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000004) begin 
+                    // $display("IORD [%08X]=>%08X : Interrupt Timer Control", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15000008) begin 
+                    // $display("IORD [%08X]=>%08X : Debug Control", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15001000) begin 
+                    SysBus.DData = RND_NUM;
+                    // $display("IORD [%08X]=>%08X : Random Number Generator", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h15001004) begin 
+                    SysBus.DData = TICKS;
+                    // $display("%m IORD [%08X]=>%08X : Timer", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000000) begin 
+                    // $display("IORD [%08X]=>%08X : Status Flags, Assert", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000004) begin 
+                    // $display("IORD [%08X]=>%08X : Status Flags, Assert", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000008) begin 
+                    // $display("IORD [%08X]=>%08X : Status Flags, Signature Start", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h2000000C) begin 
+                    // $display("IORD [%08X]=>%08X : Status Flags, Signature End", SysBus.DAddr, SysBus.DData);
+                end else if (SysBus.DAddr == 'h20000010) begin 
+                    // $display("IORD [%08X]=>%08X : Status Flags, Signature Write", SysBus.DAddr, SysBus.DData);
+                end else if ((SysBus.DAddr>>16) == 'h1600) begin 
+                    SysBus.DData = RND_STALL;
+                    // $display("IORD [%08X]=>%08X : Stall Control", SysBus.DAddr, SysBus.DData);
+                end else begin
+                    //$display("Error IORD [%08X]=>%08X : Unknown", SysBus.DAddr, SysBus.DData);
+                    //$finish;
+                end
             end
         end
         
         // checkers
+        /*
         if (SysBus.Ird==1 && isROM==0) begin
-            //$display("ERROR: Fetch Address %08X does not have EXECUTE permission", SysBus.IAddr);
-            //$finish;
+            $display("ERROR: Fetch Address %08X does not have EXECUTE permission", SysBus.IAddr);
+            $finish;
         end
         if (SysBus.Drd==1 && isROM==0 && isRAM==0) begin
-            //$display("ERROR: Load Address %08X does not have READ permission", SysBus.DAddr);
-            //$finish;
+            $display("ERROR: Load Address %08X does not have READ permission", SysBus.DAddr);
+            $finish;
         end
         if (SysBus.Dwr==1 && isRAM==0) begin
-            //$display("ERROR: Store Address %08X does not have WRITE permission", SysBus.DAddr);
-            //$finish;
+            $display("ERROR: Store Address %08X does not have WRITE permission", SysBus.DAddr);
+            $finish;
         end
-
+        */
     end
 endmodule


### PR DESCRIPTION
This pull Request includes the feedback of IO updates for the virtual peripherals so that the RM sees the same values read from IO as the RTL