### PR TITLE
various Metrics fixes and another corev-dv interrupt test removal

### DIFF
--- a/bin/lib/cv_regression.py
+++ b/bin/lib/cv_regression.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_ISS = 'YES'
 DEFAULT_COV = 'NO'
 DEFAULT_SIMULATION_PASSED = 'SIMULATION PASSED'
+DEFAULT_SIMULATION_FAILED = 'SIMULATION FAILED'
 DEFAULT_SKIP_SIM = []
 
 def get_proj_root():
@@ -71,6 +72,7 @@ class Test:
         # Set defaults
         self.skip_sim = DEFAULT_SKIP_SIM
         self.simulation_passed = DEFAULT_SIMULATION_PASSED
+        self.simulation_failed = DEFAULT_SIMULATION_FAILED
         self.iss = DEFAULT_ISS
         self.num = 1
 

--- a/bin/templates/metrics.json.j2
+++ b/bin/templates/metrics.json.j2
@@ -40,15 +40,15 @@
         "wavesCmd": "cd {{t.dir}}; {{t.cmd}} CV_CORE={{project}} CFG={{cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RNDSEED=<seed> {{common_dsim_make_vars_waves}} {{makeargs}}",
 {% if t.results %}
         "metricsFile": "{{cfg}}/{{t.results}}{{test_suffix}}/metrics.db",
-        "wavesFile": "{{cfg}}/{{t.results}}{{test_suffix}}/{{t.name}}{{test_suffix}}.vcd",
+        "wavesFile": "{{cfg}}/{{t.results}}{{test_suffix}}/dsim.vcd",
 {% else %}
         "metricsFile": "{{cfg}}/{{t.name}}{{test_suffix}}/metrics.db",
-        "wavesFile": "{{cfg}}/{{t.name}}{{test_suffix}}/{{t.name}}{{test_suffix}}.vcd",
+        "wavesFile": "{{cfg}}/{{t.name}}{{test_suffix}}/dsim.vcd",
 {% endif %}
         "seed" : "random",
         "iterations": {{t.num}},
         "isPass": "{{t.simulation_passed}}",
-        "isFail": "... MISCOMPARE!"
+        "isFail": "{{t.simulation_failed}}"
     }{% if not is_last_test %},{% endif %}
 
 {% endfor %}

--- a/cv32e40p/regress/cv32e40p_rel_check.yaml
+++ b/cv32e40p/regress/cv32e40p_rel_check.yaml
@@ -129,12 +129,13 @@ tests:
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     num: 2
 
-  corev_rand_interrupt:
-    build: uvmt_cv32e40p
-    description: Generated corev-dv random interrupt test
-    dir: cv32e40p/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
-    num: 2
+# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+  # corev_rand_interrupt:
+  #   build: uvmt_cv32e40p
+  #   description: Generated corev-dv random interrupt test
+  #   dir: cv32e40p/sim/uvmt    
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+  #   num: 2
 
   corev_rand_debug:
     build: uvmt_cv32e40p

--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -129,13 +129,14 @@ tests:
     dir: cv32e40x/sim/uvmt    
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     num: 2
-
-  corev_rand_interrupt:
-    build: uvmt_cv32e40x
-    description: Generated corev-dv random interrupt test
-    dir: cv32e40x/sim/uvmt    
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
-    num: 2
+  
+  # FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
+  # corev_rand_interrupt:
+  #   build: uvmt_cv32e40x
+  #   description: Generated corev-dv random interrupt test
+  #   dir: cv32e40x/sim/uvmt    
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+  #   num: 2
 
   # FIXME:strichmo:This is currently known to not work, update later
   # corev_rand_debug:


### PR DESCRIPTION
Fix waves button in Metrics by using standard dsim.vcd filename for the Metrics waveform file
Fix isFail in Metrics so that assertion-fails do not show as Incomplete.
Comment out more corev-dv interrupt tests in rel_check for e40p and e40x until Metrics issue fixed.