### PR TITLE
add pkg scope to workaround compilation issue in Questa

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_csr_seq_item.sv
+++ b/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_csr_seq_item.sv
@@ -61,14 +61,13 @@ class uvma_rvfi_csr_seq_item_c#(int XLEN=DEFAULT_XLEN) extends uvml_trn_seq_item
 endclass : uvma_rvfi_csr_seq_item_c
 
 `pragma protect begin
-
 function uvma_rvfi_csr_seq_item_c::new(string name="uvma_rvfi_csr_seq_item");
    
    super.new(name);
    
 endfunction : new
 
-function bit [XLEN-1:0] uvma_rvfi_csr_seq_item_c::get_csr_retirement_data();
+function bit [uvma_rvfi_csr_seq_item_c::XLEN-1:0] uvma_rvfi_csr_seq_item_c::get_csr_retirement_data();
 
    // Any bits with wmask set should use the wdata
    // All other bits should use the rdata
@@ -85,5 +84,4 @@ function string uvma_rvfi_csr_seq_item_c::convert2string();
 endfunction : convert2string
 
 `pragma protect end
-
 `endif // __UVMA_RVFI_CSR_SEQ_ITEM_SV__


### PR DESCRIPTION
This is probably a bug in Questa, but the scope identifier does seem to fix with Questa 2021.2

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>