### PR TITLE
ci_check fixes for cv32e40p and cv32e40s

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_dut_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_dut_wrap.sv
@@ -128,7 +128,7 @@ module uvmt_cv32e40p_dut_wrap #(// DUT (riscv_core) parameters.
                 rnd_byte = $random();
                 uvmt_cv32e40p_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin                
-                  uvmt_cv32e40p_tb.iss_wrap.bus.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40p_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end                
              end
           end

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -632,7 +632,7 @@ bind cv32e40p_wrapper
       if (dut_wrap.ram_i.rst_ni) begin
          if (dut_wrap.ram_i.rnd_num_req) begin
             #1ns;
-            iss_wrap.bus.mem[dut_wrap.ram_i.MMADDR_RNDNUM >> 2] = dut_wrap.ram_i.rnd_num;
+            iss_wrap.ram.mem[dut_wrap.ram_i.MMADDR_RNDNUM >> 2] = dut_wrap.ram_i.rnd_num;
          end
       end
    end

--- a/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
@@ -97,12 +97,12 @@ class uvme_cv32e40s_cfg_c extends uvma_core_cntrl_cfg_c;
    }
 
    constraint default_cv32e40s_boot_cons {
-      hart_id           inside {[2:10]};
-      boot_addr         == 'h0000_0080;
-      mtvec_addr        == 'h0000_0000;
-      nmi_addr          == 'h2000_0000;
-      dm_halt_addr      == 'h1a11_0800;
-      dm_exception_addr == 'h1a11_1000;
+      (!hart_id_plusarg_valid)           -> (hart_id           == 'h0000_0000);
+      (!boot_addr_plusarg_valid)         -> (boot_addr         == 'h0000_0080);
+      (!mtvec_addr_plusarg_valid)        -> (mtvec_addr        == 'h0000_0000);
+      (!nmi_addr_plusarg_valid)          -> (nmi_addr          == 'h2000_0000);
+      (!dm_halt_addr_plusarg_valid)      -> (dm_halt_addr      == 'h1a11_0800);
+      (!dm_exception_addr_plusarg_valid) -> (dm_exception_addr == 'h1a11_1000);
    }
 
    constraint agent_cfg_cons {

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -127,7 +127,7 @@ module uvmt_cv32e40s_dut_wrap
                 rnd_byte = $random();
                 uvmt_cv32e40s_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin
-                  uvmt_cv32e40s_tb.iss_wrap.bus.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40s_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end                
              end
           end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
@@ -45,7 +45,8 @@ module uvmt_cv32e40s_iss_wrap
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
                 .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
 
-   CPU #(.ID(ID), .VARIANT("CV32E40S")) cpu(bus, io);
+   // FIXME:strichmo:This should be switched to CV32E40X when Imperas releases the model update
+   CPU #(.ID(ID), .VARIANT("CV32E40X")) cpu(bus, io);
 
    bit use_iss = 0;
    

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pkg.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pkg.sv
@@ -27,7 +27,6 @@
 `include "uvmt_cv32e40s_macros.sv"
 
 
-
 /**
  * Encapsulates all the types and test cases for the verification of an
  * CV32E40S RTL design.
@@ -38,7 +37,7 @@ package uvmt_cv32e40s_pkg;
    import uvme_cv32e40s_pkg::*;
    import uvml_hrtbt_pkg::*;
    import uvml_logs_pkg::*;
-   //import uvma_debug_pkg::*;
+   import uvma_rvvi_ovpsim_pkg::*;
    
    // Constants / Parameters / Structs / Enums
    `include "uvmt_cv32e40s_constants.sv"

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
@@ -129,6 +129,11 @@ class uvmt_cv32e40s_base_test_c extends uvm_test;
    extern virtual function void phase_ended(uvm_phase phase);
 
    /**
+    * post_randomize hook to complete configuration of test/environment config object
+    */
+   extern function void post_randomize();
+
+   /**
     * Retrieves virtual interfaces from UVM configuration database.
     */
    extern function void retrieve_vifs();
@@ -348,6 +353,20 @@ function void uvmt_cv32e40s_base_test_c::phase_ended(uvm_phase phase);
    end
    
 endfunction : phase_ended
+
+function void uvmt_cv32e40s_base_test_c::post_randomize();
+
+   // Point the RVVI in the cv32e40s environment to the OVPSIM mem path
+   begin
+      uvma_rvvi_ovpsim_cfg_c#(uvme_cv32e40s_pkg::ILEN, uvme_cv32e40s_pkg::XLEN) rvvi_ovpsim_cfg;
+      if (!$cast(rvvi_ovpsim_cfg, env_cfg.rvvi_cfg)) begin
+         `uvm_fatal("RVVICFG", "Could not cast rvvi_cfg to rvvi_ovpsim_cfg");
+      end
+
+      rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40s_tb.iss_wrap.ram.mem";
+   end
+
+endfunction : post_randomize
 
 
 function void uvmt_cv32e40s_base_test_c::retrieve_vifs();


### PR DESCRIPTION
Tweaks to get e40p, e40x and e40s ci_checks all passing.

ISS memory locations needed to be fixed
Temporarily use E40X variant in unified ISS model.
