### PR TITLE
fix memory leak, do not enqueue rvfi instruction if rvvi is not enabled

### DIFF
--- a/lib/uvm_agents/uvma_rvvi/uvma_rvvi_sqr.sv
+++ b/lib/uvm_agents/uvma_rvvi/uvma_rvvi_sqr.sv
@@ -88,7 +88,11 @@ function void uvma_rvvi_sqr_c::build_phase(uvm_phase phase);
 endfunction : build_phase
 
 function void uvma_rvvi_sqr_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) rvfi_instr);      
-   rvfi_instr_q.push_back(rvfi_instr);
+
+   if (cfg.enabled) begin
+      rvfi_instr_q.push_back(rvfi_instr);
+   end
+   
 endfunction : write_rvfi_instr
 
 `endif // __UVMA_RVVI_SQR_SV__


### PR DESCRIPTION
Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>