### PR TITLE
e40x warning cleanup and add fencei UVM agent

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
@@ -36,8 +36,8 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
    rand uvma_debug_cfg_c            debug_cfg;
    rand uvma_obi_memory_cfg_c       obi_memory_instr_cfg;
    rand uvma_obi_memory_cfg_c       obi_memory_data_cfg;
+   rand uvma_fencei_cfg_c           fencei_cfg;
    rand uvma_rvfi_cfg_c#(ILEN,XLEN) rvfi_cfg;
-
    rand uvma_rvvi_cfg_c#(ILEN,XLEN) rvvi_cfg;
 
    `uvm_object_utils_begin(uvme_cv32e40x_cfg_c)
@@ -56,6 +56,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       `uvm_field_object(obi_memory_data_cfg  , UVM_DEFAULT)
       `uvm_field_object(rvfi_cfg             , UVM_DEFAULT)
       `uvm_field_object(rvvi_cfg             , UVM_DEFAULT)
+      `uvm_field_object(fencei_cfg           , UVM_DEFAULT)
    `uvm_object_utils_end
 
    constraint defaults_cons {
@@ -140,6 +141,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
          rvvi_cfg.enabled              == use_iss;
          obi_memory_instr_cfg.enabled  == 1;
          obi_memory_data_cfg.enabled   == 1;
+         fencei_cfg.enabled            == 1;
       }
 
       obi_memory_instr_cfg.version       == UVMA_OBI_MEMORY_VERSION_1P2;
@@ -189,6 +191,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
          obi_memory_data_cfg.is_active  == UVM_ACTIVE;
          rvfi_cfg.is_active             == UVM_PASSIVE;
          rvvi_cfg.is_active             == UVM_ACTIVE;
+         fencei_cfg.is_active           == UVM_ACTIVE;
       }
 
       if (trn_log_enabled) {
@@ -273,6 +276,7 @@ function uvme_cv32e40x_cfg_c::new(string name="uvme_cv32e40x_cfg");
    obi_memory_data_cfg  = uvma_obi_memory_cfg_c::type_id::create("obi_memory_data_cfg" );
    rvfi_cfg = uvma_rvfi_cfg_c#(ILEN,XLEN)::type_id::create("rvfi_cfg");
    rvvi_cfg = uvma_rvvi_ovpsim_cfg_c#(ILEN,XLEN)::type_id::create("rvvi_cfg");
+   fencei_cfg = uvma_fencei_cfg_c::type_id::create("fencei_cfg");
 
    isacov_cfg.core_cfg = this;
    rvfi_cfg.core_cfg = this;
@@ -358,7 +362,3 @@ endfunction : configure_disable_csr_checks
 
 
 `endif // __UVME_CV32E40X_CFG_SV__
-
-
-
-

--- a/cv32e40x/env/uvme/uvme_cv32e40x_cntxt.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cntxt.sv
@@ -41,6 +41,7 @@ class uvme_cv32e40x_cntxt_c extends uvm_object;
    uvma_obi_memory_cntxt_c           obi_memory_data_cntxt;
    uvma_rvfi_cntxt_c#(ILEN,XLEN)     rvfi_cntxt;
    uvma_rvvi_cntxt_c#(ILEN,XLEN)     rvvi_cntxt;
+   uvma_fencei_cntxt_c               fencei_cntxt;
 
    // Memory modelling
    rand uvml_mem_c                   mem;
@@ -88,6 +89,8 @@ function uvme_cv32e40x_cntxt_c::new(string name="uvme_cv32e40x_cntxt");
    obi_memory_data_cntxt  = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_data_cntxt" );
    rvfi_cntxt       = uvma_rvfi_cntxt_c#(ILEN,XLEN)::type_id::create("rvfi_cntxt");
    rvvi_cntxt       = uvma_rvvi_ovpsim_cntxt_c#(ILEN,XLEN)::type_id::create("rvvi_cntxt");
+   fencei_cntxt     = uvma_fencei_cntxt_c::type_id::create("fencei_cntxt");
+
    mem = uvml_mem_c#(XLEN)::type_id::create("mem");
 
    sample_cfg_e   = new("sample_cfg_e"  );

--- a/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
@@ -46,6 +46,7 @@ class uvme_cv32e40x_env_c extends uvm_env;
    uvma_obi_memory_agent_c          obi_memory_data_agent ;
    uvma_rvfi_agent_c#(ILEN,XLEN)    rvfi_agent;
    uvma_rvvi_agent_c#(ILEN,XLEN)    rvvi_agent;
+   uvma_fencei_agent_c              fencei_agent ;
 
    `uvm_component_utils_begin(uvme_cv32e40x_env_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -345,6 +346,7 @@ function void uvme_cv32e40x_env_c::assign_cfg();
    uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_data_agent",  "cfg", cfg.obi_memory_data_cfg);
    uvm_config_db#(uvma_rvfi_cfg_c#(ILEN,XLEN))::set(this, "rvfi_agent", "cfg", cfg.rvfi_cfg);
    uvm_config_db#(uvma_rvvi_cfg_c#(ILEN,XLEN))::set(this, "rvvi_agent", "cfg", cfg.rvvi_cfg);
+   uvm_config_db#(uvma_fencei_cfg_c)::set(this, "fencei_agent", "cfg", cfg.fencei_cfg);
 
 endfunction: assign_cfg
 
@@ -359,6 +361,7 @@ function void uvme_cv32e40x_env_c::assign_cntxt();
    uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_data_agent",  "cntxt", cntxt.obi_memory_data_cntxt);
    uvm_config_db#(uvma_rvfi_cntxt_c#(ILEN,XLEN))::set(this, "rvfi_agent", "cntxt", cntxt.rvfi_cntxt);
    uvm_config_db#(uvma_rvvi_cntxt_c#(ILEN,XLEN))::set(this, "rvvi_agent", "cntxt", cntxt.rvvi_cntxt);
+   uvm_config_db#(uvma_fencei_cntxt_c)::set(this, "rvvi_agent", "cntxt", cntxt.fencei_cntxt);
 
 endfunction: assign_cntxt
 
@@ -374,6 +377,7 @@ function void uvme_cv32e40x_env_c::create_agents();
    obi_memory_data_agent  = uvma_obi_memory_agent_c::type_id::create("obi_memory_data_agent",  this);
    rvfi_agent = uvma_rvfi_agent_c#(ILEN,XLEN)::type_id::create("rvfi_agent", this);
    rvvi_agent = uvma_rvvi_ovpsim_agent_c#(ILEN,XLEN)::type_id::create("rvvi_agent", this);
+   fencei_agent = uvma_fencei_agent_c::type_id::create("fencei_agent", this);
 
 endfunction: create_agents
 
@@ -454,5 +458,3 @@ endfunction: assemble_vsequencer
 
 
 `endif // __UVME_CV32E40X_ENV_SV__
-
-

--- a/cv32e40x/env/uvme/uvme_cv32e40x_pkg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_pkg.sv
@@ -48,6 +48,7 @@ package uvme_cv32e40x_pkg;
    import uvma_rvfi_pkg::*;
    import uvma_rvvi_pkg::*;
    import uvma_rvvi_ovpsim_pkg::*;
+   import uvma_fencei_pkg::*;
 
    // Forward decls
    typedef class uvme_cv32e40x_vsqr_c;

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 409d18e33efe11cd41ce66ef018e9b5ce7075f6f
+CV_CORE_HASH   ?= feb1ccdf1e183a7a50079ffd6cbbe107defe9e5e
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x.flist
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x.flist
@@ -6,15 +6,15 @@
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 // Libraries
 -f ${DV_UVML_HRTBT_PATH}/uvml_hrtbt_pkg.flist
@@ -33,6 +33,7 @@
 -f ${DV_UVMA_INTERRUPT_PATH}/uvma_interrupt_pkg.flist
 -f ${DV_UVMA_DEBUG_PATH}/uvma_debug_pkg.flist
 -f ${DV_UVMA_RVVI_OVPSIM_PATH}/uvma_rvvi_ovpsim_pkg.flist
+-f ${DV_UVMA_FENCEI_PATH}/uvma_fencei_pkg.flist
 
 // Environments
 -f ${DV_UVME_PATH}/uvme_cv32e40x_pkg.flist

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -59,7 +59,8 @@ module uvmt_cv32e40x_dut_wrap
     uvme_cv32e40x_core_cntrl_if  core_cntrl_if,
     uvmt_cv32e40x_core_status_if core_status_if,
     uvma_obi_memory_if           obi_instr_if_i,
-    uvma_obi_memory_if           obi_data_if_i
+    uvma_obi_memory_if           obi_data_if_i,
+    uvma_fencei_if               fencei_if_i
   );
 
     import uvm_pkg::*; // needed for the UVM messaging service (`uvm_info(), etc.)
@@ -190,6 +191,9 @@ module uvmt_cv32e40x_dut_wrap
          .irq_i                  ( interrupt_if.irq               ),
          .irq_ack_o              ( irq_ack                        ),
          .irq_id_o               ( irq_id                         ),
+
+         .fencei_flush_req_o     ( fencei_if_i.flush_req          ),
+         .fencei_flush_ack_i     ( fencei_if_i.flush_ack          ),
 
          .debug_req_i            ( debug_if.debug_req             ),
          .debug_havereset_o      ( debug_havereset                ),

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_interrupt_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_interrupt_assert.sv
@@ -48,9 +48,8 @@ module uvmt_cv32e40x_interrupt_assert
     input [31:0] if_stage_instr_rdata_i, // Instruction word data
 
     // Instruction ID stage (determines executed instructions)
-    input        id_stage_instr_valid_i, // instruction word is valid
-    input [31:0] id_stage_instr_rdata_i, // Instruction word data
-    input [4:0]  ctrl_fsm_cs,            // Controller FSM to get hint for interrupt taken
+    input              id_stage_instr_valid_i, // instruction word is valid
+    input [31:0]       id_stage_instr_rdata_i, // Instruction word data
 
     // Determine whether to cancel instruction if branch taken
     input branch_taken_ex,

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -70,6 +70,10 @@ module uvmt_cv32e40x_tb;
      .clk(clknrst_if.clk),
      .reset_n(clknrst_if.reset_n)
    );
+   uvma_fencei_if               fencei_if_i(
+     .clk(clknrst_if.clk),
+     .reset_n(clknrst_if.reset_n)
+   );
 
    // DUT Wrapper Interfaces
    uvmt_cv32e40x_vp_status_if       vp_status_if(.tests_passed(),
@@ -521,7 +525,9 @@ module uvmt_cv32e40x_tb;
      uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env.interrupt_agent"), .field_name("vif"),      .value(interrupt_if));
      uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_instr_agent"), .field_name("vif"), .value(obi_instr_if_i) );
      uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_data_agent"),  .field_name("vif"), .value(obi_data_if_i) );
+     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei"),     .field_name("vif"), .value(fencei_if_i));
      uvm_config_db#(virtual uvma_rvfi_instr_if          )::set(.cntxt(null), .inst_name("*.env.rvfi_agent"), .field_name("instr_vif0"),.value(dut_wrap.cv32e40x_wrapper_i.rvfi_instr_if_0_i));
+     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei_agent"), .field_name("fencei_vif"),     .value(fencei_if_i)  );
      uvm_config_db#(virtual uvmt_cv32e40x_vp_status_if  )::set(.cntxt(null), .inst_name("*"),                .field_name("vp_status_vif"),    .value(vp_status_if) );
      uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env"),            .field_name("intr_vif"),         .value(interrupt_if) );
      uvm_config_db#(virtual uvma_debug_if               )::set(.cntxt(null), .inst_name("*.env"),            .field_name("debug_vif"),        .value(debug_if)     );

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -325,7 +325,7 @@ module uvmt_cv32e40x_tb;
 
   // Bind in verification modules to the design
   bind cv32e40x_core
-    uvmt_cv32e40x_interrupt_assert interrupt_assert_i(.mcause_n({cs_registers_i.mcause_n.interrupt, cs_registers_i.mcause_n.exception_code}),
+    uvmt_cv32e40x_interrupt_assert interrupt_assert_i(.mcause_n({cs_registers_i.mcause_n.interrupt, cs_registers_i.mcause_n.exception_code[4:0]}),
                                                       .mip(cs_registers_i.mip),
                                                       .mie_q(cs_registers_i.mie_q),
                                                       .mstatus_mie(cs_registers_i.mstatus_q.mie),
@@ -335,7 +335,6 @@ module uvmt_cv32e40x_tb;
                                                       .id_stage_instr_valid_i(wb_stage_i.instr_valid),
                                                       .id_stage_instr_rdata_i(wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata),
                                                       .branch_taken_ex(controller_i.controller_fsm_i.branch_taken_ex),
-                                                      .ctrl_fsm_cs(controller_i.controller_fsm_i.ctrl_fsm_cs),
                                                       .debug_mode_q(controller_i.controller_fsm_i.debug_mode_q),
                                                       .*);
 

--- a/lib/uvm_agents/uvma_fencei/seq/uvma_fencei_seq_item.sv
+++ b/lib/uvm_agents/uvma_fencei/seq/uvma_fencei_seq_item.sv
@@ -1,0 +1,70 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_SEQ_ITEM_SV__
+`define __UVMA_FENCEI_SEQ_ITEM_SV__
+
+
+/**
+ * Object created by Fenci agent sequences
+ */
+class uvma_fencei_seq_item_c extends uvml_trn_seq_item_c;
+
+   // Latency used by active masters to delay driving request
+   int unsigned            req_latency;
+
+   // Latency used by active slaves to delay driving acknowledge
+   // A monitor will also use this to log latency of an acknowledge
+   int unsigned            ack_latency;
+
+   static protected string _log_format_string = "0x%08x %s 0x%01x 0x%08x";
+
+   `uvm_object_param_utils_begin(uvma_fencei_seq_item_c)
+      `uvm_field_int(req_latency, UVM_DEFAULT)
+      `uvm_field_int(ack_latency, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_seq_item");
+
+   /**
+    * One-liner log message
+    */
+   extern function string convert2string();
+
+endclass : uvma_fencei_seq_item_c
+
+`pragma protect begin
+
+function uvma_fencei_seq_item_c::new(string name="uvma_fencei_seq_item");
+
+   super.new(name);
+
+endfunction : new
+
+function string uvma_fencei_seq_item_c::convert2string();
+
+   convert2string = $sformatf("FENCEI: Ack latency: %0d", ack_latency);
+
+endfunction : convert2string
+
+
+`pragma protect end
+
+
+`endif // __UVMA_FENCEI_SEQ_ITEM_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_agent.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_agent.sv
@@ -1,0 +1,242 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_AGENT_SV__
+`define __UVMA_FENCEI_AGENT_SV__
+
+/**
+ * Top-level component that encapsulates, builds and connects all others.
+ * Capable of driving/monitoring Clock & Reset interface.
+ */
+class uvma_fencei_agent_c extends uvm_agent;
+
+   // Objects
+   uvma_fencei_cfg_c    cfg;
+   uvma_fencei_cntxt_c  cntxt;
+
+   // Components
+   uvma_fencei_mon_c               monitor;
+   uvma_fencei_drv_c               driver;
+   uvma_fencei_sqr_c               sequencer;
+   uvma_fencei_mon_trn_logger_c    mon_trn_logger;
+
+   // TLM
+   uvm_analysis_port#(uvma_fencei_seq_item_c) mon_ap;
+
+   `uvm_component_param_utils_begin(uvma_fencei_agent_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_agent", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null
+    * 2. Builds all components
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * 1. Links agent's analysis ports to sub-components'
+    * 2. Connects coverage models and loggers
+    */
+   extern virtual function void connect_phase(uvm_phase phase);
+
+   /**
+    * Uses uvm_config_db to retrieve cfg and hand out to sub-components.
+    */
+   extern function void get_and_set_cfg();
+
+   /**
+    * Uses uvm_config_db to retrieve cntxt and hand out to sub-components.
+    */
+   extern function void get_and_set_cntxt();
+
+   /**
+    * Uses uvm_config_db to retrieve the Virtual Interface (vif) associated with this
+    * agent.
+    */
+   extern function void retrieve_vif();
+
+   /**
+    * Creates sub-components.
+    */
+   extern function void create_components();
+
+   /**
+    * Connects sequencer and driver's TLM port(s).
+    */
+   extern function void connect_sequencer_and_driver();
+
+   /**
+    * Connects agent's TLM ports to driver's and monitor's.
+    */
+   extern function void connect_analysis_ports();
+
+   /**
+    * Connects monitor's TLM ports to sequencer's transaction FIFO
+    */
+   extern function void connect_rsp_path();
+
+   /**
+    * Connects coverage model to monitor and driver's analysis ports.
+    */
+   extern function void connect_cov_model();
+
+   /**
+    * Connects transaction loggers to monitor and driver's analysis ports.
+    */
+   extern function void connect_trn_loggers();
+
+endclass : uvma_fencei_agent_c
+
+
+function uvma_fencei_agent_c::new(string name="uvma_fencei_agent", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_fencei_agent_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   get_and_set_cfg  ();
+   get_and_set_cntxt();
+   retrieve_vif     ();
+   create_components();
+
+endfunction : build_phase
+
+
+function void uvma_fencei_agent_c::connect_phase(uvm_phase phase);
+
+   super.connect_phase(phase);
+
+   connect_sequencer_and_driver();
+   connect_analysis_ports();
+   connect_rsp_path();
+
+   if (cfg.cov_model_enabled) begin
+      connect_cov_model();
+   end
+   if (cfg.trn_log_enabled) begin
+      connect_trn_loggers();
+   end
+
+endfunction: connect_phase
+
+
+function void uvma_fencei_agent_c::get_and_set_cfg();
+
+   void'(uvm_config_db#(uvma_fencei_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+   else begin
+      `uvm_info("CFG", $sformatf("Found configuration handle:\n%s", cfg.sprint()), UVM_DEBUG)
+      uvm_config_db#(uvma_fencei_cfg_c)::set(this, "*", "cfg", cfg);
+   end
+
+endfunction : get_and_set_cfg
+
+
+function void uvma_fencei_agent_c::get_and_set_cntxt();
+
+   void'(uvm_config_db#(uvma_fencei_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_info("CNTXT", "Context handle is null; creating.", UVM_DEBUG)
+      cntxt = uvma_fencei_cntxt_c::type_id::create("cntxt");
+   end
+   uvm_config_db#(uvma_fencei_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+endfunction : get_and_set_cntxt
+
+
+function void uvma_fencei_agent_c::retrieve_vif();
+
+   // Retrieve instruction interface
+   if (!uvm_config_db#(virtual uvma_fencei_if)::get(this, "", "fencei_vif", cntxt.fencei_vif)) begin
+      `uvm_fatal("VIF", $sformatf("Could not find vif handle of type %s in uvm_config_db",
+                                  $typename(cntxt.fencei_vif)))
+   end
+   else begin
+      `uvm_info("VIF", $sformatf("Found vif handle of type %s in uvm_config_db",
+                                 $typename(cntxt.fencei_vif)), UVM_DEBUG)
+   end
+
+endfunction : retrieve_vif
+
+
+function void uvma_fencei_agent_c::create_components();
+
+   monitor         = uvma_fencei_mon_c::type_id::create("monitor`", this);
+   mon_trn_logger  = uvma_fencei_mon_trn_logger_c::type_id::create("mon_trn_logger" , this);
+   if (cfg.is_active == UVM_ACTIVE) begin
+      driver       = uvma_fencei_drv_c::type_id::create("driver", this);
+      sequencer    = uvma_fencei_sqr_c::type_id::create("sequencer", this);
+   end
+
+endfunction : create_components
+
+
+function void uvma_fencei_agent_c::connect_sequencer_and_driver();
+
+   if (cfg.is_active == UVM_ACTIVE) begin
+      driver.seq_item_port.connect(sequencer.seq_item_export);
+   end
+
+endfunction : connect_sequencer_and_driver
+
+
+function void uvma_fencei_agent_c::connect_analysis_ports();
+
+   mon_ap = monitor.ap;
+
+endfunction : connect_analysis_ports
+
+
+function void uvma_fencei_agent_c::connect_rsp_path();
+
+   // if (cfg.is_active == UVM_ACTIVE) begin
+   //    mon_ap.connect(sequencer.fencei_export);
+   // end
+
+endfunction : connect_rsp_path
+
+
+function void uvma_fencei_agent_c::connect_cov_model();
+
+   //mon_ap.connect(cov_model.mon_trn_fifo.analysis_export);
+
+endfunction : connect_cov_model
+
+
+function void uvma_fencei_agent_c::connect_trn_loggers();
+
+   mon_ap.connect(mon_trn_logger.fencei_export);
+
+endfunction : connect_trn_loggers
+
+
+`endif // __UVMA_FENCEI_AGENT_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_assert.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_assert.sv
@@ -1,0 +1,53 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module uvma_fencei_assert
+  import uvm_pkg::*;
+  (
+    input                    clk,
+    input                    reset_n,
+
+    input                    flush_req,
+    input                    flush_ack
+  );
+
+  // ---------------------------------------------------------------------------
+  // Local variables
+  // ---------------------------------------------------------------------------
+  string info_tag = "UVMA_FENCEI_ASSERT";
+
+  // ---------------------------------------------------------------------------
+  // Clocking blocks
+  // ---------------------------------------------------------------------------
+
+  // Single clock, single reset design, use default clocking
+  default clocking @(posedge clk); endclocking
+  default disable iff !(reset_n);
+
+  // ---------------------------------------------------------------------------
+  // Begin module code
+  // ---------------------------------------------------------------------------
+
+  // Fence request may not deassert until acknowledged
+  property p_req_until_ack;
+    flush_req ##0 !flush_ack |=> flush_req;
+  endproperty : p_req_until_ack
+
+  a_req_until_ack: assert property(p_req_until_ack)
+  else
+    `uvm_error(info_tag, "flush request not held until ack")
+
+endmodule : uvma_fencei_assert

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_cfg.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_cfg.sv
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_CFG_SV__
+`define __UVMA_FENCEI_CFG_SV__
+
+
+/**
+ * Object encapsulating all parameters for creating, connecting and running all
+ * Clock & Reset agent (uvma_fencei_agent_c) components.
+ */
+class uvma_fencei_cfg_c extends uvm_object;
+
+   // Common options
+   rand bit                      enabled;
+   rand uvm_active_passive_enum  is_active;
+
+   rand bit                      cov_model_enabled;
+   rand bit                      trn_log_enabled;
+
+   // ACK latency modes
+   rand uvma_fencei_drv_ack_enum drv_ack_mode;
+   rand int unsigned             drv_ack_fixed_latency;
+   rand int unsigned             drv_ack_random_latency_min;
+   rand int unsigned             drv_ack_random_latency_max;
+
+   `uvm_object_utils_begin(uvma_fencei_cfg_c)
+      `uvm_field_int (                          enabled                    , UVM_DEFAULT)
+      `uvm_field_enum(uvm_active_passive_enum,  is_active                  , UVM_DEFAULT)
+      `uvm_field_int (                          cov_model_enabled          , UVM_DEFAULT)
+      `uvm_field_int (                          trn_log_enabled            , UVM_DEFAULT)
+      `uvm_field_enum(uvma_fencei_drv_ack_enum, drv_ack_mode               , UVM_DEFAULT)
+      `uvm_field_int (                          drv_ack_fixed_latency      , UVM_DEFAULT)
+      `uvm_field_int (                          drv_ack_random_latency_min , UVM_DEFAULT)
+      `uvm_field_int (                          drv_ack_random_latency_max , UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   constraint defaults_cons {
+      soft enabled           == 1;
+      soft is_active         == UVM_PASSIVE;
+      soft cov_model_enabled == 0;
+      soft trn_log_enabled   == 1;
+   }
+
+   constraint default_fixed_ack_latency_cons {
+      soft drv_ack_fixed_latency inside {[0:12]};
+   }
+
+   constraint valid_random_ack_latency_cons {
+      drv_ack_random_latency_min <= drv_ack_random_latency_max;
+   }
+
+   constraint default_random_latency_cons {
+      soft drv_ack_random_latency_min inside {[0:12]};
+      soft drv_ack_random_latency_max inside {[0:12]};
+   }
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_cfg");
+
+   /**
+    * Calculate a new random gnt latency
+    */
+   extern function int unsigned calc_random_ack_latency();
+
+endclass : uvma_fencei_cfg_c
+
+function uvma_fencei_cfg_c::new(string name="uvma_fencei_cfg");
+
+   super.new(name);
+
+endfunction : new
+
+function int unsigned uvma_fencei_cfg_c::calc_random_ack_latency();
+
+   int unsigned ack_latency;
+
+   case (drv_ack_mode)
+      UVMA_FENCEI_DRV_ACK_MODE_CONSTANT      : ack_latency = 0;
+      UVMA_FENCEI_DRV_ACK_MODE_FIXED_LATENCY : ack_latency = drv_ack_fixed_latency;
+      UVMA_FENCEI_DRV_ACK_MODE_RANDOM_LATENCY: begin
+         ack_latency = $urandom_range(drv_ack_random_latency_min, drv_ack_random_latency_max);
+      end
+   endcase
+
+   return ack_latency;
+
+endfunction : calc_random_ack_latency
+
+`endif // __UVMA_FENCEI_CFG_SV__
+

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_cntxt.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_cntxt.sv
@@ -1,0 +1,77 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_CNTXT_SV__
+`define __UVMA_FENCEI_CNTXT_SV__
+
+/**
+ * Object encapsulating all state variables for all Fencei agent
+ * (uvma_fencei_agent_c) components.
+ */
+class uvma_fencei_cntxt_c extends uvm_object;
+
+   // Handle to fetch interface
+   virtual uvma_fencei_if  fencei_vif;
+
+   // Events
+   uvm_event sample_cfg_e;
+   uvm_event sample_cntxt_e;
+
+   // Integrals
+   uvma_fencei_reset_state_enum  reset_state        = UVMA_FENCEI_RESET_STATE_PRE_RESET;
+
+   `uvm_object_utils_begin(uvma_fencei_cntxt_c)
+      `uvm_field_enum(uvma_fencei_reset_state_enum, reset_state, UVM_DEFAULT)
+      `uvm_field_event(                             sample_cfg_e  , UVM_DEFAULT)
+      `uvm_field_event(                             sample_cntxt_e, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   /**
+    * Builds events.
+    */
+   extern function new(string name="uvma_fencei_cntxt");
+
+   /**
+    * TODO Describe uvma_fencei_cntxt_c::reset()
+    */
+   extern function void reset();
+
+endclass : uvma_fencei_cntxt_c
+
+
+`pragma protect begin
+
+
+function uvma_fencei_cntxt_c::new(string name="uvma_fencei_cntxt");
+
+   super.new(name);
+
+   sample_cfg_e   = new("sample_cfg_e"  );
+   sample_cntxt_e = new("sample_cntxt_e");
+
+endfunction : new
+
+function void uvma_fencei_cntxt_c::reset();
+
+
+endfunction : reset
+
+
+`pragma protect end
+
+
+`endif // __UVMA_FENCEI_CNTXT_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_constants.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_constants.sv
@@ -1,0 +1,22 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_CONSTANTS_SV__
+`define __UVMA_FENCEI_CONSTANTS_SV__
+
+
+`endif // __UVMA_FENCEI_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_drv.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_drv.sv
@@ -1,0 +1,199 @@
+//
+// Copyright 2021 OpenHW Group
+// Copyright 2021 Silicon Labs
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
+// not use this file except in compliance with the License, or, at your option,
+// the Apache License version 2.0. You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_DRV_SV__
+`define __UVMA_FENCEI_DRV_SV__
+
+
+/**
+ * Component driving a Open Bus Interface virtual interface (uvma_obi_if).
+ * @note The req & rsp's roles are switched when this driver is in 'slv' mode.
+ * @todo Move implementation to a sequence-based approach
+ */
+class uvma_fencei_drv_c extends uvm_driver#(
+   .REQ(uvma_fencei_seq_item_c),
+   .RSP(uvma_fencei_seq_item_c      )
+);
+
+   // Objects
+   uvma_fencei_cfg_c    cfg;
+   uvma_fencei_cntxt_c  cntxt;
+
+   `uvm_component_utils_begin(uvma_fencei_drv_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_drv", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null.
+    * 2. Builds ap.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Oversees driving, depending on the reset state, by calling drv_<pre|in|post>_reset() tasks.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Called by run_phase() while agent is in pre-reset state.
+    */
+   extern task drv_pre_reset();
+
+   /**
+    * Called by run_phase() while agent is in reset state.
+    */
+   extern task drv_in_reset();
+
+   /**
+    * Called by run_phase() while agent is in post-reset state.
+    */
+   extern task drv_post_reset();
+
+   /**
+    * Drives the 'flush_ack' signal in response to 'flush_req' being asserted.
+    */
+   extern task drv_slv_flush_ack();
+
+endclass : uvma_fencei_drv_c
+
+
+function uvma_fencei_drv_c::new(string name="uvma_fencei_drv", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_fencei_drv_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_fencei_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+   uvm_config_db#(uvma_fencei_cfg_c)::set(this, "*", "cfg", cfg);
+
+   void'(uvm_config_db#(uvma_fencei_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+   uvm_config_db#(uvma_fencei_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+endfunction : build_phase
+
+
+task uvma_fencei_drv_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+   if (cfg.enabled && cfg.is_active) begin
+      fork
+         begin
+            forever begin
+               drv_slv_flush_ack();
+            end
+         end
+
+         begin
+            forever begin
+               case (cntxt.reset_state)
+                  UVMA_FENCEI_RESET_STATE_PRE_RESET : drv_pre_reset ();
+                  UVMA_FENCEI_RESET_STATE_IN_RESET  : drv_in_reset  ();
+                  UVMA_FENCEI_RESET_STATE_POST_RESET: drv_post_reset();
+
+                  default: `uvm_fatal("FENCEI_DRV", $sformatf("Invalid reset_state: %0d", cntxt.reset_state))
+               endcase
+            end
+         end
+      join_none
+   end
+
+endtask : run_phase
+
+
+task uvma_fencei_drv_c::drv_pre_reset();
+
+   cntxt.fencei_vif.drv_slv_cb.flush_ack  <= 1'b0;
+   @(cntxt.fencei_vif.drv_slv_cb);
+
+endtask : drv_pre_reset
+
+
+task uvma_fencei_drv_c::drv_in_reset();
+
+   cntxt.fencei_vif.drv_slv_cb.flush_ack <= 1'b0;
+   @(cntxt.fencei_vif.drv_slv_cb);
+
+endtask : drv_in_reset
+
+
+task uvma_fencei_drv_c::drv_post_reset();
+
+   @(cntxt.fencei_vif.drv_slv_cb);
+
+endtask : drv_post_reset
+
+
+task uvma_fencei_drv_c::drv_slv_flush_ack();
+
+   case (cntxt.reset_state)
+      UVMA_FENCEI_RESET_STATE_POST_RESET: begin
+
+         // Pre-calculate the "next" latency
+         int unsigned effective_latency = cfg.calc_random_ack_latency();
+
+         // In case 0 latency was selected, we must go ahead and drive gnt (combinatorial path)
+         if (effective_latency == 0) begin
+            cntxt.fencei_vif.drv_slv_cb.flush_ack <= 1'b1;
+         end
+         else begin
+            cntxt.fencei_vif.drv_slv_cb.flush_ack <= 1'b0;
+         end
+
+         // Advance the clock
+         @(cntxt.fencei_vif.drv_slv_cb);
+
+         // Break out of this loop upon the next req and gnt
+         while (!(cntxt.fencei_vif.drv_slv_cb.flush_req && cntxt.fencei_vif.drv_slv_cb.flush_ack)) begin
+            // Only count down a non-zero effective latency if someone is requesting (req asserted)
+            if (effective_latency && cntxt.fencei_vif.drv_slv_cb.flush_req)
+               effective_latency--;
+
+            if (!effective_latency) begin
+               cntxt.fencei_vif.drv_slv_cb.flush_ack <= 1'b1;
+            end
+
+            @(cntxt.fencei_vif.drv_slv_cb);
+         end
+      end
+      // If we are in another reset state, it is critical to advance time within the reset loop
+      default: @(cntxt.fencei_vif.drv_slv_cb);
+   endcase
+
+endtask : drv_slv_flush_ack
+
+
+`endif // __UVMA_FENCEI_DRV_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_if.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_if.sv
@@ -1,0 +1,63 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_IF_SV__
+`define __UVMA_FENCEI_IF_SV__
+
+/**
+ * Encapsulates all signals and clocking of FENCEI flush request/acknowledge interface
+ */
+interface uvma_fencei_if
+  import uvma_fencei_pkg::*;
+  (
+    input                      clk,
+    input                      reset_n
+  );
+
+  // -------------------------------------------------------------------
+  // Interface signals
+  // -------------------------------------------------------------------
+  wire flush_req;
+  wire flush_ack;
+
+  // -------------------------------------------------------------------
+  // Local variables
+  // -------------------------------------------------------------------
+
+  // -------------------------------------------------------------------
+  // Begin module code
+  // -------------------------------------------------------------------
+
+  clocking drv_mst_cb @(posedge clk or reset_n);
+    input  #1step flush_ack;
+    output        flush_req;
+  endclocking : drv_mst_cb
+
+  clocking drv_slv_cb @(posedge clk or reset_n);
+    input  #1step flush_req;
+    input  #1step output flush_ack;
+  endclocking : drv_slv_cb
+
+  clocking mon_cb @(posedge clk or reset_n);
+    input  #1step flush_req,
+                  flush_ack;
+  endclocking : mon_cb
+
+endinterface : uvma_fencei_if
+
+
+`endif // __UVMA_FENCEI_IF_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_macros.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_macros.sv
@@ -1,0 +1,25 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_MACROS_SV__
+`define __UVMA_FENCEI_MACROS_SV__
+
+
+
+
+
+`endif // __UVMA_FENCEI_MACROS_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_mon.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_mon.sv
@@ -1,0 +1,175 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_MON_SV__
+`define __UVMA_FENCEI_MON_SV__
+
+
+/**
+ * Component sampling transactions from a Clock & Reset virtual interface
+ * (uvma_fencei_if).
+ */
+class uvma_fencei_mon_c extends uvm_monitor;
+
+   // Objects
+   uvma_fencei_cfg_c    cfg;
+   uvma_fencei_cntxt_c  cntxt;
+
+   // TLM
+   uvm_analysis_port#(uvma_fencei_seq_item_c)  ap;
+
+   string log_tag = "FENCEIMONLOG";
+
+   `uvm_component_utils_begin(uvma_fencei_mon_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_mon", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null.
+    * 2. Builds ap.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Oversees monitoring via monitor_clk() and monitor_reset() tasks in parallel
+    * forks.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Monitors passive_mp for asynchronous reset and updates the context's reset state.
+    */
+   extern task observe_reset();
+
+   /**
+    * Monitor pre-reset phase
+    */
+   extern virtual task fencei_mon_pre_reset();
+
+   /**
+    * Monitor in-reset phase
+    */
+   extern virtual task fencei_mon_in_reset();
+
+   /**
+    * Monitor post-reset phase
+    */
+   extern virtual task fencei_mon_post_reset();
+
+endclass : uvma_fencei_mon_c
+
+function uvma_fencei_mon_c::new(string name="uvma_fencei_mon", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+function void uvma_fencei_mon_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_fencei_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvma_fencei_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+   ap = new("ap", this);
+
+endfunction : build_phase
+
+task uvma_fencei_mon_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+   if (cfg.enabled) begin
+      fork
+         observe_reset();
+
+         forever begin
+            case (cntxt.reset_state)
+               UVMA_FENCEI_RESET_STATE_PRE_RESET:  fencei_mon_pre_reset();
+               UVMA_FENCEI_RESET_STATE_IN_RESET:   fencei_mon_in_reset();
+               UVMA_FENCEI_RESET_STATE_POST_RESET: fencei_mon_post_reset();
+            endcase
+         end
+      join
+   end
+endtask : run_phase
+
+task uvma_fencei_mon_c::observe_reset();
+
+   forever begin
+      wait (cntxt.fencei_vif.reset_n === 0);
+      cntxt.reset_state = UVMA_FENCEI_RESET_STATE_IN_RESET;
+      `uvm_info("FENCEI_MON", $sformatf("RESET_STATE_IN_RESET"), UVM_NONE)
+      wait (cntxt.fencei_vif.reset_n === 1);
+      cntxt.reset_state = UVMA_FENCEI_RESET_STATE_POST_RESET;
+      `uvm_info("FENCEI_MON", $sformatf("RESET_STATE_POST_RESET"), UVM_NONE)
+   end
+
+endtask : observe_reset
+
+task uvma_fencei_mon_c::fencei_mon_pre_reset();
+
+   @(cntxt.fencei_vif.mon_cb);
+
+endtask : fencei_mon_pre_reset
+
+task uvma_fencei_mon_c::fencei_mon_in_reset();
+
+   @(cntxt.fencei_vif.mon_cb);
+
+endtask : fencei_mon_in_reset
+
+task uvma_fencei_mon_c::fencei_mon_post_reset();
+
+   while(1) begin
+      @(cntxt.fencei_vif.mon_cb);
+
+      if (cntxt.fencei_vif.mon_cb.flush_req) begin
+         uvma_fencei_seq_item_c mon_trn;
+
+         mon_trn = uvma_fencei_seq_item_c::type_id::create("fencei_mon_trn");
+
+         // Wait for acknowledge, incrementing latency
+         while (!cntxt.fencei_vif.mon_cb.flush_ack) begin
+            mon_trn.ack_latency++;
+            @(cntxt.fencei_vif.mon_cb);
+         end
+
+         `uvm_info(log_tag, $sformatf("%s", mon_trn.convert2string()), UVM_HIGH);
+
+         ap.write(mon_trn);
+      end
+   end
+
+endtask : fencei_mon_post_reset
+
+`endif // __UVMA_FENCEI_MON_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_mon_trn_logger.sv
@@ -1,0 +1,83 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_MON_TRN_LOGGER_SV__
+`define __UVMA_FENCEI_MON_TRN_LOGGER_SV__
+
+/**
+ * Component writing Fencei monitor transactions fencei data to disk as plain text.
+ */
+class uvma_fencei_mon_trn_logger_c extends uvml_logs_mon_trn_logger_c#(
+   .T_TRN  (uvml_trn_seq_item_c),
+   .T_CFG  (uvma_fencei_cfg_c    ),
+   .T_CNTXT(uvma_fencei_cntxt_c  )
+);
+
+   uvm_analysis_imp_fencei#(uvma_fencei_seq_item_c, uvma_fencei_mon_trn_logger_c) fencei_export;
+
+   `uvm_component_param_utils(uvma_fencei_mon_trn_logger_c)
+
+   /**
+    * Default constructor.
+    */
+   function new(string name="uvma_fencei_mon_trn_logger", uvm_component parent=null);
+
+      super.new(name, parent);
+
+      fencei_export = new("fencei_export", this);
+
+   endfunction : new
+
+   /**
+    * Build phase - attempt to load a firmware itb file (instruction table file)
+    */
+   function void build_phase(uvm_phase phase);
+
+   endfunction : build_phase
+
+
+   /**
+    * Writes contents of t to disk
+    */
+   virtual function void write(uvml_trn_seq_item_c t);
+
+   endfunction : write
+
+   virtual function void write_fencei(uvma_fencei_seq_item_c t);
+
+      string instr;
+
+      instr = $sformatf("%s", t.convert2string());
+
+      fwrite(instr);
+
+   endfunction : write_fencei
+
+   /**
+    * Writes log header to disk
+    */
+   virtual function void print_header();
+
+      fwrite("-----------------------------------------------------------");
+
+   endfunction : print_header
+
+endclass : uvma_fencei_mon_trn_logger_c
+
+
+`endif // __UVMA_FENCEI_MON_TRN_LOGGER_SV__
+

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_pkg.flist
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_pkg.flist
@@ -1,0 +1,24 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+// Directories
++incdir+${DV_UVMA_FENCEI_PATH}
+
+// Files
+${DV_UVMA_FENCEI_PATH}/uvma_fencei_pkg.sv

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_pkg.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_pkg.sv
@@ -1,0 +1,70 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_PKG_SV__
+`define __UVMA_FENCEI_PKG_SV__
+
+
+// Pre-processor macros
+`include "uvm_macros.svh"
+`include "uvml_hrtbt_macros.sv"
+`include "uvma_fencei_macros.sv"
+
+/**
+ * Encapsulates all the types needed for an UVM agent capable of driving and/or
+ * monitoring Clock & Reset.
+ */
+package uvma_fencei_pkg;
+
+   import uvm_pkg       ::*;
+   import uvml_hrtbt_pkg::*;
+   import uvml_trn_pkg  ::*;
+   import uvml_logs_pkg ::*;
+   import uvma_core_cntrl_pkg::*;
+
+   // Analysis implementation declarations
+   `uvm_analysis_imp_decl(_fencei)
+
+   // Constants / Structs / Enums
+   `include "uvma_fencei_constants.sv"
+   `include "uvma_fencei_tdefs.sv"
+
+   // Objects
+   `include "uvma_fencei_cfg.sv"
+   `include "uvma_fencei_cntxt.sv"
+
+   // High-level transactions
+   `include "seq/uvma_fencei_seq_item.sv"
+
+   // Agent components
+   `include "uvma_fencei_mon_trn_logger.sv"
+   `include "uvma_fencei_mon.sv"
+   `include "uvma_fencei_sqr.sv"
+   `include "uvma_fencei_drv.sv"
+   `include "uvma_fencei_agent.sv"
+
+endpackage : uvma_fencei_pkg
+
+// Interface(s) / Module(s) / Checker(s)
+`include "uvma_fencei_if.sv"
+`include "uvma_fencei_assert.sv"
+
+`endif // __UVMA_FENCEI_PKG_SV__
+
+

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_sqr.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_sqr.sv
@@ -1,0 +1,84 @@
+//
+// Copyright 2021 OpenHW Group
+// Copyright 2021 Datum Technology Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
+// not use this file except in compliance with the License, or, at your option,
+// the Apache License version 2.0. You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+
+
+`ifndef __UVMA_FENCEI_SQR_SV__
+`define __UVMA_FENCEI_SQR_SV__
+
+
+/**
+ * Component running Open Bus Interface sequences extending uvma_obi_base_seq_c.
+ * Provides sequence items for uvma_obi_drv_c.
+ */
+class uvma_fencei_sqr_c extends uvm_sequencer#(
+   .REQ(uvma_fencei_seq_item_c),
+   .RSP(uvma_fencei_seq_item_c)
+);
+
+   // Objects
+   uvma_fencei_cfg_c    cfg;
+   uvma_fencei_cntxt_c  cntxt;
+
+   // TLM
+   uvm_tlm_analysis_fifo #(uvma_fencei_seq_item_c)  mon_trn_fifo;
+
+   `uvm_component_utils_begin(uvma_fencei_sqr_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_fencei_sqr", uvm_component parent=null);
+
+   /**
+    * Ensures cfg & cntxt handles are not null
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+endclass : uvma_fencei_sqr_c
+
+
+function uvma_fencei_sqr_c::new(string name="uvma_fencei_sqr", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_fencei_sqr_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_fencei_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvma_fencei_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+   mon_trn_fifo = new("mon_trn_fifo", this);
+
+endfunction : build_phase
+
+
+`endif // __UVMA_FENCEI_SQR_SV__

--- a/lib/uvm_agents/uvma_fencei/uvma_fencei_tdefs.sv
+++ b/lib/uvm_agents/uvma_fencei/uvma_fencei_tdefs.sv
@@ -1,0 +1,34 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_FENCEI_TDEFS_SV__
+`define __UVMA_FENCEI_TDEFS_SV__
+
+typedef enum {
+   UVMA_FENCEI_DRV_ACK_MODE_CONSTANT,
+   UVMA_FENCEI_DRV_ACK_MODE_FIXED_LATENCY,
+   UVMA_FENCEI_DRV_ACK_MODE_RANDOM_LATENCY
+} uvma_fencei_drv_ack_enum;
+
+typedef enum {
+   UVMA_FENCEI_RESET_STATE_PRE_RESET ,
+   UVMA_FENCEI_RESET_STATE_IN_RESET  ,
+   UVMA_FENCEI_RESET_STATE_POST_RESET
+} uvma_fencei_reset_state_enum;
+
+
+`endif // __UVMA_FENCEI_TDEFS_SV__

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -103,6 +103,7 @@ export DV_UVMA_CLKNRST_PATH     = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clknrst
 export DV_UVMA_INTERRUPT_PATH   = $(CORE_V_VERIF)/lib/uvm_agents/uvma_interrupt
 export DV_UVMA_DEBUG_PATH       = $(CORE_V_VERIF)/lib/uvm_agents/uvma_debug
 export DV_UVMA_OBI_MEMORY_PATH  = $(CORE_V_VERIF)/lib/uvm_agents/uvma_obi_memory
+export DV_UVMA_FENCEI_PATH      = $(CORE_V_VERIF)/lib/uvm_agents/uvma_fencei
 export DV_UVML_TRN_PATH         = $(CORE_V_VERIF)/lib/uvm_libs/uvml_trn
 export DV_UVML_LOGS_PATH        = $(CORE_V_VERIF)/lib/uvm_libs/uvml_logs
 export DV_UVML_SB_PATH          = $(CORE_V_VERIF)/lib/uvm_libs/uvml_sb


### PR DESCRIPTION
Cleans up lingering warnings in the core-v-verif CV32E40X testbench.
Adds a basic UVM agent for the fence.i instruction interface (on the E40X/S) to provide random ack response to fence.i.  A driver, monitor and assertion module were added.
