### PR TITLE
create an RVVI_memory interface to hold memory variable in lieu of st…

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_dut_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_dut_wrap.sv
@@ -128,7 +128,7 @@ module uvmt_cv32e40p_dut_wrap #(// DUT (riscv_core) parameters.
                 rnd_byte = $random();
                 uvmt_cv32e40p_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin                
-                  uvmt_cv32e40p_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40p_tb.iss_wrap.ram.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end                
              end
           end

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
@@ -39,13 +39,12 @@ module uvmt_cv32e40p_iss_wrap
 
     RVVI_bus    bus();
     RVVI_io     io();
-    RVVI_memory memory();
 
     MONITOR     mon(bus, io);
     RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
 
     CPU #(.ID(ID), .VARIANT("CV32E40P")) cpu(bus, io);
 

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
@@ -37,14 +37,15 @@ module uvmt_cv32e40p_iss_wrap
     uvmt_cv32e40p_isa_covg_if     isa_covg_if
    );
 
-    RVVI_bus bus();
-    RVVI_io  io();
+    RVVI_bus    bus();
+    RVVI_io     io();
+    RVVI_memory memory();
 
     MONITOR     mon(bus, io);
     RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
 
     CPU #(.ID(ID), .VARIANT("CV32E40P")) cpu(bus, io);
 

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -632,7 +632,7 @@ bind cv32e40p_wrapper
       if (dut_wrap.ram_i.rst_ni) begin
          if (dut_wrap.ram_i.rnd_num_req) begin
             #1ns;
-            iss_wrap.ram.mem[dut_wrap.ram_i.MMADDR_RNDNUM >> 2] = dut_wrap.ram_i.rnd_num;
+            iss_wrap.ram.memory.mem[dut_wrap.ram_i.MMADDR_RNDNUM >> 2] = dut_wrap.ram_i.rnd_num;
          end
       end
    end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -127,7 +127,7 @@ module uvmt_cv32e40s_dut_wrap
                 rnd_byte = $random();
                 uvmt_cv32e40s_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin
-                  uvmt_cv32e40s_tb.iss_wrap.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40s_tb.iss_wrap.ram.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end                
              end
           end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -127,7 +127,7 @@ module uvmt_cv32e40s_dut_wrap
                 rnd_byte = $random();
                 uvmt_cv32e40s_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin
-                  uvmt_cv32e40s_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40s_tb.iss_wrap.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end                
              end
           end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
@@ -36,14 +36,15 @@ module uvmt_cv32e40s_iss_wrap
     uvma_clknrst_if               clknrst_if    
    );
    
-   RVVI_bus bus();
-   RVVI_io  io();
+   RVVI_bus    bus();
+   RVVI_io     io();
+   RVVI_memory memory();
 
    MONITOR     mon(bus, io);
    RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
 
    // FIXME:strichmo:This should be switched to CV32E40X when Imperas releases the model update
    CPU #(.ID(ID), .VARIANT("CV32E40X")) cpu(bus, io);

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_iss_wrap.sv
@@ -38,13 +38,12 @@ module uvmt_cv32e40s_iss_wrap
    
    RVVI_bus    bus();
    RVVI_io     io();
-   RVVI_memory memory();
 
    MONITOR     mon(bus, io);
    RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
 
    // FIXME:strichmo:This should be switched to CV32E40X when Imperas releases the model update
    CPU #(.ID(ID), .VARIANT("CV32E40X")) cpu(bus, io);

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -681,7 +681,7 @@ bind cv32e40s_wrapper
      uvm_config_db#(virtual RVVI_control                )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("control_vif"), .value(iss_wrap.cpu.control));
      uvm_config_db#(virtual RVVI_bus                    )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_bus_vif"), .value(iss_wrap.bus));
      uvm_config_db#(virtual RVVI_io                     )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_io_vif"), .value(iss_wrap.io));
-     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.memory));
+     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.ram.memory));
      uvm_config_db#(virtual uvmt_cv32e40s_vp_status_if      )::set(.cntxt(null), .inst_name("*"), .field_name("vp_status_vif"),       .value(vp_status_if)      );
      uvm_config_db#(virtual uvme_cv32e40s_core_cntrl_if     )::set(.cntxt(null), .inst_name("*"), .field_name("core_cntrl_vif"),      .value(core_cntrl_if)     );
      uvm_config_db#(virtual uvmt_cv32e40s_core_status_if    )::set(.cntxt(null), .inst_name("*"), .field_name("core_status_vif"),     .value(core_status_if)    );     

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -681,6 +681,7 @@ bind cv32e40s_wrapper
      uvm_config_db#(virtual RVVI_control                )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("control_vif"), .value(iss_wrap.cpu.control));
      uvm_config_db#(virtual RVVI_bus                    )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_bus_vif"), .value(iss_wrap.bus));
      uvm_config_db#(virtual RVVI_io                     )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_io_vif"), .value(iss_wrap.io));
+     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.memory));
      uvm_config_db#(virtual uvmt_cv32e40s_vp_status_if      )::set(.cntxt(null), .inst_name("*"), .field_name("vp_status_vif"),       .value(vp_status_if)      );
      uvm_config_db#(virtual uvme_cv32e40s_core_cntrl_if     )::set(.cntxt(null), .inst_name("*"), .field_name("core_cntrl_vif"),      .value(core_cntrl_if)     );
      uvm_config_db#(virtual uvmt_cv32e40s_core_status_if    )::set(.cntxt(null), .inst_name("*"), .field_name("core_status_vif"),     .value(core_status_if)    );     

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
@@ -356,15 +356,6 @@ endfunction : phase_ended
 
 function void uvmt_cv32e40s_base_test_c::post_randomize();
 
-   // Point the RVVI in the cv32e40s environment to the OVPSIM mem path
-   begin
-      uvma_rvvi_ovpsim_cfg_c#(uvme_cv32e40s_pkg::ILEN, uvme_cv32e40s_pkg::XLEN) rvvi_ovpsim_cfg;
-      if (!$cast(rvvi_ovpsim_cfg, env_cfg.rvvi_cfg)) begin
-         `uvm_fatal("RVVICFG", "Could not cast rvvi_cfg to rvvi_ovpsim_cfg");
-      end
-
-      rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40s_tb.iss_wrap.ram.mem";
-   end
 
 endfunction : post_randomize
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -127,7 +127,7 @@ module uvmt_cv32e40x_dut_wrap
                 rnd_byte = $random();
                 uvmt_cv32e40x_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin
-                  uvmt_cv32e40x_tb.iss_wrap.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                  uvmt_cv32e40x_tb.iss_wrap.ram.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
                 end
              end
           end

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -127,8 +127,8 @@ module uvmt_cv32e40x_dut_wrap
                 rnd_byte = $random();
                 uvmt_cv32e40x_tb.dut_wrap.ram_i.dp_ram_i.mem[index]=rnd_byte;
                 if ($test$plusargs("USE_ISS")) begin
-                  uvmt_cv32e40x_tb.iss_wrap.ram.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
-                end                
+                  uvmt_cv32e40x_tb.iss_wrap.memory.mem[index/4][((((index%4)+1)*8)-1)-:8]=rnd_byte; // convert byte to 32-bit addressing
+                end
              end
           end
           if ($test$plusargs("USE_ISS")) begin

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_iss_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_iss_wrap.sv
@@ -37,14 +37,13 @@ module uvmt_cv32e40x_iss_wrap
    );
    
    RVVI_bus     bus();
-   RVVI_io      io();
-   RVVI_memory  memory();
+   RVVI_io      io();   
 
    MONITOR     mon(bus, io);
    RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
 
    CPU #(.ID(ID), .VARIANT("CV32E40X")) cpu(bus, io);
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_iss_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_iss_wrap.sv
@@ -36,14 +36,15 @@ module uvmt_cv32e40x_iss_wrap
     uvma_clknrst_if               clknrst_if    
    );
    
-   RVVI_bus bus();
-   RVVI_io  io();
+   RVVI_bus     bus();
+   RVVI_io      io();
+   RVVI_memory  memory();
 
    MONITOR     mon(bus, io);
    RAM         #(
                 .ROM_START_ADDR(ROM_START_ADDR),
                 .ROM_BYTE_SIZE(ROM_BYTE_SIZE),
-                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus);
+                .RAM_BYTE_SIZE(RAM_BYTE_SIZE)) ram(bus, memory);
 
    CPU #(.ID(ID), .VARIANT("CV32E40X")) cpu(bus, io);
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -678,7 +678,7 @@ bind cv32e40x_wrapper
      uvm_config_db#(virtual RVVI_control                )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("control_vif"), .value(iss_wrap.cpu.control));
      uvm_config_db#(virtual RVVI_bus                    )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_bus_vif"), .value(iss_wrap.bus));
      uvm_config_db#(virtual RVVI_io                     )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_io_vif"), .value(iss_wrap.io));
-     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.memory));
+     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.ram.memory));
      uvm_config_db#(virtual uvmt_cv32e40x_vp_status_if      )::set(.cntxt(null), .inst_name("*"), .field_name("vp_status_vif"),       .value(vp_status_if)      );
      uvm_config_db#(virtual uvme_cv32e40x_core_cntrl_if     )::set(.cntxt(null), .inst_name("*"), .field_name("core_cntrl_vif"),      .value(core_cntrl_if)     );
      uvm_config_db#(virtual uvmt_cv32e40x_core_status_if    )::set(.cntxt(null), .inst_name("*"), .field_name("core_status_vif"),     .value(core_status_if)    );     

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -678,6 +678,7 @@ bind cv32e40x_wrapper
      uvm_config_db#(virtual RVVI_control                )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("control_vif"), .value(iss_wrap.cpu.control));
      uvm_config_db#(virtual RVVI_bus                    )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_bus_vif"), .value(iss_wrap.bus));
      uvm_config_db#(virtual RVVI_io                     )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_io_vif"), .value(iss_wrap.io));
+     uvm_config_db#(virtual RVVI_memory                 )::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("ovpsim_mem_vif"), .value(iss_wrap.memory));
      uvm_config_db#(virtual uvmt_cv32e40x_vp_status_if      )::set(.cntxt(null), .inst_name("*"), .field_name("vp_status_vif"),       .value(vp_status_if)      );
      uvm_config_db#(virtual uvme_cv32e40x_core_cntrl_if     )::set(.cntxt(null), .inst_name("*"), .field_name("core_cntrl_vif"),      .value(core_cntrl_if)     );
      uvm_config_db#(virtual uvmt_cv32e40x_core_status_if    )::set(.cntxt(null), .inst_name("*"), .field_name("core_status_vif"),     .value(core_status_if)    );     

--- a/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
+++ b/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
@@ -356,15 +356,6 @@ endfunction : phase_ended
 
 function void uvmt_cv32e40x_base_test_c::post_randomize();
 
-   // Point the RVVI in the cv32e40x environment to the OVPSIM mem path
-   begin
-      uvma_rvvi_ovpsim_cfg_c#(uvme_cv32e40x_pkg::ILEN, uvme_cv32e40x_pkg::XLEN) rvvi_ovpsim_cfg;
-      if (!$cast(rvvi_ovpsim_cfg, env_cfg.rvvi_cfg)) begin
-         `uvm_fatal("RVVICFG", "Could not cast rvvi_cfg to rvvi_ovpsim_cfg");
-      end
-
-      rvvi_ovpsim_cfg.ovpsim_mem_path = "uvmt_cv32e40x_tb.iss_wrap.ram.mem";
-   end
 
 endfunction : post_randomize
 

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_agent.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_agent.sv
@@ -179,6 +179,16 @@ function void uvma_rvvi_ovpsim_agent_c::retrieve_vif();
       `uvm_info("VIF", $sformatf("Found vif handle of type %s in uvm_config_db", 
                                  $typename(rvvi_ovpsim_cntxt.ovpsim_io_vif)), UVM_DEBUG)
    end
+
+   if (!uvm_config_db#(virtual RVVI_memory)::get(this, "", $sformatf("ovpsim_mem_vif"), rvvi_ovpsim_cntxt.ovpsim_mem_vif)) begin
+      `uvm_fatal("VIF", $sformatf("Could not find vif handle of type %s in uvm_config_db", 
+                                    $typename(rvvi_ovpsim_cntxt.ovpsim_mem_vif)))
+   end
+   else begin
+      `uvm_info("VIF", $sformatf("Found vif handle of type %s in uvm_config_db", 
+                                 $typename(rvvi_ovpsim_cntxt.ovpsim_mem_vif)), UVM_DEBUG)
+   end
+
 endfunction : retrieve_vif
 
 

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cfg.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cfg.sv
@@ -28,10 +28,7 @@
 class uvma_rvvi_ovpsim_cfg_c#(int ILEN=uvma_rvvi_pkg::DEFAULT_ILEN,
                               int XLEN=uvma_rvvi_pkg::DEFAULT_XLEN) extends uvma_rvvi_cfg_c#(ILEN,XLEN);
 
-   string ovpsim_mem_path;
-      
    `uvm_object_utils_begin(uvma_rvvi_ovpsim_cfg_c)
-      `uvm_field_string(ovpsim_mem_path, UVM_DEFAULT)
    `uvm_object_utils_end
       
    /**

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cntxt.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_cntxt.sv
@@ -25,11 +25,11 @@
  */
 class uvma_rvvi_ovpsim_cntxt_c#(int ILEN=uvma_rvvi_pkg::DEFAULT_ILEN, 
                                 int XLEN=uvma_rvvi_pkg::DEFAULT_XLEN) extends uvma_rvvi_cntxt_c#(ILEN,XLEN);
-
-   // FIXME: to get access to deferint, should be part of RVVI
+   
    virtual RVVI_bus                     ovpsim_bus_vif;
    virtual RVVI_io                      ovpsim_io_vif;
-   
+   virtual RVVI_memory                  ovpsim_mem_vif;
+
    `uvm_object_param_utils_begin(uvma_rvvi_ovpsim_cntxt_c)
    `uvm_object_utils_end
 

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_drv.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_drv.sv
@@ -132,25 +132,12 @@ task uvma_rvvi_ovpsim_drv_c::stepi(REQ req);
    // Check for read of volatile memory locations, backdoor init the RVVI memory when found to ensure
    // the ISS sees the same data as the DUT
    if (rvvi_ovpsim_seq_item.mem_rmask && cfg.is_mem_addr_volatile(rvvi_ovpsim_seq_item.mem_addr)) begin
-      string mem_hdl_path;
 
       `uvm_info("RVVIDRV", $sformatf("Setting volatile bus read data @ 0x%08x to 0x%08x", 
                                      rvvi_ovpsim_seq_item.mem_addr, 
                                      rvvi_ovpsim_seq_item.mem_rdata), UVM_HIGH);
 
-      // Construct an HDL path to the memory in the OVPSIM model and backdoor write to it
-      if (rvvi_ovpsim_cfg.ovpsim_mem_path == "") begin
-         `uvm_fatal("RVVIOVPDRV", 
-                    $sformatf("Volatile memory address of 0x%08x read, but no ovpsim_mem_path configured",
-                              rvvi_ovpsim_seq_item.mem_addr));
-      end
-
-      mem_hdl_path = { rvvi_ovpsim_cfg.ovpsim_mem_path, $sformatf("[%0d]", rvvi_ovpsim_seq_item.mem_addr >> 2) };
-
-      if (!uvm_hdl_deposit(mem_hdl_path, rvvi_ovpsim_seq_item.mem_rdata)) begin
-         `uvm_fatal("RVVIOVPDRV",
-                    $sformatf("Backdoor memory write to path failed: [%s]", mem_hdl_path));
-      end      
+      rvvi_ovpsim_cntxt.ovpsim_mem_vif.mem[rvvi_ovpsim_seq_item.mem_addr >> 2] = rvvi_ovpsim_seq_item.mem_rdata;
    end
 
    // Signal an interrupt to the ISS if mcause and rvfi_intr signals external interrupt  

--- a/vendor_lib/imperas/design/monitor.sv
+++ b/vendor_lib/imperas/design/monitor.sv
@@ -116,7 +116,7 @@ module MONITOR
         fd_signature = $fopen(sig_file, "w");
 
         while (addr < end_signature.addr) begin
-            $fwrite(fd_signature, "%x\n", ram.mem[addr>>2]);
+            $fwrite(fd_signature, "%x\n", ram.memory.mem[addr>>2]);
             addr = addr + 4;
         end
   

--- a/vendor_lib/imperas/design/ram.sv
+++ b/vendor_lib/imperas/design/ram.sv
@@ -30,17 +30,17 @@ module RAM
     parameter int RAM_BYTE_SIZE  = 'h20000
 )
 (
-    RVVI_bus bus,
-    RVVI_memory memory
+    RVVI_bus bus   
 );
-
 
     Uns32 daddr4, iaddr4;
     Uns32 value;
     bit isROM, isRAM;
     Uns32 loROM, hiROM;
     Uns32 loRAM, hiRAM;
-    
+
+    RVVI_memory memory();
+
     initial begin
         loROM = ROM_START_ADDR;
         hiROM = loROM + ROM_BYTE_SIZE - 1;

--- a/vendor_lib/imperas/design/ram.sv
+++ b/vendor_lib/imperas/design/ram.sv
@@ -30,7 +30,8 @@ module RAM
     parameter int RAM_BYTE_SIZE  = 'h20000
 )
 (
-    RVVI_bus bus
+    RVVI_bus bus,
+    RVVI_memory memory
 );
 
 
@@ -39,8 +40,6 @@ module RAM
     bit isROM, isRAM;
     Uns32 loROM, hiROM;
     Uns32 loRAM, hiRAM;
-
-    reg [31:0] mem [bit[29:0]];
     
     initial begin
         loROM = ROM_START_ADDR;
@@ -66,13 +65,13 @@ module RAM
         iaddr4 = bus.IAddr >> 2;
         
         // Uninitialized Memory
-        if (!mem.exists(daddr4)) mem[daddr4] = 'h0;
-        if (!mem.exists(iaddr4)) mem[iaddr4] = 'h0;
+        if (!memory.mem.exists(daddr4)) memory.mem[daddr4] = 'h0;
+        if (!memory.mem.exists(iaddr4)) memory.mem[iaddr4] = 'h0;
 
         // READ (ROM & RAM)
         if (isROM || isRAM) begin
             if (bus.Drd==1) begin
-                bus.DData = mem[daddr4] & byte2bit(bus.Dbe);
+                bus.DData = memory.mem[daddr4] & byte2bit(bus.Dbe);
                 //$display("Load  %08x <= [%08X]", bus.DData, daddr4);
             end
         end
@@ -80,8 +79,8 @@ module RAM
         // WRITE
         if (isRAM) begin
             if (bus.Dwr==1) begin
-                value = mem[daddr4] & ~(byte2bit(bus.Dbe));
-                mem[daddr4] = value | (bus.DData & byte2bit(bus.Dbe));
+                value = memory.mem[daddr4] & ~(byte2bit(bus.Dbe));
+                memory.mem[daddr4] = value | (bus.DData & byte2bit(bus.Dbe));
                 //$display("Store %08x <= %08X", daddr4, mem[daddr4]);
                 
             end
@@ -90,7 +89,7 @@ module RAM
         // EXEC
         if (isROM) begin
             if (bus.Ird==1) begin
-                bus.IData = mem[iaddr4] & byte2bit(bus.Ibe);
+                bus.IData = memory.mem[iaddr4] & byte2bit(bus.Ibe);
                 //$display("Fetch %08x <= [%08X]", bus.IData, iaddr4);
             end
         end

--- a/vendor_lib/imperas/imperas_DV_COREV/sv/imperas_CV32.sv
+++ b/vendor_lib/imperas/imperas_DV_COREV/sv/imperas_CV32.sv
@@ -139,6 +139,12 @@ interface RVVI_bus;
 
 endinterface
 
+interface RVVI_memory;
+
+    reg [31:0] mem [bit[29:0]];
+
+endinterface
+
 module CPU #(
     parameter int ID = 0,
     parameter string VARIANT = "UNSET"
@@ -182,11 +188,11 @@ module CPU #(
     // Bus direct transactors
     //
     function automatic int read(input int address);
-        if (!ram.mem.exists(address)) ram.mem[address] = 'h0;
-        return ram.mem[address];
+        if (!ram.memory.mem.exists(address)) ram.memory.mem[address] = 'h0;
+        return ram.memory.mem[address];
     endfunction
     function automatic void write(input int address, input int data);
-        ram.mem[address] = data;
+        ram.memory.mem[address] = data;
     endfunction
 
     //


### PR DESCRIPTION
…ring-based HDL path

some simulators could not use an associative array with uvm_hdl_deposit

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>