### PR TITLE
update dsim version to fix sva and cov issues

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -19,13 +19,13 @@
       },
       {
         "name":     "uvmt_cv32e40x",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210322.7.0-12052021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210322.10.0-01062021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
-        "name":     "uvmt_cv32e40x_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210322.7.0-12052021",
+        "name":     "uvmt_cv32e40x_compliance_build",        
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210322.10.0-01062021",
         "cmd":      "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work DSIM_RESULTS=/mux-flow/build/results WAVES=1"
       }

--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -130,13 +130,12 @@ tests:
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     num: 2
   
-  # FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
-  # corev_rand_interrupt:
-  #   build: uvmt_cv32e40x
-  #   description: Generated corev-dv random interrupt test
-  #   dir: cv32e40x/sim/uvmt    
-  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
-  #   num: 2
+  corev_rand_interrupt:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random interrupt test
+    dir: cv32e40x/sim/uvmt    
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+    num: 2
 
   # FIXME:strichmo:This is currently known to not work, update later
   # corev_rand_debug:
@@ -162,13 +161,12 @@ tests:
   #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
   #   num: 2
 
-# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
-#  corev_rand_interrupt_wfi:
-#    build: uvmt_cv32e40x
-#    description: Generated corev-dv random interrupt WFI test
-#    dir: cv32e40x/sim/uvmt    
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
-#    num: 2
+  corev_rand_interrupt_wfi:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random interrupt WFI test
+    dir: cv32e40x/sim/uvmt    
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
+    num: 2
 
 
   # FIXME:strichmo:This is currently known to not work, update later
@@ -179,21 +177,19 @@ tests:
   #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
   #   num: 2
 
-# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
-#  corev_rand_interrupt_exception:
-#    build: uvmt_cv32e40x
-#    description: Generated corev-dv random interrupt WFI test with exceptions
-#    dir: cv32e40x/sim/uvmt    
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
-#    num: 2
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random interrupt WFI test with exceptions
+    dir: cv32e40x/sim/uvmt    
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
+    num: 2
 
-# FIXME:mikeopenhwgroup:Temporarily removing due to known false negative with DSIM
-#  corev_rand_interrupt_nested:
-#    build: uvmt_cv32e40x
-#    description: Generated corev-dv random interrupt WFI test with random nested interrupts
-#    dir: cv32e40x/sim/uvmt    
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
-#    num: 2
+  corev_rand_interrupt_nested:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random interrupt WFI test with random nested interrupts
+    dir: cv32e40x/sim/uvmt    
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
+    num: 2
 
   illegal:
     build: uvmt_cv32e40x


### PR DESCRIPTION
Previously removed WFI tests from rel_check regression are now restored.

Note that the e40p will be upgraded in a separate PR.
