### PR TITLE
Fix verilator for CV32E40P

### DIFF
--- a/cv32e40p/sim/Common.mk
+++ b/cv32e40p/sim/Common.mk
@@ -15,20 +15,21 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40p
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= a8a3847
+CV_CORE_HASH   ?= 523b80f
 CV_CORE_TAG    ?= none
-# The CV_CORE_HASH above points to an equivalent RTL with respect to v1.0.0 RTL freeze version
-# There are some implementation and testbench updates in the above hash
+# The CV_CORE_HASH above points to version of the RTL that is newer, but
+# ilogically equivalent RTL with respect to v1.0.0 RTL freeze version.
+# There are some implementation and testbench updates in the above hash.
 # Set CV_CORE_TAG as below to point to the exact cv32e40p repo as that used at RTL freeze
 #CV_CORE_TAG    ?= cv32e40p_v1.0.0
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master
-RISCVDV_HASH		?= 0b625258549e733082c12e5dc749f05aefb07d5a
+RISCVDV_HASH    ?= 0b625258549e733082c12e5dc749f05aefb07d5a
 
 EMBENCH_REPO    ?= https://github.com/embench/embench-iot.git
 EMBENCH_BRANCH  ?= master
-EMBENCH_HASH		?= 6934ddd1ff445245ee032d4258fdeb9828b72af4
+EMBENCH_HASH    ?= 6934ddd1ff445245ee032d4258fdeb9828b72af4
 
 COMPLIANCE_REPO   ?= https://github.com/riscv/riscv-compliance
 COMPLIANCE_BRANCH ?= master

--- a/cv32e40p/tb/core/mm_ram.sv
+++ b/cv32e40p/tb/core/mm_ram.sv
@@ -471,18 +471,19 @@ module mm_ram
             data_rdata_mux = core_data_rdata;
         end else if(select_rdata_q == RND_STALL) begin
             data_rdata_mux = rnd_stall_rdata;
-            uvmt_cv32e40p_tb.iss_wrap.ram.RND_STALL = data_rdata_mux;
 `ifndef VERILATOR
+            uvmt_cv32e40p_tb.iss_wrap.ram.RND_STALL = data_rdata_mux;
             `uvm_fatal(MM_RAM_TAG, $sformatf("out of bounds read from %08x\nRandom stall generator is not supported with Verilator", data_addr_i));
 `endif
         end else if (select_rdata_q == RND_NUM) begin
             data_rdata_mux = rnd_num;
+`ifndef VERILATOR
             uvmt_cv32e40p_tb.iss_wrap.ram.RND_NUM = data_rdata_mux;
-
+`endif
         end else if (select_rdata_q == TICKS) begin
             data_rdata_mux = cycle_count_q;
-            uvmt_cv32e40p_tb.iss_wrap.ram.TICKS = data_rdata_mux;
 `ifndef VERILATOR
+            uvmt_cv32e40p_tb.iss_wrap.ram.TICKS = data_rdata_mux;
             if (cycle_count_overflow_q) begin
                 `uvm_fatal(MM_RAM_TAG, "cycle counter read after overflow");
             end

--- a/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
@@ -113,21 +113,15 @@ task uvma_debug_drv_c::run_phase(uvm_phase phase);
 endtask : run_phase
 
 
-
+// WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
 task uvma_debug_drv_c::drv_req(uvma_debug_seq_item_c req);
-   `uvm_info("DEBUGDRV", $sformatf("Driving debug: %s",req.sprint()), UVM_HIGH); 
-   cntxt.vif.drv_cb.debug_drv <= 1'b1;
- //  while(1) begin
-       repeat (req.active_cycles) @(cntxt.vif.mon_cb);
-       cntxt.vif.drv_cb.debug_drv <= 1'b0;           
- //  end
 
-   // TODO Implement uvma_debug_drv_c::drv_req()
-   //      Ex: cntxt.vif.drv_cb.abc <= req.abc;
-   //          cntxt.vif.drv_cb.xyz <= req.xyz;
-   
-   // WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
-   
+   `uvm_info("DEBUGDRV", $sformatf("Driving debug:\n%s",req.sprint()), UVM_HIGH)
+   @(cntxt.vif.drv_cb) cntxt.vif.drv_cb.debug_drv <= 1'b1;
+   repeat (req.active_cycles) @(cntxt.vif.mon_cb);
+   cntxt.vif.drv_cb.debug_drv <= 1'b0;
+   `uvm_info("DEBUGDRV", $sformatf("Released debug:\n%s",req.sprint()), UVM_HIGH)
+
 endtask : drv_req
 
 

--- a/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
@@ -113,11 +113,11 @@ task uvma_debug_drv_c::run_phase(uvm_phase phase);
 endtask : run_phase
 
 
-// WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
 task uvma_debug_drv_c::drv_req(uvma_debug_seq_item_c req);
 
+   @(cntxt.vif.drv_cb); // WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
    `uvm_info("DEBUGDRV", $sformatf("Driving debug:\n%s",req.sprint()), UVM_HIGH)
-   @(cntxt.vif.drv_cb) cntxt.vif.drv_cb.debug_drv <= 1'b1;
+   cntxt.vif.drv_cb.debug_drv <= 1'b1;
    repeat (req.active_cycles) @(cntxt.vif.mon_cb);
    cntxt.vif.drv_cb.debug_drv <= 1'b0;
    `uvm_info("DEBUGDRV", $sformatf("Released debug:\n%s",req.sprint()), UVM_HIGH)


### PR DESCRIPTION
Please hold you nose and review.  I just noticed that the fixes put in for the cycle-counter virtual peripheral do not work for Verilator.

Also points to the latest version of CV32E40P RTL.