### PR TITLE
move the ovpsim mem variable configuration to an HDL path

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_pkg.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_pkg.sv
@@ -38,7 +38,8 @@ package uvmt_cv32e40x_pkg;
    import uvme_cv32e40x_pkg::*;
    import uvml_hrtbt_pkg::*;
    import uvml_logs_pkg::*;
-   //import uvma_debug_pkg::*;
+   import uvma_rvvi_ovpsim_pkg::*;
+   
    
    // Constants / Parameters / Structs / Enums
    `include "uvmt_cv32e40x_constants.sv"

--- a/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
+++ b/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
@@ -129,6 +129,11 @@ class uvmt_cv32e40x_base_test_c extends uvm_test;
    extern virtual function void phase_ended(uvm_phase phase);
 
    /**
+    * post_randomize hook to complete configuration of test/environment config object
+    */
+   extern function void post_randomize();
+
+   /**
     * Retrieves virtual interfaces from UVM configuration database.
     */
    extern function void retrieve_vifs();
@@ -348,6 +353,22 @@ function void uvmt_cv32e40x_base_test_c::phase_ended(uvm_phase phase);
    end
    
 endfunction : phase_ended
+
+function void uvmt_cv32e40x_base_test_c::post_randomize();
+
+   // Point the RVVI in the cv32e40x environment to the OVPSIM mem path
+   begin
+      uvma_rvvi_ovpsim_cfg_c#(uvme_cv32e40x_pkg::ILEN, uvme_cv32e40x_pkg::XLEN) rvvi_ovpsim_cfg;
+      if (!$cast(rvvi_ovpsim_cfg, env_cfg.rvvi_cfg)) begin
+         `uvm_fatal("RVVICFG", "Could not cast rvvi_cfg to rvvi_ovpsim_cfg");
+      end
+
+      // FIXME: Lee Moore, please revert this commented out line when mem variable is moved back to ram
+      //rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40x_tb.iss_wrap.ram.mem";
+      rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40x_tb.iss_wrap.bus.mem";
+   end
+
+endfunction : post_randomize
 
 
 function void uvmt_cv32e40x_base_test_c::retrieve_vifs();

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cfg.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cfg.sv
@@ -27,8 +27,11 @@
  */
 class uvma_rvvi_ovpsim_cfg_c#(int ILEN=uvma_rvvi_pkg::DEFAULT_ILEN,
                               int XLEN=uvma_rvvi_pkg::DEFAULT_XLEN) extends uvma_rvvi_cfg_c#(ILEN,XLEN);
-   
+
+   string ovpsim_mem_path;
+      
    `uvm_object_utils_begin(uvma_rvvi_ovpsim_cfg_c)
+      `uvm_field_string(ovpsim_mem_path, UVM_DEFAULT)
    `uvm_object_utils_end
       
    /**


### PR DESCRIPTION
Enables Imperas to restructure memory storage variable as needed.
Enables interfaces to avoid cross-module references to remain SV LRM compliant.

@eroom1966 will need to fix the path from bus.mem in 
cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv

```
      // FIXME: Lee Moore, please revert this commented out line when mem variable is moved back to ram
      //rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40x_tb.iss_wrap.ram.mem";
      rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40x_tb.iss_wrap.bus.mem";
```

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>