### PR TITLE
Fix cp_uimm in cg_csritype

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -136,7 +136,7 @@ covergroup cg_csritype(
   cp_csr: coverpoint instr.csr {
     bins CSR[] = {[USTATUS:VLENB]} with (cfg_illegal_csr[item] == 0);
   }
-  cp_immu: coverpoint instr.immu[31:12];
+  cp_uimm: coverpoint instr.rs1;
 endgroup : cg_csritype
 
 covergroup cg_cr(


### PR DESCRIPTION
As per https://github.com/openhwgroup/core-v-verif/issues/664 this PR updates `cp_uimm` in sampling of `cg_csritype`.

The problem was a slightly confusing term in riscv formats, `uimm` (_"unsigned immediate"_) which name is used only in csr instructions and some compressed instructions. It is not the same as how `imm` differs between the instruction formats (e.g. U-type, R-type, etc). Hence, the existing `immu[31:12]` did not sample the immediate of csr instructions.

ps. There is also a question of whether "special" fields like `uimm` and `shamt` should be made into new properties of the instruction class or if it is fine to reuse the existing canonical fields like `rs1` and `rs2`. (i vote for the latter)