### PR TITLE
add skip_sim for DSIM on debug and interrupts tests until dsim fixed

### DIFF
--- a/cv32e40x/regress/cv32e40x_ci_check.yaml
+++ b/cv32e40x/regress/cv32e40x_ci_check.yaml
@@ -23,6 +23,8 @@ tests:
     description: Interrupt directed test  
     dir: cv32e40x/sim/uvmt
     cmd: make test COREV=YES TEST=interrupt_test
+    # FIXME:strichmo:Restore dsim when Issue #712 is fixed by Metrics
+    skip_sim: dsim
 
   corev_rand_interrupt:
     build: uvmt_cv32e40x
@@ -41,6 +43,8 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test COREV=YES TEST=debug_test
     makearg: USER_RUN_FLAGS=+rand_stall_obi_disable
+    # FIXME:strichmo:Restore dsim when Issue #712 is fixed by Metrics
+    skip_sim: dsim
 
   csr_instructions:
     build: uvmt_cv32e40x

--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -140,6 +140,8 @@ tests:
     dir: cv32e40x/sim/uvmt    
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     num: 2    
+    # FIXME:strichmo:Restore dsim when Issue #712 is fixed by Metrics
+    skip_sim: dsim
 
   # FIXME:strichmo:This is currently known to not work, update later
   # corev_rand_debug:
@@ -226,7 +228,9 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test COREV=YES TEST=debug_test
     makearg: USER_RUN_FLAGS=+rand_stall_obi_disable
-    
+    # FIXME:strichmo:Restore dsim when Issue #712 is fixed by Metrics
+    skip_sim: dsim
+
   # FIXME:strichmo:This is currently known to not work, update later
   # debug_test_reset:
   #   build: uvmt_cv32e40x
@@ -245,6 +249,8 @@ tests:
     description: Interrupt test
     dir: cv32e40x/sim/uvmt
     cmd: make test COREV=YES TEST=interrupt_test
+    # FIXME:strichmo:Restore dsim when Issue #712 is fixed by Metrics
+    skip_sim: dsim
 
   isa_fcov_holes:
     build: uvmt_cv32e40x


### PR DESCRIPTION
Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>