### PR TITLE
Temporarily remove "WFI" interrupt tests

### DIFF
--- a/cv32e40p/regress/cv32e40p_rel_check.yaml
+++ b/cv32e40p/regress/cv32e40p_rel_check.yaml
@@ -157,33 +157,34 @@ tests:
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
     num: 2
 
-  corev_rand_interrupt_wfi:
-    build: uvmt_cv32e40p
-    description: Generated corev-dv random interrupt WFI test
-    dir: cv32e40p/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
-    num: 2
-
-  corev_rand_interrupt_debug:
-    build: uvmt_cv32e40p
-    description: Generated corev-dv random interrupt WFI test with debug
-    dir: cv32e40p/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
-    num: 2
-
-  corev_rand_interrupt_exception:
-    build: uvmt_cv32e40p
-    description: Generated corev-dv random interrupt WFI test with exceptions
-    dir: cv32e40p/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
-    num: 2
-
-  corev_rand_interrupt_nested:
-    build: uvmt_cv32e40p
-    description: Generated corev-dv random interrupt WFI test with random nested interrupts
-    dir: cv32e40p/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
-    num: 2
+# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+#  corev_rand_interrupt_wfi:
+#    build: uvmt_cv32e40p
+#    description: Generated corev-dv random interrupt WFI test
+#    dir: cv32e40p/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
+#    num: 2
+#
+#  corev_rand_interrupt_debug:
+#    build: uvmt_cv32e40p
+#    description: Generated corev-dv random interrupt WFI test with debug
+#    dir: cv32e40p/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
+#    num: 2
+#
+#  corev_rand_interrupt_exception:
+#    build: uvmt_cv32e40p
+#    description: Generated corev-dv random interrupt WFI test with exceptions
+#    dir: cv32e40p/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
+#    num: 2
+#
+#  corev_rand_interrupt_nested:
+#    build: uvmt_cv32e40p
+#    description: Generated corev-dv random interrupt WFI test with random nested interrupts
+#    dir: cv32e40p/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
+#    num: 2
 
   illegal:
     build: uvmt_cv32e40p

--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -161,14 +161,15 @@ tests:
   #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
   #   num: 2
 
-  corev_rand_interrupt_wfi:
-    build: uvmt_cv32e40x
-    description: Generated corev-dv random interrupt WFI test
-    dir: cv32e40x/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
-    num: 2
+# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+#  corev_rand_interrupt_wfi:
+#    build: uvmt_cv32e40x
+#    description: Generated corev-dv random interrupt WFI test
+#    dir: cv32e40x/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
+#    num: 2
 
-  
+
   # FIXME:strichmo:This is currently known to not work, update later
   # corev_rand_interrupt_debug:
   #   build: uvmt_cv32e40x
@@ -177,19 +178,21 @@ tests:
   #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
   #   num: 2
 
-  corev_rand_interrupt_exception:
-    build: uvmt_cv32e40x
-    description: Generated corev-dv random interrupt WFI test with exceptions
-    dir: cv32e40x/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
-    num: 2
+# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+#  corev_rand_interrupt_exception:
+#    build: uvmt_cv32e40x
+#    description: Generated corev-dv random interrupt WFI test with exceptions
+#    dir: cv32e40x/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
+#    num: 2
 
-  corev_rand_interrupt_nested:
-    build: uvmt_cv32e40x
-    description: Generated corev-dv random interrupt WFI test with random nested interrupts
-    dir: cv32e40x/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
-    num: 2
+# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+#  corev_rand_interrupt_nested:
+#    build: uvmt_cv32e40x
+#    description: Generated corev-dv random interrupt WFI test with random nested interrupts
+#    dir: cv32e40x/sim/uvmt    
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
+#    num: 2
 
   illegal:
     build: uvmt_cv32e40x


### PR DESCRIPTION
As discussed in today's VTG meeting.  These failures are known false negatives that give grief to integrations onto the release branches.  We can reinstate once the false negative is resolved.

Note that these will need to be pushed to the e40x/release and e40s/release branches.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>