### PR TITLE
add instruction trace table generation and trace to rvfi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.nm
 *.elf
 *.hex
+*.itb
 *.map
 *.o
 *.objdump

--- a/bin/objdump2itb
+++ b/bin/objdump2itb
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+################################################################################
+#
+# Copyright 2021 OpenHW Group
+# Copyright 2021 Silicon Labs
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# 
+################################################################################
+#
+# dump2itb: python script to parse a GNU binutils objdump output file
+#           into an instruction table format, which is a custom
+#           text file more suitable for parsing using the standard IEEE 1800 
+#           text parsing functions
+#
+# The objdump should set the following flags to ensure that the regexps will 
+# parse the expected text properly
+# % objdump -d -l -s program.elf > program.objdump
+# 
+# The instruction table file format for a single instruction is:
+# 
+# #<num_of_src_lines>
+# #<stc_line_0>
+# #<stc_line_1>
+# #...
+# #<src_line_n>
+# <instr_addr> <instr_func> <basename of instr_src> <line_num> <opcode> <num of asm words> <asm_word_0> <asm_word_1> <...> <asm_word_n> 
+#
+# An esample: Note that the pound signs are part of the format
+# #6
+# #       // Expect DCSR
+# #       //   31:28 XDEBUGER Version = 4
+# #       //    8:6   Cause           = 2 Trigger
+# #       //    1:0   Privelege       = 3 Machine
+# #       // TBD FIXME BUG documentation update needed
+# #       li   t1, 4<<28 | 2<<6 | 3<<0 | 1<<15
+# 437324064 _debugger_trigger_match_ebreak debugger.S 171 40008337 2 lui x6,0x40008
+#
+#
+# Author: Steve Richmond
+#  email: steve.richmond@silabs.com
+#
+# Written with Python 3.5.1 on RHEL 7.7.  Your python mileage may vary.
+#
+################################################################################
+
+import string
+import sys
+import re
+import argparse
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class CFunction:
+    def __init__(self, addr, name):
+        self.addr = addr
+        self.name = name
+
+# Regular expression to extract a function from objdump
+# Example:
+# 00000256 <end_handler_incr_mepc>:
+FUNC_PATTERN     = "(?P<addr>[0-9a-f]{8}) <(?P<name>\S*)>:"
+FUNC_RE          = re.compile(FUNC_PATTERN)
+
+# Regular expression to extract an individual instruction
+# Example:
+#      264:       00a31363                bne     t1,a0,26a <end_handler_incr_mepc2>
+INST_PATTERN     = "(?P<addr>[0-9a-f]{1,8}):\t*(?P<mcode>[0-9a-f]{4}([0-9a-f]{4})?)\s{2,}(?P<asm>[a-z].*)$"
+INST_RE          = re.compile(INST_PATTERN)
+
+# Regular expression to extract a source annotation for each instruction
+# Example:
+# /work/strichmo/core-v-verif/cv32e40x/tests/programs/custom/debug_test_trigger/debugger.S:47
+SRC_FILE_PATTERN = "^(?P<dir>/\S+)/(?P<file>[^/\s]+):(?P<line>[0-9]*)$" 
+SRC_FILE_RE      = re.compile(SRC_FILE_PATTERN)
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('objdump', help='Required objdump file for parsing.  Use - to read STDIN')
+parser.add_argument('--debug', action='store_true', help='Enable more debug messages')
+
+# Main function
+def objdump2itb():
+    '''Parse an objdump file'''
+    args = parser.parse_args(sys.argv[1:])
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    parse(args.objdump)
+
+def parse(objdump):
+    '''Parse the file'''
+
+    if objdump == '-':
+        fp = sys.stdin
+    else:
+        fp = open(objdump)
+
+    current_cfunction = None
+    current_src_file = None
+    current_src_line = 0
+    current_src_code = ""    
+    used_src = 0
+
+    for line in fp:
+        line_orig = line.strip('\n')
+        line = line.strip()
+        if not line:
+            continue
+
+        # Parse function
+        func = FUNC_RE.match(line)
+        if func:
+            d = func.groupdict()
+            current_cfunction = CFunction(d["addr"], d["name"])
+            current_src_code = ""   # reset the source code lines
+            used_src = 0
+            continue
+
+        # Parse source file
+        src_file = SRC_FILE_RE.match(line)
+        if src_file:
+            d = src_file.groupdict()
+            current_src_file = d["file"]
+            current_src_line = d["line"]  
+            current_src_code = ""   # reset the source code lines
+            used_src = 0
+            continue
+
+        # Parse instruction
+        inst = INST_RE.match(line)
+        if inst:
+            d = inst.groupdict()
+            addr = d["addr"]
+            mcode = d["mcode"]
+            asm = d["asm"]
+            mcode = mcode.replace(" ", "")
+            asm = asm.replace("\t", " ").strip()            
+            addr = int("0x{}".format(addr), 0)
+            fname = current_cfunction.name
+            asm_len = len(asm.split())
+            
+            used_src = 1
+            if current_src_code == "":
+                src_len = 0
+                print("#{}".format(src_len))
+            else:
+                src_len = len(current_src_code.split('\n')); 
+                print("#{}\n{}".format(src_len, current_src_code))
+
+            print("{} {} {} {} {} {} {}".format(addr, fname, current_src_file, current_src_line, mcode, asm_len, asm))
+            
+            logger.debug("Addr: '{:x}' Func: '{}' Source File: '{}' Source lineno: '{}' mcode: '{}' Asm: '{}'".format(
+                           int(addr), fname, current_src_file, current_src_line, mcode, asm))
+            continue
+
+        # no match on filters
+        if current_src_code:
+            src_len = len(current_src_code.split('\n')); 
+            if (src_len < 10):   # keep src from getting too long, also good if filenames are missing
+                current_src_code += "\n#" + line_orig
+        else:
+            if current_src_file:    # don't start adding source before first src file
+                # first src line no newline before
+                current_src_code = "#" + line_orig
+        
+        logger.debug("Unmatched (treating as source line): '{}'".format(line))
+
+
+if __name__ == '__main__':
+    objdump2itb()
+

--- a/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_table_seq_item.sv
+++ b/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_table_seq_item.sv
@@ -1,0 +1,78 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_RVFI_INSTR_TABLE_SEQ_ITEM_SV__
+`define __UVMA_RVFI_INSTR_TABLE_SEQ_ITEM_SV__
+
+
+/**
+ * Object created by Rvfi agent sequences extending uvma_rvfi_seq_base_c.
+ */
+class uvma_rvfi_instr_table_seq_item_c#(int ILEN=DEFAULT_ILEN,
+                                        int XLEN=DEFAULT_XLEN) extends uvml_trn_seq_item_c;
+
+
+   bit[XLEN-1:0] addr;
+   string        mcode;
+   string        asm;
+   string        src_function;
+   string        filename;
+   int unsigned  lineno;
+   string        src_code[];
+
+   static protected string _log_format_string = "0x%08x %s 0x%01x 0x%08x";
+
+   `uvm_object_param_utils_begin(uvma_rvfi_instr_table_seq_item_c)
+      `uvm_field_string(src_function   , UVM_DEFAULT)
+      `uvm_field_int(addr              , UVM_DEFAULT)
+      `uvm_field_string(mcode          , UVM_DEFAULT)
+      `uvm_field_string(asm            , UVM_DEFAULT)
+      `uvm_field_string(src_function   , UVM_DEFAULT)
+      `uvm_field_string(filename       , UVM_DEFAULT)
+      `uvm_field_int(lineno            , UVM_DEFAULT | UVM_DEC)
+      `uvm_field_array_string(src_code , UVM_DEFAULT)
+   `uvm_object_utils_end
+   
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_rvfi_instr_table_seq_item");
+
+   /**
+    * One-liner log message
+    */
+   extern function string convert2string();
+
+endclass : uvma_rvfi_instr_table_seq_item_c
+
+`pragma protect begin
+
+function uvma_rvfi_instr_table_seq_item_c::new(string name="uvma_rvfi_instr_table_seq_item");
+   
+   super.new(name);
+   
+endfunction : new
+
+function string uvma_rvfi_instr_table_seq_item_c::convert2string();
+
+   // Fixme: implement me!
+
+endfunction : convert2string
+
+`pragma protect end
+
+
+`endif // __UVMA_RVFI_INSTR_TABLE_SEQ_ITEM_SV__

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_pkg.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_pkg.sv
@@ -52,9 +52,10 @@ package uvma_rvfi_pkg;
    // High-level transactions
    `include "seq/uvma_rvfi_csr_seq_item.sv"   
    `include "seq/uvma_rvfi_instr_seq_item.sv"
-   `include "uvma_rvfi_mon_trn_logger.sv"
-   
+   `include "seq/uvma_rvfi_instr_table_seq_item.sv"
+      
    // Agent components   
+   `include "uvma_rvfi_mon_trn_logger.sv"
    `include "uvma_rvfi_instr_mon.sv"   
    `include "uvma_rvfi_agent.sv"
       
@@ -66,4 +67,5 @@ endpackage : uvma_rvfi_pkg
 `include "uvma_rvfi_assert.sv"
 
 `endif // __UVMA_RVFI_PKG_SV__
+
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -375,6 +375,13 @@ endif
 		-M no-aliases \
 		-M numeric \
 		-S $*.elf > $*.objdump
+	$(RISCV_EXE_PREFIX)objdump \
+                -d \
+                -S \
+				-M no-aliases \
+				-M numeric \
+                -l \
+				$*.elf | ${CORE_V_VERIF}/bin/objdump2itb - > $*.itb
 
 bsp:
 	@echo "$(BANNER)"

--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -221,7 +221,8 @@ test: $(DSIM_SIM_PREREQ) $(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX)
 			-sv_lib $(OVP_MODEL_DPI) \
 			+UVM_TESTNAME=$(TEST_UVM_TEST) \
 			+firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
-			+elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf
+			+elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
+			+itb_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
 
 # Similar to above, but for the ASM directory.
 asm: comp $(ASM_DIR)/$(ASM_PROG).hex $(ASM_DIR)/$(ASM_PROG).elf

--- a/mk/uvmt/riviera.mk
+++ b/mk/uvmt/riviera.mk
@@ -303,7 +303,9 @@ hello-world:
 	$(MAKE) test TEST=hello-world
 
 custom: VSIM_TEST=$(CUSTOM_PROG)
-custom: VSIM_FLAGS += +firmware=$(CUSTOM_DIR)/$(CUSTOM_PROG).hex +elf_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).elf
+custom: VSIM_FLAGS += +firmware=$(CUSTOM_DIR)/$(CUSTOM_PROG).hex 
+custom: VSIM_FLAGS += +elf_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).elf
+custom: VSIM_FLAGS += +itb_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).itb
 custom: TEST_UVM_TEST=uvmt_$(CV_CORE_LC)_firmware_test_c
 custom: $(CUSTOM_DIR)/$(CUSTOM_PROG).hex run
 

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -359,6 +359,7 @@ endif
 clean_test_programs: clean-bsp
 	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.o       -exec rm {} \;
 	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.hex     -exec rm {} \;
+	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.itb     -exec rm {} \;
 	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.elf     -exec rm {} \;
 	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.map     -exec rm {} \;
 	find $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/uvmt/test-programs -name *.readelf -exec rm {} \;

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -225,6 +225,7 @@ test: $(VCS_SIM_PREREQ) $(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).
 			$(TEST_PLUSARGS) \
 			+UVM_TESTNAME=$(TEST_UVM_TEST) \
 			+elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
+			+itb_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb \
 			+firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex
 
 ################################################################################

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -427,7 +427,9 @@ hello-world:
 	$(MAKE) test TEST=hello-world
 
 custom: VSIM_TEST=$(CUSTOM_PROG)
-custom: VSIM_FLAGS += +firmware=$(CUSTOM_DIR)/$(CUSTOM_PROG).hex +elf_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).elf
+custom: VSIM_FLAGS += +firmware=$(CUSTOM_DIR)/$(CUSTOM_PROG).hex
+custom: VSIM_FLAGS += +elf_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).elf
+custom: VSIM_FLAGS += +itb_file=$(CUSTOM_DIR)/$(CUSTOM_PROG).itb
 custom: TEST_UVM_TEST=uvmt_$(CV_CORE_LC)_firmware_test_c
 custom: $(CUSTOM_DIR)/$(CUSTOM_PROG).hex run
 
@@ -440,7 +442,9 @@ export OPT_RUN_INDEX_SUFFIX=_$(RUN_INDEX)
 endif
 
 test: VSIM_TEST=$(TEST_PROGRAM)
-test: VSIM_FLAGS += +firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex +elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf
+test: VSIM_FLAGS += +firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex 
+test: VSIM_FLAGS += +elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf
+test: VSIM_FLAGS += +itb_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
 test: $(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex run
 
 ################################################################################

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -335,7 +335,8 @@ test: $(XRUN_SIM_PREREQ) $(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX)
 			+UVM_TESTNAME=$(TEST_UVM_TEST) \
 			+elf_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
 			+nm_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).nm \
-			+firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex
+			+firmware=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
+			+itb_file=$(TEST_TEST_DIR)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb			
 	$(POST_TEST)
 
 ################################################################################


### PR DESCRIPTION
Annotates the RVFI with execution information from the ELF file of the program being executed:

Example:
```
       0.000 ns: RVFI  Order       PC    Instr M rs1 rs1_data rs2 rs2_data  rd  rd_data mem mem_addr mem_data instr
      54.000 ns: RVFI      1 00000080 0000d197 M x 1 00000000 x 0 00000000 x 3 0000d080  -- -------- -------- _start crt0.S 23 - auipc x3,0xd
      74.000 ns: RVFI      2 00000084 42018193 M x 3 0000d080 x 0 00000000 x 3 0000d4a0  -- -------- -------- _start crt0.S 24 - addi x3,x3,1056 # d4a0 <__global_pointer$>
      89.000 ns: RVFI      3 00000088 00400117 M x 0 00000000 x 4 00000000 x 2 00400088  -- -------- -------- _start crt0.S 28 - auipc x2,0x400
     110.000 ns: RVFI      4 0000008c f7810113 M x 2 00400088 x24 00000000 x 2 00400000  -- -------- -------- _start crt0.S 28 - addi x2,x2,-136 # 400000 <__heap_end>
     125.000 ns: RVFI      5 00000090 00000517 M x 0 00000000 x 0 00000000 x10 00000090  -- -------- -------- _start crt0.S 31 - auipc x10,0x0
     140.000 ns: RVFI      6 00000094 f7050513 M x10 00000090 x16 00000000 x10 00000000  -- -------- -------- _start crt0.S 31 - addi x10,x10,-144 # 0 <__vector_start>
     164.000 ns: RVFI      7 00000098 00156513 M x10 00000000 x 1 00000000 x10 00000001  -- -------- -------- _start crt0.S 32 - ori x10,x10,1
     176.000 ns: RVFI      8 0000009c 30551073 M x10 00000001 x 5 00000000 x 0 00000000  -- -------- -------- _start crt0.S 33 - csrrw x0,mtvec,x10
     194.000 ns: RVFI      9 000000a0 20418513 M x 3 0000d4a0 x 4 00000000 x10 0000d6a4  -- -------- -------- _start crt0.S 36 - addi x10,x3,516 # d6a4 <_PathLocale>
     212.000 ns: RVFI     10 000000a4 24c18613 M x 3 0000d4a0 x12 00000000 x12 0000d6ec  -- -------- -------- _start crt0.S 37 - addi x12,x3,588 # d6ec <__bss_end>
     230.000 ns: RVFI     11 000000a8 ----8e09 M x12 0000d6ec x10 0000d6a4 x12 00000048  -- -------- -------- _start crt0.S 38 - c.sub x12,x10
     239.000 ns: RVFI     12 000000aa ----4581 M x 0 00000000 x 0 00000000 x11 00000000  -- -------- -------- _start crt0.S 39 - c.li x11,0
     248.000 ns: RVFI     13 000000ac ----2bd1 M x 0 00000000 x20 00000000 x 1 000000ae  -- -------- -------- _start crt0.S 40 - c.jal 680 <memset>
     272.000 ns: RVFI     14 00000680 00f00313 M x 0 00000000 x15 00000000 x 6 0000000f  -- -------- -------- memset memset.S 30 - addi x6,x0,15
     290.000 ns: RVFI     15 00000684 00050713 M x10 0000d6a4 x 0 00000000 x14 0000d6a4  -- -------- -------- memset memset.S 31 - addi x14,x10,0
     308.000 ns: RVFI     16 00000688 02c37e63 M x 6 0000000f x12 00000048 x 0 00000000  -- -------- -------- memset memset.S 32 - bgeu x6,x12,6c4 <memset+0x44>

```

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>