### PR TITLE
Fixes to get e40s bench up and running to master branch

### DIFF
--- a/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
@@ -74,13 +74,15 @@ class uvme_cv32e40s_cfg_c extends uvma_core_cntrl_cfg_c;
       ext_zifencei_supported == 1;
       ext_zicsr_supported   == 1;
 
-      ext_a_supported == 0;
-      ext_p_supported == 0;
-      ext_v_supported == 0;
-      ext_f_supported == 0;
-      ext_d_supported == 0;
-      // FIXME: add to core-v-verf/lib/uvma_agents/uvma_core_cntrl/uvma_core_cntrl_cfg.sv
-      //ext_b_supported == 0;
+      ext_a_supported   == 0;
+      ext_p_supported   == 0;
+      ext_v_supported   == 0;
+      ext_f_supported   == 0;
+      ext_d_supported   == 0;
+      ext_zba_supported == 0;
+      ext_zbb_supported == 0;
+      ext_zbc_supported == 0;
+      ext_zbs_supported == 0;
 
       mode_s_supported == 0;
       mode_u_supported == 0;

--- a/cv32e40s/sim/Common.mk
+++ b/cv32e40s/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= b251cbf4ff2bb4daab1cc7e5eea56bf5d60d5e52
+CV_CORE_HASH   ?= 21dd9c93ef51dc42810266f00d352e199d1dc2c1
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -20,7 +20,7 @@
 
 
    `ifdef PMA_CUSTOM_CFG
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 3;
+      parameter int                CORE_PARAM_PMA_NUM_REGIONS = 3;
       parameter cv32e40s_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
          // Overlap "shadow" of main code (.text), for testing overlap priority
          cv32e40s_pkg::pma_region_t'{
@@ -48,7 +48,7 @@
             atomic         : 1}
          };
    `elsif PMA_DEBUG_CFG
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 2;
+      parameter int                CORE_PARAM_PMA_NUM_REGIONS = 2;
       parameter cv32e40s_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
          // Everything is initially executable
          cv32e40s_pkg::pma_region_t'{
@@ -68,8 +68,8 @@
             atomic         : 0}
          };
    `else
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 0;
-      parameter cv32e40s_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:0] = '{'z};
+      parameter int                CORE_PARAM_PMA_NUM_REGIONS = 0;
+      parameter cv32e40s_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{default:cv32e40s_pkg::PMA_R_DEFAULT};
    `endif
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -44,8 +44,8 @@ module uvmt_cv32e40s_dut_wrap
 
   #(// DUT (riscv_core) parameters.                            
     parameter NUM_MHPMCOUNTERS    =  1,
-    parameter int unsigned PMA_NUM_REGIONS =  0,
-    parameter pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT},
+    parameter int PMA_NUM_REGIONS =  0,
+    parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT},
     // Remaining parameters are used by TB components only
               INSTR_ADDR_WIDTH    =  32,
               INSTR_RDATA_WIDTH   =  32,
@@ -199,6 +199,9 @@ module uvmt_cv32e40s_dut_wrap
          .debug_havereset_o      ( debug_havereset                ),
          .debug_running_o        ( debug_running                  ),
          .debug_halted_o         ( debug_halted                   ),
+
+         .fencei_flush_req_o     ( /*TODO: connect to fencei agent*/),
+         .fencei_flush_ack_i     ( 1'b1/*TODO: connect to fencei agent*/),
 
          .fetch_enable_i         ( core_cntrl_if.fetch_en         ),
          .core_sleep_o           ( core_status_if.core_busy       )

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -43,7 +43,7 @@ module uvmt_cv32e40s_tb;
 `endif
 
    parameter int PMA_NUM_REGIONS = 0;
-   parameter cv32e40s_pkg::pma_region_t PMA_CFG[(PMA_NUM_REGIONS ? (PMA_NUM_REGIONS-1) : 0):0] = '{default:PMA_R_DEFAULT};
+   parameter cv32e40s_pkg::pma_region_t PMA_CFG[PMA_NUM_REGIONS-1:0] = '{default:PMA_R_DEFAULT};
 
    // ENV (testbench) parameters
    parameter int ENV_PARAM_INSTR_ADDR_WIDTH  = 32;


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openhwgroup/core-v-verif/pull/883

retargeted to the master branch with some cleanup for core cntrl extension switches for the Zb* extensions.

This passes all e40s ci_check but I am pushing up anyway to get these fixes working and I am not sure of the expected state of the E40S ci_check.
