### PR TITLE
incorporate new RVFI debug signals and latest RTL

### DIFF
--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 48137ad3d539dac221d4d9c2497b0cfbda7de299
+CV_CORE_HASH   ?= adcb717bce94386c47feb7b7179ec75a0a381d87
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
@@ -68,7 +68,7 @@
             atomic         : 0}
          };
    `else
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 0;
+      parameter int                        CORE_PARAM_PMA_NUM_REGIONS = 0;
       parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[-1:0] =  '{default:cv32e40x_pkg::PMA_R_DEFAULT};
    `endif
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
@@ -69,7 +69,7 @@
          };
    `else
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 0;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:0] = '{'z};
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[-1:0] =  '{default:cv32e40x_pkg::PMA_R_DEFAULT};
    `endif
 
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
@@ -55,7 +55,7 @@ module uvmt_cv32e40x_debug_assert
   // Single clock, single reset design, use default clocking
   default clocking @(posedge cov_assert_if.clk_i); endclocking
   default disable iff !(cov_assert_if.rst_ni);
-  
+
   assign cov_assert_if.is_ebreak =
     cov_assert_if.wb_stage_instr_valid_i
     && !cov_assert_if.wb_err
@@ -112,7 +112,7 @@ module uvmt_cv32e40x_debug_assert
         |->
         cov_assert_if.debug_mode_q && (cov_assert_if.wb_stage_pc == halt_addr_at_entry)
         && (cov_assert_if.depc_q == pc_at_dbg_req);
-    endproperty   
+    endproperty
 
     a_debug_mode_pc: assert property(p_debug_mode_pc)
         else `uvm_error(info_tag, $sformatf("Debug mode entered with wrong pc. pc==%08x", cov_assert_if.wb_stage_pc));
@@ -222,7 +222,7 @@ module uvmt_cv32e40x_debug_assert
         s_conse_next_retire
         ##0 cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40x_pkg::DBG_CAUSE_TRIGGER)
             && (cov_assert_if.depc_q == tdata2_at_entry) && (cov_assert_if.wb_stage_pc == halt_addr_at_entry);
-    endproperty   
+    endproperty
 
     a_trigger_match: assert property(p_trigger_match)
         else `uvm_error(info_tag,
@@ -332,7 +332,7 @@ module uvmt_cv32e40x_debug_assert
         else `uvm_error(info_tag, "PC not set to exception handler after single step with exception");
 
 
-    // Trigger during single step 
+    // Trigger during single step
     property p_single_step_trigger;
         !cov_assert_if.debug_mode_q && cov_assert_if.dcsr_q[2]
         && cov_assert_if.addr_match && cov_assert_if.wb_valid && cov_assert_if.tdata1[2]
@@ -422,7 +422,7 @@ module uvmt_cv32e40x_debug_assert
 
 
     // Check that trigger regs cannot be written from M-mode
-    // TSEL, and TDATA3 are tied to zero, hence no register to check 
+    // TSEL, and TDATA3 are tied to zero, hence no register to check
     property p_mmode_tdata1_write;
         !cov_assert_if.debug_mode_q && cov_assert_if.csr_access && cov_assert_if.csr_op == 'h1
         && cov_assert_if.wb_stage_instr_rdata_i[31:20] == 'h7A1
@@ -471,7 +471,7 @@ module uvmt_cv32e40x_debug_assert
         else
             `uvm_error(info_tag, "Minstret not counting when mcountinhibit[2] is cleared!");
 
-    // Check debug_req_i and irq on same cycle. 
+    // Check debug_req_i and irq on same cycle.
     // Should result in debug mode with regular pc in depc,
     // not pc from interrupt handler
     // PC is checked in another assertion
@@ -494,8 +494,8 @@ module uvmt_cv32e40x_debug_assert
         |->
         s_conse_next_retire
         ##0 cov_assert_if.debug_mode_q && (cov_assert_if.depc_q == boot_addr_at_entry);
-    endproperty    
-      
+    endproperty
+
     a_debug_at_reset : assert property(p_debug_at_reset)
         else `uvm_error(info_tag, "Debug mode not entered correctly at reset!");
 
@@ -519,7 +519,7 @@ module uvmt_cv32e40x_debug_assert
     // Need to confirm that the assertion can be reached for non-trivial cases
     cov_illegal_insn_debug_req_nonzero : cover property(
         s_illegal_insn_debug_req_ante |-> s_illegal_insn_debug_req_conse ##0 (cov_assert_if.depc_q != 0));
-    
+
     a_illegal_insn_debug_req : assert property(s_illegal_insn_debug_req_ante |-> s_illegal_insn_debug_req_conse)
         else `uvm_error(info_tag, "Debug mode not entered correctly while handling illegal instruction!");
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -43,8 +43,8 @@ module uvmt_cv32e40x_dut_wrap
   import cv32e40x_pkg::*;
 
   #(// DUT (riscv_core) parameters.
-    parameter NUM_MHPMCOUNTERS    =  1,
-    parameter int unsigned PMA_NUM_REGIONS =  0,
+    parameter              NUM_MHPMCOUNTERS    =  1,
+    parameter int          PMA_NUM_REGIONS =  0,
     parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS-1):0] = '{default:PMA_R_DEFAULT},
     // Remaining parameters are used by TB components only
               INSTR_ADDR_WIDTH    =  32,

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -45,7 +45,7 @@ module uvmt_cv32e40x_dut_wrap
   #(// DUT (riscv_core) parameters.
     parameter NUM_MHPMCOUNTERS    =  1,
     parameter int unsigned PMA_NUM_REGIONS =  0,
-    parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT},
+    parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS-1):0] = '{default:PMA_R_DEFAULT},
     // Remaining parameters are used by TB components only
               INSTR_ADDR_WIDTH    =  32,
               INSTR_RDATA_WIDTH   =  32,

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -43,7 +43,7 @@ module uvmt_cv32e40x_tb;
 `endif
 
    parameter int PMA_NUM_REGIONS = 0;
-   parameter cv32e40x_pkg::pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT};
+   parameter cv32e40x_pkg::pma_region_t PMA_CFG[(PMA_NUM_REGIONS-1):0] = '{default:PMA_R_DEFAULT};
 
    // ENV (testbench) parameters
    parameter int ENV_PARAM_INSTR_ADDR_WIDTH  = 32;
@@ -106,7 +106,8 @@ module uvmt_cv32e40x_tb;
                                                                    .rvfi_trap(rvfi_i.rvfi_trap[0]),
                                                                    .rvfi_halt(rvfi_i.rvfi_halt[0]),
                                                                    .rvfi_intr(rvfi_i.rvfi_intr[0]),
-                                                                   .rvfi_dbg(rvfi_i.rvfi_dbg[0]),
+                                                                   .rvfi_dbg(rvfi_i.rvfi_dbg),
+                                                                   .rvfi_dbg_mode(rvfi_i.rvfi_dbg_mode),
                                                                    .rvfi_mode(rvfi_i.rvfi_mode[uvma_rvfi_pkg::MODE_WL*0+:uvma_rvfi_pkg::MODE_WL]),
                                                                    .rvfi_ixl(rvfi_i.rvfi_ixl[uvma_rvfi_pkg::IXL_WL*0+:uvma_rvfi_pkg::IXL_WL]),
                                                                    .rvfi_pc_rdata(rvfi_i.rvfi_pc_rdata[uvme_cv32e40x_pkg::XLEN*0+:uvme_cv32e40x_pkg::XLEN]),

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
@@ -227,7 +227,7 @@ interface uvmt_cv32e40x_debug_cov_assert_if
     illegal_insn_i,
     illegal_insn_q,
     ecall_insn_i,
-    boot_addr_i, 
+    boot_addr_i,
     rvfi_pc_wdata,
     rvfi_pc_rdata,
     debug_req_i,

--- a/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_seq_item.sv
+++ b/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_seq_item.sv
@@ -29,7 +29,8 @@ class uvma_rvfi_instr_seq_item_c#(int ILEN=DEFAULT_ILEN,
    rand bit [ILEN-1:0]           insn;
    rand bit                      trap;
    rand bit                      halt;
-   rand bit                      dbg;
+   rand bit                      dbg_mode;
+   rand bit [RVFI_DBG_WL-1:0]    dbg;
    rand bit                      intr;   
    rand uvma_rvfi_mode           mode;
    rand bit [IXL_WL-1:0]         ixl;
@@ -71,6 +72,7 @@ class uvma_rvfi_instr_seq_item_c#(int ILEN=DEFAULT_ILEN,
       `uvm_field_int(insn, UVM_DEFAULT)
       `uvm_field_int(trap, UVM_DEFAULT)
       `uvm_field_int(halt, UVM_DEFAULT)
+      `uvm_field_int(dbg_mode, UVM_DEFAULT)
       `uvm_field_int(dbg, UVM_DEFAULT)
       `uvm_field_int(intr, UVM_DEFAULT)      
       `uvm_field_enum(uvma_rvfi_mode, mode, UVM_DEFAULT)

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
@@ -23,6 +23,7 @@ localparam ORDER_WL         = 64;
 localparam MODE_WL          = 2;
 localparam IXL_WL           = 2;
 localparam GPR_ADDR_WL      = 5;
+localparam RVFI_DBG_WL      = 3;
 
 localparam DEFAULT_ILEN     = 32;
 localparam DEFAULT_XLEN     = 32;

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -36,7 +36,8 @@ interface uvma_rvfi_instr_if
     input [ILEN-1:0]           rvfi_insn,
     input                      rvfi_trap,
     input                      rvfi_halt,
-    input                      rvfi_dbg,
+    input [RVFI_DBG_WL-1:0]    rvfi_dbg,
+    input                      rvfi_dbg_mode,
     input                      rvfi_intr,    
     input [MODE_WL-1:0]        rvfi_mode,
     input [IXL_WL-1:0]         rvfi_ixl,
@@ -91,6 +92,7 @@ interface uvma_rvfi_instr_if
         rvfi_trap,
         rvfi_halt,
         rvfi_dbg,
+        rvfi_dbg_mode,
         rvfi_intr,
         rvfi_mode,
         rvfi_ixl,
@@ -119,3 +121,4 @@ endinterface : uvma_rvfi_instr_if
 
 
 `endif // __UVMA_RVFI_INSTR_IF_SV__
+

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -133,6 +133,7 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
          mon_trn.trap     = cntxt.instr_vif[nret_id].mon_cb.rvfi_trap;
          mon_trn.halt     = cntxt.instr_vif[nret_id].mon_cb.rvfi_halt;
          mon_trn.dbg      = cntxt.instr_vif[nret_id].mon_cb.rvfi_dbg;
+         mon_trn.dbg_mode = cntxt.instr_vif[nret_id].mon_cb.rvfi_dbg_mode;
          mon_trn.intr     = cntxt.instr_vif[nret_id].mon_cb.rvfi_intr;
          $cast(mon_trn.mode, cntxt.instr_vif[nret_id].mon_cb.rvfi_mode);
          mon_trn.ixl      = cntxt.instr_vif[nret_id].mon_cb.rvfi_ixl;

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/seq/uvma_rvvi_ovpsim_control_seq.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/seq/uvma_rvvi_ovpsim_control_seq.sv
@@ -67,10 +67,8 @@ task uvma_rvvi_ovpsim_control_seq_c::step_rm(uvma_rvfi_instr_seq_item_c#(ILEN,XL
       // order is a hack to detect debug out of reset
       // When the new RVFI debug is released, this should only use those 
       // fields to discern an external request
-      dbg == (rvfi_instr.dbg && (rvfi_instr.intr || (rvfi_instr.order == 1)));
+      dbg_req == (rvfi_instr.dbg_mode && rvfi_instr.dbg inside {3,5});
       
-      dcsr_cause == csr_dcsr[8:6];
-
       nmi  == rvfi_instr.insn_nmi;
       intr_id == rvfi_instr.insn_interrupt_id;
       

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/seq/uvma_rvvi_ovpsim_control_seq_item.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/seq/uvma_rvvi_ovpsim_control_seq_item.sv
@@ -28,11 +28,8 @@ class uvma_rvvi_ovpsim_control_seq_item_c#(int ILEN=uvma_rvvi_pkg::DEFAULT_ILEN,
    // Set to signal this instructions is first instruction of interrupt handler
    rand bit intr;
 
-   // Set to signal entry into debug handler
-   rand bit dbg;
-
-   // If the debug handler is entered, this enum is valid and specifies the DCSR CAUSE of why debug was entered
-   rand dcsr_cause_t dcsr_cause;
+   // Set to signa external debug request
+   rand bit dbg_req;
 
    // Set to signal entry into NMI handler
    rand bit nmi;
@@ -55,15 +52,14 @@ class uvma_rvvi_ovpsim_control_seq_item_c#(int ILEN=uvma_rvvi_pkg::DEFAULT_ILEN,
    static protected string _log_format_string = "0x%08x %s 0x%01x 0x%08x";
 
    `uvm_object_param_utils_begin(uvma_rvvi_ovpsim_control_seq_item_c#(ILEN,XLEN))      
-      `uvm_field_int(intr, UVM_DEFAULT)
-      `uvm_field_int(dbg, UVM_DEFAULT)
-      `uvm_field_enum(dcsr_cause_t, dcsr_cause, UVM_DEFAULT)
-      `uvm_field_int(nmi, UVM_DEFAULT)
-      `uvm_field_int(mip, UVM_DEFAULT)
-      `uvm_field_int(intr_id, UVM_DEFAULT)
-      `uvm_field_int(rd1_addr, UVM_DEFAULT)
+      `uvm_field_int(intr,      UVM_DEFAULT)
+      `uvm_field_int(dbg_req,   UVM_DEFAULT)
+      `uvm_field_int(nmi,       UVM_DEFAULT)
+      `uvm_field_int(mip,       UVM_DEFAULT)
+      `uvm_field_int(intr_id,   UVM_DEFAULT)
+      `uvm_field_int(rd1_addr,  UVM_DEFAULT)
       `uvm_field_int(rd1_wdata, UVM_DEFAULT)
-      `uvm_field_int(mem_addr, UVM_DEFAULT)
+      `uvm_field_int(mem_addr,  UVM_DEFAULT)
       `uvm_field_int(mem_rdata, UVM_DEFAULT)
       `uvm_field_int(mem_rmask, UVM_DEFAULT)
    `uvm_object_utils_end


### PR DESCRIPTION
Manually integrate https://github.com/openhwgroup/core-v-verif/pull/817 with the latest cv32e40x RTL.
