### PR TITLE
gen_corev-dv makefile target cleanup

### DIFF
--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -409,10 +409,6 @@ corev-dv: clean_riscv-dv \
 
 gen_corev-dv:
 	mkdir -p $(XRUN_COREVDV_RESULTS)/$(TEST)
-	# Clean old assembler generated tests in results
-	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
-		rm -f ${XRUN_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S; \
-	done
 	cd  $(XRUN_COREVDV_RESULTS)/$(TEST) && \
 	$(XRUN) -R -xmlibdirname ../xcelium.d \
 		$(XRUN_RUN_FLAGS) \
@@ -422,11 +418,9 @@ gen_corev-dv:
 		+num_of_tests=$(GEN_NUM_TESTS) \
 		+UVM_TESTNAME=$(GEN_UVM_TEST) \
 		+asm_file_name_opts=$(TEST) \
-		$(GEN_PLUSARGS)
-	# Copy out final assembler files to test directory
+		$(GEN_PLUSARGS) && \
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
-		ls -l ${XRUN_COREVDV_RESULTS}/${TEST} > /dev/null; \
-		cp ${XRUN_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${GEN_TEST_DIR}; \
+		rsync --remove-source-files -t ${XRUN_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${GEN_TEST_DIR}; \
 	done
 
 ################################################################################

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -420,7 +420,7 @@ gen_corev-dv:
 		+asm_file_name_opts=$(TEST) \
 		$(GEN_PLUSARGS) && \
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
-		rsync --remove-source-files -t ${XRUN_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${GEN_TEST_DIR}; \
+		rsync --whole-file --remove-source-files -t ${XRUN_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${GEN_TEST_DIR}; \
 	done
 
 ################################################################################


### PR DESCRIPTION
Simplified gen_corev-dv makefile target as follows:

- Removed superfluous clean old tests-section
(rsync will fail if output files are missing, and will properly overwrite files in the destination directory anyway)

- replaced cp with rsync, to enable cleanup of output folder after completion 
(This will ensure that only newly generated files are copied to the test location)

- Comment removed to enable && \ after xrun-command and avoid the no-op ls-command 
(Comments do not play well inside split lines)

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>