### PR TITLE
fix ecall in E40P with latest OVPSIM

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
@@ -49,7 +49,7 @@ module uvmt_cv32e40p_iss_wrap
     CPU #(.ID(ID), .VARIANT("CV32E40P")) cpu(bus, io);
 
    assign bus.Clk = clknrst_if.clk;
-   
+
    // monitor rvvi updates
    always @(cpu.state.notify) begin
        int i;
@@ -61,11 +61,21 @@ module uvmt_cv32e40p_iss_wrap
        if (cpu.state.valid) begin
            // $display("Instruction Retired %08X %08X", cpu.state.pc, cpu.state.pcw);
            -> step_compare_if.ovp_cpu_valid;
+       end else if (cpu.state.trap &&
+                    cpu.state.decode == "ecall" &&
+                    cpu.io.irq_ack_o == 0 &&
+                    (!cpu.io.DM || !cpu.state.csr["dcsr"][2])) begin
+           // With introduction of OVPSIM model v20200821.377
+           // the valid behavior was changed, the above clause was introduced to all signal valid
+           // instruction on valid ecalls, which must be checked out by the step and compare interface
+           // Eventually this module should be replaced by a RVFI/RVVI UVM scoreboard which will not rely on this
+           // $display("Instruction Retired %08X %08X", cpu.state.pc, cpu.state.pcw);
+           -> step_compare_if.ovp_cpu_valid;
        end else if (cpu.state.trap) begin
            // $display("Instruction Fault %08X %08X", cpu.state.pc, cpu.state.pcw);
            -> step_compare_if.ovp_cpu_trap;
        end
-       
+
    end
 
    // monitor debug control updates
@@ -104,10 +114,10 @@ module uvmt_cv32e40p_iss_wrap
             isa_covg_if.ins.ops[i].key=key;
             isa_covg_if.ins.ops[i].val=val;
         end
-        `uvm_info("OVPSIM", $sformatf("Decoded instr: %s%s pc: 0x%08x",                                       
+        `uvm_info("OVPSIM", $sformatf("Decoded instr: %s%s pc: 0x%08x",
                                       isa_covg_if.ins.compressed ? "c." : "",
                                       decode,
-                                      isa_covg_if.ins.pc), 
+                                      isa_covg_if.ins.pc),
                             UVM_DEBUG)
         ->isa_covg_if.ins_valid;
     endfunction


### PR DESCRIPTION
patch changed valid behavior in iss by adding ecall exceptions in ste…p and compare

this should be temporary until RVFI/RVVI ported to E40P

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>