### PR TITLE
change options to objdump for better debug

### DIFF
--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -378,7 +378,11 @@ endif
 	@echo ""
 	$(RISCV_EXE_PREFIX)readelf -a $< > $*.readelf
 	@echo ""
-	$(RISCV_EXE_PREFIX)objdump -d -S $*.elf > $*.objdump
+	$(RISCV_EXE_PREFIX)objdump \
+		-d \
+		-M no-aliases \
+		-M numeric \
+		-S $*.elf > $*.objdump
 
 bsp:
 	@echo "$(BANNER)"


### PR DESCRIPTION
use isa registers instead of ABI (x0-x31)
delineate compressed instructions in pnemonics with c. prefix

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>