### PR TITLE
fix cycle count print virtual peripheral

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
@@ -257,7 +257,7 @@ task uvme_cv32e40x_env_c::run_phase(uvm_phase phase);
             void'(data_slv_seq.register_vp_vseq("vp_rand_num", 32'h1500_1000, 1, uvma_obi_memory_vp_rand_num_seq_c::get_type()));
             void'(data_slv_seq.register_vp_vseq("vp_virtual_printer", 32'h1000_0000, 11, uvma_obi_memory_vp_virtual_printer_seq_c::get_type()));
             void'(data_slv_seq.register_vp_vseq("vp_sig_writer", 32'h2000_0008, 3, uvma_obi_memory_vp_sig_writer_seq_c::get_type()));
-            void'(data_slv_seq.register_vp_vseq("vp_cycle_counter", 32'h1500_1004, 1, uvma_obi_memory_vp_cycle_counter_seq_c::get_type()));
+            void'(data_slv_seq.register_vp_vseq("vp_cycle_counter", 32'h1500_1004, 2, uvma_obi_memory_vp_cycle_counter_seq_c::get_type()));
 
             begin
                uvme_cv32e40x_vp_status_flags_seq_c vp_seq;

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
@@ -160,7 +160,7 @@ class uvma_obi_memory_cfg_c extends uvm_object;
          drv_slv_gnt_fixed_latency == 0;
 
          drv_slv_rvalid_mode == UVMA_OBI_MEMORY_DRV_SLV_RVALID_MODE_FIXED_LATENCY;
-         drv_slv_rvalid_fixed_latency == 0;
+         drv_slv_rvalid_fixed_latency == 1;
       }
    }
 

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_base_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_base_seq.sv
@@ -120,6 +120,7 @@ function void uvma_obi_memory_slv_base_seq_c::add_r_fields(uvma_obi_memory_mon_t
    // Take care to leave rchk last as it will likely incorporate a checksum of all other response fields
 
    slv_rsp.rid = mon_req.aid;
+   add_latencies(slv_rsp);
    if (cfg.version >= UVMA_OBI_MEMORY_VERSION_1P2) begin
       add_err(slv_rsp);
       add_exokay(mon_req, slv_rsp);

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_cycle_counter_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_cycle_counter_seq.sv
@@ -50,9 +50,20 @@ class uvma_obi_memory_vp_cycle_counter_seq_c extends uvma_obi_memory_vp_base_seq
    extern virtual task vp_body(uvma_obi_memory_mon_trn_c mon_trn);
 
    /**
+    * Implements the virtual register to read or write the counter
+    */
+   extern virtual task rw_counter(uvma_obi_memory_mon_trn_c mon_trn, uvma_obi_memory_slv_seq_item_c slv_rsp);
+
+   /**
+    * Implements the virtual register to read or write the counter
+    */
+   extern virtual task print_counter(uvma_obi_memory_mon_trn_c mon_trn);
+
+   /**
     * Implements the counting thread, should always be fork-join_none'd
     */
    extern virtual task count_cycles();
+
 
 endclass : uvma_obi_memory_vp_cycle_counter_seq_c
 
@@ -81,20 +92,10 @@ task uvma_obi_memory_vp_cycle_counter_seq_c::vp_body(uvma_obi_memory_mon_trn_c m
    
    slv_rsp.err = 1'b0;
 
-   if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
-      // First stop the thread, reset counter to write data, then restart
-      
-      _stop_count_cycles = 1;
-      wait (_stop_count_cycles == 0);
-
-      cycle_counter = mon_trn.data;
-      fork         
-         count_cycles();
-      join_none
-   end
-   else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin      
-      slv_rsp.rdata = cycle_counter;
-   end
+   case (mon_trn.address)
+      32'h1500_1004: rw_counter(mon_trn, slv_rsp);
+      32'h1500_1008: print_counter(mon_trn);
+   endcase
 
    add_r_fields(mon_trn, slv_rsp);
    slv_rsp.set_sequencer(p_sequencer);
@@ -127,4 +128,32 @@ task uvma_obi_memory_vp_cycle_counter_seq_c::count_cycles();
 
 endtask : count_cycles
 
+task uvma_obi_memory_vp_cycle_counter_seq_c::rw_counter(uvma_obi_memory_mon_trn_c mon_trn, uvma_obi_memory_slv_seq_item_c slv_rsp);
+
+   if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
+      // First stop the thread, reset counter to write data, then restart
+      
+      _stop_count_cycles = 1;
+      wait (_stop_count_cycles == 0);
+
+      cycle_counter = mon_trn.data;
+      fork         
+         count_cycles();
+      join_none
+   end
+   else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin      
+      slv_rsp.rdata = cycle_counter;
+   end
+
+endtask : rw_counter
+
+task uvma_obi_memory_vp_cycle_counter_seq_c::print_counter(uvma_obi_memory_mon_trn_c mon_trn);
+
+   if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
+      `uvm_info("CYCLE", $sformatf("Cycle count is %0d", cycle_counter), UVM_LOW);
+   end
+
+endtask : print_counter
+
 `endif // __UVMA_OBI_MEMORY_VP_CYCLE_COUNTER_SEQ_SV__
+


### PR DESCRIPTION
virtual peripheral register to print cycle count was missing
fix adding latencies on rvalid in the uvma obi memory sequence