### PR TITLE
Replace max_data_zero_instr_stall plusarg with rand_stall_obi_disable

### DIFF
--- a/cv32e40p/tests/programs/custom/perf_counters_instructions/test.yaml
+++ b/cv32e40p/tests/programs/custom/perf_counters_instructions/test.yaml
@@ -3,4 +3,4 @@ uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
     Performance Counters Basic Test
 plusargs: >
-    +max_data_zero_instr_stall
+    +rand_stall_obi_disable


### PR DESCRIPTION
Replace `max_data_zero_instr_stall` plusarg (used in the now deprecated mm_ram.sv) with `rand_stall_obi_disable` supported by the new obi_memory_agent (see [uvma_obi_memory_cfg.sv](https://github.com/openhwgroup/core-v-verif/blob/master/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv#L225)).

The obi_memory_agent does not have a `max_data_zero_instr_stall` plusarg, and without some tight constraints on the instruction fetch OBI bus the `perf_counters_instructions` directed test will not accurately predict performance counter values.  This change also constrains the data load/store OBI bus, so we may wish to implement a `max_data_zero_instr_stall` type constraint in the future.

Signed-off-by: MikeOpenHWGroup <mike@openhwgroup.org>