### PR TITLE
remove absolute addresses within virtual peripheral sequences

### DIFF
--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_status_flags_seq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_status_flags_seq.sv
@@ -72,24 +72,26 @@ task uvme_cv32e40p_vp_status_flags_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
 
    if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
       `uvm_info("VP_VSEQ", $sformatf("Call to virtual peripheral 'vp_status_flags':\n%s", mon_trn.sprint()), UVM_DEBUG)
-      if (mon_trn.address == 32'h2000_0000) begin
-         if (mon_trn.data == 'd123456789) begin
-            `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
-            cv32e40p_cntxt.vp_status_vif.tests_passed = 1;
-            cv32e40p_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40p_cntxt.vp_status_vif.exit_value   = 0;
+      case (get_vp_index(mon_trn))
+         0: begin
+            if (mon_trn.data == 'd123456789) begin
+               `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
+               cv32e40p_cntxt.vp_status_vif.tests_passed = 1;
+               cv32e40p_cntxt.vp_status_vif.exit_valid   = 1;
+               cv32e40p_cntxt.vp_status_vif.exit_value   = 0;
+            end
+            else if (mon_trn.data == 'd1) begin
+               cv32e40p_cntxt.vp_status_vif.tests_failed = 1;
+               cv32e40p_cntxt.vp_status_vif.exit_valid   = 1;
+               cv32e40p_cntxt.vp_status_vif.exit_value   = 1;
+            end
          end
-         else if (mon_trn.data == 'd1) begin
-            cv32e40p_cntxt.vp_status_vif.tests_failed = 1;
-            cv32e40p_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40p_cntxt.vp_status_vif.exit_value   = 1;
-         end
-      end
-      else if (mon_trn.address == 32'h2000_0004) begin
-         `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
-         cv32e40p_cntxt.vp_status_vif.exit_valid = 1;
-         cv32e40p_cntxt.vp_status_vif.exit_value = mon_trn.data;
-      end      
+         1: begin
+            `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
+            cv32e40p_cntxt.vp_status_vif.exit_valid = 1;
+            cv32e40p_cntxt.vp_status_vif.exit_value = mon_trn.data;
+         end      
+      endcase
    end
    else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin
       slv_rsp.rdata = 0;

--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_status_flags_seq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_status_flags_seq.sv
@@ -72,24 +72,26 @@ task uvme_cv32e40s_vp_status_flags_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
 
    if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
       `uvm_info("VP_VSEQ", $sformatf("Call to virtual peripheral 'vp_status_flags':\n%s", mon_trn.sprint()), UVM_DEBUG)
-      if (mon_trn.address == 32'h2000_0000) begin
-         if (mon_trn.data == 'd123456789) begin
-            `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
-            cv32e40s_cntxt.vp_status_vif.tests_passed = 1;
-            cv32e40s_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40s_cntxt.vp_status_vif.exit_value   = 0;
+      case (get_vp_index(mon_trn))
+         0: begin
+            if (mon_trn.data == 'd123456789) begin
+               `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
+               cv32e40s_cntxt.vp_status_vif.tests_passed = 1;
+               cv32e40s_cntxt.vp_status_vif.exit_valid   = 1;
+               cv32e40s_cntxt.vp_status_vif.exit_value   = 0;
+            end
+            else if (mon_trn.data == 'd1) begin
+               cv32e40s_cntxt.vp_status_vif.tests_failed = 1;
+               cv32e40s_cntxt.vp_status_vif.exit_valid   = 1;
+               cv32e40s_cntxt.vp_status_vif.exit_value   = 1;
+            end
          end
-         else if (mon_trn.data == 'd1) begin
-            cv32e40s_cntxt.vp_status_vif.tests_failed = 1;
-            cv32e40s_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40s_cntxt.vp_status_vif.exit_value   = 1;
+         1: begin
+            `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
+            cv32e40s_cntxt.vp_status_vif.exit_valid = 1;
+            cv32e40s_cntxt.vp_status_vif.exit_value = mon_trn.data;
          end
-      end
-      else if (mon_trn.address == 32'h2000_0004) begin
-         `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
-         cv32e40s_cntxt.vp_status_vif.exit_valid = 1;
-         cv32e40s_cntxt.vp_status_vif.exit_value = mon_trn.data;
-      end      
+      endcase
    end
    else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin
       slv_rsp.rdata = 0;

--- a/cv32e40x/env/uvme/vseq/uvme_cv32e40x_vp_status_flags_seq.sv
+++ b/cv32e40x/env/uvme/vseq/uvme_cv32e40x_vp_status_flags_seq.sv
@@ -72,24 +72,27 @@ task uvme_cv32e40x_vp_status_flags_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
 
    if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
       `uvm_info("VP_VSEQ", $sformatf("Call to virtual peripheral 'vp_status_flags':\n%s", mon_trn.sprint()), UVM_DEBUG)
-      if (mon_trn.address == 32'h2000_0000) begin
-         if (mon_trn.data == 'd123456789) begin
-            `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
-            cv32e40x_cntxt.vp_status_vif.tests_passed = 1;
-            cv32e40x_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40x_cntxt.vp_status_vif.exit_value   = 0;
+
+      case (get_vp_index(mon_trn))
+         0:  begin
+            if (mon_trn.data == 'd123456789) begin
+               `uvm_info("VP_VSEQ", "virtual peripheral: TEST PASSED", UVM_DEBUG)
+               cv32e40x_cntxt.vp_status_vif.tests_passed = 1;
+               cv32e40x_cntxt.vp_status_vif.exit_valid   = 1;
+               cv32e40x_cntxt.vp_status_vif.exit_value   = 0;
+            end         
+            else if (mon_trn.data == 'd1) begin
+               cv32e40x_cntxt.vp_status_vif.tests_failed = 1;
+               cv32e40x_cntxt.vp_status_vif.exit_valid   = 1;
+              cv32e40x_cntxt.vp_status_vif.exit_value   = 1;
+            end
          end
-         else if (mon_trn.data == 'd1) begin
-            cv32e40x_cntxt.vp_status_vif.tests_failed = 1;
-            cv32e40x_cntxt.vp_status_vif.exit_valid   = 1;
-            cv32e40x_cntxt.vp_status_vif.exit_value   = 1;
-         end
-      end
-      else if (mon_trn.address == 32'h2000_0004) begin
-         `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
-         cv32e40x_cntxt.vp_status_vif.exit_valid = 1;
-         cv32e40x_cntxt.vp_status_vif.exit_value = mon_trn.data;
-      end      
+         1: begin
+            `uvm_info("VP_VSEQ", "virtual peripheral: END OF SIM", UVM_DEBUG)
+            cv32e40x_cntxt.vp_status_vif.exit_valid = 1;
+            cv32e40x_cntxt.vp_status_vif.exit_value = mon_trn.data;
+         end      
+      endcase
    end
    else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin
       slv_rsp.rdata = 0;

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
@@ -45,7 +45,7 @@ class uvma_obi_memory_slv_seq_c extends uvma_obi_memory_slv_base_seq_c;
     * Register sequences with a range of addresses on this OBI
     */
    extern virtual function uvma_obi_memory_vp_base_seq_c register_vp_vseq(string name, 
-                                                                          bit[31:0] start_addr, 
+                                                                          bit[31:0] start_address, 
                                                                           int unsigned num_words,
                                                                           uvm_object_wrapper seq_type);
 
@@ -171,7 +171,10 @@ task uvma_obi_memory_slv_seq_c::do_mem_operation(ref uvma_obi_memory_mon_trn_c m
 
 endtask : do_mem_operation
 
-function uvma_obi_memory_vp_base_seq_c uvma_obi_memory_slv_seq_c::register_vp_vseq(string name, bit[31:0] start_addr, int unsigned num_words, uvm_object_wrapper seq_type);
+function uvma_obi_memory_vp_base_seq_c uvma_obi_memory_slv_seq_c::register_vp_vseq(string name, 
+                                                                                   bit[31:0] start_address, 
+                                                                                   int unsigned num_words, 
+                                                                                   uvm_object_wrapper seq_type);
 
    uvma_obi_memory_vp_base_seq_c vp_seq;
 
@@ -186,9 +189,13 @@ function uvma_obi_memory_vp_base_seq_c uvma_obi_memory_slv_seq_c::register_vp_vs
       `uvm_fatal("OBIVPVSEQ", $sformatf("Could not cast seq_type of type name: %s to a uvma_obi_memory_vp_base_seq_c type", seq_type.get_type_name()))
    end
 
+   // Configure fields in the virtual peripheral sequence
+   vp_seq.start_address = start_address;
+   vp_seq.num_words     = num_words;
+
    // Use hash to efficiently look up word-aligned addresses to this handle
    for (int unsigned word = 0; word < num_words; word++) begin
-      bit[31:0] addr = (start_addr & ~32'h3) + (4 * word);
+      bit[31:0] addr = (start_address & ~32'h3) + (4 * word);
 
       // If an address is being claimed twice, then issue a fatal error
       if (vp_seq_table.exists(addr)) begin

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_base_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_base_seq.sv
@@ -28,6 +28,16 @@ virtual class uvma_obi_memory_vp_base_seq_c extends uvma_obi_memory_slv_base_seq
 
    uvma_obi_memory_mon_trn_c       mon_trn_q[$]; // Used to add transactions to execute (monitored requests)
 
+   // Base address of this virtual peripheral, used to generated offset index for multi-register
+   // virtual perhipeerals
+   // Should be filled in during registration
+   bit [31:0] start_address; 
+
+   // The configured number of virtual perhperal registers (each 32-bits wide) supported by 
+   // this virtual peripheral sequence
+   // Should be filled in during registration
+   int unsigned num_words;
+
    `uvm_field_utils_begin(uvma_obi_memory_vp_base_seq_c)
    `uvm_field_utils_end
       
@@ -41,6 +51,11 @@ virtual class uvma_obi_memory_vp_base_seq_c extends uvma_obi_memory_slv_base_seq
     * claimed by this virtual peripheral
     */
    extern virtual task body();
+
+   /**
+    * Utility to get an index for virtual peripheral with multiple registers
+    */
+   extern virtual function int unsigned get_vp_index(uvma_obi_memory_mon_trn_c mon_trn);
 
    /**
     * Derived classes must implement
@@ -66,5 +81,34 @@ task uvma_obi_memory_vp_base_seq_c::body();
    end
 
 endtask : body
+
+
+function int unsigned uvma_obi_memory_vp_base_seq_c::get_vp_index(uvma_obi_memory_mon_trn_c mon_trn);
+
+   int unsigned index;
+
+   // Fatal error if the address in the incoming transaction is less than the configured base address
+   if (mon_trn.address < start_address) begin
+      `uvm_fatal("FATAL", $sformatf("%s: get_vp_index(), mon_trn.address 0x%08x is less than start address 0x%08x", 
+                                    this.get_name(), 
+                                    mon_trn.address,
+                                    start_address));
+   end                                   
+
+   index = (mon_trn.address - start_address) >> 2;
+
+   // Fatal if the index is greater than expected
+   if (index >= num_words) begin
+      `uvm_fatal("FATAL", $sformatf("%s: get_vp_index(), mon_trn.address 0x%08x base address 0x%08x, should only have %0s vp registers", 
+                                    this.get_name(), 
+                                    mon_trn.address,
+                                    start_address,
+                                    num_words));
+   end
+
+   return index;
+
+endfunction : get_vp_index
+
 
 `endif // __UVMA_OBI_MEMORY_VP_BASE_SEQ_SV__

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_cycle_counter_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_cycle_counter_seq.sv
@@ -92,9 +92,9 @@ task uvma_obi_memory_vp_cycle_counter_seq_c::vp_body(uvma_obi_memory_mon_trn_c m
    
    slv_rsp.err = 1'b0;
 
-   case (mon_trn.address)
-      32'h1500_1004: rw_counter(mon_trn, slv_rsp);
-      32'h1500_1008: print_counter(mon_trn);
+   case (get_vp_index(mon_trn))
+      0: rw_counter(mon_trn, slv_rsp);
+      1: print_counter(mon_trn);
    endcase
 
    add_r_fields(mon_trn, slv_rsp);

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_interrupt_timer_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_interrupt_timer_seq.sv
@@ -89,10 +89,10 @@ task uvma_obi_memory_vp_interrupt_timer_seq_c::vp_body(uvma_obi_memory_mon_trn_c
    if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
 
       `uvm_info("VP_VSEQ", $sformatf("Call to virtual peripheral 'interrupt_timer_control':\n%s", mon_trn.sprint()), UVM_HIGH)
-      if (mon_trn.address == 32'h1500_0000) begin
+      if (get_vp_index(mon_trn) == 0) begin
          interrupt_value = mon_trn.data;
       end
-      else if (mon_trn.address == 32'h1500_0004) begin
+      else if (get_vp_index(mon_trn) == 1) begin
          interrupt_timer_value = mon_trn.data;
          ->interrupt_timer_start;
       end

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_sig_writer_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_sig_writer_seq.sv
@@ -74,31 +74,29 @@ task uvma_obi_memory_vp_sig_writer_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
    `uvm_create  (slv_rsp)
    slv_rsp.err = 1'b0;   
 
-   if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
-      
-      if (mon_trn.address == 32'h2000_0008) begin
-         signature_start_address = mon_trn.data;
-      end
-      else if (mon_trn.address == 32'h2000_000C) begin
-         signature_end_address = mon_trn.data;
-      end
-      else if (mon_trn.address == 32'h2000_0010) begin
-         for (int unsigned ii=signature_start_address; ii<signature_end_address; ii++) begin
-            `uvm_info("VP_SIG_WRITER", "Dumping signature", UVM_HIGH/*NONE*/)
-            if (use_sig_file) begin
-               $fdisplay(sig_fd, "%x%x%x%x", cntxt.mem.read(ii+3), 
-                                             cntxt.mem.read(ii+2), 
-                                             cntxt.mem.read(ii+1), 
-                                             cntxt.mem.read(ii+0));
-            end
-            else begin
-               `uvm_info("VP_VSEQ", $sformatf("%x%x%x%x", cntxt.mem.read(ii+3), 
-                                                          cntxt.mem.read(ii+2), 
-                                                          cntxt.mem.read(ii+1), 
-                                                          cntxt.mem.read(ii+0)), UVM_HIGH/*NONE*/)
+   if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin            
+      case (get_vp_index(mon_trn))
+         0: signature_start_address = mon_trn.data;   
+         1: signature_end_address = mon_trn.data;
+
+         2: begin
+            for (int unsigned ii=signature_start_address; ii<signature_end_address; ii++) begin
+               `uvm_info("VP_SIG_WRITER", "Dumping signature", UVM_HIGH/*NONE*/)
+               if (use_sig_file) begin
+                  $fdisplay(sig_fd, "%x%x%x%x", cntxt.mem.read(ii+3), 
+                                                cntxt.mem.read(ii+2), 
+                                                cntxt.mem.read(ii+1), 
+                                                cntxt.mem.read(ii+0));
+               end
+               else begin
+                  `uvm_info("VP_VSEQ", $sformatf("%x%x%x%x", cntxt.mem.read(ii+3), 
+                                                            cntxt.mem.read(ii+2), 
+                                                            cntxt.mem.read(ii+1), 
+                                                            cntxt.mem.read(ii+0)), UVM_HIGH/*NONE*/)
+               end
             end
          end
-      end
+      endcase
    end
    else if (mon_trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin
       slv_rsp.rdata = 0;


### PR DESCRIPTION
Virtual peripherals should be installable at *any* address.  This PR provides a method and VP base variables to ensure that implementations can retrieve a register offset index independent of the the implementation's absolute address.

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>