### PR TITLE
fix handling and recovery of data bus errors in data bus error directed test

### DIFF
--- a/cv32e40x/bsp/handlers.S
+++ b/cv32e40x/bsp/handlers.S
@@ -242,6 +242,7 @@ end_handler_ret:
 
 .section .nmi, "ax"
 .global nmi_handler
+.global nmi_end_handler_ret
 
 nmi_handler:
 	addi sp,sp,-64


### PR DESCRIPTION
This was accidentally omitted from a previous PR.  The test was updated such that the custom handlers in the test will properly handshake with the BSP.  Thus data_bus_error will now pass with USE_ISS=0.
