### PR TITLE
Strichmo/pr/pma cov and sb

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_env.sv
@@ -46,7 +46,8 @@ class uvme_cv32e40x_env_c extends uvm_env;
    uvma_obi_memory_agent_c          obi_memory_data_agent ;
    uvma_rvfi_agent_c#(ILEN,XLEN)    rvfi_agent;
    uvma_rvvi_agent_c#(ILEN,XLEN)    rvvi_agent;
-   uvma_fencei_agent_c              fencei_agent ;
+   uvma_fencei_agent_c              fencei_agent;
+   uvma_pma_agent_c#(ILEN,XLEN)     pma_agent;
 
    `uvm_component_utils_begin(uvme_cv32e40x_env_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -313,6 +314,7 @@ function void uvme_cv32e40x_env_c::assign_cfg();
    uvm_config_db#(uvma_rvfi_cfg_c#(ILEN,XLEN))::set(this, "rvfi_agent", "cfg", cfg.rvfi_cfg);
    uvm_config_db#(uvma_rvvi_cfg_c#(ILEN,XLEN))::set(this, "rvvi_agent", "cfg", cfg.rvvi_cfg);
    uvm_config_db#(uvma_fencei_cfg_c)::set(this, "fencei_agent", "cfg", cfg.fencei_cfg);
+   uvm_config_db#(uvma_pma_cfg_c)::set(this, "pma_agent", "cfg", cfg.pma_cfg);
 
 endfunction: assign_cfg
 
@@ -344,6 +346,7 @@ function void uvme_cv32e40x_env_c::create_agents();
    rvfi_agent = uvma_rvfi_agent_c#(ILEN,XLEN)::type_id::create("rvfi_agent", this);
    rvvi_agent = uvma_rvvi_ovpsim_agent_c#(ILEN,XLEN)::type_id::create("rvvi_agent", this);
    fencei_agent = uvma_fencei_agent_c::type_id::create("fencei_agent", this);
+   pma_agent = uvma_pma_agent_c#(ILEN,XLEN)::type_id::create("pma_agent", this);
 
 endfunction: create_agents
 
@@ -369,7 +372,6 @@ function void uvme_cv32e40x_env_c::create_cov_model();
 
    cov_model = uvme_cv32e40x_cov_model_c::type_id::create("cov_model", this);
 
-
 endfunction: create_cov_model
 
 
@@ -388,23 +390,33 @@ endfunction : connect_rvfi_rvvi
 
 function void uvme_cv32e40x_env_c::connect_scoreboard();
 
-   // Connect the CORE Scoreboard
-   rvvi_agent.state_mon_ap.connect(core_sb.rvvi_state_export);
-   foreach (rvfi_agent.instr_mon_ap[i])
-      rvfi_agent.instr_mon_ap[i].connect(core_sb.rvfi_instr_export);
+   // Connect the CORE Scoreboard (but only if the ISS is running)
+   if (cfg.use_iss) begin
+      rvvi_agent.state_mon_ap.connect(core_sb.rvvi_state_export);
+      foreach (rvfi_agent.instr_mon_ap[i])
+         rvfi_agent.instr_mon_ap[i].connect(core_sb.rvfi_instr_export);
+   end
+
+   // Connect the PMA scoreboard
+   foreach (rvfi_agent.instr_mon_ap[i]) begin
+      rvfi_agent.instr_mon_ap[i].connect(pma_agent.scoreboard.rvfi_instr_export);
+   end
+   obi_memory_instr_agent.mon_ap.connect(pma_agent.scoreboard.obi_i_export);
+   obi_memory_data_agent.mon_ap.connect(pma_agent.scoreboard.obi_d_export);
 
 endfunction: connect_scoreboard
 
 
 function void uvme_cv32e40x_env_c::connect_coverage_model();
 
-   isacov_agent.monitor.ap.connect(cov_model.interrupt_covg.instr_mon_export);
    isacov_agent.monitor.ap.connect(cov_model.exceptions_covg.isacov_mon_export);
    isacov_agent.monitor.ap.connect(cov_model.counters_covg.isacov_mon_export);
 
+   obi_memory_data_agent.mon_ap.connect(pma_agent.monitor.obi_d_export);
    foreach (rvfi_agent.instr_mon_ap[i]) begin
       rvfi_agent.instr_mon_ap[i].connect(isacov_agent.monitor.rvfi_instr_export);
       rvfi_agent.instr_mon_ap[i].connect(cov_model.interrupt_covg.interrupt_mon_export);
+      rvfi_agent.instr_mon_ap[i].connect(pma_agent.monitor.rvfi_instr_export);
    end
 
 endfunction: connect_coverage_model

--- a/cv32e40x/env/uvme/uvme_cv32e40x_pkg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_pkg.sv
@@ -49,6 +49,7 @@ package uvme_cv32e40x_pkg;
    import uvma_rvvi_pkg::*;
    import uvma_rvvi_ovpsim_pkg::*;
    import uvma_fencei_pkg::*;
+   import uvma_pma_pkg::*;
 
    // Forward decls
    typedef class uvme_cv32e40x_vsqr_c;
@@ -99,4 +100,5 @@ endpackage : uvme_cv32e40x_pkg
 `include "uvme_cv32e40x_core_cntrl_if.sv"
 
 `endif // __UVME_CV32E40X_PKG_SV__
+
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x.flist
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x.flist
@@ -29,6 +29,7 @@
 -f ${DV_UVMA_RVFI_PATH}/uvma_rvfi_pkg.flist
 -f ${DV_UVMA_RVVI_PATH}/uvma_rvvi_pkg.flist
 -f ${DV_UVMA_ISACOV_PATH}/uvma_isacov_pkg.flist
+-f ${DV_UVMA_PMA_PATH}/src/uvma_pma_pkg.flist
 -f ${DV_UVMA_CLKNRST_PATH}/uvma_clknrst_pkg.flist
 -f ${DV_UVMA_INTERRUPT_PATH}/uvma_interrupt_pkg.flist
 -f ${DV_UVMA_DEBUG_PATH}/uvma_debug_pkg.flist

--- a/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
+++ b/cv32e40x/tests/uvmt/base-tests/uvmt_cv32e40x_base_test.sv
@@ -55,9 +55,9 @@ class uvmt_cv32e40x_base_test_c extends uvm_test;
 
 
    constraint env_cfg_cons {
-      env_cfg.enabled         == 1;
-      env_cfg.is_active       == UVM_ACTIVE;
-      env_cfg.trn_log_enabled == 1;
+      env_cfg.enabled               == 1;
+      env_cfg.is_active             == UVM_ACTIVE;
+      env_cfg.trn_log_enabled       == 1;
 
       // FIXME:STRICHMO:undo temp variable when Issue 675 is solved
       env_cfg.rvfi_cfg.nmi_handler_addr        == env_cfg.nmi_addr;

--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_cfg.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_cfg.sv
@@ -173,10 +173,6 @@
       soft trn_log_enabled        == 1;
    }
 
-   constraint scoreboard_cons {
-      (!use_iss) -> (scoreboarding_enabled == 0);
-   }
-
    constraint addr_xlen_align_cons {
       if (xlen == MXL_32) {
          boot_addr[MAX_XLEN-1:32]         == '0;

--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_pma_region.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_pma_region.sv
@@ -1,4 +1,4 @@
-// 
+//
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
@@ -6,15 +6,15 @@
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 `ifndef __UVMA_CORE_CNTRL_PMA_REGION_SV__
 `define __UVMA_CORE_CNTRL_PMA_REGION_SV__
@@ -41,7 +41,7 @@
 
    // Is this memory bufferable
    rand bit                      bufferable;
-   
+
    // Is this memory cacheable
    rand bit                      cacheable;
 
@@ -57,7 +57,7 @@
       `uvm_field_int(               cacheable       , UVM_DEFAULT | UVM_NOPRINT)
       `uvm_field_int(               atomic          , UVM_DEFAULT | UVM_NOPRINT)
    `uvm_field_utils_end
-   
+
    constraint addr_range_cons {
       word_addr_low <= word_addr_high;
    }
@@ -95,7 +95,7 @@
  endclass : uvma_core_cntrl_pma_region_c
 
 function uvma_core_cntrl_pma_region_c::new(string name="uvma_core_cntrl_pma_region_c");
-   
+
    super.new(name);
 
 endfunction : new
@@ -104,7 +104,7 @@ function void uvma_core_cntrl_pma_region_c::do_print(uvm_printer printer);
 
    super.do_print(printer);
 
-   printer.print_string("xlen", xlen.name());   
+   printer.print_string("xlen", xlen.name());
    printer.print_string("word_addr_low", $sformatf("0x%08x (0x%08x)", word_addr_low, get_byte_addr(word_addr_low)));
    printer.print_string("word_addr_high", $sformatf("0x%08x (0x%08x)", word_addr_high, get_byte_addr(word_addr_high)));
    printer.print_field("main", main, 1);
@@ -116,8 +116,9 @@ endfunction : do_print
 
 function bit uvma_core_cntrl_pma_region_c::is_addr_in_region(bit [MAX_XLEN-1:0] byte_addr);
 
-   if (((byte_addr >> 2) >= word_addr_low) && 
-       ((byte_addr >> 2) <= word_addr_high))
+   // Per User manual, do not include the upper word address
+   if (((byte_addr >> 2) >= word_addr_low) &&
+       ((byte_addr >> 2) < word_addr_high))
       return 1;
 
    return 0;
@@ -131,7 +132,7 @@ function bit [MAX_XLEN-1:0] uvma_core_cntrl_pma_region_c::get_byte_addr(bit [MAX
    MXL_32:  return byte_addr[31:0];
    MXL_64:  return byte_addr[63:0];
    MXL_128: return byte_addr[127:0];
-   endcase  
+   endcase
 
    `uvm_fatal("PMA", "Should not fall through to here");
 

--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_constants.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_constants.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_CONSTANTS_SV__
@@ -37,5 +37,8 @@ const int unsigned  uvma_obi_memory_default_drv_slv_gnt_random_latency_max     =
 const int unsigned  uvma_obi_memory_default_drv_slv_rvalid_fixed_latency       =  1;
 const int unsigned  uvma_obi_memory_default_drv_slv_rvalid_random_latency_min  =  0;
 const int unsigned  uvma_obi_memory_default_drv_slv_rvalid_random_latency_max  = 10;
+
+const int unsigned  UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT = 0;
+const int unsigned  UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT = 1;
 
 `endif // __UVMA_OBI_MEMORY_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_pma/LICENSE.md
+++ b/lib/uvm_agents/uvma_pma/LICENSE.md
@@ -1,0 +1,73 @@
+# Solderpad Hardware License v2.1
+
+This license operates as a wraparound license to the Apache License Version 2.0
+(the "Apache License") and incorporates the terms and conditions of the Apache
+License (which can be found here: http://apache.org/licenses/LICENSE-2.0), with
+the following additions and modifications. It must be read in conjunction with
+the Apache License. Section 1 below modifies definitions and terminology in the
+Apache License and Section 2 below replaces Section 2 of the Apache License. The
+Appendix replaces the Appendix in the Apache License. You may, at your option,
+choose to treat any Work released under this license as released under the
+Apache License (thus ignoring all sections written below entirely).
+
+1. Terminology in the Apache License is supplemented or modified as follows:
+
+- "Authorship": any reference to 'authorship' shall be taken to read "authorship
+  or design".
+
+- "Copyright owner": any reference to 'copyright owner' shall be taken to read
+  "Rights owner".
+
+- "Copyright statement": the reference to 'copyright statement' shall be taken
+  to read �copyright or other statement pertaining to Rights�.
+
+- The following new definition shall be added to the Definitions section of the
+  Apache License:
+
+- "Rights" means copyright and any similar right including design right (whether
+  registered or unregistered), rights in semiconductor topographies (mask works)
+  and database rights (but excluding Patents and Trademarks).
+
+- The following definitions shall replace the corresponding definitions in the
+  Apache License:
+
+- "License" shall mean this Solderpad Hardware License version 2.1, being the
+  terms and conditions for use, manufacture, instantiation, adaptation,
+  reproduction, and distribution as defined by Sections 1 through 9 of this
+  document.
+
+- "Licensor" shall mean the owner of the Rights or entity authorized by the
+  owner of the Rights that is granting the License.
+
+- "Derivative Works" shall mean any work, whether in Source or Object form, that
+  is based on (or derived from) the Work and for which the editorial revisions,
+  annotations, elaborations, or other modifications represent, as a whole, an
+  original work of authorship or design. For the purposes of this License,
+  Derivative Works shall not include works that remain reversibly separable
+  from, or merely link (or bind by name) or physically connect to or
+  interoperate with the Work and Derivative Works thereof.
+
+- "Object" form shall mean any form resulting from mechanical transformation or
+  translation of a Source form or the application of a Source form to physical
+  material, including but not limited to compiled object code, generated
+  documentation, the instantiation of a hardware design or physical object or
+  material and conversions to other media types, including intermediate forms
+  such as bytecodes, FPGA bitstreams, moulds, artwork and semiconductor
+  topographies (mask works).
+
+- "Source" form shall mean the preferred form for making modifications,
+  including but not limited to source code, net lists, board layouts, CAD files,
+  documentation source, and configuration files.
+
+- "Work" shall mean the work of authorship or design, whether in Source or
+  Object form, made available under the License, as indicated by a notice
+  relating to Rights that is included in or attached to the work (an example is
+  provided in the Appendix below).
+
+2. Grant of License. Subject to the terms and conditions of this License, each
+   Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+   no-charge, royalty-free, irrevocable license under the Rights to reproduce,
+   prepare Derivative Works of, make, adapt, repair, publicly display, publicly
+   perform, sublicense, and distribute the Work and such Derivative Works in
+   Source or Object form and do anything in relation to the Work as if the
+   Rights did not exist.

--- a/lib/uvm_agents/uvma_pma/README.md
+++ b/lib/uvm_agents/uvma_pma/README.md
@@ -1,0 +1,26 @@
+# OpenHW Group Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent
+
+
+# About
+This package contains the OpenHW Group Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent.
+
+TODO Describe Memory attribution agent for OpenHW Group CORE-V verification testbenches
+
+
+# Block Diagram
+![alt text](./docs/agent_block_diagram.png "Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent Block Diagram")
+
+# Directory Structure
+* `bin` - Scripts, metadata and other miscellaneous files
+* `docs` - Documents describing the OpenHW Group Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent
+* `examples` - Samples for users
+* `src` - Source code for this package
+
+
+# Dependencies
+It is dependent on the following packages:
+
+* `uvm_pkg`
+* `uvml_hrtbt_pkg`
+* `uvml_trn_pkg`
+* `uvml_logs_pkg`

--- a/lib/uvm_agents/uvma_pma/bin/package.py
+++ b/lib/uvm_agents/uvma_pma/bin/package.py
@@ -1,0 +1,20 @@
+# Copyright 2021 OpenHW Group
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+########################################################################################################################
+# Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+# with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+#                                       https://solderpad.org/licenses/SHL-2.1/
+# Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+########################################################################################################################
+
+
+import tarfile
+import os.path
+
+def make_tarfile(output_filename, source_dir):
+    with tarfile.open(output_filename, "w:gz") as tar:
+        tar.add(source_dir, arcname=os.path.basename(source_dir))
+
+make_tarfile("uvma_pma_pkg.tgz", "../"")

--- a/lib/uvm_agents/uvma_pma/docs/agent_block_diagram.svg
+++ b/lib/uvm_agents/uvma_pma/docs/agent_block_diagram.svg
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ev="http://www.w3.org/2001/xml-events"
+      xmlns:v="http://schemas.microsoft.com/visio/2003/SVGExtensions/" width="5.18135in" height="5.85299in"
+      viewBox="0 0 373.057 421.415" xml:space="preserve" color-interpolation-filters="sRGB" class="st19">
+   <v:documentProperties v:langID="4105" v:metric="true" v:viewMarkup="false">
+      <v:userDefs>
+         <v:ud v:nameU="msvNoAutoConnect" v:val="VT0(1):26"/>
+      </v:userDefs>
+   </v:documentProperties>
+
+   <style type="text/css">
+   <![CDATA[
+      .st1 {fill:none;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st2 {fill:#000000;font-family:Calibri;font-size:0.833336em;font-weight:bold}
+      .st3 {fill:#000000;font-family:Calibri;font-size:0.666664em}
+      .st4 {font-size:1.25001em;font-weight:bold}
+      .st5 {fill:#ffffff;stroke:#ff0000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st6 {fill:none;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.75}
+      .st7 {fill:#ffffff;stroke:#0070c0;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st8 {marker-end:url(#mrkr5-29);stroke:#0070c0;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st9 {fill:#0070c0;fill-opacity:1;stroke:#0070c0;stroke-opacity:1;stroke-width:0.28409090909091}
+      .st10 {marker-end:url(#mrkr5-40);stroke:#ff0000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st11 {fill:#ff0000;fill-opacity:1;stroke:#ff0000;stroke-opacity:1;stroke-width:0.28409090909091}
+      .st12 {fill:#ff0000;font-family:Calibri;font-size:0.833336em;font-weight:bold}
+      .st13 {fill:#0070c0;font-family:Calibri;font-size:0.833336em;font-weight:bold}
+      .st14 {fill:#7030a0;font-family:Calibri;font-size:0.833336em;font-weight:bold}
+      .st15 {fill:#f2f2f2;stroke:#000000;stroke-linecap:round;stroke-linejoin:round;stroke-width:1}
+      .st16 {fill:#ffffff;stroke:#7030a0;stroke-linecap:round;stroke-linejoin:round;stroke-width:1.5}
+      .st17 {fill:#000000;font-family:Calibri;font-size:0.833336em}
+      .st18 {font-size:1em}
+      .st19 {fill:none;fill-rule:evenodd;font-size:12px;overflow:visible;stroke-linecap:square;stroke-miterlimit:3}
+   ]]>
+   </style>
+
+   <defs id="Markers">
+      <g id="lend5">
+         <path d="M 2 1 L 0 0 L 1.98117 -0.993387 C 1.67173 -0.364515 1.67301 0.372641 1.98465 1.00043 " style="stroke:none"/>
+      </g>
+      <marker id="mrkr5-29" class="st9" v:arrowType="5" v:arrowSize="2" v:setback="6.16" refX="-6.16" orient="auto"
+            markerUnits="strokeWidth" overflow="visible">
+         <use xlink:href="#lend5" transform="scale(-3.52,-3.52) "/>
+      </marker>
+      <marker id="mrkr5-40" class="st11" v:arrowType="5" v:arrowSize="2" v:setback="6.16" refX="-6.16" orient="auto"
+            markerUnits="strokeWidth" overflow="visible">
+         <use xlink:href="#lend5" transform="scale(-3.52,-3.52) "/>
+      </marker>
+   </defs>
+   <g v:mID="0" v:index="1" v:groupContext="foregroundPage">
+      <title>Page-1</title>
+      <v:pageProperties v:drawingScale="0.0393701" v:pageScale="0.0393701" v:drawingUnits="24" v:shadowOffsetX="8.50394"
+            v:shadowOffsetY="-8.50394"/>
+      <v:layer v:name="Connector" v:index="0"/>
+      <g id="shape4-1" v:mID="4" v:groupContext="shape" transform="translate(18.5,-49.5561)">
+         <title>Sheet.4</title>
+         <desc>&#60;uvma_pma_agent_c&#62;</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197" v:verticalAlign="0"/>
+         <v:textRect cx="168.029" cy="254.171" width="336.06" height="334.488"/>
+         <rect x="0" y="86.9272" width="336.058" height="334.488" class="st1"/>
+         <text x="4" y="99.93" class="st2" v:langID="4105"><v:paragraph/><v:tabList/>&#60;uvma_pma_agent_c&#62;</text>    </g>
+      <g id="shape10-4" v:mID="10" v:groupContext="shape" transform="translate(30.0165,-327.54)">
+         <title>Sheet.10</title>
+         <desc>&#60;uvma_pma_cfg_c&#62; cfg</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+         <v:textRect cx="63.9921" cy="404.502" width="127.99" height="33.8267"/>
+         <rect x="0" y="387.589" width="127.984" height="33.8267" class="st1"/>
+         <text x="30.25" y="400.9" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_cfg_c&#62;<v:newlineChar/><tspan
+                  x="57.95" dy="1.14em" class="st4">cfg</tspan></text>     </g>
+      <g id="shape11-8" v:mID="11" v:groupContext="shape" transform="translate(215.433,-327.54)">
+         <title>Sheet.11</title>
+         <desc>&#60;uvma_pma_cntxt_c&#62; cntxt</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+         <v:textRect cx="63.9921" cy="404.502" width="127.99" height="33.8267"/>
+         <rect x="0" y="387.589" width="127.984" height="33.8267" class="st1"/>
+         <text x="26.84" y="400.9" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_cntxt_c&#62;<v:newlineChar/><tspan
+                  x="53.45" dy="1.14em" class="st4">cntxt</tspan></text>      </g>
+      <g id="group20-12" transform="translate(237.543,-35.5246)" v:mID="20" v:groupContext="group">
+         <title>Sheet.20</title>
+         <g id="shape6-13" v:mID="6" v:groupContext="shape" transform="translate(34.5198,-6.53571)">
+            <title>Diamond.6</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:prompt="" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M7.36 421.42 L14.72 414.05 L7.36 406.69 L0 414.05 L7.36 421.42 Z" class="st5"/>
+         </g>
+         <g id="shape19-15" v:mID="19" v:groupContext="shape">
+            <title>Sheet.19</title>
+            <desc>mon_ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="19.1339" cy="413.758" width="38.27" height="15.3151"/>
+            <rect x="0" y="406.1" width="38.2677" height="15.3151" class="st6"/>
+            <text x="7.44" y="416.16" class="st3" v:langID="4105"><v:paragraph v:horizAlign="2"/><v:tabList/>mon_ap</text>       </g>
+      </g>
+      <g id="group21-18" transform="translate(86.0001,-35.5246)" v:mID="21" v:groupContext="group">
+         <title>Sheet.21</title>
+         <g id="shape1-19" v:mID="1" v:groupContext="shape" transform="translate(-6.99441E-15,-6.53571)">
+            <title>Diamond.322</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:prompt="" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M7.36 421.42 L14.72 414.05 L7.36 406.69 L0 414.05 L7.36 421.42 Z" class="st7"/>
+         </g>
+         <g id="shape18-21" v:mID="18" v:groupContext="shape" transform="translate(11.8895,0)">
+            <title>Sheet.18</title>
+            <desc>drv_ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="15.5591" cy="413.758" width="31.12" height="15.3151"/>
+            <rect x="0" y="406.1" width="31.1182" height="15.3151" class="st6"/>
+            <text x="4" y="416.16" class="st3" v:langID="4105"><v:paragraph/><v:tabList/>drv_ap</text>         </g>
+      </g>
+      <g id="shape26-24" v:mID="26" v:groupContext="shape" v:layerMember="0" transform="translate(86.2441,-261.074)">
+         <title>Dynamic connector.346</title>
+         <path d="M7.09 422.01 L7.09 428.84" class="st8"/>
+      </g>
+      <g id="shape27-30" v:mID="27" v:groupContext="shape" v:layerMember="0" transform="translate(86.2598,-129.793)">
+         <title>Dynamic connector.27</title>
+         <path d="M7.07 421.42 L7.07 434.09 L7.1 434.09 L7.1 488.26" class="st8"/>
+      </g>
+      <g id="shape28-35" v:mID="28" v:groupContext="shape" v:layerMember="0" transform="translate(272.339,-129.793)">
+         <title>Dynamic connector.28</title>
+         <path d="M7.09 421.42 L7.09 488.26" class="st10"/>
+      </g>
+      <g id="shape39-41" v:mID="39" v:groupContext="shape" v:layerMember="0" transform="translate(93.0236,-129.793)">
+         <title>Dynamic connector.39</title>
+         <path d="M0.31 421.42 L0.31 477.81 L7.71 477.81" class="st8"/>
+      </g>
+      <g id="shape40-46" v:mID="40" v:groupContext="shape" v:layerMember="0" transform="translate(279.536,-129.793)">
+         <title>Dynamic connector.40</title>
+         <path d="M-0.11 421.42 L-0.11 449.55 L-7.9 449.55" class="st10"/>
+      </g>
+      <g id="shape47-51" v:mID="47" v:groupContext="shape" transform="translate(219.969,-18.375)">
+         <title>Sheet.47</title>
+         <desc>&#60;uvma_pma_mon_trn_c&#62;</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+         <v:textRect cx="59.5276" cy="413.758" width="119.06" height="15.3151"/>
+         <rect x="0" y="406.1" width="119.055" height="15.3151" class="st6"/>
+         <text x="4.74" y="416.76" class="st12" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_mon_trn_c&#62;</text>    </g>
+      <g id="shape48-54" v:mID="48" v:groupContext="shape" transform="translate(29.7874,-18.375)">
+         <title>Sheet.48</title>
+         <desc>&#60;uvma_pma_seq_item_c&#62;</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+         <v:textRect cx="63.9921" cy="413.758" width="127.99" height="15.3151"/>
+         <rect x="0" y="406.1" width="127.984" height="15.3151" class="st6"/>
+         <text x="8.09" y="416.76" class="st13" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_seq_item_c&#62;</text>      </g>
+      <g id="shape43-57" v:mID="43" v:groupContext="shape" transform="translate(-160.686,170.599) rotate(-90)">
+         <title>Sheet.43</title>
+         <path d="M0 421.42 L4.59 421.42" class="st8"/>
+      </g>
+      <g id="shape45-62" v:mID="45" v:groupContext="shape" transform="translate(-121.001,170.599) rotate(-90)">
+         <title>Sheet.45</title>
+         <path d="M0 421.42 L4.59 421.42" class="st10"/>
+      </g>
+      <g id="shape53-67" v:mID="53" v:groupContext="shape" transform="translate(127.001,-387.725)">
+         <title>Sheet.53</title>
+         <desc>&#60;uvma_pma_if&#62;</desc>
+         <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+         <v:textRect cx="59.5276" cy="413.758" width="119.06" height="15.3151"/>
+         <rect x="0" y="406.1" width="119.055" height="15.3151" class="st6"/>
+         <text x="24.63" y="416.76" class="st14" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_if&#62;</text>    </g>
+      <g id="group54-70" transform="translate(112.175,-90.0127)" v:mID="54" v:groupContext="group">
+         <title>Sheet.54</title>
+         <g id="shape29-71" v:mID="29" v:groupContext="shape">
+            <title>Sheet.29</title>
+            <desc>&#60;uvma_pma_mon_trn_logger_c&#62; mon_trn_logger</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="73.8432" cy="409.775" width="147.69" height="23.2816"/>
+            <rect x="0" y="398.134" width="147.686" height="23.2816" class="st15"/>
+            <text x="18.49" y="406.17" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_mon_trn_logger_c&#62;<v:newlineChar/><tspan
+                     x="40.28" dy="1.14em" class="st4">mon_trn_logger</tspan></text>         </g>
+         <g id="shape30-75" v:mID="30" v:groupContext="shape" transform="translate(142.075,825.579) scale(1,-1)">
+            <title>Circle.30</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M0 415.8 A5.61129 5.61129 0 0 1 11.22 415.8 A5.61129 5.61129 0 0 1 0 415.8 Z" class="st5"/>
+         </g>
+      </g>
+      <g id="group57-77" transform="translate(106.89,-61.7578)" v:mID="57" v:groupContext="group">
+         <title>Sheet.57</title>
+         <g id="shape33-78" v:mID="33" v:groupContext="shape" transform="translate(5.12809,0)">
+            <title>Sheet.33</title>
+            <desc>&#60;uvma_pma_seq_item_logger_c&#62; seq_item_logger</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="73.94" cy="409.775" width="147.89" height="23.2816"/>
+            <rect x="0" y="398.134" width="147.88" height="23.2816" class="st15"/>
+            <text x="17.73" y="406.17" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_seq_item_logger_c&#62;<v:newlineChar/><tspan
+                     x="39.27" dy="1.14em" class="st4">seq_item_logger</tspan></text>        </g>
+         <g id="shape34-82" v:mID="34" v:groupContext="shape" transform="translate(-1.69864E-14,825.579) scale(1,-1)">
+            <title>Circle.34</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M0 415.8 A5.61129 5.61129 0 0 1 11.22 415.8 A5.61129 5.61129 0 0 1 0 415.8 Z" class="st7"/>
+         </g>
+      </g>
+      <g id="group59-84" transform="translate(29.5512,-123.257)" v:mID="59" v:groupContext="group">
+         <title>Sheet.59</title>
+         <g id="shape7-85" v:mID="7" v:groupContext="shape" transform="translate(7.99361E-15,-13.8978)">
+            <title>Sheet.7</title>
+            <desc>&#60;uvma_pma_drv_c&#62; driver</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="63.9921" cy="368.837" width="127.99" height="105.157"/>
+            <rect x="0" y="316.258" width="127.984" height="105.157" class="st15"/>
+            <text x="29.74" y="359.24" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_drv_c&#62;<v:newlineChar/><tspan
+                     x="51.64" dy="1.14em" class="st4">driver</tspan><v:newlineChar/></text>       </g>
+         <g id="shape2-89" v:mID="2" v:groupContext="shape" transform="translate(58.1682,718.598) scale(1,-1)">
+            <title>Circle.323</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M0 415.8 A5.61129 5.61129 0 0 1 11.22 415.8 A5.61129 5.61129 0 0 1 0 415.8 Z" class="st7"/>
+         </g>
+         <g id="shape3-91" v:mID="3" v:groupContext="shape" transform="translate(19.1524,-29.7638)">
+            <title>Sheet.3</title>
+            <desc>vif</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="44.6271" cy="414.053" width="89.26" height="14.7241"/>
+            <rect x="0" y="406.691" width="89.2543" height="14.7241" class="st16"/>
+            <text x="39.7" y="417.05" class="st17" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>vif</text>         </g>
+         <g id="shape14-94" v:mID="14" v:groupContext="shape" transform="translate(56.4175,-6.53571)">
+            <title>Diamond.14</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:prompt="" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M7.36 421.42 L14.72 414.05 L7.36 406.69 L0 414.05 L7.36 421.42 Z" class="st7"/>
+         </g>
+         <g id="shape16-96" v:mID="16" v:groupContext="shape" transform="translate(68.3069,0)">
+            <title>Sheet.16</title>
+            <desc>ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="8.47251" cy="413.758" width="16.95" height="15.3151"/>
+            <rect x="0" y="406.1" width="16.945" height="15.3151" class="st6"/>
+            <text x="4.45" y="416.16" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>ap</text>        </g>
+         <g id="shape25-99" v:mID="25" v:groupContext="shape" transform="translate(3.04724,-117.913)">
+            <title>Sheet.25</title>
+            <desc>seq_item_port</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="28.3465" cy="413.758" width="56.7" height="15.3151"/>
+            <rect x="0" y="406.1" width="56.6929" height="15.3151" class="st6"/>
+            <text x="4.63" y="416.16" class="st3" v:langID="4105"><v:paragraph v:horizAlign="2"/><v:tabList/>seq_item_port</text>         </g>
+      </g>
+      <g id="group60-102" transform="translate(29.5512,-252.509)" v:mID="60" v:groupContext="group">
+         <title>Sheet.60</title>
+         <g id="shape5-103" v:mID="5" v:groupContext="shape" transform="translate(0,-13.7413)">
+            <title>Sheet.5</title>
+            <desc>&#60;uvma_pma_sqr_c&#62; sequencer</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="63.9921" cy="396.534" width="127.99" height="49.7628"/>
+            <rect x="0" y="371.653" width="127.984" height="49.7628" class="st15"/>
+            <text x="29.98" y="392.93" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_sqr_c&#62;<v:newlineChar/><tspan
+                     x="42.53" dy="1.14em" class="st4">sequencer</tspan></text>        </g>
+         <g id="shape23-107" v:mID="23" v:groupContext="shape" transform="translate(58.1406,-7.97539)">
+            <title>Sheet.23</title>
+            <rect x="0" y="410.077" width="11.3386" height="11.3386" class="st7"/>
+         </g>
+         <g id="shape24-109" v:mID="24" v:groupContext="shape" transform="translate(68.6521,0)">
+            <title>Sheet.24</title>
+            <desc>seq_item_export</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="32.3944" cy="413.758" width="64.79" height="15.3151"/>
+            <rect x="0" y="406.1" width="64.7888" height="15.3151" class="st6"/>
+            <text x="4" y="416.16" class="st3" v:langID="4105"><v:paragraph/><v:tabList/>seq_item_export</text>         </g>
+      </g>
+      <g id="group61-112" transform="translate(214.914,-247.981)" v:mID="61" v:groupContext="group">
+         <title>Sheet.61</title>
+         <g id="shape9-113" v:mID="9" v:groupContext="shape" transform="translate(0.519476,-18.2687)">
+            <title>Sheet.9</title>
+            <desc>&#60;uvma_pma_cov_model_c&#62; cov_model</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="63.9921" cy="396.534" width="127.99" height="49.7628"/>
+            <rect x="0" y="371.653" width="127.984" height="49.7628" class="st15"/>
+            <text x="17.13" y="392.93" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_cov_model_c&#62;<v:newlineChar/><tspan
+                     x="41.17" dy="1.14em" class="st4">cov_model</tspan></text>        </g>
+         <g id="shape13-117" v:mID="13" v:groupContext="shape" transform="translate(79.8896,818.028) scale(1,-1)">
+            <title>Circle.13</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M0 415.8 A5.61129 5.61129 0 0 1 11.22 415.8 A5.61129 5.61129 0 0 1 0 415.8 Z" class="st5"/>
+         </g>
+         <g id="shape41-119" v:mID="41" v:groupContext="shape" transform="translate(40.2045,818.028) scale(1,-1)">
+            <title>Circle.41</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M0 415.8 A5.61129 5.61129 0 0 1 11.22 415.8 A5.61129 5.61129 0 0 1 0 415.8 Z" class="st7"/>
+         </g>
+         <g id="shape44-121" v:mID="44" v:groupContext="shape">
+            <title>Sheet.44</title>
+            <desc>from driver ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="21.5039" cy="413.758" width="43.01" height="15.3151"/>
+            <rect x="0" y="406.1" width="43.0077" height="15.3151" class="st6"/>
+            <text x="23.17" y="411.36" class="st3" v:langID="4105"><v:paragraph v:horizAlign="2"/><v:tabList/>from <tspan
+                     x="9.95" dy="1.2em" class="st18">driver ap</tspan></text>         </g>
+         <g id="shape46-125" v:mID="46" v:groupContext="shape" transform="translate(87.3385,-5.68434E-14)">
+            <title>Sheet.46</title>
+            <desc>from monitor ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="24.622" cy="413.758" width="49.25" height="15.3151"/>
+            <rect x="0" y="406.1" width="49.244" height="15.3151" class="st6"/>
+            <text x="4" y="411.36" class="st3" v:langID="4105"><v:paragraph/><v:tabList/>from <tspan x="4" dy="1.2em"
+                     class="st18">monitor ap</tspan></text>       </g>
+      </g>
+      <g id="group62-129" transform="translate(215.433,-123.257)" v:mID="62" v:groupContext="group">
+         <title>Sheet.62</title>
+         <g id="shape8-130" v:mID="8" v:groupContext="shape" transform="translate(0,-13.8978)">
+            <title>Sheet.8</title>
+            <desc>&#60;uvma_pma_mon_c&#62; monitor</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="63.9921" cy="368.837" width="127.99" height="105.157"/>
+            <rect x="0" y="316.258" width="127.984" height="105.157" class="st15"/>
+            <text x="27.63" y="359.24" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>&#60;uvma_pma_mon_c&#62;<v:newlineChar/><tspan
+                     x="47.13" dy="1.14em" class="st4">monitor</tspan><v:newlineChar/></text>         </g>
+         <g id="shape12-134" v:mID="12" v:groupContext="shape" transform="translate(19.365,-29.2129)">
+            <title>Sheet.12</title>
+            <desc>vif</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="44.6271" cy="414.053" width="89.26" height="14.7241"/>
+            <rect x="0" y="406.691" width="89.2543" height="14.7241" class="st16"/>
+            <text x="39.7" y="417.05" class="st17" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>vif</text>         </g>
+         <g id="shape15-137" v:mID="15" v:groupContext="shape" transform="translate(56.6301,-6.53571)">
+            <title>Diamond.15</title>
+            <v:userDefs>
+               <v:ud v:nameU="visVersion" v:prompt="" v:val="VT0(15):26"/>
+            </v:userDefs>
+            <path d="M7.36 421.42 L14.72 414.05 L7.36 406.69 L0 414.05 L7.36 421.42 Z" class="st5"/>
+         </g>
+         <g id="shape17-139" v:mID="17" v:groupContext="shape" transform="translate(43.4329,0)">
+            <title>Sheet.17</title>
+            <desc>ap</desc>
+            <v:textBlock v:margins="rect(4,4,4,4)" v:tabSpace="42.5197"/>
+            <v:textRect cx="8.47251" cy="413.758" width="16.95" height="15.3151"/>
+            <rect x="0" y="406.1" width="16.945" height="15.3151" class="st6"/>
+            <text x="4.45" y="416.16" class="st3" v:langID="4105"><v:paragraph v:horizAlign="1"/><v:tabList/>ap</text>        </g>
+      </g>
+   </g>
+</svg>

--- a/lib/uvm_agents/uvma_pma/examples/instantiation.sv
+++ b/lib/uvm_agents/uvma_pma/examples/instantiation.sv
@@ -1,0 +1,70 @@
+// Copyright 2021 OpenHW Group
+// 
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+/**
+ * This file contains sample code that demonstrates how to add an instance of the Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent
+ * to a UVM environment.
+ * NOTE It is recommended to split up class member declaration and definition.  These classes are all inline to keep the
+ * example short.
+ */
+
+
+/**
+ * Object encapsulating all configuration information for my_env.
+ */
+class my_env_cfg_c extends uvm_object;
+   
+   rand uvma_pma_cfg_c  pma_cfg;
+   
+   `uvm_object_utils_begin(my_env_cfg_c)
+      `uvm_field_object(pma_cfg, UVM_DEFAULT)
+   `uvm_object_utils_end
+   
+   constraint defaults_cons {
+      soft pma_cfg.enabled == 1;
+   }
+   
+   function new(uvm_component parent=null, string name="my_env");
+      super.new(parent, name);
+      cfg = uvma_pma_cfg_c::type_id::create("pma_cfg");
+   endfunction : new
+   
+endclass : my_env_cfg_c
+
+
+/**
+ * Component encapsulating the environment.
+ */
+class my_env_c extends uvm_env;
+   
+   rand my_env_cfg_c  cfg;
+   uvma_pma_agent_c  pma_agent;
+   
+   `uvm_component_utils_begin(my_env_c)
+      `uvm_field_object(cfg, UVM_DEFAULT)
+   `uvm_component_utils_end
+   
+   function new(uvm_component parent=null, string name="my_env");
+      super.new(parent, name);
+   endfunction : new
+   
+   virtual function void build_phase(uvm_phase phase);
+      super.build_phase(phase);
+      if (!cfg) begin
+         `uvm_fatal("MY_ENV", "cfg is null")
+      end
+      else begin
+         uvm_config_db#(uvma_pma_cfg_c)::set(this, "pma_agent", "cfg", cfg.pma_cfg);
+         pma_agent = uvma_pma_agent_c::type_id::create("pma_agent", this);
+      end
+   endfunction : build_phase
+   
+endclass : my_env_c

--- a/lib/uvm_agents/uvma_pma/examples/sequence.sv
+++ b/lib/uvm_agents/uvma_pma/examples/sequence.sv
@@ -1,0 +1,72 @@
+// Copyright 2021 OpenHW Group
+// 
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+/**
+ * This file contains sample code that demonstrates how to add a new sequence to the Memory attribution agent for OpenHW Group CORE-V verification testbenches UVM Agent.
+ */
+
+
+`ifndef __UVMA_PMA_MY_SEQ_SV__
+`define __UVMA_PMA_MY_SEQ_SV__
+
+
+/**
+ * Sample sequence that runs 5 fully random items by default.
+ */
+class uvma_pma_my_seq_c extends uvma_pma_base_seq_c;
+   
+   // Fields
+   rand int unsigned  num_items;
+   
+   
+   `uvm_object_utils_begin(uvma_pma_my_seq_c)
+      `uvm_field_int(num_items, UVM_DEFAULT)
+   `uvm_object_utils_end
+   
+   
+   /**
+    * Default values for random fields.
+    */
+   constraint defaults_cons {
+      soft num_items == 5;
+   }
+   
+   
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_my_seq");
+   
+   /**
+    * Generates num_items of fully random reqs.
+    */
+   extern virtual task body();
+   
+endclass : uvma_pma_my_seq_c
+
+
+function uvma_pma_my_seq_c::new(string name="uvma_pma_my_seq");
+   
+   super.new(name);
+   
+endfunction : new
+
+
+task uvma_pma_my_seq_c::body();
+   
+   repeat (num_items) begin
+      `uvm_do(req)
+   end
+   
+endtask : body
+
+
+`endif __UVMA_PMA_MY_SEQ_SV__

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
@@ -1,0 +1,182 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_AGENT_SV__
+`define __UVMA_PMA_AGENT_SV__
+
+
+/**
+ * Top-level component that encapsulates, builds and connects all others.  Capable of driving/monitoring
+ * Memory attribution agent for OpenHW Group CORE-V verification testbenches interface.
+ */
+class uvma_pma_agent_c#(int ILEN=DEFAULT_ILEN,
+                        int XLEN=DEFAULT_XLEN) extends uvm_agent;
+
+   // Objects
+   uvma_pma_cfg_c#(ILEN,XLEN)  cfg;
+   uvma_pma_cntxt_c            cntxt;
+
+   // Components
+   uvma_pma_mon_c#(ILEN,XLEN)  monitor;
+   uvma_pma_sb_c               scoreboard;
+   uvma_pma_cov_model_c        cov_model;
+   uvma_pma_mon_trn_logger_c   mon_trn_logger;
+
+   // TLM
+   uvm_analysis_port#(uvma_pma_mon_trn_c )  mon_ap;
+
+
+   `uvm_component_utils_begin(uvma_pma_agent_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_agent", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null
+    * 2. Builds all components
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * 1. Links agent's analysis ports to sub-components'
+    * 2. Connects coverage models and loggers
+    */
+   extern virtual function void connect_phase(uvm_phase phase);
+
+   /**
+    * Uses uvm_config_db to retrieve cfg and hand out to sub-components.
+    */
+   extern function void get_and_set_cfg();
+
+   /**
+    * Uses uvm_config_db to retrieve cntxt and hand out to sub-components.
+    */
+   extern function void get_and_set_cntxt();
+
+   /**
+    * Creates sub-components.
+    */
+   extern function void create_components();
+
+   /**
+    * Connects agent's TLM ports to driver's and monitor's.
+    */
+   extern function void connect_analysis_ports();
+
+   /**
+    * Connects coverage model to monitor and driver's analysis ports.
+    */
+   extern function void connect_cov_model();
+
+   /**
+    * Connects transaction loggers to monitor and driver's analysis ports.
+    */
+   extern function void connect_trn_loggers();
+
+endclass : uvma_pma_agent_c
+
+
+function uvma_pma_agent_c::new(string name="uvma_pma_agent", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_agent_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   get_and_set_cfg  ();
+   get_and_set_cntxt();
+   create_components();
+
+endfunction : build_phase
+
+
+function void uvma_pma_agent_c::connect_phase(uvm_phase phase);
+
+   super.connect_phase(phase);
+
+   connect_analysis_ports      ();
+
+   if (cfg.cov_model_enabled) begin
+      connect_cov_model();
+   end
+   if (cfg.trn_log_enabled) begin
+      connect_trn_loggers();
+   end
+
+endfunction: connect_phase
+
+
+function void uvma_pma_agent_c::get_and_set_cfg();
+
+   void'(uvm_config_db#(uvma_pma_cfg_c#(ILEN,XLEN))::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+   else begin
+      `uvm_info("CFG", $sformatf("Found configuration handle:\n%s", cfg.sprint()), UVM_DEBUG)
+      uvm_config_db#(uvma_pma_cfg_c#(ILEN,XLEN))::set(this, "*", "cfg", cfg);
+   end
+
+endfunction : get_and_set_cfg
+
+function void uvma_pma_agent_c::get_and_set_cntxt();
+
+   void'(uvm_config_db#(uvma_pma_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_info("CNTXT", "Context handle is null; creating.", UVM_DEBUG)
+      cntxt = uvma_pma_cntxt_c::type_id::create("cntxt");
+   end
+   uvm_config_db#(uvma_pma_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+endfunction : get_and_set_cntxt
+
+function void uvma_pma_agent_c::create_components();
+
+   monitor         = uvma_pma_mon_c#(ILEN,XLEN)           ::type_id::create("monitor"        , this);
+   scoreboard      = uvma_pma_sb_c#(ILEN,XLEN)            ::type_id::create("scoreboard"     , this);
+   cov_model       = uvma_pma_cov_model_c                 ::type_id::create("cov_model"      , this);
+   mon_trn_logger  = uvma_pma_mon_trn_logger_c#(ILEN,XLEN)::type_id::create("mon_trn_logger" , this);
+
+endfunction : create_components
+
+
+function void uvma_pma_agent_c::connect_analysis_ports();
+
+   mon_ap = monitor.ap;
+
+endfunction : connect_analysis_ports
+
+
+function void uvma_pma_agent_c::connect_cov_model();
+
+   mon_ap.connect(cov_model.mon_trn_fifo .analysis_export);
+
+endfunction : connect_cov_model
+
+
+function void uvma_pma_agent_c::connect_trn_loggers();
+
+   mon_ap.connect(mon_trn_logger .analysis_export);
+
+endfunction : connect_trn_loggers
+
+
+`endif // __UVMA_PMA_AGENT_SV__

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
@@ -28,6 +28,7 @@ class uvma_pma_agent_c#(int ILEN=DEFAULT_ILEN,
    uvma_pma_mon_c#(ILEN,XLEN)  monitor;
    uvma_pma_sb_c               scoreboard;
    uvma_pma_cov_model_c        cov_model;
+   uvma_pma_region_cov_model_c region_cov_model[];
    uvma_pma_mon_trn_logger_c   mon_trn_logger;
 
    // TLM
@@ -153,6 +154,11 @@ function void uvma_pma_agent_c::create_components();
    monitor         = uvma_pma_mon_c#(ILEN,XLEN)           ::type_id::create("monitor"        , this);
    scoreboard      = uvma_pma_sb_c#(ILEN,XLEN)            ::type_id::create("scoreboard"     , this);
    cov_model       = uvma_pma_cov_model_c                 ::type_id::create("cov_model"      , this);
+   region_cov_model = new[cfg.regions.size()];
+   foreach (region_cov_model[i]) begin
+      region_cov_model[i] = uvma_pma_region_cov_model_c   ::type_id::create($sformatf("region_cov_model%0d", i), this);
+      region_cov_model[i].region_index = i;
+   end
    mon_trn_logger  = uvma_pma_mon_trn_logger_c#(ILEN,XLEN)::type_id::create("mon_trn_logger" , this);
 
 endfunction : create_components
@@ -167,7 +173,10 @@ endfunction : connect_analysis_ports
 
 function void uvma_pma_agent_c::connect_cov_model();
 
-   mon_ap.connect(cov_model.mon_trn_fifo .analysis_export);
+   mon_ap.connect(cov_model.mon_trn_fifo.analysis_export);
+   foreach (region_cov_model[i]) begin
+      mon_ap.connect(region_cov_model[i].mon_trn_fifo.analysis_export);
+   end
 
 endfunction : connect_cov_model
 

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_cov_model.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_cov_model.sv
@@ -1,0 +1,224 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_COV_MODEL_SV__
+`define __UVMA_PMA_COV_MODEL_SV__
+
+covergroup cg_pma_access(
+   string name,
+   int unsigned max_pma_regions
+) with function sample(uvma_pma_mon_trn_c           trn,
+                       uvma_core_cntrl_pma_region_c pma_region);
+   option.name = name;
+   `per_instance_fcov
+
+   cp_index: coverpoint (trn.region_index) {
+      bins INDEX[] = {[0:max_pma_regions-1]};
+   }
+
+   cp_main: coverpoint (pma_region.main) {
+      bins IO   = {0};
+      bins MAIN = {1};
+   }
+
+   cp_bufferable: coverpoint (pma_region.bufferable) {
+      bins NONBUF = {0};
+      bins BUF    = {1};
+   }
+
+   cp_cacheable: coverpoint (pma_region.cacheable) {
+      bins NONCACHE = {0};
+      bins CACHE    = {1};
+   }
+
+   cp_atomic: coverpoint (pma_region.atomic) {
+      bins NONATOMIC = {0};
+      bins ATOMIC    = {1};
+   }
+
+   cp_access: coverpoint(trn.access) {
+      bins INSTR = {UVMA_PMA_ACCESS_INSTR};
+      bins DATA  = {UVMA_PMA_ACCESS_DATA};
+   }
+
+   cp_rw: coverpoint(trn.rw) {
+      bins READ  = {UVMA_PMA_RW_READ};
+      bins WRITE = {UVMA_PMA_RW_WRITE};
+   }
+
+   cross_pma: cross cp_index, cp_main, cp_bufferable, cp_cacheable, cp_atomic, cp_access, cp_rw {
+      ignore_bins IGN_INSTR_WRITE = binsof(cp_rw) intersect {UVMA_PMA_RW_WRITE} &&
+                                    binsof(cp_access) intersect {UVMA_PMA_ACCESS_INSTR};
+      ignore_bins IGN_INSTR_IO = binsof(cp_main) intersect {0} &&
+                                 binsof(cp_access) intersect {UVMA_PMA_ACCESS_INSTR};
+   }
+
+endgroup :  cg_pma_access
+
+covergroup cg_pma_default_access(
+   string name
+) with function sample(uvma_pma_mon_trn_c           trn);
+   option.name = name;
+   `per_instance_fcov
+
+   cp_access: coverpoint(trn.access) {
+      bins INSTR = {UVMA_PMA_ACCESS_INSTR};
+      bins DATA  = {UVMA_PMA_ACCESS_DATA};
+   }
+
+   cp_rw: coverpoint(trn.rw) {
+      bins READ  = {UVMA_PMA_RW_READ};
+      bins WRITE = {UVMA_PMA_RW_WRITE};
+   }
+
+   cross_pma: cross cp_access, cp_rw {
+      ignore_bins IGN_INSTR_WRITE = binsof(cp_rw) intersect {UVMA_PMA_RW_WRITE} &&
+                                    binsof(cp_access) intersect {UVMA_PMA_ACCESS_INSTR};
+   }
+
+endgroup :  cg_pma_default_access
+
+covergroup cg_pma_deconfigured_access(
+   string name
+) with function sample(uvma_pma_mon_trn_c           trn);
+   option.name = name;
+   `per_instance_fcov
+
+   cp_access: coverpoint(trn.access) {
+      bins INSTR = {UVMA_PMA_ACCESS_INSTR};
+      bins DATA  = {UVMA_PMA_ACCESS_DATA};
+   }
+
+   cp_rw: coverpoint(trn.rw) {
+      bins READ  = {UVMA_PMA_RW_READ};
+      bins WRITE = {UVMA_PMA_RW_WRITE};
+   }
+
+   cross_pma: cross cp_access, cp_rw {
+      ignore_bins IGN_INSTR_WRITE = binsof(cp_rw) intersect {UVMA_PMA_RW_WRITE} &&
+                                    binsof(cp_access) intersect {UVMA_PMA_ACCESS_INSTR};
+   }
+
+endgroup :  cg_pma_deconfigured_access
+
+/**
+ * Component encapsulating PMA agent for OpenHW Group CORE-V verification testbenches functional coverage model.
+ */
+class uvma_pma_cov_model_c extends uvm_component;
+
+   // Objects
+   uvma_pma_cfg_c       cfg;
+   uvma_pma_mon_trn_c   mon_trn;
+
+   // TLM
+   uvm_tlm_analysis_fifo#(uvma_pma_mon_trn_c)  mon_trn_fifo;
+
+   // Covergroups
+   cg_pma_access              pma_access_covg;
+   cg_pma_default_access      pma_default_access_covg;
+   cg_pma_deconfigured_access pma_deconfigured_access_covg;
+
+   `uvm_component_utils_begin(uvma_pma_cov_model_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_cov_model", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg handle is not null.
+    * 2. Builds fifos.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Forks all sampling loops
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * TODO Describe uvma_pma_cov_model_c::sample_mon_trn()
+    */
+   extern function void sample_mon_trn();
+
+endclass : uvma_pma_cov_model_c
+
+
+function uvma_pma_cov_model_c::new(string name="uvma_pma_cov_model", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_cov_model_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_pma_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   if (cfg.trn_log_enabled && cfg.cov_model_enabled) begin
+      if (cfg.regions.size()) begin
+         pma_access_covg = new("pma_access_covg", cfg.regions.size());
+         pma_default_access_covg = new("pma_default_access_covg");
+      end
+      else begin
+         pma_deconfigured_access_covg = new("pma_deconfigured_access_covg");
+      end
+   end
+
+   mon_trn_fifo  = new("mon_trn_fifo" , this);
+
+endfunction : build_phase
+
+
+task uvma_pma_cov_model_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+   fork
+      // Monitor transactions
+      forever begin
+         mon_trn_fifo.get(mon_trn);
+         if (cfg.enabled && cfg.cov_model_enabled) begin
+            sample_mon_trn();
+         end
+      end
+
+   join_none
+
+endtask : run_phase
+
+
+function void uvma_pma_cov_model_c::sample_mon_trn();
+
+   if (mon_trn.is_default) begin
+      if (cfg.regions.size() == 0) begin
+         pma_deconfigured_access_covg.sample(mon_trn);
+      end
+      else begin
+         pma_default_access_covg.sample(mon_trn);
+      end
+   end
+   else if (mon_trn.region_index != -1) begin
+      pma_access_covg.sample(mon_trn, cfg.regions[mon_trn.region_index]);
+   end
+
+endfunction : sample_mon_trn
+
+
+`endif // __UVMA_PMA_COV_MODEL_SV__
+

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_mon.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_mon.sv
@@ -1,0 +1,143 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_MON_SV__
+`define __UVMA_PMA_MON_SV__
+
+/**
+ * Component sampling transactions from a Memory attribution agent for OpenHW Group CORE-V verification testbenches virtual interface (uvma_pma_if).
+ */
+class uvma_pma_mon_c#(int ILEN=DEFAULT_ILEN,
+                      int XLEN=DEFAULT_XLEN) extends uvm_monitor;
+
+   // Objects
+   uvma_pma_cfg_c    cfg;
+
+   // TLM ports
+   uvm_analysis_port#(uvma_pma_mon_trn_c)  ap;
+
+   // TLM exports
+   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_pma_mon_c) rvfi_instr_export;
+   uvm_analysis_imp_obi_d#(uvma_obi_memory_mon_trn_c, uvma_pma_mon_c)                   obi_d_export;
+
+   `uvm_component_param_utils_begin(uvma_pma_mon_c#(ILEN,XLEN))
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_mon", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg handle is not null.
+    * 2. Builds ap.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Oversees monitoring, depending on the reset state, by calling mon_<pre|in|post>_reset() tasks.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * RVFI instructions
+    */
+   extern virtual function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+   /**
+    * OBI data
+    */
+   extern virtual function void write_obi_d(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Appends cfg, prints out trn and issues heartbeat.
+    */
+   extern virtual function void process_trn(ref uvma_pma_mon_trn_c trn);
+
+endclass : uvma_pma_mon_c
+
+
+function uvma_pma_mon_c::new(string name="uvma_pma_mon", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_mon_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_pma_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   ap = new("ap", this);
+
+   rvfi_instr_export = new("rvfi_instr_export", this);
+   obi_d_export      = new("obi_d_export", this);
+
+endfunction : build_phase
+
+task uvma_pma_mon_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+endtask : run_phase
+
+function void uvma_pma_mon_c::process_trn(ref uvma_pma_mon_trn_c trn);
+
+   trn.cfg = cfg;
+   trn.__originator = get_full_name();
+   `uvm_info("${name_uppecase}_MON", $sformatf("Sampled transaction from the virtual interface:\n%s", trn.sprint()), UVM_HIGH)
+   `uvml_hrtbt()
+
+endfunction : process_trn
+
+function void uvma_pma_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+   // Create a new monitor transaction with mapped index region
+   uvma_pma_mon_trn_c mon_trn;
+
+   mon_trn              = uvma_pma_mon_trn_c#(ILEN,XLEN)::type_id::create("mon_trn");
+   process_trn(mon_trn);
+   mon_trn.access       = UVMA_PMA_ACCESS_INSTR;
+   mon_trn.rw           = UVMA_PMA_RW_READ;
+   mon_trn.region_index = cfg.get_pma_region_for_addr(instr.pc_rdata);
+   if (mon_trn.region_index == -1 && cfg.regions.size() == 0) begin
+      mon_trn.is_default = 1;
+   end
+
+   ap.write(mon_trn);
+
+endfunction : write_rvfi_instr
+
+function void uvma_pma_mon_c::write_obi_d(uvma_obi_memory_mon_trn_c obi);
+
+   // Create a new monitor transaction with mapped index region
+   uvma_pma_mon_trn_c mon_trn;
+
+   mon_trn              = uvma_pma_mon_trn_c#(ILEN,XLEN)::type_id::create("mon_trn");
+   process_trn(mon_trn);
+   mon_trn.access       = UVMA_PMA_ACCESS_DATA;
+   mon_trn.rw           = (obi.access_type == UVMA_OBI_MEMORY_ACCESS_READ) ? UVMA_PMA_RW_READ : UVMA_PMA_RW_WRITE;
+   mon_trn.region_index = cfg.get_pma_region_for_addr(obi.address);
+   if (mon_trn.region_index == -1) begin
+      mon_trn.is_default = 1;
+   end
+
+   ap.write(mon_trn);
+
+endfunction : write_obi_d
+
+`endif // __UVMA_PMA_MON_SV__

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_mon_trn_logger.sv
@@ -1,0 +1,71 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_MON_TRN_LOGGER_SV__
+`define __UVMA_PMA_MON_TRN_LOGGER_SV__
+
+
+/**
+ * Component writing Memory attribution agent for OpenHW Group CORE-V verification testbenches monitor transactions debug data to disk as plain text.
+ */
+class uvma_pma_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
+                                 int XLEN=DEFAULT_XLEN)  extends uvml_logs_mon_trn_logger_c#(
+   .T_TRN  (uvma_pma_mon_trn_c),
+   .T_CFG  (uvma_pma_cfg_c    ),
+   .T_CNTXT(uvma_pma_cntxt_c  )
+);
+
+   `uvm_component_utils(uvma_pma_mon_trn_logger_c)
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_mon_trn_logger", uvm_component parent=null);
+
+   /**
+    * Writes contents of t to disk
+    */
+   extern virtual function void write(uvma_pma_mon_trn_c t);
+
+   /**
+    * Writes log header to disk
+    */
+   extern virtual function void print_header();
+
+endclass : uvma_pma_mon_trn_logger_c
+
+
+function uvma_pma_mon_trn_logger_c::new(string name="uvma_pma_mon_trn_logger", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_mon_trn_logger_c::write(uvma_pma_mon_trn_c t);
+
+   // TODO Implement uvma_pma_mon_trn_logger_c::write()
+   // Ex: fwrite($sformatf(" %t | %08h | %02b | %04d | %02h |", $realtime(), t.a, t.b, t.c, t.d));
+
+endfunction : write
+
+
+function void uvma_pma_mon_trn_logger_c::print_header();
+
+   // TODO Implement uvma_pma_mon_trn_logger_c::print_header()
+   // Ex: fwrite("----------------------------------------------");
+   //     fwrite(" TIME | FIELD A | FIELD B | FIELD C | FIELD D ");
+   //     fwrite("----------------------------------------------");
+
+endfunction : print_header
+
+
+`endif // __UVMA_PMA_MON_TRN_LOGGER_SV__

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_sb.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_sb.sv
@@ -1,0 +1,379 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_SB_SV__
+`define __UVMA_PMA_SB_SV__
+
+/**
+ * Component sampling transactions from a Memory attribution agent for OpenHW Group CORE-V verification testbenches virtual interface (uvma_pma_if).
+ */
+class uvma_pma_sb_c#(int ILEN=DEFAULT_ILEN,
+                     int XLEN=DEFAULT_XLEN) extends uvm_component;
+
+   // Objects
+   uvma_pma_cfg_c    cfg;
+
+   // Counters
+   int unsigned obi_i_checked_cnt;
+   int unsigned obi_d_checked_cnt;
+
+   // TLM exports
+   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_pma_sb_c)  rvfi_instr_export;
+   uvm_analysis_imp_obi_i#(uvma_obi_memory_mon_trn_c, uvma_pma_sb_c)                    obi_i_export;
+   uvm_analysis_imp_obi_d#(uvma_obi_memory_mon_trn_c, uvma_pma_sb_c)                    obi_d_export;
+
+   `uvm_component_param_utils_begin(uvma_pma_sb_c#(ILEN,XLEN))
+      `uvm_field_object(cfg           , UVM_DEFAULT)
+      `uvm_field_int(obi_i_checked_cnt, UVM_DEFAULT)
+      `uvm_field_int(obi_d_checked_cnt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_sb", uvm_component parent=null);
+
+   /**
+    * Ensures cfg handle is not null.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Oversees monitoring, depending on the reset state, by calling mon_<pre|in|post>_reset() tasks.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Report stats from checker
+    */
+   extern virtual function void report_phase(uvm_phase phase);
+
+   /**
+    * Print out checked counters when aborting test due to fatal or too many errors
+    */
+   extern function void pre_abort();
+
+   /**
+    * RVFI instructions
+    */
+   extern virtual function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+   /**
+    * OBI instruction
+    */
+   extern virtual function void write_obi_i(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * OBI data
+    */
+   extern virtual function void write_obi_d(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Check an OBI instruction fetch for a deconfigured PMA region (PMA disabled)
+    */
+   extern virtual function void check_obi_i_deconfigured(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Check an OBI instruction fetch for a mappped region
+    */
+   extern virtual function void check_obi_i_mapped_region(uvma_obi_memory_mon_trn_c obi, int index);
+
+   /**
+    * Check an OBI instruction fetch for a default PMA region (PMA enabled, but address does not map to any region)
+    */
+   extern virtual function void check_obi_i_default_region(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Check an OBI data accessfor a deconfigured PMA region (PMA disabled)
+    */
+   extern virtual function void check_obi_d_deconfigured(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Check an OBI data access for a mappped region
+    */
+   extern virtual function void check_obi_d_mapped_region(uvma_obi_memory_mon_trn_c obi, int index);
+
+   /**
+    * Check an OBI data access for a default PMA region (PMA enabled, but address does not map to any region)
+    */
+   extern virtual function void check_obi_d_default_region(uvma_obi_memory_mon_trn_c obi);
+
+   /**
+    * Common print report state
+    */
+   extern virtual function void print_checked_stats();
+
+endclass : uvma_pma_sb_c
+
+
+function uvma_pma_sb_c::new(string name="uvma_pma_sb", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_sb_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_pma_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   rvfi_instr_export = new("rvfi_instr_export", this);
+   obi_i_export      = new("obi_i_export",      this);
+   obi_d_export      = new("obi_d_export",      this);
+endfunction : build_phase
+
+task uvma_pma_sb_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+endtask : run_phase
+
+function void uvma_pma_sb_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+endfunction : write_rvfi_instr
+
+
+function void uvma_pma_sb_c::write_obi_i(uvma_obi_memory_mon_trn_c obi);
+
+   int index;
+
+   // If scoreboard not enabled, then bail out
+   if (!cfg.scoreboard_enabled)
+      return;
+
+   // Will check this OBI
+   obi_i_checked_cnt++;
+
+   // If deconfigured then check directly
+   if (cfg.regions.size() == 0) begin
+      check_obi_i_deconfigured(obi);
+
+      return;
+   end
+
+   // Get expected index of the OBI transaction
+   index = cfg.get_pma_region_for_addr(obi.address);
+
+   // If the region does not map, then we are in the default OBI region
+   if (index == -1) begin
+      check_obi_i_default_region(obi);
+
+      return;
+   end
+
+   check_obi_i_mapped_region(obi, index);
+
+endfunction : write_obi_i
+
+function void uvma_pma_sb_c::write_obi_d(uvma_obi_memory_mon_trn_c obi);
+
+   int index;
+
+   // If scoreboard not enabled, then bail out
+   if (!cfg.scoreboard_enabled)
+      return;
+
+   obi_d_checked_cnt++;
+
+   // If deconfigured then check directly
+   if (cfg.regions.size() == 0) begin
+      check_obi_d_deconfigured(obi);
+
+      return;
+   end
+
+   // Get expected index of the OBI transaction
+   index = cfg.get_pma_region_for_addr(obi.address);
+
+   // If the region does not map, then we are in the default OBI region
+   if (index == -1) begin
+      check_obi_d_default_region(obi);
+
+      return;
+   end
+
+   check_obi_d_mapped_region(obi, index);
+
+endfunction : write_obi_d
+
+function void uvma_pma_sb_c::report_phase(uvm_phase phase);
+
+   print_checked_stats();
+
+endfunction : report_phase
+
+function void uvma_pma_sb_c::pre_abort();
+
+   print_checked_stats();
+
+endfunction : pre_abort
+
+function void uvma_pma_sb_c::print_checked_stats();
+
+   `uvm_info("PMASB", $sformatf("checked %0d OBI I transactions", obi_i_checked_cnt), UVM_NONE);
+   `uvm_info("PMASB", $sformatf("checked %0d OBI D transactions", obi_d_checked_cnt), UVM_NONE);
+
+endfunction : print_checked_stats
+
+function void uvma_pma_sb_c::check_obi_i_deconfigured(uvma_obi_memory_mon_trn_c obi);
+
+   // Check: Bufferable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT]) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x bufferable bit set for deconfigured PMA",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: Cacheable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT]) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x cacheable bit set for deconfigured PMA",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: atomic attributes should be 0
+   if (obi.atop) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x atop is not zero, OBI: 0x%0x",
+                                       obi.access_type.name(), obi.address,
+                                       obi.atop));
+   end
+
+endfunction : check_obi_i_deconfigured
+
+function void uvma_pma_sb_c::check_obi_i_default_region(uvma_obi_memory_mon_trn_c obi);
+
+   // Check: Bufferable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT]) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x bufferable bit set for PMA default region",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: Cacheable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT]) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x cacheable bit set for PMA default region",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: atomic attributes should be 0
+   if (obi.atop) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x atop is not zero, OBI: 0x%0x",
+                                       obi.access_type.name(), obi.address,
+                                       obi.atop));
+   end
+
+endfunction : check_obi_i_default_region
+
+function void uvma_pma_sb_c::check_obi_i_mapped_region(uvma_obi_memory_mon_trn_c obi, int index);
+
+   // Check: Must be main memory
+   if (!cfg.regions[index].main) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x, region: %0d instruction fetch from I/O memory",
+                                       obi.access_type.name(), obi.address, index));
+   end
+
+   // Check: Bufferable bit must be 0 in OBI
+   //FIXME:strichmo:Will change PMA design to adhere to this
+   // if (obi.memtype[0]) begin
+   //    `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x bufferable bit set for instruction",
+   //                                     obi.access_type.name(), obi.address));
+   // end
+
+   // Check: Cacheable bit must match mem_type[0] in OBI
+   if (obi.memtype[1] != cfg.regions[index].cacheable) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x, region: %0d cacheable bit mismatch, OBI: %0d, PMA: %0d",
+                                       obi.access_type.name(), obi.address, index,
+                                       obi.memtype[1], cfg.regions[index].cacheable));
+   end
+
+   // Check: atomic attributes should be 0
+   if (obi.atop) begin
+      `uvm_error("PMAOBII", $sformatf("OBI I %s address: 0x%08x, region: %0d atop is not zero, OBI: 0x%0x",
+                                       obi.access_type.name(), obi.address, index,
+                                       obi.atop));
+   end
+
+endfunction : check_obi_i_mapped_region
+
+function void uvma_pma_sb_c::check_obi_d_deconfigured(uvma_obi_memory_mon_trn_c obi);
+
+   // Check: Bufferable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT]) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x bufferable bit set for deconfigured PMA",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: Cacheable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT]) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x cacheable bit set for deconfigured PMA",
+                                       obi.access_type.name(), obi.address));
+   end
+
+endfunction : check_obi_d_deconfigured
+
+function void uvma_pma_sb_c::check_obi_d_default_region(uvma_obi_memory_mon_trn_c obi);
+
+   // Check: Bufferable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT]) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x bufferable bit set for PMA default region",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: Cacheable bit must be 0 in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT]) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x cacheable bit set for PMA default region",
+                                       obi.access_type.name(), obi.address));
+   end
+
+   // Check: atomic attributes should be 0
+   if (obi.atop) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x atop is not zero for PMA default region, OBI: 0x%0x",
+                                       obi.access_type.name(), obi.address,
+                                       obi.atop));
+   end
+
+endfunction : check_obi_d_default_region
+
+
+function void uvma_pma_sb_c::check_obi_d_mapped_region(uvma_obi_memory_mon_trn_c obi, int index);
+
+   // Check: Must be main memory
+   if (!cfg.regions[index].main) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x, region: %0d  instruction fetch from I/O memory",
+                                       obi.access_type.name(), obi.address, index));
+   end
+
+   // Check: Cacheable bit must match mem_type[0] in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT] != cfg.regions[index].bufferable) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x, region: %0d bufferable bit mismatch, OBI: %0d, PMA: %0d",
+                                       obi.access_type.name(), obi.address, index,
+                                       obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_BUFFERABLE_BIT], cfg.regions[index].bufferable));
+   end
+
+   // Check: Cacheable bit must match mem_type[0] in OBI
+   if (obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT] != cfg.regions[index].cacheable) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x, region: %0d cacheable bit mismatch, OBI: %0d, PMA: %0d",
+                                       obi.access_type.name(), obi.address, index,
+                                       obi.memtype[UVMA_OBI_MEMORY_MEMTYPE_CACHEABLE_BIT], cfg.regions[index].cacheable));
+   end
+
+   // Check: atomic attributes should be 0
+   if (obi.atop) begin
+      `uvm_error("PMAOBID", $sformatf("OBI D %s address: 0x%08x, region: %0d atop is not zero, OBI: 0x%0x",
+                                       obi.access_type.name(), obi.address, index,
+                                       obi.atop));
+   end
+
+endfunction : check_obi_d_mapped_region
+
+`endif // __UVMA_PMA_SB_SV__

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
@@ -1,0 +1,88 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_CFG_SV__
+`define __UVMA_PMA_CFG_SV__
+
+
+/**
+ * Object encapsulating all parameters for creating, connecting and running all Memory attribution agent for OpenHW Group CORE-V verification testbenches agent (uvma_pma_agent_c) components.
+ */
+class uvma_pma_cfg_c#(int ILEN=DEFAULT_ILEN,
+                      int XLEN=DEFAULT_XLEN) extends uvm_object;
+
+   // Generic options
+   rand bit                      enabled;
+   rand uvm_active_passive_enum  is_active;
+   rand uvm_sequencer_arb_mode   sqr_arb_mode;
+   rand bit                      scoreboard_enabled;
+   rand bit                      cov_model_enabled;
+   rand bit                      trn_log_enabled;
+
+   // PMA regions
+   uvma_core_cntrl_pma_region_c  regions[];
+
+   `uvm_object_param_utils_begin(uvma_pma_cfg_c#(ILEN,XLEN))
+      `uvm_field_int (                         enabled           , UVM_DEFAULT)
+      `uvm_field_enum(uvm_active_passive_enum, is_active         , UVM_DEFAULT)
+      `uvm_field_int (                         scoreboard_enabled, UVM_DEFAULT)
+      `uvm_field_int (                         cov_model_enabled , UVM_DEFAULT)
+      `uvm_field_int (                         trn_log_enabled   , UVM_DEFAULT)
+      `uvm_field_array_object(                 regions           , UVM_DEFAULT)
+   `uvm_object_utils_end
+
+
+   constraint only_passive_cons {
+      is_active              == UVM_PASSIVE;
+   }
+
+   constraint defaults_cons {
+      soft enabled            == 1;
+      soft cov_model_enabled  == 0;
+      soft scoreboard_enabled == 1;
+      soft trn_log_enabled    == 1;
+   }
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_cfg");
+
+   /**
+    * Return PMA region index for address, returns -1 if not mapped
+    */
+   extern virtual function int get_pma_region_for_addr(bit [XLEN-1:0] addr);
+
+endclass : uvma_pma_cfg_c
+
+
+function uvma_pma_cfg_c::new(string name="uvma_pma_cfg");
+
+   super.new(name);
+
+endfunction : new
+
+
+function int uvma_pma_cfg_c::get_pma_region_for_addr(bit[XLEN-1:0] addr);
+
+   // In default PMA configurations overlapping regions map from low index to high
+   for (int i = 0; i < regions.size(); i++) begin
+      if (regions[i].is_addr_in_region(addr))
+         return i;
+   end
+
+   return -1;
+
+endfunction : get_pma_region_for_addr
+
+
+`endif // __UVMA_PMA_CFG_SV__

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cntxt.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cntxt.sv
@@ -1,0 +1,50 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_PMA_CNTXT_SV__
+`define __UVMA_PMA_CNTXT_SV__
+
+/**
+ * Object encapsulating all state variables for all PMA agent
+ * (uvma_pma_agent_c) components.
+ *
+ * Note that the PMA Agent does not have a signal interface however the cntxt
+ * is included to satisfy the base classes for uvma agents in core-v-verif
+ */
+class uvma_pma_cntxt_c extends uvm_object;
+
+   `uvm_object_utils_begin(uvma_pma_cntxt_c)
+   `uvm_object_utils_end
+
+   extern function new(string name="uvma_pma_cntxt");
+
+endclass : uvma_pma_cntxt_c
+
+
+`pragma protect begin
+
+
+function uvma_pma_cntxt_c::new(string name="uvma_pma_cntxt");
+
+   super.new(name);
+
+endfunction : new
+
+`pragma protect end
+
+
+`endif // __UVMA_PMA_CNTXT_SV__

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_mon_trn.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_mon_trn.sv
@@ -1,0 +1,62 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_MON_TRN_SV__
+`define __UVMA_PMA_MON_TRN_SV__
+
+
+/**
+ * Object rebuilt from the Memory attribution agent for OpenHW Group CORE-V verification testbenches monitor.  Analog of uvma_pma_seq_item_c.
+ */
+class uvma_pma_mon_trn_c#(int ILEN=DEFAULT_ILEN,
+                          int XLEN=DEFAULT_XLEN) extends uvml_trn_mon_trn_c;
+
+   // Metadata
+   uvma_pma_cfg_c#(ILEN,XLEN)  cfg;
+
+   // PMA region index
+   int unsigned region_index;
+
+   // Alternatively set the default region if the address does not map into
+   // any PMA region
+   // Note that this means it is either mppping to a deconfigured PMA (cfg.regions.size() == 0)
+   // or the default PMA region (cfg.regions.size() != 0)
+   bit is_default;
+
+   // Access type (instruction or data)
+   uvma_pma_access_enum access;
+
+   // Read or write
+   uvma_pma_rw_enum rw;
+
+   `uvm_object_param_utils_begin(uvma_pma_mon_trn_c#(ILEN,XLEN))
+      `uvm_field_int(                       region_index, UVM_DEFAULT)
+      `uvm_field_int(                       is_default,   UVM_DEFAULT)
+      `uvm_field_enum(uvma_pma_access_enum, access,       UVM_DEFAULT)
+      `uvm_field_enum(uvma_pma_rw_enum,     rw,           UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_pma_mon_trn");
+
+endclass : uvma_pma_mon_trn_c
+
+
+function uvma_pma_mon_trn_c::new(string name="uvma_pma_mon_trn");
+
+   super.new(name);
+
+endfunction : new
+
+
+`endif // __UVMA_PMA_MON_TRN_SV__

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_constants.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_constants.sv
@@ -1,0 +1,19 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_CONSTANTS_SV__
+`define __UVMA_PMA_CONSTANTS_SV__
+
+
+localparam DEFAULT_ILEN     = 32;
+localparam DEFAULT_XLEN     = 32;
+
+`endif // __UVMA_PMA_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_macros.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_macros.sv
@@ -1,0 +1,19 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_MACROS_SV__
+`define __UVMA_PMA_MACROS_SV__
+
+`define per_instance_fcov `ifndef DSIM option.per_instance = 1; `endif
+
+
+
+`endif // __UVMA_PMA_MACROS_SV__

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.flist
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.flist
@@ -1,0 +1,18 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+// Directories
++incdir+${DV_UVMA_PMA_PATH}/src
++incdir+${DV_UVMA_PMA_PATH}/src/comps
++incdir+${DV_UVMA_PMA_PATH}/src/obj
+
+// Files
+${DV_UVMA_PMA_PATH}/src/uvma_pma_pkg.sv

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
@@ -1,0 +1,60 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_PKG_SV__
+`define __UVMA_PMA_PKG_SV__
+
+
+// Pre-processor macros
+`include "uvm_macros.svh"
+`include "uvml_hrtbt_macros.sv"
+`include "uvma_pma_macros.sv"
+
+
+/**
+ * Encapsulates all the types needed for an UVM agent capable of driving and/or monitoring Memory attribution agent for OpenHW Group CORE-V verification testbenches.
+ */
+package uvma_pma_pkg;
+
+   import uvm_pkg            ::*;
+   import uvml_hrtbt_pkg     ::*;
+   import uvml_trn_pkg       ::*;
+   import uvml_logs_pkg      ::*;
+   import uvma_core_cntrl_pkg::*;
+   import uvma_obi_memory_pkg::*;
+   import uvma_rvfi_pkg      ::*;
+
+   `uvm_analysis_imp_decl(_rvfi_instr)
+   `uvm_analysis_imp_decl(_obi_i)
+   `uvm_analysis_imp_decl(_obi_d)
+
+   // Constants / Structs / Enums
+   `include "uvma_pma_constants.sv"
+   `include "uvma_pma_tdefs.sv"
+
+   // Objects
+   `include "uvma_pma_cfg.sv"
+   `include "uvma_pma_cntxt.sv"
+
+   // High-level transactions
+   `include "uvma_pma_mon_trn.sv"
+   `include "uvma_pma_mon_trn_logger.sv"
+
+   // Agent components
+   `include "uvma_pma_cov_model.sv"
+   `include "uvma_pma_sb.sv"
+   `include "uvma_pma_mon.sv"
+   `include "uvma_pma_agent.sv"
+
+endpackage : uvma_pma_pkg
+
+
+`endif // __UVMA_PMA_PKG_SV__

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
@@ -50,6 +50,7 @@ package uvma_pma_pkg;
 
    // Agent components
    `include "uvma_pma_cov_model.sv"
+   `include "uvma_pma_region_cov_model.sv"
    `include "uvma_pma_sb.sv"
    `include "uvma_pma_mon.sv"
    `include "uvma_pma_agent.sv"

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_tdefs.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_tdefs.sv
@@ -1,0 +1,25 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_TDEFS_SV__
+`define __UVMA_PMA_TDEFS_SV__
+
+typedef enum {
+   UVMA_PMA_ACCESS_INSTR,
+   UVMA_PMA_ACCESS_DATA
+} uvma_pma_access_enum;
+
+typedef enum {
+   UVMA_PMA_RW_WRITE,
+   UVMA_PMA_RW_READ
+} uvma_pma_rw_enum;
+
+`endif // __UVMA_PMA_TDEFS_SV__

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -112,6 +112,7 @@ export DV_UVMA_RVVI_OVPSIM_PATH = $(CORE_V_VERIF)/lib/uvm_agents/uvma_rvvi_ovpsi
 export DV_UVMA_CLKNRST_PATH     = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clknrst
 export DV_UVMA_INTERRUPT_PATH   = $(CORE_V_VERIF)/lib/uvm_agents/uvma_interrupt
 export DV_UVMA_DEBUG_PATH       = $(CORE_V_VERIF)/lib/uvm_agents/uvma_debug
+export DV_UVMA_PMA_PATH         = $(CORE_V_VERIF)/lib/uvm_agents/uvma_pma
 export DV_UVMA_OBI_MEMORY_PATH  = $(CORE_V_VERIF)/lib/uvm_agents/uvma_obi_memory
 export DV_UVMA_FENCEI_PATH      = $(CORE_V_VERIF)/lib/uvm_agents/uvma_fencei
 export DV_UVML_TRN_PATH         = $(CORE_V_VERIF)/lib/uvm_libs/uvml_trn


### PR DESCRIPTION
Integrate a PMA Agent (using the standard templates).  
The PMA agent consists of a monitor, scoreboard and coverage model.  It does not contain a pin interface as it uses the existing core control configuration object to "get" the PMA configuration.
Integrated to the cv32e40x and checking OBI transactions (with some FIXMEs for TBD functionality with respect to OBI I fetches and bufferable bits).
