### PR TITLE
warning fixes with ISACOV

### DIFF
--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -327,12 +327,12 @@ typedef enum bit[CSR_ADDR_WL-1:0] {
 
 // Package level methods to map instruction to type
 function instr_type_t get_instr_type(instr_name_t name);
-  instr_name_t itypes[] = '{
+  static instr_name_t itypes[] = '{
     LB, LH, LW, LBU, LHU,
     ADDI, SLTI, SLTIU, XORI, ORI, ANDI, SLLI, SRLI, SRAI,
     JALR
     };
-  instr_name_t rtypes[] = '{
+  static instr_name_t rtypes[] = '{
     // I-ext
     ADD, SUB, SLL, SLT, SLTU, XOR, SRL, SRA, OR, AND,
     // M-ext

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -74,6 +74,7 @@ OPT_RV_ISA_DIR = $(if $(RISCV_ISA),/$(RISCV_ISA),)
 VLOG_FLAGS    ?= \
 				-suppress 2577 \
 				-suppress 2583 \
+				-suppress 13185 \
 				-suppress 13314 \
 				-suppress 13288 \
         		-suppress 2181 \
@@ -106,6 +107,9 @@ VSIM_FLAGS        += $(VSIM_USER_FLAGS)
 VSIM_FLAGS        += $(USER_RUN_FLAGS)
 VSIM_FLAGS        += -sv_seed $(RNDSEED)
 VSIM_FLAGS        += -suppress 7031
+VSIM_FLAGS        += -suppress 8858
+VSIM_FLAGS        += -suppress 8522
+VSIM_FLAGS        += -suppress 8550
 VSIM_DEBUG_FLAGS  ?= -debugdb
 VSIM_GUI_FLAGS    ?= -gui -debugdb
 VSIM_SCRIPT_DIR	   = $(abspath $(MAKE_PATH)/../tools/vsim)

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -223,6 +223,11 @@ XRUN_COMP_COREV_DV_FLAGS += -nowarn BNDWRN
 XRUN_RUN_COV    += -nowarn COVCGN
 XRUN_RUN_COV    += -nowarn CGPIZE
 
+# Empty overgroup warnings (we purposely empty covergroups as part of filtering w/ configuration variables)
+XRUN_RUN_COV    += -nowarn WCRTUP
+XRUN_RUN_COV    += -nowarn WCOVPT
+XRUN_RUN_COV    += -nowarn WCROSS
+
 # Un-named covergroup instances
 XRUN_RUN_COV    += -nowarn CGDEFN
 


### PR DESCRIPTION
For Questa and Xcelium suppress multiple warnings dealing with empty cross and coverpoints.  This is part of the methodology of configuring coverage in ISACOV.

Add static initializer in ISACOV to fix a warning from Xcelium.
