### PR TITLE
Update probes in testbench after design updates

### DIFF
--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= ed7cfdfdcd8c86cd2df41dfad25810997221756e
+CV_CORE_HASH   ?= e0fdb3a9e15ee304b4e63da1934c927ab47df757
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -163,7 +163,6 @@ module uvmt_cv32e40x_dut_wrap #(// DUT (riscv_core) parameters.
          .clk_i                  ( clknrst_if.clk                 ),
          .rst_ni                 ( clknrst_if.reset_n             ),
 
-         .pulp_clock_en_i        ( core_cntrl_if.pulp_clock_en    ),
          .scan_cg_en_i           ( core_cntrl_if.scan_cg_en       ),
 
          .boot_addr_i            ( core_cntrl_if.boot_addr        ),

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -166,7 +166,7 @@ bind cv32e40x_wrapper
                                                       .mie_n(cs_registers_i.mie_bypass_o),
                                                       .mstatus_mie(cs_registers_i.mstatus_q.mie),
                                                       .mtvec_mode_q(cs_registers_i.mtvec_q[1:0]),
-                                                      .if_stage_instr_rvalid_i(if_stage_i.m_c_obi_instr_if.rvalid),
+                                                      .if_stage_instr_rvalid_i(if_stage_i.m_c_obi_instr_if.s_rvalid.rvalid),
                                                       .if_stage_instr_rdata_i(if_stage_i.m_c_obi_instr_if.resp_payload.rdata),
                                                       .id_stage_instr_valid_i(id_stage_i.if_id_pipe_i.instr_valid),
                                                       .id_stage_instr_rdata_i(id_stage_i.if_id_pipe_i.instr.bus_resp.rdata),
@@ -183,7 +183,7 @@ bind cv32e40x_wrapper
       .clk_i(clknrst_if.clk),
       .rst_ni(clknrst_if.reset_n),
       .fetch_enable_i(dut_wrap.cv32e40x_wrapper_i.core_i.fetch_enable_i),
-      .if_stage_instr_rvalid_i(dut_wrap.cv32e40x_wrapper_i.core_i.if_stage_i.m_c_obi_instr_if.rvalid),
+      .if_stage_instr_rvalid_i(dut_wrap.cv32e40x_wrapper_i.core_i.if_stage_i.m_c_obi_instr_if.s_rvalid.rvalid),
       .if_stage_instr_rdata_i(dut_wrap.cv32e40x_wrapper_i.core_i.if_stage_i.m_c_obi_instr_if.resp_payload.rdata),
       .id_stage_instr_valid_i(dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.if_id_pipe_i.instr_valid),
       .id_stage_instr_rdata_i(dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.if_id_pipe_i.instr.bus_resp.rdata),
@@ -227,7 +227,7 @@ bind cv32e40x_wrapper
       .csr_access(dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.csr_en),
       .csr_op(dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.csr_op),
       .csr_op_dec(dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.decoder_i.csr_op),
-      .csr_addr(dut_wrap.cv32e40x_wrapper_i.core_i.csr_addr),
+      .csr_addr(dut_wrap.cv32e40x_wrapper_i.core_i.cs_registers_i.csr_addr),
       .csr_we_int(dut_wrap.cv32e40x_wrapper_i.core_i.cs_registers_i.csr_we_int),
       .irq_ack_o(dut_wrap.cv32e40x_wrapper_i.core_i.irq_ack_o),
       .irq_id_o(dut_wrap.cv32e40x_wrapper_i.core_i.irq_id_o),
@@ -276,7 +276,7 @@ bind cv32e40x_wrapper
       
       assign clknrst_if_iss.reset_n = clknrst_if.reset_n;
       generate for (genvar gv_i = 0; gv_i < 32; gv_i++) begin : get_gpr
-        assign step_compare_if.riscy_GPR[gv_i] = dut_wrap.cv32e40x_wrapper_i.core_i.id_stage_i.register_file_wrapper_i.register_file_i.mem[gv_i];
+        assign step_compare_if.riscy_GPR[gv_i] = dut_wrap.cv32e40x_wrapper_i.core_i.register_file_wrapper_i.register_file_i.mem[gv_i];
       end
       endgenerate
 


### PR DESCRIPTION
Signed-off-by: Oivind Ekelund <oivind.ekelund@silabs.com>

In addition to the probe updates, there has been changes to the interface of cv32e40x and cv32e40x_wrapper:
Signals added: instr_memtype_o, instr_prot_o, data_memtype_o, data_prot_o, fencei_flush_req_o, nmi_addr_i, fencei_flush_ack_i
Signals removed: .pulp_clock_en_i
This PR removes pulp_clock_en_i, but TB cleanup is still needed. 
The added signals are unconnected in the TB.