### PR TITLE
allow interrupt and debug to be signalled on same RVFI instruction

### DIFF
--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= eb13dfaea2c7638b7ebf6b63463812202ced315c
+CV_CORE_HASH   ?= d0a6a7249c6ec4efafb339b88ced393d9f65a2a6
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -186,7 +186,7 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
             mon_trn.insn_nmi = 1;
             mon_trn.insn_interrupt_id = { 1'b0, csr_mcause[XLEN-2:0] };
          end
-         else if (mon_trn.intr && !mon_trn.dbg) begin
+         else if (mon_trn.intr) begin
              bit [XLEN-1:0] csr_mcause = mon_trn.csrs["mcause"].get_csr_retirement_data();
 
             if (csr_mcause[31]) begin


### PR DESCRIPTION
reference model will update interrupt CSR and take the debug handler
updates the E40X RTL to bring in bugfix for https://github.com/openhwgroup/cv32e40x/issues/204