### PR TITLE
standardize logs and cleanup logs for rvvi, rvfi and obi

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
@@ -199,15 +199,16 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       }
 
       if (trn_log_enabled) {
-         isacov_cfg.trn_log_enabled            == 1;
-         clknrst_cfg.trn_log_enabled           == 1;
-         interrupt_cfg.trn_log_enabled         == 1;
-         debug_cfg.trn_log_enabled             == 1;
+         // Setting a reasonable set of logs
+         isacov_cfg.trn_log_enabled            == 0;
+         clknrst_cfg.trn_log_enabled           == 0;
+         interrupt_cfg.trn_log_enabled         == 0;
+         debug_cfg.trn_log_enabled             == 0;
          obi_memory_instr_cfg.trn_log_enabled  == 1;
          obi_memory_data_cfg.trn_log_enabled   == 1;
          rvfi_cfg.trn_log_enabled              == 1;
          rvvi_cfg.trn_log_enabled              == 1;
-         isacov_cfg.trn_log_enabled            == 1;
+         isacov_cfg.trn_log_enabled            == 0;
       } else {
          isacov_cfg.trn_log_enabled            == 0;
          clknrst_cfg.trn_log_enabled           == 0;
@@ -305,6 +306,9 @@ function uvme_cv32e40x_cfg_c::new(string name="uvme_cv32e40x_cfg");
    rvfi_cfg = uvma_rvfi_cfg_c#(ILEN,XLEN)::type_id::create("rvfi_cfg");
    rvvi_cfg = uvma_rvvi_ovpsim_cfg_c#(ILEN,XLEN)::type_id::create("rvvi_cfg");
    fencei_cfg = uvma_fencei_cfg_c::type_id::create("fencei_cfg");
+
+   obi_memory_instr_cfg.mon_logger_name = "OBII";
+   obi_memory_data_cfg.mon_logger_name  = "OBID";
 
    isacov_cfg.core_cfg = this;
    rvfi_cfg.core_cfg = this;

--- a/cv32e40x/regress/cv32e40x_obi_bus_err.yaml
+++ b/cv32e40x/regress/cv32e40x_obi_bus_err.yaml
@@ -14,7 +14,7 @@ builds:
 tests:
   corev_rand_instr_obi_err:
     build: uvmt_cv32e40x
-    description: UVM Hello World Test
+    description: Random OBI instruction bus error test
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_obi_err
     num: 20

--- a/cv32e40x/regress/cv32e40x_obi_bus_err.yaml
+++ b/cv32e40x/regress/cv32e40x_obi_bus_err.yaml
@@ -12,7 +12,7 @@ builds:
     dir: cv32e40x/sim/uvmt
 
 tests:
-  hello-world:
+  corev_rand_instr_obi_err:
     build: uvmt_cv32e40x
     description: UVM Hello World Test
     dir: cv32e40x/sim/uvmt

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_MON_SV__
@@ -26,125 +26,125 @@
  * (uvma_obi_if).
  */
 class uvma_obi_memory_mon_c extends uvm_monitor;
-   
+
    // Objects
    uvma_obi_memory_cfg_c    cfg;
    uvma_obi_memory_cntxt_c  cntxt;
-   
+
    // TLM
    uvm_analysis_port#(uvma_obi_memory_mon_trn_c)  ap;
    uvm_analysis_port#(uvma_obi_memory_mon_trn_c)  sequencer_ap;
-   
+
    // Handles to virtual interface modport
    virtual uvma_obi_memory_if.passive_mp  passive_mp;
-   
-   
+
+
    `uvm_component_utils_begin(uvma_obi_memory_mon_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
       `uvm_field_object(cntxt, UVM_DEFAULT)
    `uvm_component_utils_end
-   
+
    /**
     * Default constructor.
     */
    extern function new(string name="uvma_obi_memory_mon", uvm_component parent=null);
-   
+
    /**
     * 1. Ensures cfg & cntxt handles are not null.
     * 2. Builds ap.
     */
    extern virtual function void build_phase(uvm_phase phase);
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::run_phase()
     */
    extern virtual task run_phase(uvm_phase phase);
-   
+
    /**
     * Monitors passive_mp for asynchronous reset and updates the context's reset state.
     */
    extern task observe_reset();
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::mon_chan_a_pre_reset/mon_chan_a_in_reset/mon_chan_a_post_reset()
     */
    extern task mon_chan_a_pre_reset ();
    extern task mon_chan_a_in_reset  ();
    extern task mon_chan_a_post_reset();
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::mon_chan_r_pre_reset/mon_chan_r_in_reset/mon_chan_r_post_reset()
     */
    extern task mon_chan_r_pre_reset ();
    extern task mon_chan_r_in_reset  ();
    extern task mon_chan_r_post_reset();
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::mon_chan_a_trn()
     */
    extern task mon_chan_a_trn(output uvma_obi_memory_mon_trn_c trn);
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::mon_chan_r_trn()
     */
    extern task mon_chan_r_trn(uvma_obi_memory_mon_trn_c trn);
-   
+
    /**
     * User hooks for modifying transactions after they've been sampled but before they're sent out the analysis port(s).
     */
    extern virtual function void process_a_trn(uvma_obi_memory_mon_trn_c trn);
    extern virtual function void process_r_trn(uvma_obi_memory_mon_trn_c trn);
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::send_trn_to_sequencer()
     */
    extern task send_trn_to_sequencer(ref uvma_obi_memory_mon_trn_c trn);
-   
+
    /**
     * TODO Describe uvma_obi_memory_mon_c::sample_trn_a_from_vif()
     */
    extern task sample_trn_a_from_vif(uvma_obi_memory_mon_trn_c trn);
    extern task sample_trn_r_from_vif(uvma_obi_memory_mon_trn_c trn);
-   
+
 endclass : uvma_obi_memory_mon_c
 
 
 function uvma_obi_memory_mon_c::new(string name="uvma_obi_memory_mon", uvm_component parent=null);
-   
+
    super.new(name, parent);
-   
+
 endfunction : new
 
 
 function void uvma_obi_memory_mon_c::build_phase(uvm_phase phase);
-   
+
    super.build_phase(phase);
-   
+
    void'(uvm_config_db#(uvma_obi_memory_cfg_c)::get(this, "", "cfg", cfg));
    if (!cfg) begin
       `uvm_fatal("CFG", "Configuration handle is null")
    end
-   
+
    void'(uvm_config_db#(uvma_obi_memory_cntxt_c)::get(this, "", "cntxt", cntxt));
    if (!cntxt) begin
       `uvm_fatal("CNTXT", "Context handle is null")
    end
    passive_mp = cntxt.vif.passive_mp;
-   
+
    ap           = new("ap"          , this);
    sequencer_ap = new("sequencer_ap", this);
-  
+
 endfunction : build_phase
 
 
 task uvma_obi_memory_mon_c::run_phase(uvm_phase phase);
-   
+
    super.run_phase(phase);
-   
+
    if (cfg.enabled) begin
       fork
          observe_reset();
-         
+
          begin : chan_a
             forever begin
                case (cntxt.reset_state)
@@ -154,7 +154,7 @@ task uvma_obi_memory_mon_c::run_phase(uvm_phase phase);
                endcase
             end
          end
-         
+
          begin : chan_r
             forever begin
                case (cntxt.reset_state)
@@ -166,12 +166,12 @@ task uvma_obi_memory_mon_c::run_phase(uvm_phase phase);
          end
       join_none
    end
-   
+
 endtask : run_phase
 
 
 task uvma_obi_memory_mon_c::observe_reset();
-   
+
    forever begin
       wait (cntxt.vif.reset_n === 0);
       cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_IN_RESET;
@@ -180,35 +180,35 @@ task uvma_obi_memory_mon_c::observe_reset();
       cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_POST_RESET;
       `uvm_info("OBI_MEMORY_MON", $sformatf("RESET_STATE_POST_RESET"), UVM_NONE)
    end
-   
+
 endtask : observe_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_a_pre_reset();
-   
+
    @(passive_mp.mon_cb);
-   
+
 endtask : mon_chan_a_pre_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_a_in_reset();
-   
+
    @(passive_mp.mon_cb);
-   
+
 endtask : mon_chan_a_in_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_a_post_reset();
-   
+
    uvma_obi_memory_mon_trn_c  trn;
-   
+
    mon_chan_a_trn(trn);
    trn.cfg = cfg;
    cntxt.mon_outstanding_reads_q.push_back(trn);
    `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel A:\n%s", trn.sprint()), UVM_HIGH)
    process_a_trn(trn);
    `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel A after process_a_trn():\n%s", trn.sprint()), UVM_HIGH)
-   
+
    if (cfg.enabled && cfg.is_active && (cfg.drv_mode == UVMA_OBI_MEMORY_MODE_SLV)) begin
       send_trn_to_sequencer(trn);
       `uvm_info("OBI_MEMORY_MON", $sformatf("Sent trn to sequencer"), UVM_HIGH)
@@ -220,23 +220,23 @@ endtask : mon_chan_a_post_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_r_pre_reset();
-   
+
    @(passive_mp.mon_cb);
-   
+
 endtask : mon_chan_r_pre_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_r_in_reset();
-   
+
    @(passive_mp.mon_cb);
-   
+
 endtask : mon_chan_r_in_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_r_post_reset();
-   
+
    uvma_obi_memory_mon_trn_c  trn;
-      
+
    wait (cntxt.mon_outstanding_reads_q.size());
    trn = cntxt.mon_outstanding_reads_q.pop_front();
 
@@ -253,57 +253,57 @@ endtask : mon_chan_r_post_reset
 
 
 task uvma_obi_memory_mon_c::mon_chan_a_trn(output uvma_obi_memory_mon_trn_c trn);
-   
+
    trn = uvma_obi_memory_mon_trn_c::type_id::create("trn");
-   
+
    while((passive_mp.mon_cb.req !== 1'b1) || (passive_mp.mon_cb.gnt !== 1'b1)) begin
       @(passive_mp.mon_cb);
       trn.gnt_latency++;
    end
-   
+
    sample_trn_a_from_vif(trn);
-   trn.__timestamp_start = $realtime();   
-   
+   trn.__timestamp_start = $realtime();
+
 endtask : mon_chan_a_trn
 
 
-task uvma_obi_memory_mon_c::mon_chan_r_trn(uvma_obi_memory_mon_trn_c trn);   
-      
+task uvma_obi_memory_mon_c::mon_chan_r_trn(uvma_obi_memory_mon_trn_c trn);
+
    // 1.1 only requires rvalid
    // fixme:strichmo:for 1.2 this must take rready into account as well
    while (passive_mp.mon_cb.rvalid !== 1'b1) begin
       @(passive_mp.mon_cb);
       trn.rvalid_latency++;
    end
-   
+
    sample_trn_r_from_vif(trn);
    trn.__timestamp_end = $realtime();
-   
+
 endtask : mon_chan_r_trn
 
 
 function void uvma_obi_memory_mon_c::process_a_trn(uvma_obi_memory_mon_trn_c trn);
-   
-   
+
+
 endfunction : process_a_trn
 
 
 function void uvma_obi_memory_mon_c::process_r_trn(uvma_obi_memory_mon_trn_c trn);
-   
-   
+
+
 endfunction : process_r_trn
 
 
 task uvma_obi_memory_mon_c::send_trn_to_sequencer(ref uvma_obi_memory_mon_trn_c trn);
-   
+
    sequencer_ap.write(trn);
-   
+
 endtask : send_trn_to_sequencer
 
 task uvma_obi_memory_mon_c::sample_trn_a_from_vif(uvma_obi_memory_mon_trn_c trn);
-   
+
    trn.__originator = this.get_full_name();
-   
+
    if (passive_mp.mon_cb.we === 1'b1) begin
       trn.access_type = UVMA_OBI_MEMORY_ACCESS_WRITE;
    end
@@ -314,13 +314,13 @@ task uvma_obi_memory_mon_c::sample_trn_a_from_vif(uvma_obi_memory_mon_trn_c trn)
       `uvm_error("OBI_MEMORY_MON", $sformatf("Invalid value for we:%b", passive_mp.mon_cb.we))
       trn.__has_error = 1;
    end
-   
+
    for (int unsigned ii=0; ii<cfg.addr_width; ii++) begin
       trn.address[ii] = passive_mp.mon_cb.addr[ii];
    end
    for (int unsigned ii=0; ii<(cfg.data_width/8); ii++) begin
       trn.be[ii] = passive_mp.mon_cb.be[ii];
-   end   
+   end
    if (trn.access_type == UVMA_OBI_MEMORY_ACCESS_WRITE) begin
       for (int unsigned ii=0; ii<cfg.data_width; ii++) begin
          trn.data[ii] = passive_mp.mon_cb.wdata[ii];
@@ -328,7 +328,7 @@ task uvma_obi_memory_mon_c::sample_trn_a_from_vif(uvma_obi_memory_mon_trn_c trn)
    end
 
    // 1P2 signals
-   if (cfg.is_1p2_or_higher()) begin      
+   if (cfg.is_1p2_or_higher()) begin
       for (int unsigned ii=0; ii<cfg.auser_width; ii++) begin
          trn.auser[ii] = passive_mp.mon_cb.auser[ii];
       end
@@ -337,8 +337,14 @@ task uvma_obi_memory_mon_c::sample_trn_a_from_vif(uvma_obi_memory_mon_trn_c trn)
             trn.wuser[ii] = passive_mp.mon_cb.wuser[ii];
          end
       end
-      for (int unsigned ii=0; ii<cfg.id_width; ii++) begin
-         trn.aid[ii] = passive_mp.mon_cb.aid[ii];
+      // ID: Use zero for aid if id_width is configured to 0
+      if (cfg.id_width == 0) begin
+         trn.aid = '0;
+      end
+      else begin
+         for (int unsigned ii=0; ii<cfg.id_width; ii++) begin
+            trn.aid[ii] = passive_mp.mon_cb.aid[ii];
+         end
       end
       trn.atop    = passive_mp.mon_cb.atop;
       trn.memtype = passive_mp.mon_cb.memtype;
@@ -352,9 +358,9 @@ endtask : sample_trn_a_from_vif
 
 
 task uvma_obi_memory_mon_c::sample_trn_r_from_vif(uvma_obi_memory_mon_trn_c trn);
-   
+
    trn.__originator = this.get_full_name();
-      
+
    if (trn.access_type == UVMA_OBI_MEMORY_ACCESS_READ) begin
       for (int unsigned ii=0; ii<cfg.data_width; ii++) begin
          trn.data[ii] = passive_mp.mon_cb.rdata[ii];
@@ -362,7 +368,7 @@ task uvma_obi_memory_mon_c::sample_trn_r_from_vif(uvma_obi_memory_mon_trn_c trn)
    end
 
    // 1P2 signals
-   if (cfg.is_1p2_or_higher()) begin      
+   if (cfg.is_1p2_or_higher()) begin
       trn.err = passive_mp.mon_cb.err;
       for (int unsigned ii=0; ii<cfg.ruser_width; ii++) begin
          trn.ruser[ii] = passive_mp.mon_cb.ruser[ii];

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon_trn_logger.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_MON_TRN_LOGGER_SV__
@@ -29,69 +29,95 @@ class uvma_obi_memory_mon_trn_logger_c extends uvml_logs_mon_trn_logger_c#(
    .T_CFG  (uvma_obi_memory_cfg_c    ),
    .T_CNTXT(uvma_obi_memory_cntxt_c  )
 );
-   
+
+
    `uvm_component_utils(uvma_obi_memory_mon_trn_logger_c)
-   
-   
+
    /**
     * Default constructor.
     */
    function new(string name="uvma_obi_memory_mon_trn_logger", uvm_component parent=null);
-      
+
       super.new(name, parent);
-      
+
    endfunction : new
-   
+
    /**
     * Writes contents of t to disk
     */
    virtual function void write(uvma_obi_memory_mon_trn_c t);
-      
-      string access_str = "";
-      string err_str    = "";
-      string be_str     = "";
-      string data_str   = "";
-      string auser_str  = "";
-      string wuser_str  = "";
-      string ruser_str  = "";
-      string id_str     = "";
-      
-      case (t.access_type)
-         UVMA_OBI_MEMORY_ACCESS_READ : access_str = "R  ";
-         UVMA_OBI_MEMORY_ACCESS_WRITE: access_str = "  W";
-         default              : access_str = " ? ";
-      endcase
-      
-      case (t.err)
-         0: err_str = "    ";
-         1: err_str = " ERR";
-      endcase
-      
-      case (t.access_type)
-         UVMA_OBI_MEMORY_ACCESS_READ : ruser_str = $sformatf("%h", t.ruser);
-         UVMA_OBI_MEMORY_ACCESS_WRITE: wuser_str = $sformatf("%h", t.wuser);
-      endcase
-      
-      data_str  = $sformatf("%b", t.data );
-      auser_str = $sformatf("%h", t.auser);
-      be_str    = $sformatf("%b", t.be   );
-      id_str    = $sformatf("%b", t.aid  );
-      
-      fwrite($sformatf(" %t | %s | %s | %s | %s | %s | %s | %h | %s | %s ", $realtime(), access_str, id_str, auser_str, wuser_str, ruser_str, err_str, t.address, be_str, data_str));
-      
+
+      string format_header_str_1p1 = "%15s | %6s | %2s | %8s | %4s | %8s";
+      string format_header_str_1p2 = "%15s | %6s | %2s | %8s | %4s | %8s | %2s | %2s | %2s | %2s | %2s | %2s | %2s";
+      string log_msg;
+
+      // Log the 1p1 signals
+      log_msg = $sformatf("%15s | %6s | %2s | %08x |  %1x | %8s",
+                          $sformatf("%t", $time),
+                          cfg.mon_logger_name,
+                          t.access_type == UVMA_OBI_MEMORY_ACCESS_READ ? "R" : "W",
+                          t.address,
+                          t.be,
+                          t.get_data_str());
+
+
+      if (cfg.version == UVMA_OBI_MEMORY_VERSION_1P2) begin
+         log_msg = $sformatf("%s | %2x |    %1x |   %2x | %3s",
+                             log_msg,
+                             t.aid,
+                             t.prot,
+                             t.atop,
+                             t.err ? "ERR" : "OK");
+         if (cfg.auser_width > 0)
+            log_msg = $sformatf("%s |     %1x", log_msg, t.auser);
+         if (cfg.wuser_width > 0)
+            log_msg = $sformatf("%s |     %1x", log_msg, t.wuser);
+         if (cfg.ruser_width > 0)
+            log_msg = $sformatf("%s |     %1x", log_msg, t.ruser);
+      end
+
+      fwrite(log_msg);
+
    endfunction : write
-   
+
    /**
     * Writes log header to disk
     */
    virtual function void print_header();
-      
-      fwrite("---------------------------------------------------------------------------------");
-      fwrite("        TIME        | R/W |  ID  | AUSER | WUSER | RUSER | ERR | ADDRESS  |  BE  | DATA");
-      fwrite("---------------------------------------------------------------------------------");
-      
+
+      if (cfg.version == UVMA_OBI_MEMORY_VERSION_1P1) begin
+         string banner_str = {80{"-"}};
+         string format_header_str_1p1 = "%15s | %6s | %2s | %8s | %2s | %8s";
+
+
+         fwrite(banner_str);
+         fwrite($sformatf(format_header_str_1p1,
+                          "TIME", "OBI", "RW", "ADDR", "BE", "DATA"));
+         fwrite(banner_str);
+      end
+      else begin
+         string banner_str = {106{"-"}};
+         string format_header_str_1p2 = "%15s | %6s | %2s | %8s | %2s | %8s | %2s | %2s | %2s | %2s";
+         string header_str;
+
+         header_str = $sformatf(format_header_str_1p2,
+                                "TIME", "OBI", "RW", "ADDR", "BE", "DATA",
+                                "ID", "PROT", "ATOP", "ERR");
+
+         if (cfg.auser_width > 0)
+            header_str = $sformatf("%s | %2s", header_str, "AUSER");
+         if (cfg.ruser_width > 0)
+            header_str = $sformatf("%s | %2s", header_str, "RUSER");
+         if (cfg.wuser_width > 0)
+            header_str = $sformatf("%s | %2s", header_str, "WUSER");
+
+         fwrite(banner_str);
+         fwrite(header_str);
+         fwrite(banner_str);
+      end
+
    endfunction : print_header
-   
+
 endclass : uvma_obi_memory_mon_trn_logger_c
 
 
@@ -99,25 +125,25 @@ endclass : uvma_obi_memory_mon_trn_logger_c
  * Component writing OBI monitor transactions debug data to disk as JavaScript Object Notation (JSON).
  */
 class uvma_obi_memory_mon_trn_logger_json_c extends uvma_obi_memory_mon_trn_logger_c;
-   
+
    `uvm_component_utils(uvma_obi_memory_mon_trn_logger_json_c)
-   
-   
+
+
    /**
     * Set file extension to '.json'.
     */
    function new(string name="uvma_obi_memory_mon_trn_logger_json", uvm_component parent=null);
-      
+
       super.new(name, parent);
       fextension = "json";
-      
+
    endfunction : new
-   
+
    /**
     * Writes contents of t to disk.
     */
    virtual function void write(uvma_obi_memory_mon_trn_c t);
-      
+
       // TODO Implement uvma_obi_memory_mon_trn_logger_json_c::write()
       // Ex: fwrite({"{",
       //       $sformatf("\"time\":\"%0t\",", $realtime()),
@@ -126,18 +152,18 @@ class uvma_obi_memory_mon_trn_logger_json_c extends uvma_obi_memory_mon_trn_logg
       //       $sformatf("\"c\":%d,"        , t.c        ),
       //       $sformatf("\"d\":%h,"        , t.c        ),
       //     "},"});
-      
+
    endfunction : write
-   
+
    /**
     * Empty function.
     */
    virtual function void print_header();
-      
+
       // Do nothing: JSON files do not use headers.
-      
+
    endfunction : print_header
-   
+
 endclass : uvma_obi_memory_mon_trn_logger_json_c
 
 

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_CFG_SV__
@@ -26,7 +26,7 @@
  * Open Bus Interface agent (uvma_obi_agent_c) components.
  */
 class uvma_obi_memory_cfg_c extends uvm_object;
-   
+
    // Generic options
    rand bit                      enabled;
    rand uvm_active_passive_enum  is_active;
@@ -36,6 +36,8 @@ class uvma_obi_memory_cfg_c extends uvm_object;
 
    bit                           stall_disable;
    bit                           rvalid_singles_stall;
+
+   string                        mon_logger_name = "OBI";
 
    // Protocol parameters
    rand uvma_obi_memory_version_enum    version;
@@ -59,7 +61,7 @@ class uvma_obi_memory_cfg_c extends uvm_object;
    rand int unsigned                              drv_slv_gnt_fixed_latency;
    rand int unsigned                              drv_slv_gnt_random_latency_min;
    rand int unsigned                              drv_slv_gnt_random_latency_max;
-      
+
    rand uvma_obi_memory_drv_slv_rvalid_mode_enum  drv_slv_rvalid_mode;
    rand int unsigned                              drv_slv_rvalid_fixed_latency;
    rand int unsigned                              drv_slv_rvalid_random_latency_min;
@@ -68,11 +70,11 @@ class uvma_obi_memory_cfg_c extends uvm_object;
    rand uvma_obi_memory_drv_slv_err_mode_enum     drv_slv_err_mode;
    rand int unsigned                              drv_slv_err_ok_wgt;
    rand int unsigned                              drv_slv_err_fault_wgt;
-   
+
    rand uvma_obi_memory_drv_slv_exokay_mode_enum drv_slv_exokay_mode;
    rand int unsigned                             drv_slv_exokay_failure_wgt;
    rand int unsigned                             drv_slv_exokay_success_wgt;
-   
+
    // Directed error generation memory address range
    // If the valid bit is asserted any address in range will repsond with error = 1
    bit [31:0]                                    directed_slv_err_addr_min;
@@ -85,7 +87,7 @@ class uvma_obi_memory_cfg_c extends uvm_object;
    bit [31:0]                                    directed_slv_exokay_addr_min;
    bit [31:0]                                    directed_slv_exokay_addr_max;
    bit                                           directed_slv_exokay_valid;
-   
+
 
    `uvm_object_utils_begin(uvma_obi_memory_cfg_c)
       `uvm_field_int (                         enabled          , UVM_DEFAULT)
@@ -96,11 +98,11 @@ class uvma_obi_memory_cfg_c extends uvm_object;
 
       `uvm_field_int (                         stall_disable            , UVM_DEFAULT)
       `uvm_field_int (                         rvalid_singles_stall     , UVM_DEFAULT)
-      
+
       `uvm_field_enum(uvma_obi_memory_version_enum, version, UVM_DEFAULT)
       `uvm_field_int (                        auser_width  , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        wuser_width  , UVM_DEFAULT | UVM_DEC)
-      `uvm_field_int (                        ruser_width  , UVM_DEFAULT | UVM_DEC)      
+      `uvm_field_int (                        ruser_width  , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        addr_width   , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        achk_width   , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        rchk_width   , UVM_DEFAULT | UVM_DEC)
@@ -109,12 +111,12 @@ class uvma_obi_memory_cfg_c extends uvm_object;
       `uvm_field_int (                        read_enabled , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        write_enabled, UVM_DEFAULT | UVM_DEC)
       `uvm_field_enum(uvma_obi_memory_mode_enum               , drv_mode                      , UVM_DEFAULT)
-      `uvm_field_enum(uvma_obi_memory_drv_idle_enum           , drv_idle                      , UVM_DEFAULT)      
+      `uvm_field_enum(uvma_obi_memory_drv_idle_enum           , drv_idle                      , UVM_DEFAULT)
       `uvm_field_int (                                          drv_slv_gnt                   , UVM_DEFAULT)
       `uvm_field_enum(uvma_obi_memory_drv_slv_gnt_mode_enum   , drv_slv_gnt_mode              , UVM_DEFAULT)
       `uvm_field_int (                                          drv_slv_gnt_fixed_latency     , UVM_DEFAULT)
       `uvm_field_int (                                          drv_slv_gnt_random_latency_min, UVM_DEFAULT)
-      `uvm_field_int (                                          drv_slv_gnt_random_latency_max, UVM_DEFAULT)      
+      `uvm_field_int (                                          drv_slv_gnt_random_latency_max, UVM_DEFAULT)
       `uvm_field_enum(uvma_obi_memory_drv_slv_rvalid_mode_enum, drv_slv_rvalid_mode              , UVM_DEFAULT)
       `uvm_field_int (                                          drv_slv_rvalid_fixed_latency     , UVM_DEFAULT)
       `uvm_field_int (                                          drv_slv_rvalid_random_latency_min, UVM_DEFAULT)
@@ -133,14 +135,14 @@ class uvma_obi_memory_cfg_c extends uvm_object;
       `uvm_field_int ( directed_slv_exokay_addr_max   , UVM_DEFAULT)
       `uvm_field_int ( directed_slv_exokay_valid      , UVM_DEFAULT)
    `uvm_object_utils_end
-   
+
    constraint defaults_cons {
       soft enabled              == 1;
       soft is_active            == UVM_PASSIVE;
       soft sqr_arb_mode         == UVM_SEQ_ARB_FIFO;
       soft cov_model_enabled    == 0;
       soft trn_log_enabled      == 1;
-      
+
       soft version                        == UVMA_OBI_MEMORY_VERSION_1P1;
       /*soft*/ ignore_rready              == 1;
       soft auser_width                    == uvma_obi_memory_default_auser_width;
@@ -162,7 +164,7 @@ class uvma_obi_memory_cfg_c extends uvm_object;
       soft drv_slv_rvalid_fixed_latency      == uvma_obi_memory_default_drv_slv_rvalid_fixed_latency;
       soft drv_slv_rvalid_random_latency_min == uvma_obi_memory_default_drv_slv_rvalid_random_latency_min;
       soft drv_slv_rvalid_random_latency_max == uvma_obi_memory_default_drv_slv_rvalid_random_latency_max;
-      soft drv_slv_err_mode               == UVMA_OBI_MEMORY_DRV_SLV_ERR_MODE_OK;      
+      soft drv_slv_err_mode               == UVMA_OBI_MEMORY_DRV_SLV_ERR_MODE_OK;
       soft drv_slv_exokay_mode            == UVMA_OBI_MEMORY_DRV_SLV_EXOKAY_MODE_SUCCESS;
    }
 
@@ -187,11 +189,11 @@ class uvma_obi_memory_cfg_c extends uvm_object;
 
    constraint gnt_min_max_cons {
       drv_slv_gnt_random_latency_min <= drv_slv_gnt_random_latency_max;
-   }  
+   }
 
    constraint rvalid_min_max_cons {
       drv_slv_rvalid_random_latency_min <= drv_slv_rvalid_random_latency_max;
-   }  
+   }
 
    constraint err_wgts_cons {
       // Keep the weights for errors within some bounds
@@ -209,7 +211,7 @@ class uvma_obi_memory_cfg_c extends uvm_object;
     * Default constructor.
     */
    extern function new(string name="uvma_obi_memory_cfg");
-   
+
    /**
     * Calculate a new random gnt latency
     */
@@ -228,10 +230,10 @@ class uvma_obi_memory_cfg_c extends uvm_object;
    /**
     * Calculate a random atomic exokay response from random knobs
     */
-   extern function bit calc_random_exokay(bit[31:0] addr);   
+   extern function bit calc_random_exokay(bit[31:0] addr);
 
    /**
-    * Returns 1 if this OBI agent supports version 1.2 or higher    
+    * Returns 1 if this OBI agent supports version 1.2 or higher
     */
    extern function bit is_1p2_or_higher();
 
@@ -239,9 +241,9 @@ endclass : uvma_obi_memory_cfg_c
 
 
 function uvma_obi_memory_cfg_c::new(string name="uvma_obi_memory_cfg");
-   
+
    super.new(name);
-   
+
    // Read plusargs to determine any special randomizations
    if ($test$plusargs("rand_stall_obi_disable")) begin
       stall_disable = 1;
@@ -289,9 +291,9 @@ function bit uvma_obi_memory_cfg_c::calc_random_err(bit[31:0] addr);
 
    bit err;
 
-   
+
    // Check for a directed error reponse first
-   if (directed_slv_err_valid && 
+   if (directed_slv_err_valid &&
        (addr >= directed_slv_err_addr_min) &&
        (addr <= directed_slv_err_addr_max)) begin
       return 1;
@@ -316,7 +318,7 @@ function bit uvma_obi_memory_cfg_c::calc_random_exokay(bit[31:0] addr);
    bit exokay;
 
    // Check for a directed error reponse first
-   if (directed_slv_exokay_valid && 
+   if (directed_slv_exokay_valid &&
        (addr <= directed_slv_exokay_addr_min) &&
        (addr <= directed_slv_exokay_addr_min)) begin
       return 0;

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_mon_trn.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_mon_trn.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_MON_TRN_SV__
@@ -26,7 +26,7 @@
  * uvma_obi_base_seq_item_c.
  */
 class uvma_obi_memory_mon_trn_c extends uvml_trn_mon_trn_c;
-   
+
    // Data
    uvma_obi_memory_access_type_enum  access_type; ///< Read or write
    uvma_obi_memory_addr_l_t          address    ; ///< Read/Write Address
@@ -50,7 +50,7 @@ class uvma_obi_memory_mon_trn_c extends uvml_trn_mon_trn_c;
    int unsigned           gnt_latency   ; ///< Number of cycles before gnt is asserted after req is asserted
    int unsigned           rvalid_latency; ///< Number of cycles before rvalid is asserted after gnt is asserted
    //int unsigned           rready_latency; ///< Number of cycles before rready is asserted after rvalid is asserted
-      
+
    `uvm_object_utils_begin(uvma_obi_memory_mon_trn_c)
       `uvm_field_enum(uvma_obi_memory_access_type_enum, access_type, UVM_DEFAULT          )
       `uvm_field_int (                                  address    , UVM_DEFAULT          )
@@ -67,27 +67,63 @@ class uvma_obi_memory_mon_trn_c extends uvml_trn_mon_trn_c;
       `uvm_field_int (                                  prot       , UVM_DEFAULT          )
       `uvm_field_int (                                  achk       , UVM_DEFAULT          )
       `uvm_field_int (                                  rchk       , UVM_DEFAULT          )
-      
+
       `uvm_field_int(gnt_latency   , UVM_DEFAULT + UVM_DEC + UVM_NOCOMPARE)
       `uvm_field_int(rvalid_latency, UVM_DEFAULT + UVM_DEC + UVM_NOCOMPARE)
    `uvm_object_utils_end
-   
-   
+
+
    /**
     * Default constructor.
     */
    extern function new(string name="uvma_obi_memory_mon_trn");
-   
+
+   /**
+    * Fetch mask for printing
+    */
+   extern function uvma_obi_memory_data_l_t get_be_bitmask();
+
+   /**
+    * Print data with -- for non transmitted bytes
+    */
+   extern function string get_data_str();
+
 endclass : uvma_obi_memory_mon_trn_c
 
 
 function uvma_obi_memory_mon_trn_c::new(string name="uvma_obi_memory_mon_trn");
-   
+
    super.new(name);
-   
+
 endfunction : new
 
 
+function uvma_obi_memory_data_l_t uvma_obi_memory_mon_trn_c::get_be_bitmask();
+
+   uvma_obi_memory_data_l_t bitmask = '0;
+
+   for (int i = 0; i < cfg.data_width / 8; i++) begin
+      if (be[i]) bitmask |= 'hff << (i*8);
+   end
+
+   return bitmask;
+
+endfunction : get_be_bitmask
+
+function string uvma_obi_memory_mon_trn_c::get_data_str();
+
+   uvma_obi_memory_data_l_t be_bitmask = this.get_be_bitmask();
+   string data_str;
+
+   for (int i = 0; i < cfg.data_width / 8; i++) begin
+      if (be[i])
+         data_str = $sformatf("%02x%s", this.data[i*8+:8], data_str);
+      else
+         data_str = $sformatf("--%s", data_str);
+   end
+
+   return data_str;
+
+endfunction : get_data_str
+
 `endif // __UVMA_OBI_MEMORY_MON_TRN_SV__
-
-

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_mon_trn_logger.sv
@@ -1,13 +1,13 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,28 +27,28 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
    .T_CFG  (uvma_rvfi_cfg_c    ),
    .T_CNTXT(uvma_rvfi_cntxt_c  )
 );
-      
-   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_rvfi_mon_trn_logger_c) instr_export;   
 
-   const string format_header_str = "%15s: RVFI %6s %8s %8s %s %03s %08s %03s %08s %03s %08s %03s %08s %08s %s";   
-   const string format_instr_str  = "%15s: RVFI %6d %8x %8s %s x%2d %08x x%2d %08x x%2d %08x";
-   const string format_mem_str    = "%03s %08x %08s";
+   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_rvfi_mon_trn_logger_c) instr_export;
+
+   const string format_header_str = "%15s | RVFI | %6s | %8s | %8s | %s | %03s | %08s | %03s | %08s | %03s | %08s | %03s | %08s | %08s | %s";
+   const string format_instr_str  = "%15s | RVFI | %6d | %8x | %8s | %s | x%-2d | %08x | x%-2d | %08x | x%-2d | %08x";
+   const string format_mem_str    = "| %02s | %08x | %08s |";
 
    uvma_rvfi_instr_table_seq_item_c#(ILEN,XLEN) instr_table[bit[XLEN-1:0]];
 
    `uvm_component_param_utils(uvma_rvfi_mon_trn_logger_c)
-   
+
    /**
     * Default constructor.
     */
    function new(string name="uvma_rvfi_mon_trn_logger", uvm_component parent=null);
-      
+
       super.new(name, parent);
-      
-      instr_export = new("instr_export", this);      
+
+      instr_export = new("instr_export", this);
 
    endfunction : new
-   
+
    /**
     * Build phase - attempt to load a firmware itb file (instruction table file)
     */
@@ -68,7 +68,7 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
       if ($value$plusargs("itb_file=%s", file)) begin
          int unsigned itb_lineno;
          int fh;
-         
+
          fh = $fopen(file, "r");
          if (fh == 0) begin
             `uvm_fatal("RVFIMONLOG", $sformatf("Could not open itb file: %s", file));
@@ -76,14 +76,14 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
 
          while (!$feof(fh)) begin
             string       str;
-            
+
             int unsigned num;
             int unsigned c;
             string       src_code_q[$];
             uvma_rvfi_instr_table_seq_item_c instr;
 
             itb_lineno++;
-            c = $fscanf(fh, "%1s%d", str, num); 
+            c = $fscanf(fh, "%1s%d", str, num);
             instr = uvma_rvfi_instr_table_seq_item_c#(ILEN,XLEN)::type_id::create("instr");
 
             `uvm_info("RVFIMONLOG", $sformatf("Parsing line_num: %0d with %0d lines of src", itb_lineno, num), UVM_HIGH)
@@ -138,25 +138,25 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
     */
    virtual function void write(uvml_trn_seq_item_c t);
    endfunction : write
-   
-   virtual function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) t);      
+
+   virtual function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) t);
       string instr;
 
       instr = $sformatf(format_instr_str, $sformatf("%t", $time),
                         t.order,
-                        t.pc_rdata, 
+                        t.pc_rdata,
                         t.get_insn_word_str(),
                         get_mode_str(t.mode),
-                        t.rs1_addr, t.rs1_rdata, 
+                        t.rs1_addr, t.rs1_rdata,
                         t.rs2_addr, t.rs2_rdata,
                         t.rd1_addr, t.rd1_wdata);
 
-      if (t.mem_wmask) 
-         instr = $sformatf({"%s ", format_mem_str}, instr, "WR", t.mem_addr, t.get_mem_data_string());
+      if (t.mem_wmask)
+         instr = $sformatf({"%s ", format_mem_str}, instr, " WR", t.mem_addr, t.get_mem_data_string());
       else if (t.mem_rmask)
-         instr = $sformatf({"%s ", format_mem_str}, instr, "RD", t.mem_addr, t.get_mem_data_string());
+         instr = $sformatf({"%s ", format_mem_str}, instr, " RD", t.mem_addr, t.get_mem_data_string());
       else
-         instr = $sformatf("%s  -- -------- --------", instr);
+         instr = $sformatf("%s |  -- | -------- | -------- |", instr);
 
       if (t.insn_interrupt)
          instr = $sformatf("%s INTR %0d", instr, t.insn_interrupt_id);
@@ -166,7 +166,7 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
          instr = $sformatf("%s DEBUG", instr);
 
       if (instr_table.exists(t.pc_rdata)) begin
-         instr = $sformatf("%s %s %s %0d - %s", 
+         instr = $sformatf("%s %s %s %0d - %s",
                            instr,
                            instr_table[t.pc_rdata].src_function,
                            instr_table[t.pc_rdata].filename,
@@ -182,11 +182,17 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
     * Writes log header to disk
     */
    virtual function void print_header();
-      fwrite($sformatf(format_header_str, $sformatf("%t", $time),
-                       "Order", "PC", "Instr", "M", "rs1", "rs1_data", "rs2", "rs2_data", "rd", "rd_data", "mem", "mem_addr", "mem_data", "instr"));
+
+      string banner = {160{"-"}};
+
+      fwrite(banner);
+      fwrite($sformatf(format_header_str,
+                       " TIME", "ORDER", "PC", "INSTR", "M", "RS1", "RS1_DATA", "RS2", "RS2_DATA", "RD",
+                       "RD_DATA", "MEM", "MEM_ADDR", "MEM_DATA", "INSTRUCTION"));
+      fwrite(banner);
 
    endfunction : print_header
-   
+
 endclass : uvma_rvfi_mon_trn_logger_c
 
 

--- a/lib/uvm_agents/uvma_rvvi/uvma_rvvi_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_rvvi/uvma_rvvi_mon_trn_logger.sv
@@ -1,13 +1,13 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,58 +29,58 @@ class uvma_rvvi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
    .T_CFG  (uvma_rvvi_cfg_c#(ILEN,XLEN) ),
    .T_CNTXT(uvma_rvvi_cntxt_c#(ILEN,XLEN))
 );
-      
+
    uvm_analysis_imp_rvvi_state#(uvma_rvvi_state_seq_item_c, uvma_rvvi_mon_trn_logger_c) state_export;
 
    `uvm_component_utils(uvma_rvvi_mon_trn_logger_c)
 
-   const string format_header_str     = "%15s: RVVI %6s %8s %8s %s %3s %8s";
-   const string format_instr_str      = "%15s: RVVI %6d %8x %8s %s x%2s %8s";
-   const string format_non_instr_str  = "%15s: RVVI %s";
+   const string format_header_str     = "%15s | RVVI | %6s | %8s | %8s | %s | %3s | %8s";
+   const string format_instr_str      = "%15s | RVVI | %6d | %8x | %8s | %s | %3s | %8s";
+   const string format_non_instr_str  = "%15s | RVVI | %s";
 
    /**
     * Default constructor.
     */
    function new(string name="uvma_rvvi_mon_trn_logger", uvm_component parent=null);
-      
+
       super.new(name, parent);
-      
+
       state_export = new("state_export", this);
    endfunction : new
-   
+
    /**
     * Writes contents of t to disk
     */
    virtual function void write(uvml_trn_seq_item_c t);
       //fwrite($sformatf("%t: %s: %s", $time, agent_name, t.convert2string()));
    endfunction : write
-   
+
    virtual function void write_rvvi_state(uvma_rvvi_state_seq_item_c t);
       if (t.valid)
          log_valid_insn(t);
-      else 
-         log_invalid_insn(t);         
+      else
+         log_invalid_insn(t);
    endfunction : write_rvvi_state
 
-   virtual function void log_valid_insn(uvma_rvvi_state_seq_item_c t);      
+   virtual function void log_valid_insn(uvma_rvvi_state_seq_item_c t);
 
-      string  gpr_index_str = "--";
+      string  gpr_index_str = "---";
       string  gpr_data_str  = "--------";
       string  log_str;
 
       if (t.gpr_update.size()) begin
          int unsigned index;
          void'(t.gpr_update.first(index));
-         gpr_index_str = $sformatf("%2d", index);
+         gpr_index_str = $sformatf("x%-2d", index);
          gpr_data_str = $sformatf("%08x", t.gpr_update[index]);
       end
 
-      log_str = $sformatf(format_instr_str, 
+      log_str = $sformatf(format_instr_str,
                           $sformatf("%t", $time),
                           t.order,
                           t.pc,
                           t.get_insn_word_str(),
-                          get_mode_str(t.mode),                       
+                          get_mode_str(t.mode),
                           gpr_index_str,
                           gpr_data_str);
 
@@ -91,7 +91,7 @@ class uvma_rvvi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
 
    endfunction : log_valid_insn
 
-   virtual function void log_invalid_insn(uvma_rvvi_state_seq_item_c t);      
+   virtual function void log_invalid_insn(uvma_rvvi_state_seq_item_c t);
 
       string action;
 
@@ -111,8 +111,13 @@ class uvma_rvvi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
     * Writes log header to disk
     */
    virtual function void print_header();
-      fwrite($sformatf(format_header_str, $sformatf("%t", $time),
-                       "Order", "PC", "Instr", "M", "rd", "rd_data"));
+
+      string banner = {76{"-"}};
+
+      fwrite(banner);
+      fwrite($sformatf(format_header_str,
+                       "TIME", "ORDER", "PC", "INSTR", "M", "RD", "RD_DATA "));
+      fwrite(banner);
 
    endfunction : print_header
 


### PR DESCRIPTION
Various cleanup for the monitor logs
ensure some standardization in order of fields and formatting of logs in these agent to optimize debug

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>