### PR TITLE
Expand ISACOV with sequences, groups, and hazards

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
@@ -28,11 +28,12 @@ class uvme_cv32e40x_cfg_c extends uvm_object;
    // Integrals
    rand bit                      enabled;
    rand uvm_active_passive_enum  is_active;
+   rand bit                      use_isacov;
+
    rand bit                      scoreboarding_enabled;
    rand bit                      cov_model_enabled;
    rand bit                      trn_log_enabled;
-   rand int unsigned             sys_clk_period;
-   //rand int unsigned             debug_clk_period;
+   rand int unsigned             sys_clk_period;   
    
    // Agent cfg handles
    rand uvma_isacov_cfg_c     isacov_cfg;
@@ -40,13 +41,7 @@ class uvme_cv32e40x_cfg_c extends uvm_object;
    rand uvma_interrupt_cfg_c  interrupt_cfg;
    rand uvma_debug_cfg_c      debug_cfg;
    rand uvma_obi_cfg_c        obi_instr_cfg;
-   rand uvma_obi_cfg_c        obi_data_cfg;
-   
-   // Objects   
-   // TODO Add scoreboard configuration handles
-   //      Ex: rand uvml_sb_cfg_c  sb_egress_cfg;
-   //          rand uvml_sb_cfg_c  sb_ingress_cfg;
-   
+   rand uvma_obi_cfg_c        obi_data_cfg;      
    
    `uvm_object_utils_begin(uvme_cv32e40x_cfg_c)
       `uvm_field_int (                         enabled                     , UVM_DEFAULT          )
@@ -54,8 +49,7 @@ class uvme_cv32e40x_cfg_c extends uvm_object;
       `uvm_field_int (                         scoreboarding_enabled       , UVM_DEFAULT          )
       `uvm_field_int (                         cov_model_enabled           , UVM_DEFAULT          )
       `uvm_field_int (                         trn_log_enabled             , UVM_DEFAULT          )
-      `uvm_field_int (                         sys_clk_period            , UVM_DEFAULT + UVM_DEC)
-      //`uvm_field_int (                         debug_clk_period            , UVM_DEFAULT + UVM_DEC)
+      `uvm_field_int (                         sys_clk_period            , UVM_DEFAULT + UVM_DEC)      
       
       `uvm_field_object(isacov_cfg, UVM_DEFAULT)
       `uvm_field_object(clknrst_cfg, UVM_DEFAULT)
@@ -63,10 +57,7 @@ class uvme_cv32e40x_cfg_c extends uvm_object;
       `uvm_field_object(debug_cfg  , UVM_DEFAULT)
       `uvm_field_object(obi_instr_cfg, UVM_DEFAULT)
       `uvm_field_object(obi_data_cfg, UVM_DEFAULT)
-            
-      // TODO Add scoreboard cfg field macros
-      //      Ex: `uvm_field_object(sb_egress_cfg , UVM_DEFAULT)
-      //          `uvm_field_object(sb_ingress_cfg, UVM_DEFAULT)
+
    `uvm_object_utils_end
    
    
@@ -92,13 +83,18 @@ class uvme_cv32e40x_cfg_c extends uvm_object;
       obi_instr_cfg.read_enabled  == 1;
       obi_data_cfg.write_enabled  == 1;
       obi_data_cfg.read_enabled   == 1;
-      isacov_cfg.enabled              == 0;  // TODO don't need "== 0" after uvma_isacov has matured enough
-      isacov_cfg.ext_i_enabled        == 1;
-      isacov_cfg.ext_m_enabled        == 1;
-      isacov_cfg.ext_c_enabled        == 1;
-      isacov_cfg.ext_zifencei_enabled == 1;
-      isacov_cfg.ext_zicsr_enabled    == 1;
-
+      isacov_cfg.enabled                    == use_isacov;  // TODO don't need "== 0" after uvma_isacov has matured enough
+      isacov_cfg.ext_i_enabled              == 1;
+      isacov_cfg.ext_m_enabled              == 1;
+      isacov_cfg.ext_c_enabled              == 1;
+      isacov_cfg.ext_a_enabled              == 0;
+      isacov_cfg.ext_zifencei_enabled       == 1;
+      isacov_cfg.ext_zicsr_enabled          == 1;
+      isacov_cfg.mode_u_enabled             == 0;
+      isacov_cfg.mode_s_enabled             == 0;
+      isacov_cfg.seq_instr_group_x2_enabled == 1;
+      isacov_cfg.seq_instr_group_x3_enabled == 1;
+      isacov_cfg.seq_instr_group_x4_enabled == 0;
       if (is_active == UVM_ACTIVE) {
          isacov_cfg.is_active    == UVM_PASSIVE;
          clknrst_cfg.is_active   == UVM_ACTIVE;
@@ -143,10 +139,7 @@ function uvme_cv32e40x_cfg_c::new(string name="uvme_cv32e40x_cfg");
    obi_instr_cfg = uvma_obi_cfg_c::type_id::create("obi_instr_cfg");
    obi_data_cfg  = uvma_obi_cfg_c::type_id::create("obi_data_cfg");
       
-   // TODO Create scoreboard cfg objects
-   //      Ex: sb_egress_cfg  = uvml_sb_cfg_c::type_id::create("sb_egress_cfg" );
-   //          sb_ingress_cfg = uvml_sb_cfg_c::type_id::create("sb_ingress_cfg");
-   
+   use_isacov = $test$plusargs("USE_ISACOV") ? 1 : 0;
 endfunction : new
 
 

--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -193,6 +193,7 @@ covergroup cg_instr(string name,
   option.name = name;
 
   cp_instr: coverpoint(instr.name);
+  cp_instr_prev: coverpoint(instr.name);
 
   cp_group: coverpoint (instr.group) {
     bins LOAD = {LOAD_GROUP};
@@ -744,8 +745,8 @@ function bit uvma_isacov_cov_model_c::is_csr_hazard(uvma_isacov_instr_c instr,
 
   // CSR hazard, previous instruction wrote to a valid CSR
   if (instr_prev.group inside {CSR_GROUP} &&
-      instr.is_csr_write() &&
-      !cfg.cfg_illegal_csr[instr.csr])
+      instr_prev.is_csr_write() &&
+      !cfg.cfg_illegal_csr[instr_prev.csr])
     return 1;
 
   return 0;

--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -73,6 +73,29 @@ covergroup cg_jtype(string name) with function sample (uvma_isacov_instr_c instr
   cp_immj: coverpoint instr.immj;
 endgroup : cg_jtype
 
+covergroup cg_csrtype(string name,
+                      bit[CSR_MASK_WL-1:0] cfg_illegal_csr) with function sample (uvma_isacov_instr_c instr);
+  option.per_instance = 1;
+  option.name = name;
+
+  cp_rs1: coverpoint instr.rs1;
+  cp_rd: coverpoint instr.rd;
+  cp_csr: coverpoint instr.csr {
+    bins CSR[] = {[USTATUS:VLENB]} with (cfg_illegal_csr[item] == 0);
+  }
+endgroup : cg_csrtype
+
+covergroup cg_csritype(string name,
+                       bit[CSR_MASK_WL-1:0] cfg_illegal_csr) with function sample (uvma_isacov_instr_c instr);
+  option.per_instance = 1;
+  option.name = name;
+  
+  cp_rd: coverpoint instr.rd;
+  cp_csr: coverpoint instr.csr {
+    bins CSR[] = {[USTATUS:VLENB]} with (cfg_illegal_csr[item] == 0);
+  }
+  cp_immu: coverpoint instr.immu[4:0];
+endgroup : cg_csritype
 
 covergroup cg_cr(string name) with function sample (uvma_isacov_instr_c instr);
   option.per_instance = 1;
@@ -155,6 +178,139 @@ covergroup cg_cj(string name) with function sample (uvma_isacov_instr_c instr);
   cp_c_immj: coverpoint instr.c_immj;
 endgroup : cg_cj
 
+covergroup cg_instr(string name,
+                    bit seq_instr_group_x2_enabled,
+                    bit seq_instr_group_x3_enabled,
+                    bit seq_instr_group_x4_enabled,
+                    bit [CSR_MASK_WL-1:0] cfg_illegal_csr,
+                    bit ext_a_enabled) with function sample (uvma_isacov_instr_c instr,
+                                                             uvma_isacov_instr_c instr_prev,
+                                                             uvma_isacov_instr_c instr_prev2,
+                                                             uvma_isacov_instr_c instr_prev3,
+                                                             bit raw_hazard,
+                                                             bit csr_hazard);
+  option.per_instance = 1;
+  option.name = name;
+
+  cp_instr: coverpoint(instr.name);
+
+  cp_group: coverpoint (instr.group) {
+    bins LOAD = {LOAD_GROUP};
+    bins STORE = {STORE_GROUP};
+    bins MISALIGN_LOAD = {MISALIGN_LOAD_GROUP};
+    bins MISALIGN_STORE = {MISALIGN_STORE_GROUP};
+    bins ALU = {ALU_GROUP};
+    bins BRANCH = {BRANCH_GROUP};
+    bins JUMP = {JUMP_GROUP};
+    bins FENCE = {FENCE_GROUP};
+    bins FENCE_I = {FENCE_I_GROUP};
+    bins RET = {RET_GROUP};
+    bins WFI = {WFI_GROUP};
+    bins CSR = {CSR_GROUP};
+    bins ENV = {ENV_GROUP};
+    bins MUL = {MUL_GROUP};
+    bins MULTI_MUL = {MULTI_MUL_GROUP};
+    bins DIV = {DIV_GROUP};
+    bins ALOAD  = {ALOAD_GROUP} with (ext_a_enabled);
+    bins ASTORE = {ASTORE_GROUP} with (ext_a_enabled);
+    bins AMEM   = {AMEM_GROUP} with (ext_a_enabled);
+  }
+  cp_group_prev:  coverpoint (instr_prev.group) iff (instr_prev != null) {
+    bins LOAD = {LOAD_GROUP} with (seq_instr_group_x2_enabled);
+    bins STORE = {STORE_GROUP} with (seq_instr_group_x2_enabled);
+    bins MISALIGN_LOAD = {MISALIGN_LOAD_GROUP} with (seq_instr_group_x2_enabled);
+    bins MISALIGN_STORE = {MISALIGN_STORE_GROUP} with (seq_instr_group_x2_enabled);
+    bins ALU = {ALU_GROUP} with (seq_instr_group_x2_enabled);
+    bins BRANCH = {BRANCH_GROUP} with (seq_instr_group_x2_enabled);
+    bins JUMP = {JUMP_GROUP} with (seq_instr_group_x2_enabled);
+    bins FENCE = {FENCE_GROUP} with (seq_instr_group_x2_enabled);
+    bins FENCE_I = {FENCE_I_GROUP} with (seq_instr_group_x2_enabled);
+    bins RET = {RET_GROUP} with (seq_instr_group_x2_enabled);
+    bins WFI = {WFI_GROUP} with (seq_instr_group_x2_enabled);
+    bins CSR = {CSR_GROUP} with (seq_instr_group_x2_enabled);
+    bins ENV = {ENV_GROUP} with (seq_instr_group_x2_enabled);
+    bins MUL = {MUL_GROUP} with (seq_instr_group_x2_enabled);
+    bins MULTI_MUL = {MULTI_MUL_GROUP} with (seq_instr_group_x2_enabled);
+    bins DIV = {DIV_GROUP} with (seq_instr_group_x2_enabled);
+    bins ALOAD  = {ALOAD_GROUP} with (seq_instr_group_x2_enabled && ext_a_enabled);
+    bins ASTORE = {ASTORE_GROUP} with (seq_instr_group_x2_enabled && ext_a_enabled);
+    bins AMEM   = {AMEM_GROUP} with (seq_instr_group_x2_enabled && ext_a_enabled);
+  }
+
+  cp_group_prev2: coverpoint (instr_prev2.group) iff (instr_prev2 != null) {
+    bins LOAD = {LOAD_GROUP} with (seq_instr_group_x3_enabled);
+    bins STORE = {STORE_GROUP} with (seq_instr_group_x3_enabled);
+    bins MISALIGN_LOAD = {MISALIGN_LOAD_GROUP} with (seq_instr_group_x3_enabled);
+    bins MISALIGN_STORE = {MISALIGN_STORE_GROUP} with (seq_instr_group_x3_enabled);
+    bins ALU = {ALU_GROUP} with (seq_instr_group_x3_enabled);
+    bins BRANCH = {BRANCH_GROUP} with (seq_instr_group_x3_enabled);
+    bins JUMP = {JUMP_GROUP} with (seq_instr_group_x3_enabled);
+    bins FENCE = {FENCE_GROUP} with (seq_instr_group_x3_enabled);
+    bins FENCE_I = {FENCE_I_GROUP} with (seq_instr_group_x3_enabled);
+    bins RET = {RET_GROUP} with (seq_instr_group_x3_enabled);
+    bins WFI = {WFI_GROUP} with (seq_instr_group_x3_enabled);
+    bins CSR = {CSR_GROUP} with (seq_instr_group_x3_enabled);
+    bins ENV = {ENV_GROUP} with (seq_instr_group_x3_enabled);
+    bins MUL = {MUL_GROUP} with (seq_instr_group_x3_enabled);
+    bins MULTI_MUL = {MULTI_MUL_GROUP} with (seq_instr_group_x3_enabled);
+    bins DIV = {DIV_GROUP} with (seq_instr_group_x3_enabled);
+    bins ALOAD  = {ALOAD_GROUP} with (seq_instr_group_x3_enabled && ext_a_enabled);
+    bins ASTORE = {ASTORE_GROUP} with (seq_instr_group_x3_enabled && ext_a_enabled);
+    bins AMEM   = {AMEM_GROUP} with (seq_instr_group_x3_enabled && ext_a_enabled);
+  }
+
+  cp_group_prev3: coverpoint (instr_prev3.group) iff (instr_prev3 != null) {
+    bins LOAD = {LOAD_GROUP} with (seq_instr_group_x4_enabled);
+    bins STORE = {STORE_GROUP} with (seq_instr_group_x4_enabled);
+    bins MISALIGN_LOAD = {MISALIGN_LOAD_GROUP} with (seq_instr_group_x4_enabled);
+    bins MISALIGN_STORE = {MISALIGN_STORE_GROUP} with (seq_instr_group_x4_enabled);
+    bins ALU = {ALU_GROUP} with (seq_instr_group_x4_enabled);
+    bins BRANCH = {BRANCH_GROUP} with (seq_instr_group_x4_enabled);
+    bins JUMP = {JUMP_GROUP} with (seq_instr_group_x4_enabled);
+    bins FENCE = {FENCE_GROUP} with (seq_instr_group_x4_enabled);
+    bins FENCE_I = {FENCE_I_GROUP} with (seq_instr_group_x4_enabled);
+    bins RET = {RET_GROUP} with (seq_instr_group_x4_enabled);
+    bins WFI = {WFI_GROUP} with (seq_instr_group_x4_enabled);
+    bins CSR = {CSR_GROUP} with (seq_instr_group_x4_enabled);
+    bins ENV = {ENV_GROUP} with (seq_instr_group_x4_enabled);
+    bins MUL = {MUL_GROUP} with (seq_instr_group_x4_enabled);
+    bins MULTI_MUL = {MULTI_MUL_GROUP} with (seq_instr_group_x4_enabled);
+    bins DIV = {DIV_GROUP} with (seq_instr_group_x4_enabled);
+    bins ALOAD  = {ALOAD_GROUP} with (seq_instr_group_x4_enabled && ext_a_enabled);
+    bins ASTORE = {ASTORE_GROUP} with (seq_instr_group_x4_enabled && ext_a_enabled);
+    bins AMEM   = {AMEM_GROUP} with (seq_instr_group_x4_enabled && ext_a_enabled);
+  }
+
+  cp_raw_hazard: coverpoint(raw_hazard) {
+    bins NO_RAW_HAZARD  = {0};
+    bins RAW_HAZARD     = {1};
+  }
+
+  cp_csr_hazard: coverpoint(csr_hazard) {
+    bins NO_CSR_HAZARD  = {0};
+    bins CSR_HAZARD     = {1};
+  }
+
+  cp_csr: coverpoint(instr_prev.csr) iff (instr_prev != null) {
+    bins CSR[] = {[USTATUS:VLENB]} with (cfg_illegal_csr[item] == 0);
+  }
+
+  cross_seq_x2: cross cp_group, cp_group_prev;  
+  cross_seq_x3: cross cp_group, cp_group_prev, cp_group_prev2;
+  cross_seq_x4: cross cp_group, cp_group_prev, cp_group_prev2, cp_group_prev3;
+
+  // FIXME: This will need more filtering
+  cross_seq_raw_hazard: cross cp_group, cp_group_prev, cp_raw_hazard {
+    // Ignore non-hazard bins
+    ignore_bins IGN_HAZ = binsof(cp_raw_hazard) intersect {0};
+  }
+
+  cross_csr_hazard: cross cp_csr, cp_instr, cp_csr_hazard {
+    // Ignore non-hazard bins
+    ignore_bins IGN_HAZ = binsof(cp_csr_hazard) intersect {0};
+  }
+endgroup : cg_instr
+
 
 class uvma_isacov_cov_model_c extends uvm_component;
 
@@ -162,6 +318,11 @@ class uvma_isacov_cov_model_c extends uvm_component;
 
   // Objects
   uvma_isacov_cfg_c cfg;
+
+  // Store previous instruction
+  uvma_isacov_instr_c instr_prev;
+  uvma_isacov_instr_c instr_prev2;
+  uvma_isacov_instr_c instr_prev3;
 
   // Covergroups
   //32I:
@@ -242,14 +403,16 @@ class uvma_isacov_cov_model_c extends uvm_component;
   cg_cr c_add_cg;
   cg_css c_swsp_cg;
   //Zicsr:
-  cg_itype csrrw_cg;  // TODO define type for named "csr" imm
-  cg_itype csrrs_cg;
-  cg_itype csrrc_cg;
-  cg_itype csrrwi_cg;
-  cg_itype csrrsi_cg;
-  cg_itype csrrci_cg;
+  cg_csrtype  csrrw_cg;
+  cg_csrtype  csrrs_cg;
+  cg_csrtype  csrrc_cg;
+  cg_csritype csrrwi_cg;
+  cg_csritype csrrsi_cg;
+  cg_csritype csrrci_cg;
   //Zifence_i:
   cg_itype fence_i_cg;  // TODO own cg? (not itype)
+  // Instruction groups
+  cg_instr  instr_cg;
 
   // TLM
   uvm_tlm_analysis_fifo #(uvma_isacov_mon_trn_c) mon_trn_fifo;
@@ -259,6 +422,10 @@ class uvma_isacov_cov_model_c extends uvm_component;
   extern virtual task run_phase(uvm_phase phase);
   extern function void sample (uvma_isacov_instr_c instr);
 
+  extern function bit is_raw_hazard(uvma_isacov_instr_c instr,
+                                    uvma_isacov_instr_c instr_prev);
+  extern function bit is_csr_hazard(uvma_isacov_instr_c instr,
+                                    uvma_isacov_instr_c instr_prev);
 endclass : uvma_isacov_cov_model_c
 
 
@@ -367,16 +534,22 @@ function void uvma_isacov_cov_model_c::build_phase(uvm_phase phase);
       c_swsp_cg     = new("c_swsp_cg");
     end
     if (cfg.ext_zicsr_enabled) begin
-      csrrw_cg  = new("csrrw_cg");
-      csrrs_cg  = new("csrrs_cg");
-      csrrc_cg  = new("csrrc_cg");
-      csrrwi_cg = new("csrrwi_cg");
-      csrrsi_cg = new("csrrsi_cg");
-      csrrci_cg = new("csrrci_cg");
+      csrrw_cg  = new("csrrw_cg", cfg.cfg_illegal_csr);
+      csrrs_cg  = new("csrrs_cg", cfg.cfg_illegal_csr);
+      csrrc_cg  = new("csrrc_cg", cfg.cfg_illegal_csr);
+      csrrwi_cg = new("csrrwi_cg", cfg.cfg_illegal_csr);
+      csrrsi_cg = new("csrrsi_cg", cfg.cfg_illegal_csr);
+      csrrci_cg = new("csrrci_cg", cfg.cfg_illegal_csr);
     end
     if (cfg.ext_zifencei_enabled) begin
       fence_i_cg = new("fence_i_cg");
     end
+    instr_cg = new("instr_cg",
+                   .seq_instr_group_x2_enabled(cfg.seq_instr_group_x2_enabled),
+                   .seq_instr_group_x3_enabled(cfg.seq_instr_group_x3_enabled),
+                   .seq_instr_group_x4_enabled(cfg.seq_instr_group_x4_enabled),
+                   .cfg_illegal_csr(cfg.cfg_illegal_csr),
+                   .ext_a_enabled(cfg.ext_a_enabled));
   end
 
   mon_trn_fifo = new("mon_trn_fifo", this);
@@ -533,4 +706,47 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     $display("TODO error if no match found");
   end
 
-endfunction
+  instr_cg.sample(instr, 
+                  instr_prev, 
+                  instr_prev2, 
+                  instr_prev3, 
+                  .raw_hazard(is_raw_hazard(instr, instr_prev)),
+                  .csr_hazard(is_csr_hazard(instr, instr_prev))
+                  );
+
+  // Move instructions down the pipeline
+  instr_prev3 = instr_prev2;
+  instr_prev2 = instr_prev;
+  instr_prev  = instr;
+endfunction : sample
+
+function bit uvma_isacov_cov_model_c::is_raw_hazard(uvma_isacov_instr_c instr,
+                                                    uvma_isacov_instr_c instr_prev);
+
+  if (instr_prev == null)
+    return 0;
+
+  // RAW hazard, destination register in previous is used as source in next register
+  if (instr_prev.rd_valid && 
+      instr_prev.rd != 0 &&
+      (((instr_prev.rd == instr.rs1) && instr.rs1_valid) ||
+       ((instr_prev.rd == instr.rs2) && instr.rs2_valid)))
+    return 1;
+
+  return 0;
+endfunction : is_raw_hazard
+
+function bit uvma_isacov_cov_model_c::is_csr_hazard(uvma_isacov_instr_c instr,
+                                                    uvma_isacov_instr_c instr_prev);
+
+  if (instr_prev == null)
+    return 0;
+
+  // CSR hazard, previous instruction wrote to a valid CSR
+  if (instr_prev.group inside {CSR_GROUP} &&
+      instr.is_csr_write() &&
+      !cfg.cfg_illegal_csr[instr.csr])
+    return 1;
+
+  return 0;
+endfunction : is_csr_hazard

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
@@ -20,13 +20,28 @@ class uvma_isacov_cfg_c extends uvm_object;
 
   rand bit                     enabled;
   rand uvm_active_passive_enum is_active;
+
   rand bit                     cov_model_enabled;
   rand bit                     trn_log_enabled;
   rand bit                     ext_i_enabled;
   rand bit                     ext_m_enabled;
   rand bit                     ext_c_enabled;
+  rand bit                     ext_a_enabled;  
   rand bit                     ext_zifencei_enabled;
   rand bit                     ext_zicsr_enabled;
+
+  rand bit                     mode_s_enabled;
+  rand bit                     mode_u_enabled;
+
+  rand bit                     seq_instr_group_x2_enabled;
+  rand bit                     seq_instr_group_x3_enabled;
+  rand bit                     seq_instr_group_x4_enabled;
+
+  // Bitmask to enable/disable CSRs in coverage model
+  // Mode configurations above will set cfg_illegal_csr settings when predictable
+  // Users may set any bit to 1 in this bitmask to signal that a respective CSR should be
+  // considered illegal
+  bit [CSR_MASK_WL-1:0]        cfg_illegal_csr;
 
   `uvm_object_utils_begin(uvma_isacov_cfg_c);
     `uvm_field_int(enabled, UVM_DEFAULT);
@@ -36,17 +51,62 @@ class uvma_isacov_cfg_c extends uvm_object;
     `uvm_field_int(ext_i_enabled, UVM_DEFAULT);
     `uvm_field_int(ext_m_enabled, UVM_DEFAULT);
     `uvm_field_int(ext_c_enabled, UVM_DEFAULT);
+    `uvm_field_int(ext_a_enabled, UVM_DEFAULT);
     `uvm_field_int(ext_zifencei_enabled, UVM_DEFAULT);
     `uvm_field_int(ext_zicsr_enabled, UVM_DEFAULT);
+    `uvm_field_int(mode_s_enabled, UVM_DEFAULT);
+    `uvm_field_int(mode_u_enabled, UVM_DEFAULT);
+    `uvm_field_int(seq_instr_group_x2_enabled, UVM_DEFAULT);
+    `uvm_field_int(seq_instr_group_x3_enabled, UVM_DEFAULT);
+    `uvm_field_int(seq_instr_group_x4_enabled, UVM_DEFAULT);
+    `uvm_field_int(cfg_illegal_csr, UVM_DEFAULT | UVM_NOPRINT);
   `uvm_object_utils_end;
 
   extern function new(string name = "uvma_isacov_cfg");
 
+  extern function void post_randomize();
 endclass : uvma_isacov_cfg_c
-
 
 function uvma_isacov_cfg_c::new(string name = "uvma_isacov_cfg");
 
   super.new(name);
 
+  // Populate initial cfg_illegal_csr mask based on CSR types mapped in enum instr_csr_t
+  cfg_illegal_csr = '1;
+  begin
+    instr_csr_t csr = csr.first();
+    forever begin
+      cfg_illegal_csr[csr] = 0;
+      if (csr == csr.last()) break;
+      csr = csr.next();
+    end
+  end
 endfunction : new
+
+function void uvma_isacov_cfg_c::post_randomize();
+  if (!mode_s_enabled) begin
+    cfg_illegal_csr[SSTATUS] = 1;
+    cfg_illegal_csr[SEDELEG] = 1;
+    cfg_illegal_csr[SIE] = 1;
+    cfg_illegal_csr[STVEC] = 1;
+    cfg_illegal_csr[SCOUNTEREN] = 1;
+    cfg_illegal_csr[SSCRATCH] = 1;
+    cfg_illegal_csr[SEPC] = 1;
+    cfg_illegal_csr[SCAUSE] = 1;
+    cfg_illegal_csr[STVAL] = 1;
+    cfg_illegal_csr[SIP] = 1;
+    cfg_illegal_csr[SATP] = 1;
+  end
+
+  if (!mode_u_enabled) begin
+    cfg_illegal_csr[USTATUS] = 1;
+    cfg_illegal_csr[UIE] = 1;
+    cfg_illegal_csr[UTVEC] = 1;    
+    cfg_illegal_csr[USCRATCH] = 1;
+    cfg_illegal_csr[UEPC] = 1;
+    cfg_illegal_csr[UCAUSE] = 1;
+    cfg_illegal_csr[UTVAL] = 1;
+    cfg_illegal_csr[UIP] = 1;    
+  end
+
+endfunction : post_randomize

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_constants.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_constants.sv
@@ -1,0 +1,24 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_ISACOV_CONSTANTS_SV__
+`define __UVMA_ISACOV_CONSTANTS_SV__
+
+localparam CSR_ADDR_WL = 12;
+localparam CSR_MASK_WL = (1 << CSR_ADDR_WL);
+
+`endif // __UVMA_ISACOV_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_pkg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_pkg.sv
@@ -28,6 +28,10 @@ package uvma_isacov_pkg;
   // DPI imports
   `include "dpi_dasm_imports.svh"
 
+  // Constants / Structs / Enums  
+  `include "uvma_isacov_constants.sv"
+  `include "uvma_isacov_tdefs.sv"
+
   // Objects
   `include "uvma_isacov_cfg.sv"
   `include "uvma_isacov_cntxt.sv"

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -1,0 +1,424 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_ISACOV_TDEFS_SV__
+`define __UVMA_ISACOV_TDEFS_SV__
+
+
+typedef enum {
+  UNKNOWN,  // TODO this should not be needed?
+
+  // 32I
+  LUI, AUIPC, JAL, JALR,
+  BEQ, BNE, BLT, BGE, BLTU, BGEU,
+  LB, LH, LW, LBU, LHU, SB, SH, SW,
+  ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI,
+  ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND,
+  FENCE, ECALL, EBREAK, DRET, MRET, WFI,
+
+  // 32M
+  MUL, MULH, MULHSU, MULHU,
+  DIV, DIVU, REM, REMU,
+
+  // 32C
+  C_ADDI4SPN, C_LW, C_SW,
+  C_ADDI, C_JAL, C_LI, C_ADDI16SP, C_LUI, C_SRLI, C_SRAI,
+  C_ANDI, C_SUB, C_XOR, C_OR, C_AND, C_J, C_BEQZ, C_BNEZ,
+  C_SLLI, C_LWSP, C_JR, C_MV, C_EBREAK, C_JALR, C_ADD, C_SWSP,
+
+  // 32A
+  LR_W, SC_W,
+  AMOSWAP_W, AMOADD_W, AMOXOW_W, AMOAND_W,
+  AMOOR_W, AMOMIN_W, AMOMAX_W, AMOMINU_W, AMOMAXU_W,
+
+  // Zicsr
+  CSRRW, CSRRS, CSRRC,
+  CSRRWI, CSRRSI, CSRRCI,
+
+  // Zifencei
+  FENCE_I
+} instr_name_t;
+
+typedef enum {
+  // RV32 types
+  R_TYPE,
+  I_TYPE,
+  S_TYPE,
+  B_TYPE,
+  U_TYPE,
+  J_TYPE,
+
+  CSR_TYPE,  // CSR* instruction with rs1 operand
+  CSRI_TYPE, // CSR* instruction with immu operand
+
+  UNKNOWN_TYPE // Delete when all are implemented
+} instr_type_t;
+
+typedef enum {  
+   LOAD_GROUP,
+   STORE_GROUP, 
+   MISALIGN_LOAD_GROUP,
+   MISALIGN_STORE_GROUP,
+   ALU_GROUP,
+   BRANCH_GROUP,
+   JUMP_GROUP,
+   FENCE_GROUP,
+   FENCE_I_GROUP,
+   RET_GROUP,
+   WFI_GROUP,
+   CSR_GROUP,
+   ENV_GROUP,
+   MUL_GROUP,
+   MULTI_MUL_GROUP,
+   DIV_GROUP,
+   ALOAD_GROUP,
+   ASTORE_GROUP,
+   AMEM_GROUP
+} instr_group_t;
+
+typedef enum bit[CSR_ADDR_WL-1:0] {
+  USTATUS = 'h000,
+  UIE = 'h004,
+  UTVEC = 'h005,
+  USCRATCH = 'h040,
+  UEPC = 'h041,
+  UCAUSE = 'h042,
+  UTVAL = 'h043,
+  UIP = 'h044,
+  FFLAGS = 'h001,
+  FRM = 'h002,
+  FCSR = 'h003,
+  CYCLE = 'hC00,
+  TIME = 'hC01,
+  INSTRET = 'hC02,
+  HPMCOUNTER3 = 'hC03,
+  HPMCOUNTER4 = 'hC04,
+  HPMCOUNTER5 = 'hC05,
+  HPMCOUNTER6 = 'hC06,
+  HPMCOUNTER7 = 'hC07,
+  HPMCOUNTER8 = 'hC08,
+  HPMCOUNTER9 = 'hC09,
+  HPMCOUNTER10 = 'hC0A,
+  HPMCOUNTER11 = 'hC0B,
+  HPMCOUNTER12 = 'hC0C,
+  HPMCOUNTER13 = 'hC0D,
+  HPMCOUNTER14 = 'hC0E,
+  HPMCOUNTER15 = 'hC0F,
+  HPMCOUNTER16 = 'hC10,
+  HPMCOUNTER17 = 'hC11,
+  HPMCOUNTER18 = 'hC12,
+  HPMCOUNTER19 = 'hC13,
+  HPMCOUNTER20 = 'hC14,
+  HPMCOUNTER21 = 'hC15,
+  HPMCOUNTER22 = 'hC16,
+  HPMCOUNTER23 = 'hC17,
+  HPMCOUNTER24 = 'hC18,
+  HPMCOUNTER25 = 'hC19,
+  HPMCOUNTER26 = 'hC1A,
+  HPMCOUNTER27 = 'hC1B,
+  HPMCOUNTER28 = 'hC1C,
+  HPMCOUNTER29 = 'hC1D,
+  HPMCOUNTER30 = 'hC1E,
+  HPMCOUNTER31 = 'hC1F,
+  CYCLEH = 'hC80,
+  TIMEH = 'hC81,
+  INSTRETH = 'hC82,
+  HPMCOUNTER3H = 'hC83,
+  HPMCOUNTER4H = 'hC84,
+  HPMCOUNTER5H = 'hC85,
+  HPMCOUNTER6H = 'hC86,
+  HPMCOUNTER7H = 'hC87,
+  HPMCOUNTER8H = 'hC88,
+  HPMCOUNTER9H = 'hC89,
+  HPMCOUNTER10H = 'hC8A,
+  HPMCOUNTER11H = 'hC8B,
+  HPMCOUNTER12H = 'hC8C,
+  HPMCOUNTER13H = 'hC8D,
+  HPMCOUNTER14H = 'hC8E,
+  HPMCOUNTER15H = 'hC8F,
+  HPMCOUNTER16H = 'hC90,
+  HPMCOUNTER17H = 'hC91,
+  HPMCOUNTER18H = 'hC92,
+  HPMCOUNTER19H = 'hC93,
+  HPMCOUNTER20H = 'hC94,
+  HPMCOUNTER21H = 'hC95,
+  HPMCOUNTER22H = 'hC96,
+  HPMCOUNTER23H = 'hC97,
+  HPMCOUNTER24H = 'hC98,
+  HPMCOUNTER25H = 'hC99,
+  HPMCOUNTER26H = 'hC9A,
+  HPMCOUNTER27H = 'hC9B,
+  HPMCOUNTER28H = 'hC9C,
+  HPMCOUNTER29H = 'hC9D,
+  HPMCOUNTER30H = 'hC9E,
+  HPMCOUNTER31H = 'hC9F,
+  SSTATUS = 'h100,
+  SEDELEG = 'h102,
+  SIDELEG = 'h103,
+  SIE = 'h104,
+  STVEC = 'h105,
+  SCOUNTEREN = 'h106,
+  SSCRATCH = 'h140,
+  SEPC = 'h141,
+  SCAUSE = 'h142,
+  STVAL = 'h143,
+  SIP = 'h144,
+  SATP = 'h180,
+  MVENDORID = 'hF11,
+  MARCHID = 'hF12,
+  MIMPID = 'hF13,
+  MHARTID = 'hF14,
+  MSTATUS = 'h300,
+  MISA = 'h301,
+  MEDELEG = 'h302,
+  MIDELEG = 'h303,
+  MIE = 'h304,
+  MTVEC = 'h305,
+  MCOUNTEREN = 'h306,
+  MSCRATCH = 'h340,
+  MEPC = 'h341,
+  MCAUSE = 'h342,
+  MTVAL = 'h343,
+  MIP = 'h344,
+  PMPCFG0 = 'h3A0,
+  PMPCFG1 = 'h3A1,
+  PMPCFG2 = 'h3A2,
+  PMPCFG3 = 'h3A3,
+  PMPADDR0 = 'h3B0,
+  PMPADDR1 = 'h3B1,
+  PMPADDR2 = 'h3B2,
+  PMPADDR3 = 'h3B3,
+  PMPADDR4 = 'h3B4,
+  PMPADDR5 = 'h3B5,
+  PMPADDR6 = 'h3B6,
+  PMPADDR7 = 'h3B7,
+  PMPADDR8 = 'h3B8,
+  PMPADDR9 = 'h3B9,
+  PMPADDR10 = 'h3BA,
+  PMPADDR11 = 'h3BB,
+  PMPADDR12 = 'h3BC,
+  PMPADDR13 = 'h3BD,
+  PMPADDR14 = 'h3BE,
+  PMPADDR15 = 'h3BF,
+  MCYCLE = 'hB00,
+  MINSTRET = 'hB02,
+  MHPMCOUNTER3 = 'hB03,
+  MHPMCOUNTER4 = 'hB04,
+  MHPMCOUNTER5 = 'hB05,
+  MHPMCOUNTER6 = 'hB06,
+  MHPMCOUNTER7 = 'hB07,
+  MHPMCOUNTER8 = 'hB08,
+  MHPMCOUNTER9 = 'hB09,
+  MHPMCOUNTER10 = 'hB0A,
+  MHPMCOUNTER11 = 'hB0B,
+  MHPMCOUNTER12 = 'hB0C,
+  MHPMCOUNTER13 = 'hB0D,
+  MHPMCOUNTER14 = 'hB0E,
+  MHPMCOUNTER15 = 'hB0F,
+  MHPMCOUNTER16 = 'hB10,
+  MHPMCOUNTER17 = 'hB11,
+  MHPMCOUNTER18 = 'hB12,
+  MHPMCOUNTER19 = 'hB13,
+  MHPMCOUNTER20 = 'hB14,
+  MHPMCOUNTER21 = 'hB15,
+  MHPMCOUNTER22 = 'hB16,
+  MHPMCOUNTER23 = 'hB17,
+  MHPMCOUNTER24 = 'hB18,
+  MHPMCOUNTER25 = 'hB19,
+  MHPMCOUNTER26 = 'hB1A,
+  MHPMCOUNTER27 = 'hB1B,
+  MHPMCOUNTER28 = 'hB1C,
+  MHPMCOUNTER29 = 'hB1D,
+  MHPMCOUNTER30 = 'hB1E,
+  MHPMCOUNTER31 = 'hB1F,
+  MCYCLEH = 'hB80,
+  MINSTRETH = 'hB82,
+  MHPMCOUNTER3H = 'hB83,
+  MHPMCOUNTER4H = 'hB84,
+  MHPMCOUNTER5H = 'hB85,
+  MHPMCOUNTER6H = 'hB86,
+  MHPMCOUNTER7H = 'hB87,
+  MHPMCOUNTER8H = 'hB88,
+  MHPMCOUNTER9H = 'hB89,
+  MHPMCOUNTER10H = 'hB8A,
+  MHPMCOUNTER11H = 'hB8B,
+  MHPMCOUNTER12H = 'hB8C,
+  MHPMCOUNTER13H = 'hB8D,
+  MHPMCOUNTER14H = 'hB8E,
+  MHPMCOUNTER15H = 'hB8F,
+  MHPMCOUNTER17H = 'hB90,
+  MHPMCOUNTER18H = 'hB91,
+  MHPMCOUNTER19H = 'hB92,
+  MHPMCOUNTER20H = 'hB93,
+  MHPMCOUNTER21H = 'hB94,
+  MHPMCOUNTER22H = 'hB95,
+  MHPMCOUNTER23H = 'hB96,
+  MHPMCOUNTER24H = 'hB97,
+  MHPMCOUNTER25H = 'hB98,
+  MHPMCOUNTER26H = 'hB99,
+  MHPMCOUNTER27H = 'hB9A,
+  MHPMCOUNTER28H = 'hB9B,
+  MHPMCOUNTER29H = 'hB9C,
+  MHPMCOUNTER30H = 'hB9D,
+  MHPMCOUNTER31H = 'hB9E,
+  MCOUNTINHIBIT = 'h320,
+  MHPMEVENT3 = 'h323,
+  MHPMEVENT4 = 'h324,
+  MHPMEVENT5 = 'h325,
+  MHPMEVENT6 = 'h326,
+  MHPMEVENT7 = 'h327,
+  MHPMEVENT8 = 'h328,
+  MHPMEVENT9 = 'h329,
+  MHPMEVENT10 = 'h32A,
+  MHPMEVENT11 = 'h32B,
+  MHPMEVENT12 = 'h32C,
+  MHPMEVENT13 = 'h32D,
+  MHPMEVENT14 = 'h32E,
+  MHPMEVENT15 = 'h32F,
+  MHPMEVENT16 = 'h330,
+  MHPMEVENT17 = 'h331,
+  MHPMEVENT18 = 'h332,
+  MHPMEVENT19 = 'h333,
+  MHPMEVENT20 = 'h334,
+  MHPMEVENT21 = 'h335,
+  MHPMEVENT22 = 'h336,
+  MHPMEVENT23 = 'h337,
+  MHPMEVENT24 = 'h338,
+  MHPMEVENT25 = 'h339,
+  MHPMEVENT26 = 'h33A,
+  MHPMEVENT27 = 'h33B,
+  MHPMEVENT28 = 'h33C,
+  MHPMEVENT29 = 'h33D,
+  MHPMEVENT30 = 'h33E,
+  MHPMEVENT31 = 'h33F,
+  TSELECT = 'h7A0,
+  TDATA1 = 'h7A1,
+  TDATA2 = 'h7A2,
+  TDATA3 = 'h7A3,
+  DCSR = 'h7B0,
+  DPC = 'h7B1,
+  DSCRATCH0 = 'h7B2,
+  DSCRATCH1 = 'h7B3,
+  VSTART = 'h008,
+  VXSTAT = 'h009,
+  VXRM = 'h00A,
+  VL = 'hC20,
+  VTYPE = 'hC21,
+  VLENB = 'hC22
+} instr_csr_t;
+
+
+// Package level methods to map instruction to type
+function instr_type_t get_instr_type(instr_name_t name);
+  if (name inside {ADD,SUB,SLL,SLT,SLTU,XOR,SRL,SRA,OR,AND}) 
+    return R_TYPE;
+
+  if (name inside {ADDI,SLTI,SLTIU,XORI,ORI,
+                   LB,LH,LBU,LHU,JALR})
+    return I_TYPE;
+
+  if (name inside {SB,SH,SW})
+    return S_TYPE;
+
+  if (name inside {BEQ,BNE,BLT,BGE,BLTU,BGEU})
+    return B_TYPE;
+
+  if (name inside {LUI,AUIPC})
+    return U_TYPE;
+
+  if (name inside {JAL})
+    return J_TYPE;
+
+  if (name inside {CSRRW,CSRRS,CSRRC})
+    return CSR_TYPE;
+
+  if (name inside {CSRRWI,CSRRSI,CSRRCI})
+    return CSRI_TYPE;
+
+  if (name inside {JAL})
+    return J_TYPE;
+
+  return UNKNOWN_TYPE;
+endfunction : get_instr_type
+
+// Package level methods to map instruction to type
+function instr_group_t get_instr_group(instr_name_t name);
+  if (name inside {LB,LH,LW,LBU,LHU,C_LW,C_LWSP})
+    return LOAD_GROUP;
+
+  if (name inside {SB,SH,SW,C_SW,C_SWSP})
+    return STORE_GROUP;
+
+  // FIXME: Need to implement unaligned access
+
+  if (name inside {SLL,SLLI,SRL,SRLI,SRA,SRAI,
+                   ADD,ADDI,SUB,LUI,AUIPC,
+                   XOR,XORI,OR,ORI,AND,ANDI,
+                   SLT,SLTI,SLTU,SLTIU,
+                   C_ADD,C_ADDI,C_ADDI16SP,
+                   C_ADDI4SPN,C_SLLI}) 
+    return ALU_GROUP;
+
+  if (name inside {BEQ,BNE,BLT,BGE,BLTU,BGEU,
+                   C_BEQZ,C_BNEZ})
+    return BRANCH_GROUP;
+
+  if (name inside {JAL,JALR,
+                   C_J,C_JR,C_JAL,C_JALR})
+    return JUMP_GROUP;
+
+  if (name inside {FENCE})
+    return FENCE_GROUP;
+  
+  if (name inside {FENCE_I})
+    return FENCE_I_GROUP;
+  
+  if (name inside {ECALL, EBREAK, C_EBREAK}) 
+    return ENV_GROUP;
+
+  if (name inside {DRET, MRET})
+    return RET_GROUP;
+
+  if (name inside {WFI})
+    return WFI_GROUP;
+
+  if (name inside {CSRRW,CSRRS,CSRRC,CSRRWI,CSRRSI,CSRRCI})
+    return CSR_GROUP;
+
+  if (name inside {MUL})
+    return MUL_GROUP;
+
+  if (name inside {MULH,MULHSU,MULHU})
+    return MULTI_MUL_GROUP;
+
+  if (name inside {DIV,DIVU,REM,REMU})
+    return DIV_GROUP;
+
+  if (name inside {LR_W})
+    return ALOAD_GROUP;
+
+  if (name inside {SC_W})
+    return ASTORE_GROUP;
+
+  if (name inside {AMOSWAP_W,AMOADD_W,AMOXOW_W,AMOAND_W,
+                   AMOOR_W,AMOMIN_W,AMOMAX_W,AMOMINU_W,AMOMAXU_W})
+    return AMEM_GROUP;
+  
+  `uvm_fatal("ISACOV", $sformatf("Called get_instr_group with unmapped type: %s", name.name()));
+endfunction : get_instr_group
+
+`endif // __UVMA_ISACOV_TDEFS_SV__


### PR DESCRIPTION
Hi. Sorry for making a PR from someone else's fork, but the reason is that I want to continue adding features that build upon the work in their branch. And I would also like to have each feature in their own PRs, such that both reviews and changes are more focused, flexible, and decoupled. This doesn't follow the typical flow so I wasn't sure about the best way to proceed.

Description:
Adds coverage for sequences of instructions and data dependency hazards.
Also defines csr covergroups and enum.
And it organizes into a new ...tdefs.sv file.

@strichmo, do you know any reason it should not be merged?
Is it for example not complete enough so it should wait?
An alternative might be having a temporary branch in openhwgroup/core-v-verif?

I have two PR's that (independently) build upon this PR: https://github.com/openhwgroup/core-v-verif/pull/593 https://github.com/openhwgroup/core-v-verif/pull/594.