### PR TITLE
Prevent regression scripts from parsing primary prompt variable

### DIFF
--- a/bin/templates/regress_sve.j2
+++ b/bin/templates/regress_sve.j2
@@ -3,13 +3,13 @@
 ################################################################################
 #
 # Copyright 2020 OpenHW Group
-# 
+#
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://solderpad.org/licenses/
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-# 
+#
 ################################################################################
 
 #}
@@ -25,6 +25,6 @@
 
 #!/bin/sh -fx
 
-{% for k in env %}
+{% for k in env if not k=="PS1" %}
 export {{k}}="{{env[k]}}"
 {% endfor %}


### PR DESCRIPTION
Excluded the primary prompt variable (PS1) from being parsed
into the regression enviornment.

Reasoning: Custom user prompts may cause regression scripts to
fail due to incompatible shell functionality settings.

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>