### PR TITLE
change objdump flags to optimize debugging

### DIFF
--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -372,7 +372,7 @@ endif
 	@echo ""
 	$(RISCV_EXE_PREFIX)readelf -a $< > $*.readelf
 	@echo ""
-	$(RISCV_EXE_PREFIX)objdump -D -S $*.elf > $*.objdump
+	$(RISCV_EXE_PREFIX)objdump -d -S $*.elf > $*.objdump
 
 bsp:
 	@echo "$(BANNER)"


### PR DESCRIPTION
only dump out executable sections to cut down noise and duplicate addresses in the objdump file

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>