### PR TITLE
Strichmo/pr/embench cleanup

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -3,13 +3,13 @@
 ################################################################################
 #
 # Copyright 2020 OpenHW Group
-# 
+#
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://solderpad.org/licenses/
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-# 
+#
 ################################################################################
 #
 # cv_regress: python script to generate a tool-specific regression based
@@ -57,13 +57,14 @@ def get_project_path(project):
 
 def check_valid_test(project, name):
     '''Validation step to determine if a testname in a regression is valid.
-       Some regression tools will fail if test name does not match make TEST variable.'''    
+       Some regression tools will fail if test name does not match make TEST variable.'''
     test_dirs = (os.path.join(get_project_path(project), 'tests/programs/corev-dv'),
                  os.path.join(get_project_path(project), 'tests/programs/custom'),
+                 os.path.join(get_project_path(project), 'tests/programs/embench'),
     )
-    
+
     for t in test_dirs:
-        if os.path.isdir(os.path.join(t, name)):            
+        if os.path.isdir(os.path.join(t, name)):
             return True
 
     logger.fatal('Test name: {} is not valid'.format(name))
@@ -84,7 +85,7 @@ def read_file(args, file):
     '''Read a YAML definition filelist'''
     full_regress_file = os.path.join(get_regress_path(args.project), file)
     stream = open(full_regress_file, 'r')
-    logger.info('Reading regression: {}'.format(full_regress_file))    
+    logger.info('Reading regression: {}'.format(full_regress_file))
     # Newer PyYAMLs must specify explicit loader (policy) or will issue warnings
     # Older PyYAMLs will not support the Loader argument
     # So try the new way first, then catch to the old way
@@ -103,20 +104,20 @@ def read_file(args, file):
     assert 'tests' in testlist, 'A test section with at least one test must be defined'
     for b, d in testlist['builds'].items():
         assert 'cmd' in d, 'cmd must be specified in test: ' + b
-        assert 'dir' in d, 'dir must be specified in test: ' + b        
+        assert 'dir' in d, 'dir must be specified in test: ' + b
     for t, d in testlist['tests'].items():
         assert 'build' in d, 'build must be specified in test: ' + t
         #assert 'description' in d, 'description must be specified in test: ' + t
         assert 'cmd' in d, 'cmd must be specified in test: ' + t
         assert 'dir' in d, 'dir must be specified in test: ' + t
-        
+
     # Construct a proper regression object
     regression = cv_regression.Regression(name=testlist['name'],
                                           description=testlist['description'])
 
     # Create build objects
     for k in testlist['builds']:
-        b = testlist['builds'][k]    
+        b = testlist['builds'][k]
         build = cv_regression.Build(name=k, simulator=args.simulator, **b)
         if args.cov:
             build.set_cov()
@@ -127,7 +128,7 @@ def read_file(args, file):
     # Create test objects
     for k in testlist['tests']:
         t = testlist['tests'][k]
-        
+
         try:
             if args.simulator in t['skip_sim']:
                 continue
@@ -138,7 +139,7 @@ def read_file(args, file):
             test.set_cov()
         if args.make:
             test.sub_make(args.make)
-        if args.iss != None:            
+        if args.iss != None:
             test.iss = args.iss
 
         # Determine if a test is valid, skip for compliance tests
@@ -159,8 +160,8 @@ VALID_SIMULATORS = ('dsim', 'vsim', 'vcs', 'xrun')
 DEFAULT_SIMULATOR = 'dsim'
 VALID_PROJECTS = ('cv32e40p', 'cv32e40x', 'cv32e40s', 'cv64')
 try:
-    DEFAULT_PROJECT = os.environ['CV_CORE'] 
-except KeyError:    
+    DEFAULT_PROJECT = os.environ['CV_CORE']
+except KeyError:
     DEFAULT_PROJECT = 'cv32e40p'
 DEFAULT_CFG = 'default'
 DEFAULT_PARALLEL = '30'
@@ -219,11 +220,11 @@ for f in args.file:
             unique_builds[b.name] = b
 
 # Generate output product
-env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__),                                                         
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__),
                                                         'templates')), trim_blocks=True)
 
 # Output generation
-if args.sh: 
+if args.sh:
     # Generate shell script (--script)
     template = env.get_template('regress_sh.j2')
     logger.info('Rendering template: regress_sh.j2 into: {}'.format(args.outfile))
@@ -269,9 +270,9 @@ if args.vsif:
                                  filter_dir=get_filter_dir(),
                                  unique_builds=unique_builds))
     out_fh.close()
-    
+
     # Generate a Vmanager-compatible SVE
-    template = env.get_template('regress_sve.j2')    
+    template = env.get_template('regress_sve.j2')
     logger.info('Rendering template: regress_sve.j2 into: {}'.format(sve))
     out_fh = open(sve, 'w')
     out_fh.write(template.render(env=os.environ))

--- a/bin/templates/embench_test.yaml.j2
+++ b/bin/templates/embench_test.yaml.j2
@@ -2,13 +2,13 @@
 ################################################################################
 #
 # Copyright 2020 OpenHW Group
-# 
+#
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://solderpad.org/licenses/
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-# 
+#
 ################################################################################
 # test-yaml.j2: Jinja2 template for rendering test.yaml files for run_embench
 
@@ -26,3 +26,6 @@ name: {{name}}
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
     test is part of EMBench benchmarking suite
+plusargs: >
+    +rand_stall_obi_disable
+    +trn_log_disabled

--- a/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
@@ -200,6 +200,17 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
          obi_memory_data_cfg.trn_log_enabled   == 1;
          rvfi_cfg.trn_log_enabled              == 1;
          rvvi_cfg.trn_log_enabled              == 1;
+         isacov_cfg.trn_log_enabled            == 1;
+      } else {
+         isacov_cfg.trn_log_enabled            == 0;
+         clknrst_cfg.trn_log_enabled           == 0;
+         interrupt_cfg.trn_log_enabled         == 0;
+         debug_cfg.trn_log_enabled             == 0;
+         obi_memory_instr_cfg.trn_log_enabled  == 0;
+         obi_memory_data_cfg.trn_log_enabled   == 0;
+         rvfi_cfg.trn_log_enabled              == 0;
+         rvvi_cfg.trn_log_enabled              == 0;
+         isacov_cfg.trn_log_enabled            == 0;
       }
 
       // FIXME:strichmo:restore when debug coverage model is fixed
@@ -251,6 +262,10 @@ function uvme_cv32e40x_cfg_c::new(string name="uvme_cv32e40x_cfg");
 
    if ($test$plusargs("USE_ISS"))
       use_iss = 1;
+   if ($test$plusargs("trn_log_disabled")) begin
+      trn_log_enabled = 0;
+      trn_log_enabled.rand_mode(0);
+   end
 
    isacov_cfg = uvma_isacov_cfg_c::type_id::create("isacov_cfg");
    clknrst_cfg  = uvma_clknrst_cfg_c::type_id::create("clknrst_cfg");

--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -141,40 +141,35 @@ tests:
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     num: 2
 
-  # FIXME:strichmo:This is currently known to not work, update later
-  # corev_rand_debug:
-  #   build: uvmt_cv32e40x
-  #   description: Generated corev-dv random debug test
-  #   dir: cv32e40x/sim/uvmt
-  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug
-  #   num: 2
+  corev_rand_debug:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random debug test
+    dir: cv32e40x/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug
+    num: 2
 
-  # FIXME:strichmo:This is currently known to not work, update later
-  # corev_rand_debug_single_step:
-  #   build: uvmt_cv32e40x
-  #   description: debug random test with single-stepping
-  #   dir: cv32e40x/sim/uvmt
-  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step
-  #   num: 2
+  corev_rand_debug_single_step:
+    build: uvmt_cv32e40x
+    description: debug random test with single-stepping
+    dir: cv32e40x/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_single_step
+    num: 2
 
-  # FIXME:strichmo:This is currently known to not work, update later
-  # corev_rand_debug_ebreak:
-  #   build: uvmt_cv32e40x
-  #   description: debug random test with ebreaks from ROM
-  #   dir: cv32e40x/sim/uvmt
-  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
-  #   num: 2
+  corev_rand_debug_ebreak:
+    build: uvmt_cv32e40x
+    description: debug random test with ebreaks from ROM
+    dir: cv32e40x/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak
+    num: 2
 
-  # FIXME:strichmo:This is currently known to not work, update later
-  #   corev_rand_interrupt_wfi:
-  #     build: uvmt_cv32e40x
-  #     description: Generated corev-dv random interrupt WFI test
-  #     dir: cv32e40x/sim/uvmt
-  #     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
-  #     num: 2
-  #     makearg: USER_RUN_FLAGS=+rand_stall_obi_disable
+    corev_rand_interrupt_wfi:
+      build: uvmt_cv32e40x
+      description: Generated corev-dv random interrupt WFI test
+      dir: cv32e40x/sim/uvmt
+      cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi
+      num: 2
 
-  # FIXME:strichmo:This is currently known to not work, update later
+  # FIXME:strichmo:restore this when CV32E40X issue 204 is fixed in RVFI
   # corev_rand_interrupt_debug:
   #   build: uvmt_cv32e40x
   #   description: Generated corev-dv random interrupt WFI test with debug
@@ -182,12 +177,12 @@ tests:
   #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
   #   num: 2
 
-  # corev_rand_interrupt_exception:
-  #   build: uvmt_cv32e40x
-  #   description: Generated corev-dv random interrupt WFI test with exceptions
-  #   dir: cv32e40x/sim/uvmt
-  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
-  #   num: 2
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40x
+    description: Generated corev-dv random interrupt WFI test with exceptions
+    dir: cv32e40x/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
+    num: 2
 
   corev_rand_interrupt_nested:
     build: uvmt_cv32e40x

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= d2ec2200d559efc748f824191ac59c08d0ebba72
+CV_CORE_HASH   ?= 409d18e33efe11cd41ce66ef018e9b5ce7075f6f
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/tests/embench/README.md
+++ b/cv32e40x/tests/embench/README.md
@@ -60,7 +60,9 @@ SIMULATOR option, are omitted.
 | EMB_BUILD_ONLY | NO         | Set this option to "YES" to only build the benchmarks                                                                                  |
 | EMB_TARGET     | 0(not set) | Set a target(float) for your EMBench score<br>Benchmark run will fail if target is not met<br>If no target is set, no checking is done |
 | EMB_CPU_MHZ    | 1          | Set the core frequency in MHz \*                                                                                                       |
+| EMB_PARALLEL   | NO         | Launches simulation jobs in parallel.  The user must set CV_SIM_PREFIX based on any configured jobs manager (e.g. LSF, SLURM, .etc.)   |
 | EMB_DEBUG      | NO         | Set this option to "YES" to increase verbosity of the script                                                                           |
+| EMB_TIMEOUT    | 3600       | Timeout for jobs to complete (in seconds)                                                                                              |
 
 <br>
 * This value is used for calculation in EMBench only. Measurement is done by cycle count, so this does not

--- a/cv32e40x/tests/embench/pylib/run_corev32.py
+++ b/cv32e40x/tests/embench/pylib/run_corev32.py
@@ -90,9 +90,7 @@ def build_benchmark_cmd(bench, args):
     #Utilize "make test" environment in core-v-verif
     return ['make', '-C', args.make_path, 'test',
             f"TEST=emb_{bench}", f"COMP=0",
-            f"SIMULATOR={args.simulator}", 'USE_ISS=NO',
-            'USER_RUN_FLAGS=+rand_stall_obi_disable']
-
+            f"SIMULATOR={args.simulator}", 'USE_ISS=NO']
 
 def decode_results(stdout_str, stderr_str):
     """Extract the results from the output string of the run. Return the

--- a/cv32e40x/tests/embench/pylib/run_corev32.py
+++ b/cv32e40x/tests/embench/pylib/run_corev32.py
@@ -88,7 +88,10 @@ def build_benchmark_cmd(bench, args):
     cpu_per = float(1/(args.cpu_mhz*1_000_000))
 
     #Utilize "make test" environment in core-v-verif
-    return ['make', '-C', args.make_path, 'test', f"TEST=emb_{bench}", f"SIMULATOR={args.simulator}", 'USE_ISS=NO']
+    return ['make', '-C', args.make_path, 'test',
+            f"TEST=emb_{bench}", f"COMP=0",
+            f"SIMULATOR={args.simulator}", 'USE_ISS=NO',
+            'USER_RUN_FLAGS=+rand_stall_obi_disable']
 
 
 def decode_results(stdout_str, stderr_str):
@@ -109,9 +112,8 @@ def decode_results(stdout_str, stderr_str):
         log.debug('Warning: Failed to find result')
         return 0.0
 
-    time = float(int(rcstr.group(1))*cpu_per)
+    time = float(rcstr.group(1))*cpu_per
     time_ms = time * 1000
-
 
     return time_ms
 

--- a/cv32e40x/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40x/tests/programs/custom/coremark/test.yaml
@@ -1,4 +1,18 @@
 name: coremark
 uvm_test: uvmt_cv32e40x_firmware_test_c
+default_cflags: >
+    -O3
+    -mabi=ilp32
+    -march=rv32im
+    -falign-functions=16
+    -funroll-all-loops
+    -falign-jumps=4
+    -finline-functions
+    -Wall
+    -static
+    -pedantic
+    -DPERFORMANCE_RUN=1
+    -DITERATIONS=10
+    -DFLAGS_STR=\""-mabi=ilp32 -O3 -falign-functions=16 -funroll-all-loops -falign-jumps=4 -finline-functions -Wall -pedanic -nostartfiles -static"\"
 description: >
     Runs the CoreMark benchmark

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_agent.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_agent.sv
@@ -69,8 +69,10 @@ function void uvma_isacov_agent_c::connect_phase(uvm_phase phase);
   if (cfg.enabled) begin
     mon_ap = monitor.ap;
     mon_ap.connect(cov_model.mon_trn_fifo.analysis_export);  //TODO if cfg...enabled
-    mon_ap.connect(mon_trn_logger.analysis_export);  // TODO if cfg...enabled
-  end 
+    if (cfg.trn_log_enabled) begin
+      mon_ap.connect(mon_trn_logger.analysis_export);
+    end
+  end
 
 endfunction : connect_phase
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -403,6 +403,14 @@ else
 TEST_FILES        = $(filter %.c %.S,$(wildcard  $(TEST_TEST_DIR)/*))
 endif
 
+# If a test defines "default_cflags" in its yaml, then it is responsible to define ALL flags
+# Otherwise add the default cflags in the variable CFLAGS defined above
+ifneq ($(TEST_DEFAULT_CFLAGS),)
+TEST_CFLAGS += $(TEST_DEFAULT_CFLAGS)
+else
+TEST_CFLAGS += $(CFLAGS)
+endif
+
 %.elf: $(TEST_FILES)
 	make bsp
 	@echo "$(BANNER)"
@@ -410,7 +418,6 @@ endif
 	@echo "$(BANNER)"
 	$(RISCV_EXE_PREFIX)gcc $(CFG_CFLAGS) \
 		$(TEST_CFLAGS) \
-		$(CFLAGS) \
 		-I $(ASM) \
 		-o $@ \
 		-nostartfiles \
@@ -434,19 +441,6 @@ vars_bsp:
 
 clean-bsp:
 	make clean -C $(BSP)
-
-# FIXME:strichmo:merge this into general elf rule
-COREMARK_CFLAGS = \
-	-mabi=ilp32 -march=rv32im -O3 -g -falign-functions=16 \
-	-funroll-all-loops -falign-jumps=4 -finline-functions \
-	-Wall -pedantic -nostartfiles -static
-%coremark.elf:
-	$(RISCV_EXE_PREFIX)gcc $(COREMARK_CFLAGS) -o $@ \
-		-DFLAGS_STR=\""$(COREMARK_CFLAGS)"\" \
-		-DPERFORMANCE_RUN=1 -DITERATIONS=10 \
-		$(BSP_FILES) \
-		$(TEST_FILES) \
-		-T $(BSP)/link.ld
 
 
 # compile and dump RISCV_TESTS only

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -83,6 +83,8 @@ GEN_NUM_TESTS   ?= 1
 EMB_TYPE           ?= speed
 EMB_TARGET         ?= 0
 EMB_CPU_MHZ        ?= 1
+EMB_TIMEOUT        ?= 3600
+EMB_PARALLEL_ARG    = $(if $(filter $(YES_VALS),$(EMB_PARALLEL)),YES,NO)
 EMB_BUILD_ONLY_ARG  = $(if $(filter $(YES_VALS),$(EMB_BUILD_ONLY)),YES,NO)
 EMB_DEBUG_ARG       = $(if $(filter $(YES_VALS),$(EMB_DEBUG)),YES,NO)
 # Commont test variables
@@ -284,14 +286,16 @@ dah:
 
 embench: $(EMBENCH_PKG)
 	$(CORE_V_VERIF)/bin/run_embench.py \
-	-c $(CV_CORE) \
-	-cc $(RISCV_EXE_PREFIX)gcc \
-	-sim $(SIMULATOR) \
-	-t $(EMB_TYPE) \
-	-b $(EMB_BUILD_ONLY_ARG) \
-	-tgt $(EMB_TARGET) \
-	-f $(EMB_CPU_MHZ) \
-	-d $(EMB_DEBUG_ARG) \
+		-c $(CV_CORE) \
+		-cc $(RISCV_EXE_PREFIX)gcc \
+		-sim $(SIMULATOR) \
+		-t $(EMB_TYPE) \
+		--timeout $(EMB_TIMEOUT) \
+		--parallel $(EMB_PARALLEL_ARG) \
+		-b $(EMB_BUILD_ONLY_ARG) \
+		-tgt $(EMB_TARGET) \
+		-f $(EMB_CPU_MHZ) \
+		-d $(EMB_DEBUG_ARG)
 
 ###############################################################################
 # ISACOV (ISA coverage)


### PR DESCRIPTION
Cleaning up embench speed benchmarks (size cleanup to follow).
parallel sims work now to greatly reduce time
added initial transaction log disable for testbench - greatly reduces simulation time for benchmarks, but needs a more comprehensive solution
added timeout to embench
moved coremark cflags into test yaml and removed special rules and variables in makefile
Updated RTL to latest
Uncommented lots of release check random tests that should pass now
Commented the CSR test in release check in lieu of an OVPSIM fix required due to mcause extending by a bit (bus errors)