### PR TITLE
fix bug with debug exception handler in corev-dv

### DIFF
--- a/cv32e40x/regress/cv32e40x_debug.yaml
+++ b/cv32e40x/regress/cv32e40x_debug.yaml
@@ -23,13 +23,21 @@ tests:
     description: Debug directed test
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test
-    num: 20
+    num: 10
 
   debug_test_reset:
     build: uvmt_cv32e40x
     description: Debug reset test
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_reset
+    num: 10
+
+  debug_test_trigger:
+    build: uvmt_cv32e40x
+    description: Debug trigger test
+    dir: cv32e40x/sim/uvmt
+    cmd: make test TEST=debug_test_trigger
+    num: 10
 
   debug_test_boot_set:
     build: uvmt_cv32e40x

--- a/cv32e40x/tests/programs/corev-dv/corev_rand_debug_ebreak/corev-dv.yaml
+++ b/cv32e40x/tests/programs/corev-dv/corev_rand_debug_ebreak/corev-dv.yaml
@@ -10,7 +10,7 @@ plusargs: >
     +no_data_page=1
     +no_branch_jump=0
     +boot_mode=m
-    +no_csr_instr=1
+    +no_csr_instr=0
     +no_wfi=0
     +no_ebreak=0
     +no_dret=1
@@ -19,3 +19,6 @@ plusargs: >
     +set_dcsr_ebreak=1
     +enable_debug_single_step=0
     +gen_debug_section=1
+    +num_debug_sub_program=0
+    +illegal_instr_ratio=2
+    +enable_illegal_csr_instruction=1


### PR DESCRIPTION
by using ebreak in debug exception handler we can enable traps in debug handler
extend debug regression tests

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>