### PR TITLE
Fix a couple of typos in ISACOV

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -136,7 +136,7 @@ covergroup cg_csritype(
   cp_csr: coverpoint instr.csr {
     bins CSR[] = {[USTATUS:VLENB]} with (cfg_illegal_csr[item] == 0);
   }
-  cp_immu: coverpoint instr.immu[4:0];
+  cp_immu: coverpoint instr.immu[31:12];
 endgroup : cg_csritype
 
 covergroup cg_cr(

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -311,7 +311,7 @@ typedef enum bit[CSR_ADDR_WL-1:0] {
   TDATA3         = 'h7A3,
   TINFO          = 'h7A4,
   MCONTEXT       = 'h7A8,
-  SMCONTEXT      = 'h7AA,
+  SCONTEXT       = 'h7AA,
   DCSR           = 'h7B0,
   DPC            = 'h7B1,
   DSCRATCH0      = 'h7B2,


### PR DESCRIPTION
Hi @silabs-robin.  This PR is to fix a typo I introduced in `uvma_isacov_tdefs.sv`.  While I was looking into this I noticed a second typo in `uvma_isacov_cov_model.sv`.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>