### PR TITLE
Fix argument direction for svPush

### DIFF
--- a/cv32e40x/vendor_lib/imperas/riscv_CV32E40X_OVPsim/sv/riscv_CV32E40P.sv
+++ b/cv32e40x/vendor_lib/imperas/riscv_CV32E40X_OVPsim/sv/riscv_CV32E40P.sv
@@ -154,7 +154,7 @@ module CPU #(
 
     import "DPI-C" context task          opEntry(input string s1, input string s2);
     import "DPI-C" context function void svPull(output RMDataT RMData);
-    import "DPI-C" context function void svPush(output SVDataT SVData);
+    import "DPI-C" context function void svPush(input  SVDataT SVData);
     import "DPI-C" context function void opExit();
 
     export "DPI-C" task     busFetch;

--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -37,7 +37,7 @@ DSIM_USE_ISS           ?= YES
 
 DSIM_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
-DSIM_USER_COMPILE_ARGS += "+define+$(CV_CORE_UC)_TRACE_EXECUTION"
+DSIM_USER_COMPILE_ARGS += "+define+UVM +define+$(CV_CORE_UC)_TRACE_EXECUTION"
 ifeq ($(USE_ISS),YES)
 	DSIM_RUN_FLAGS     += +USE_ISS
 endif


### PR DESCRIPTION
`import "DPI-C" context function void svPush(input  SVDataT SVData);  // was output`

Signed-off-by: Mike Thompson <mike@openhwgroup.org>