### PR TITLE
point to latest e40s RTL

### DIFF
--- a/cv32e40s/sim/Common.mk
+++ b/cv32e40s/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= e4ede55f85e9915b092dc3096e45fcef8a2641e0
+CV_CORE_HASH   ?= b251cbf4ff2bb4daab1cc7e5eea56bf5d60d5e52
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv


### PR DESCRIPTION
Should include RTL cleanups for negative index issue for DSIM.
ci_check still expected to fail until some user mode fixes are applied.

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>