### PR TITLE
PMA test fix

### DIFF
--- a/cv32e40x/tests/cfg/pma.yaml
+++ b/cv32e40x/tests/cfg/pma.yaml
@@ -4,24 +4,4 @@ compile_flags:
     +define+PMA_CUSTOM_CFG
 ovpsim: >
     --override root/cpu/misa_Extensions=0x001104
-    --override root/cpu/marchid=20
-    --override root/cpu/noinhibit_mask=0xFFFFFFF0
-    --override root/cpu/extension/PMA_NUM_REGIONS=3
-    --override root/cpu/extension/word_addr_low2=0
-    --override root/cpu/extension/word_addr_high2=0x06844204
-    --override root/cpu/extension/main2=0
-    --override root/cpu/extension/bufferable2=0
-    --override root/cpu/extension/cacheable2=0
-    --override root/cpu/extension/atomic2=0
-    --override root/cpu/extension/word_addr_low1=0
-    --override root/cpu/extension/word_addr_high1=0x06844204
-    --override root/cpu/extension/main1=1
-    --override root/cpu/extension/bufferable1=1
-    --override root/cpu/extension/cacheable1=1
-    --override root/cpu/extension/atomic1=1
-    --override root/cpu/extension/word_addr_low0=0x06844400
-    --override root/cpu/extension/word_addr_high0=0xFFFFFFFF
-    --override root/cpu/extension/main0=1
-    --override root/cpu/extension/bufferable0=0
-    --override root/cpu/extension/cacheable0=0
-    --override root/cpu/extension/atomic0=1
+    --override root/cpu/marchid=20    

--- a/cv32e40x/tests/programs/custom/pma/pma.c
+++ b/cv32e40x/tests/programs/custom/pma/pma.c
@@ -220,6 +220,9 @@ int main(void) {
 
   // sanity check that aligned load is no problem
   reset_volatiles();
+  // Must initialize memory for ISS
+  __asm__ volatile("sw %0, 0(%1)" : : "r"(0xAAAAAAAA), "r"(IO_ADDR));
+  __asm__ volatile("sw %0, 4(%1)" : : "r"(0xBBBBBBBB), "r"(IO_ADDR));
   tmp = 0;
   __asm__ volatile("lw %0, 4(%1)" : "=r"(tmp) : "r"(IO_ADDR));
   assert_or_die(!tmp, 0, "error: load should not yield zero\n");  // TODO ensure memory content matches
@@ -245,7 +248,6 @@ int main(void) {
   assert_or_die(mcause, -1, "error: main access should not change mcause\n");
   assert_or_die(mepc, -1, "error: main access should not change mepc\n");
   assert_or_die(mtval, -1, "error: main access should not change mtval\n");
-
 
   // Non-naturally aligned stores to I/O regions
 

--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_pma_region.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_pma_region.sv
@@ -49,13 +49,13 @@
    rand bit                      atomic;
 
    `uvm_object_utils_begin(uvma_core_cntrl_pma_region_c);
-      `uvm_field_enum(corev_mxl_t,  xlen            , UVM_DEFAULT)
-      `uvm_field_int(               word_addr_low   , UVM_DEFAULT)
-      `uvm_field_int(               word_addr_high  , UVM_DEFAULT)
-      `uvm_field_int(               main            , UVM_DEFAULT)
-      `uvm_field_int(               bufferable      , UVM_DEFAULT)
-      `uvm_field_int(               cacheable       , UVM_DEFAULT)
-      `uvm_field_int(               atomic          , UVM_DEFAULT)
+      `uvm_field_enum(corev_mxl_t,  xlen            , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               word_addr_low   , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               word_addr_high  , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               main            , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               bufferable      , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               cacheable       , UVM_DEFAULT | UVM_NOPRINT)
+      `uvm_field_int(               atomic          , UVM_DEFAULT | UVM_NOPRINT)
    `uvm_field_utils_end
    
    constraint addr_range_cons {
@@ -78,9 +78,19 @@
    extern function new(string name="uvma_core_cntrl_pma_region_c");
 
    /**
+    * Custom prints
+    */
+   extern function void do_print(uvm_printer printer);
+
+   /**
     * Simple lookup if address is in region
     */
    extern function bit is_addr_in_region(bit [MAX_XLEN-1:0] byte_addr);
+
+   /**
+    * Convert word address to byte address
+    */
+   extern function bit [MAX_XLEN-1:0] get_byte_addr(bit [MAX_XLEN-1:0] word_addr);
 
  endclass : uvma_core_cntrl_pma_region_c
 
@@ -89,6 +99,20 @@ function uvma_core_cntrl_pma_region_c::new(string name="uvma_core_cntrl_pma_regi
    super.new(name);
 
 endfunction : new
+
+function void uvma_core_cntrl_pma_region_c::do_print(uvm_printer printer);
+
+   super.do_print(printer);
+
+   printer.print_string("xlen", xlen.name());
+   printer.print_field("main", main, 1);
+   printer.print_string("word_addr_low", $sformatf("0x%08x (0x%08x)", word_addr_low, get_byte_addr(word_addr_low)));
+   printer.print_string("word_addr_high", $sformatf("0x%08x (0x%08x)", word_addr_high, get_byte_addr(word_addr_high)));
+   printer.print_field("bufferable", bufferable, 1);
+   printer.print_field("cacheable", cacheable, 1);
+   printer.print_field("atomic", atomic, 1);
+
+endfunction : do_print
 
 function bit uvma_core_cntrl_pma_region_c::is_addr_in_region(bit [MAX_XLEN-1:0] byte_addr);
 
@@ -99,5 +123,18 @@ function bit uvma_core_cntrl_pma_region_c::is_addr_in_region(bit [MAX_XLEN-1:0] 
    return 0;
 
 endfunction : is_addr_in_region
+
+function bit [MAX_XLEN-1:0] uvma_core_cntrl_pma_region_c::get_byte_addr(bit [MAX_XLEN-1:0] word_addr);
+   bit [MAX_XLEN-1:0] byte_addr = word_addr << 2;
+
+   case (xlen)
+   MXL_32:  return byte_addr[31:0];
+   MXL_64:  return byte_addr[63:0];
+   MXL_128: return byte_addr[127:0];
+   endcase  
+
+   `uvm_fatal("PMA", "Should not fall through to here");
+
+endfunction : get_byte_addr
 
 `endif // __UVMA_CORE_CNTRL_PMA_REGION_SV__


### PR DESCRIPTION
Adding initialization to PMA aligned I/O load test to ensure ISS matches
Test still fails because RTL does not have data PMA implemented