### PR TITLE
Diffing isacov log vs tracer log

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -522,7 +522,7 @@ bind cv32e40x_wrapper
    assign core_cntrl_if.clk = clknrst_if.clk;
 
    always @(dut_wrap.cv32e40x_wrapper_i.tracer_i.retire) -> isacov_if.retire;
-   assign isacov_if.insn = dut_wrap.cv32e40x_wrapper_i.tracer_i.insn_val;
+   assign isacov_if.instr = dut_wrap.cv32e40x_wrapper_i.tracer_i.insn_val;
    assign isacov_if.is_compressed = dut_wrap.cv32e40x_wrapper_i.tracer_i.insn_compressed;
 
    // Capture the test status and exit pulse flags

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_if.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_if.sv
@@ -23,7 +23,7 @@ interface uvma_isacov_if;
   //   1) use RVFI, and/or 2) use a TLM port instead.
 
   event        retire;
-  logic [31:0] insn;
+  logic [31:0] instr;
   logic        is_compressed;
 
 endinterface

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -108,6 +108,9 @@ function string uvma_isacov_instr_c::convert2string();
   if (name inside {SLLI, SRLI, SRAI}) begin
     return $sformatf("%s x%0d, x%0d, 0x%0x", name.name(), rd, rs1, rs2);
   end
+  if (name == FENCE_I) begin
+    return $sformatf("fence.i");
+  end
 
   // Printing based on instruction format type
   if (itype == R_TYPE) begin

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -31,7 +31,7 @@ class uvma_isacov_instr_c extends uvm_object;
   bit [11:0] immi;
   bit [11:0] imms;
   bit [12:1] immb;
-  bit [19:0] immu;
+  bit [31:12] immu;
   bit [20:1] immj;
 
   // Valid flags for fields (to calculate hazards and other coverage)
@@ -123,7 +123,7 @@ function string uvma_isacov_instr_c::convert2string();
     return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs2, $signed(immb));
   end
   if (itype == U_TYPE) begin
-    return $sformatf("%s x%0d, 0x%0x", name.name(), rd, immu);
+    return $sformatf("%s x%0d, 0x%0x", name.name(), rd, {immu, 12'd0});
   end
   if (itype == J_TYPE) begin
     return $sformatf("%s x%0d, %0d", name.name(), rd, $signed(immj));

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -101,30 +101,40 @@ function uvma_isacov_instr_c::new(string name = "isacov_instr");
 endfunction : new
 
 function string uvma_isacov_instr_c::convert2string();
+  // Printing for a few special-formatting cases
+  if (name inside {LW, LH, LB, LHU, LBU}) begin
+    return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rd, $signed(immi), rs1);
+  end
+  if (name inside {SLLI, SRLI, SRAI}) begin
+    return $sformatf("%s x%0d, x%0d, 0x%0x", name.name(), rd, rs1, rs2);
+  end
 
+  // Printing based on instruction format type
   if (itype == R_TYPE) begin
     return $sformatf("%s x%0d, x%0d, x%0d", name.name(), rd, rs1, rs2);
   end
   if (itype == I_TYPE) begin
-    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, $signed(immi));
   end
   if (itype == S_TYPE) begin
-    return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rs2, imms, rs1);
+    return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rs2, $signed(imms), rs1);
   end
   if (itype == B_TYPE) begin
-    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs1, immb);
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs2, $signed(immb));
   end
   if (itype == U_TYPE) begin
-    return $sformatf("%s x%0d, %0d", name.name(), rd, immu);
+    return $sformatf("%s x%0d, 0x%0x", name.name(), rd, immu);
   end
   if (itype == J_TYPE) begin
-    return $sformatf("%s x%0d, %0d", name.name(), rd, immj);
+    return $sformatf("%s x%0d, %0d", name.name(), rd, $signed(immj));
   end
   if (itype == CSR_TYPE) begin
     // TODO should print CSR name like assembly code does?
-    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
+    //return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
+    return $sformatf("%s x%0d, x%0d, 0x%0x", name.name(), rd, rs1, immi);
   end
 
+  // Default printing of just the instruction name
   return name.name();
 endfunction : convert2string
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -120,7 +120,7 @@ function string uvma_isacov_instr_c::convert2string();
     return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rs2, $signed(imms), rs1);
   end
   if (itype == B_TYPE) begin
-    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs2, $signed(immb));
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs2, $signed({immb, 1'b0}));
   end
   if (itype == U_TYPE) begin
     return $sformatf("%s x%0d, 0x%0x", name.name(), rd, {immu, 12'd0});

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -112,7 +112,7 @@ function string uvma_isacov_instr_c::convert2string();
     return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rs2, imms, rs1);
   end
   if (itype == B_TYPE) begin
-    return $sformatf("%s x%0d, x%0d, %0d)", name.name(), rs1, rs1, immb);
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rs1, rs1, immb);
   end
   if (itype == U_TYPE) begin
     return $sformatf("%s x%0d, %0d", name.name(), rd, immu);
@@ -121,6 +121,7 @@ function string uvma_isacov_instr_c::convert2string();
     return $sformatf("%s x%0d, %0d", name.name(), rd, immj);
   end
   if (itype == CSR_TYPE) begin
+    // TODO should print CSR name like assembly code does?
     return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
   end
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -105,8 +105,23 @@ function string uvma_isacov_instr_c::convert2string();
   if (itype == R_TYPE) begin
     return $sformatf("%s x%0d, x%0d, x%0d", name.name(), rd, rs1, rs2);
   end
+  if (itype == I_TYPE) begin
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
+  end
+  if (itype == S_TYPE) begin
+    return $sformatf("%s x%0d, %0d(x%0d)", name.name(), rs2, imms, rs1);
+  end
+  if (itype == B_TYPE) begin
+    return $sformatf("%s x%0d, x%0d, %0d)", name.name(), rs1, rs1, immb);
+  end
+  if (itype == U_TYPE) begin
+    return $sformatf("%s x%0d, %0d", name.name(), rd, immu);
+  end
+  if (itype == J_TYPE) begin
+    return $sformatf("%s x%0d, %0d", name.name(), rd, immj);
+  end
   if (itype == CSR_TYPE) begin
-    return $sformatf("%s x%0d, %s, x%0d", name.name(), rd, csr.name(), rs1);
+    return $sformatf("%s x%0d, x%0d, %0d", name.name(), rd, rs1, immi);
   end
 
   return name.name();

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -74,54 +74,43 @@ task uvma_isacov_mon_c::sample_instr();
 
   uvma_isacov_mon_trn_c mon_trn;
   string                instr_name;
-  bit [63:0]            insn;  // TODO name "instr" and fix inconsistency
+  bit [63:0]            instr;
 
   @(cntxt.vif.retire);
 
   mon_trn = uvma_isacov_mon_trn_c::type_id::create("mon_trn");
   mon_trn.instr = uvma_isacov_instr_c::type_id::create("mon_instr");
 
-  instr_name = dasm_name(cntxt.vif.insn);
+  instr_name = dasm_name(cntxt.vif.instr);
   if (instr_name_lookup.exists(instr_name)) begin
     mon_trn.instr.name = instr_name_lookup[instr_name];    
   end else begin
     mon_trn.instr.name = UNKNOWN;
-    `uvm_warning("ISACOVMON", $sformatf("TODO: error couldn't look up '%s'", instr_name));
+    `uvm_warning("ISACOVMON", $sformatf("error couldn't look up '%s'", instr_name));
   end
-  // mon_trn.instr.name =
-  //   cntxt.vif.is_compressed ?
-  //     (mon_trn.instr.name == JAL) ?
-  //       (cntxt.vif.insn[11:7] == 5'b00000) ?
-  //         C_J :
-  //       (cntxt.vif.insn[11:7] == 5'b00001) ?
-  //         C_JAL :
-  //       UNKNOWN :
-  //     (mon_trn.instr.name == LW) ?
-  //       C_LW :
-  //     UNKNOWN :
-  //  mon_trn.instr.name;  // TODO get non de-compressed binary input instead of this
   
   mon_trn.instr.itype = get_instr_type(mon_trn.instr.name);
   mon_trn.instr.group = get_instr_group(mon_trn.instr.name);
 
-  insn = $signed(cntxt.vif.insn);  // dpi_dasm expects even 32-bit words as 64 bits
+  instr = $signed(cntxt.vif.instr);  // dpi_dasm expects even 32-bit words as 64 bits
 
-  mon_trn.instr.rs1  = dasm_rs1(insn);
-  mon_trn.instr.rs2  = dasm_rs2(insn);
-  mon_trn.instr.rd   = dasm_rd(insn);
-  mon_trn.instr.immi = dasm_i_imm(insn);
-  mon_trn.instr.imms = dasm_s_imm(insn);
-  mon_trn.instr.immb = dasm_sb_imm(insn) >> 1;
-  mon_trn.instr.immu = dasm_u_imm(insn) >> 12;
-  mon_trn.instr.immj = dasm_uj_imm(insn);
+  mon_trn.instr.rs1  = dasm_rs1(instr);
+  mon_trn.instr.rs2  = dasm_rs2(instr);
+  mon_trn.instr.rd   = dasm_rd(instr);
+  mon_trn.instr.immi = dasm_i_imm(instr);
+  mon_trn.instr.imms = dasm_s_imm(instr);
+  mon_trn.instr.immb = dasm_sb_imm(instr) >> 1;
+  mon_trn.instr.immu = dasm_u_imm(instr) >> 12;
+  mon_trn.instr.immj = dasm_uj_imm(instr);
   
-  mon_trn.instr.c_immj = dasm_rvc_j_imm(insn);
-  mon_trn.instr.c_rs1p = insn[9:7];  // TODO use disassembler
-  mon_trn.instr.c_rdp = insn[4:2];  // TODO use disassembler
+  mon_trn.instr.c_immj = dasm_rvc_j_imm(instr);
+  mon_trn.instr.c_rs1p = instr[9:7];  // TODO use disassembler
+  mon_trn.instr.c_rdp = instr[4:2];  // TODO use disassembler
+  // TODO make sure RVC instrs don't arrive as decompressed instrs
   
   if (mon_trn.instr.group == CSR_GROUP) begin
-    if (!$cast(mon_trn.instr.csr, dasm_csr(insn))) begin
-      `uvm_warning("ISACOVMON", $sformatf("CSR: 0x%03x unmappable", dasm_csr(insn)));
+    if (!$cast(mon_trn.instr.csr, dasm_csr(instr))) begin
+      `uvm_warning("ISACOVMON", $sformatf("CSR: 0x%03x unmappable", dasm_csr(instr)));
     end
   end
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -109,7 +109,7 @@ task uvma_isacov_mon_c::sample_instr();
   mon_trn.instr.immi = dasm_i_imm(cntxt.vif.insn);
   mon_trn.instr.imms = dasm_s_imm(cntxt.vif.insn);
   mon_trn.instr.immb = dasm_sb_imm(cntxt.vif.insn);
-  mon_trn.instr.immu = dasm_u_imm(cntxt.vif.insn);
+  mon_trn.instr.immu = dasm_u_imm(cntxt.vif.insn) >> 12;
   mon_trn.instr.immj = dasm_uj_imm(cntxt.vif.insn);
   
   mon_trn.instr.c_immj = dasm_rvc_j_imm(cntxt.vif.insn);

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon_trn_logger.sv
@@ -41,13 +41,13 @@ endfunction : new
 
 function void uvma_isacov_mon_trn_logger_c::print_header();
 
-  fwrite("time, instr");
+  fwrite("time\tinstr");
 
 endfunction : print_header
 
 
 function void uvma_isacov_mon_trn_logger_c::write(uvma_isacov_mon_trn_c t);
 
-  fwrite($sformatf("%t, %s", $time, t.convert2string()));
+  fwrite($sformatf("%t\t%s", $time, t.convert2string()));
 
 endfunction : write

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -324,11 +324,16 @@ typedef enum bit[CSR_ADDR_WL-1:0] {
 
 // Package level methods to map instruction to type
 function instr_type_t get_instr_type(instr_name_t name);
+  instr_name_t itypes[] = '{
+    LB, LH, LW, LBU, LHU,
+    ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI,
+    JALR
+    };
+
   if (name inside {ADD,SUB,SLL,SLT,SLTU,XOR,SRL,SRA,OR,AND}) 
     return R_TYPE;
 
-  if (name inside {ADDI,SLTI,SLTIU,XORI,ORI,
-                   LB,LH,LBU,LHU,JALR})
+  if (name inside {itypes})
     return I_TYPE;
 
   if (name inside {SB,SH,SW})

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -329,8 +329,14 @@ function instr_type_t get_instr_type(instr_name_t name);
     ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI,
     JALR
     };
+  instr_name_t rtypes[] = '{
+    // I-ext
+    ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND,
+    // M-ext
+    MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU
+    };
 
-  if (name inside {ADD,SUB,SLL,SLT,SLTU,XOR,SRL,SRA,OR,AND}) 
+  if (name inside {rtypes})
     return R_TYPE;
 
   if (name inside {itypes})

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -288,6 +288,24 @@ embench: $(EMBENCH_PKG)
 	-d $(EMB_DEBUG_ARG) \
 
 ###############################################################################
+# ISACOV (ISA coverage)
+#   Compare the log against the tracer log.
+#   This checks that sampling went correctly without false positives/negatives.
+
+ISACOV_LOGDIR = $($(SIMULATOR_UC)_RESULTS)/$(CFG)/$(TEST)_$(RUN_INDEX)
+ISACOV_TRACELOG = $(ISACOV_LOGDIR)/trace_core_00000000.log
+ISACOV_AGENTLOG = $(ISACOV_LOGDIR)/uvm_test_top.env.isacov_agent.trn.log
+
+isacov_logdiff:
+	@echo checking that env/dirs/files are as expected...
+		@printenv TEST > /dev/null || (echo specify TEST; false)
+		@ls $(ISACOV_LOGDIR) > /dev/null
+		@ls $(ISACOV_TRACELOG) > /dev/null
+		@ls $(ISACOV_AGENTLOG) > /dev/null
+	@echo filtering logs...
+		@cat $(ISACOV_AGENTLOG) | awk -F '\t' '{print $$2}' > tmp
+
+###############################################################################
 # Include the targets/rules for the selected SystemVerilog simulator
 #ifeq ($(SIMULATOR), unsim)
 #include unsim.mk

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -303,7 +303,14 @@ isacov_logdiff:
 		@ls $(ISACOV_TRACELOG) > /dev/null
 		@ls $(ISACOV_AGENTLOG) > /dev/null
 	@echo filtering logs...
-		@cat $(ISACOV_AGENTLOG) | awk -F '\t' '{print $$2}' > tmp
+		@cat $(ISACOV_TRACELOG) \
+			| sed 's/\(.*\)   \(.*\)/\1/' | awk '{$$1=$$2=$$3=$$4=$$5=""; $$0=$$0; $$1=$$1; print $$0}' \
+			| tail -n +2 > trace.tmp
+		@cat $(ISACOV_AGENTLOG) \
+			| awk -F '\t' '{print $$2}' \
+			| tr A-Z a-z | tail -n +2 > agent.tmp
+	@echo diffing the instruction sequences...
+		@diff trace.tmp agent.tmp
 
 ###############################################################################
 # Include the targets/rules for the selected SystemVerilog simulator

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -310,7 +310,11 @@ isacov_logdiff:
 			| awk -F '\t' '{print $$2}' | tr A-Z a-z \
 			| tail -n +2 > agent.tmp
 	@echo diffing the instruction sequences...
-		@diff trace.tmp agent.tmp
+		@echo saving to $(ISACOV_LOGDIR)/isacov_logdiff
+		@rm -rf $(ISACOV_LOGDIR)/isacov_logdiff
+		@diff trace.tmp agent.tmp > $(ISACOV_LOGDIR)/isacov_logdiff; true
+		@rm -rf trace.tmp agent.tmp
+		@(test ! -s $(ISACOV_LOGDIR)/isacov_logdiff && echo OK) || (echo FAIL; false)
 
 ###############################################################################
 # Include the targets/rules for the selected SystemVerilog simulator

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -307,8 +307,8 @@ isacov_logdiff:
 			| sed 's/\(.*\)   \(.*\)/\1/' | awk '{$$1=$$2=$$3=$$4=$$5=""; $$0=$$0; $$1=$$1; print $$0}' \
 			| tail -n +2 > trace.tmp
 		@cat $(ISACOV_AGENTLOG) \
-			| awk -F '\t' '{print $$2}' \
-			| tr A-Z a-z | tail -n +2 > agent.tmp
+			| awk -F '\t' '{print $$2}' | tr A-Z a-z \
+			| tail -n +2 > agent.tmp
 	@echo diffing the instruction sequences...
 		@diff trace.tmp agent.tmp
 

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -311,6 +311,7 @@ test: $(XRUN_SIM_PREREQ) $(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX)
 			+elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
 			+nm_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).nm \
 			+firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex
+	$(POST_TEST)
 
 ################################################################################
 # Custom test-programs.  See comment in dsim.mk for more info


### PR DESCRIPTION
This change is for checking that ISA coverage samples correctly (try to detect false positives/negatives), and includes some corresponding fixes to the sampling/decoding itself.
It changes formatting in isacov's logging to be compatible with 40x's tracer log [1].
It also adds to get_instr_type() and convert2string() to handle those cases which were missing.
Essentially, since incoming binary words are decoded into uvm objects (which coverage samples) and these objects are printed to a log, they can be compared against a reference log (if the logs match, then the uvm objects should have correct data in them).

This diffing of logs actually did uncover some instructions being sampled wrong.
For example, branch instructions had the offset's sign bit wrong (due to Spike internals) and both B-type and U-type needed shifting of the result obtained from dpi_dasm/Spike disassembler, "M" extension weren't logged properly, etc.
Coverage for those items were then false before, until now being found and fixed.
NB! RVC (compressed) has not yet been tested thoroughly because we wait for RVFI to deliver actual compressed instructions to isacov (diffing the logs will fail on compressed instrs unless filtered [2] away).

By default, the log diffing is not enabled.
Since it needs to be done as post-processing, I added the line `$(POST_TEST)` to uvmt/xrun.mk `test:` target.
It allows e.g. `make test TEST=hello-world POST_TEST='make isacov_logdiff'` or it can be used with ci_check, and can potentially be used for any other kind of desired post-processing.


[1] The tracer log format is not standardized. I think it should have tab-separated columns, comma-separated within-column data, and allow for leading/trailing spaces per cell. And it should maybe have defined what gets printed as hex/decimal/string etc. I also don't like how non-general the filtering of the logs and file names must be because of this.

[2] One can use 'sed -i "s/c\.//" $(ISACOV_TRACELOG) && make isacov_logdiff' to filter compressed instructions before diffing the logs.