### PR TITLE
debug_req must be clocking drive

### DIFF
--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_debug_control_seq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_debug_control_seq.sv
@@ -60,7 +60,7 @@ endtask : wait_n_clocks
 
 task uvme_cv32e40s_vp_debug_control_seq_c::set_debug_req(bit debug_req);
 
-   cv32e40s_cntxt.debug_vif.debug_drv = debug_req;
+   cv32e40s_cntxt.debug_vif.drv_cb.debug_drv <= debug_req;
 
 endtask : set_debug_req
 

--- a/cv32e40x/env/uvme/vseq/uvme_cv32e40x_vp_debug_control_seq.sv
+++ b/cv32e40x/env/uvme/vseq/uvme_cv32e40x_vp_debug_control_seq.sv
@@ -60,7 +60,7 @@ endtask : wait_n_clocks
 
 task uvme_cv32e40x_vp_debug_control_seq_c::set_debug_req(bit debug_req);
 
-   cv32e40x_cntxt.debug_vif.debug_drv = debug_req;
+   cv32e40x_cntxt.debug_vif.drv_cb.debug_drv <= debug_req;
 
 endtask : set_debug_req
 


### PR DESCRIPTION
This should fix the debug_test_trigger (on master) for the cv32e40x and cv32e40s.  Adding as hotfix to assist with an ongoing issue with OVPSim.

Will follow up with a merge up to cv32e40x/release and cv32e40x/dev

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>