### PR TITLE
Address lint errors in CV32E40P environment

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -2,19 +2,19 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 //
 
@@ -536,27 +536,22 @@ module uvmt_cv32e40p_tb;
      end
    end
 
-   
+
    /**
     * End-of-test summary printout.
     */
    final begin: end_of_test
-      string             summary_string;
       uvm_report_server  rs;
       int                err_count;
       int                warning_count;
       int                fatal_count;
       static bit         sim_finished = 0;
-      
-      static string  red   = "\033[31m\033[1m";
-      static string  green = "\033[32m\033[1m";
-      static string  reset = "\033[0m";
-      
+
       rs            = uvm_top.get_report_server();
       err_count     = rs.get_severity_count(UVM_ERROR);
       warning_count = rs.get_severity_count(UVM_WARNING);
       fatal_count   = rs.get_severity_count(UVM_FATAL);
-      
+
       void'(uvm_config_db#(bit)::get(null, "", "sim_finished", sim_finished));
 
       // In all other contexts, calls to $display() in a UVM environment are
@@ -564,7 +559,7 @@ module uvmt_cv32e40p_tb;
       // and we are merely dumping a summary to stdout.
       //@DVT_LINTER_WAIVER_START "MT20210811_3" disable SVTB.29.1.3.1
       $display("\n%m: *** Test Summary ***\n");
-      
+
       if (sim_finished && (err_count == 0) && (fatal_count == 0)) begin
          $display("    PPPPPPP    AAAAAA    SSSSSS    SSSSSS   EEEEEEEE  DDDDDDD     ");
          $display("    PP    PP  AA    AA  SS    SS  SS    SS  EE        DD    DD    ");
@@ -590,7 +585,7 @@ module uvmt_cv32e40p_tb;
          $display("    FF        AA    AA    II    LL        EE        DD    DD      ");
          $display("    FF        AA    AA    II    LL        EE        DD    DD      ");
          $display("    FF        AA    AA  IIIIII  LLLLLLLL  EEEEEEEE  DDDDDDD       ");
-         
+
          if (sim_finished == 0) begin
             $display("    --------------------------------------------------------");
             $display("                   SIMULATION FAILED - ABORTED              ");

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -554,10 +554,10 @@ module uvmt_cv32e40p_tb;
 
       void'(uvm_config_db#(bit)::get(null, "", "sim_finished", sim_finished));
 
-      // In all other contexts, calls to $display() in a UVM environment are
+      // In most other contexts, calls to $display() in a UVM environment are
       // illegal. Here they are OK because the UVM environment has shut down
       // and we are merely dumping a summary to stdout.
-      //@DVT_LINTER_WAIVER_START "MT20210811_3" disable SVTB.29.1.3.1
+      //@DVT_LINTER_WAIVER_START "MT20210811_3" disable SVTB.29.1.7
       $display("\n%m: *** Test Summary ***\n");
 
       if (sim_finished && (err_count == 0) && (fatal_count == 0)) begin

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -441,10 +441,15 @@ function void uvmt_cv32e40p_base_test_c::print_banner(string text);
    
   if (test_cfg != null) begin
     if (test_cfg.print_uvm_runflow_banner) begin
+      // In most other contexts, calls to $display() in a UVM environment are
+      // illegal. Here they are OK because the following is a banner header
+      // with no fatal/error/warning or uvm_info implications.
+      //@DVT_LINTER_WAIVER_START "MT20210909_1" disable SVTB.29.1.7
       $display("");
       $display("*******************************************************************************");
       $display(text.toupper());
       $display("*******************************************************************************");
+      //@DVT_LINTER_WAIVER_END "MT20210909_1"
     end
     else begin
       `uvm_info("BASE_TEST", "Printing of UVM run-flow banner disabled", UVM_HIGH)

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
@@ -145,6 +145,11 @@ function uvma_obi_memory_cov_model_c::new(string name="uvma_obi_memory_cov_model
 endfunction : new
 
 
+// A significant chunk of the build_phase method is common between this
+// coverage model and the sequencer (uvma_obi_memory_sqr).  This is
+// appropriate so the duplicated code has a lint waiver.
+//
+//@DVT_LINTER_WAIVER_START "MT20210901_1" disable SVTB.33.1.0, SVTB.33.2.0
 function void uvma_obi_memory_cov_model_c::build_phase(uvm_phase phase);
    
    super.build_phase(phase);
@@ -173,6 +178,7 @@ function void uvma_obi_memory_cov_model_c::build_phase(uvm_phase phase);
    end
 
 endfunction : build_phase
+//@DVT_LINTER_WAIVER_END "MT20210901_1"
 
 task uvma_obi_memory_cov_model_c::run_phase(uvm_phase phase);
    

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -438,19 +438,24 @@ task uvma_obi_memory_drv_c::drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_
 endtask : drv_mstr_read_req
 
 
+// This task has redundant code with drv_mstr_read_req for the request and
+// address phases.  Rather than create a new method for the common code, the
+// waiver pragmas are in place to warn future maintainers of the situation.
 task uvma_obi_memory_drv_c::drv_mstr_write_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
+//@DVT_LINTER_WAIVER_START "MT20210901_3" disable SVTB.33.1.0, SVTB.33.2.0
    // Req Latency cycles
    repeat (req.req_latency) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Address phase
    mstr_mp.drv_mstr_cb.req <= 1'b1;
    mstr_mp.drv_mstr_cb.we  <= req.access_type;
    for (int unsigned ii=0; ii<cfg.addr_width; ii++) begin
       mstr_mp.drv_mstr_cb.addr[ii] <= req.address[ii];
    end
+//@DVT_LINTER_WAIVER_END "MT20210901_3"
    for (int unsigned ii=0; ii<cfg.data_width; ii++) begin
       mstr_mp.drv_mstr_cb.wdata[ii] <= req.wdata[ii];
    end

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_seq_item_logger.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_seq_item_logger.sv
@@ -70,6 +70,12 @@ class uvma_obi_memory_seq_item_logger_c extends uvml_logs_seq_item_logger_c#(
       
    endfunction : write
    
+// A significant chunk of the write_mstr method is common between this
+// sequence item logger and the monitor transaction logger.  Given that
+// much of this code is template generated, and is not expected to be edited
+// further, the duplicated code has a lint waiver.
+//
+//@DVT_LINTER_WAIVER_START "MT20210901_2" disable SVTB.33.1.0, SVTB.33.2.0
    /**
     * Writes contents of mstr t to disk.
     */
@@ -112,6 +118,7 @@ class uvma_obi_memory_seq_item_logger_c extends uvml_logs_seq_item_logger_c#(
       fwrite($sformatf(" %t | %s | %s | %s | %s | %s | %s | %h | %s | %s ", $realtime(), access_str, id_str, auser_str, wuser_str, ruser_str, err_str, t.address, be_str, data_str));
       
    endfunction : write_mstr
+//@DVT_LINTER_WAIVER_END "MT20210901_2"
    
    /**
     * Writes contents of slv t to disk.

--- a/lib/uvm_libs/uvml_trn/uvml_trn_seq_item.sv
+++ b/lib/uvm_libs/uvml_trn/uvml_trn_seq_item.sv
@@ -31,7 +31,7 @@ class uvml_trn_seq_item_c extends uvm_sequence_item;
    
    static int unsigned  __last_uid = 0;
    
-  `uvm_object_utils_begin(uvml_trn_mon_trn_c)
+  `uvm_object_utils_begin(uvml_trn_seq_item_c)
       `uvm_field_int(__may_drop , UVM_DEFAULT + UVM_NOPACK + UVM_NOCOMPARE)
       `uvm_field_int(__has_error, UVM_DEFAULT + UVM_NOPACK + UVM_NOCOMPARE)
   `uvm_object_utils_end


### PR DESCRIPTION
This pull request address a few more of the SV/UVM lint errors reported by [Verissimo](https://dvteclipse.com/core5verif-verissimo/1/main/index.html).  @strichmo, some of this was merged onto the master branch already in PR #840.  I'm asking for a PR to cv32e40p/dev because I goofed up on at least one waiver, and I should have been PR'ing to dev all along (my bad).

- `mm_ram.sv`: The UVM environment no longer uses mm_ram, but the "redundant code" lint error was accurate, so I cleaned that up.
- `uvmt_cv32e40p_tb.sv` and `uvmt_cv32e40p_base_test.sv`: removed unused declarations and waived the "do not use `$display()`" rule (because it does not apply in these cases - see my comments to see if you agree).
- `uvma_obi_memory_cov_model`, `uvma_obi_memory_drv.sv` and `uvma_obi_memory_seq_item_logger.sv`: these are interesting.  The linter is flagging redundant code across separate files(!).  This is very cool.  I put waivers in place for these because much of the redundant code is template generated.  @datum-dpoulin, this is something you may want to look at in your templates, but we can live with it for now.