### PR TITLE
move rvfi into the isacov instr

### DIFF
--- a/cv32e40x/env/uvme/cov/uvme_counters_covg.sv
+++ b/cv32e40x/env/uvme/cov/uvme_counters_covg.sv
@@ -21,12 +21,12 @@ covergroup cg_counters (int num_mhpmcounters)
 
   `per_instance_fcov
 
-  cp_inhibit_mcycle : coverpoint isacov.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[0];
-  cp_inhibit_minstret : coverpoint isacov.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[2];
+  cp_inhibit_mcycle : coverpoint isacov.instr.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[0];
+  cp_inhibit_minstret : coverpoint isacov.instr.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[2];
   cp_is_csr_read : coverpoint (isacov.instr.group == CSR_GROUP) && (isacov.instr.rd != 0) {
     bins is_csr_read = {1};
   }
-  cp_is_dbg_mode : coverpoint isacov.rvfi.dbg_mode {
+  cp_is_dbg_mode : coverpoint isacov.instr.rvfi.dbg_mode {
     bins dbg_mode = {1};
   }
   cp_mcycle : coverpoint (isacov.instr.csr == uvma_isacov_pkg::MCYCLE);
@@ -61,11 +61,11 @@ covergroup cg_mhpm (int idx)
 
   `per_instance_fcov
 
-  cp_inhibit : coverpoint isacov.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[idx] {
+  cp_inhibit : coverpoint isacov.instr.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[idx] {
     bins inhibit = {1};
     bins no_inhibit = {0};
   }
-  cp_event : coverpoint isacov.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
+  cp_event : coverpoint isacov.instr.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
     bins events = {[1:$]};
     bins no_events = {0};
   }
@@ -78,7 +78,7 @@ covergroup cg_mhpm (int idx)
   cp_is_mhpm_idx_h : coverpoint (isacov.instr.csr == (uvma_isacov_pkg::MCYCLEH + idx)) {
     bins mhpm_idx_h = {1};
   }
-  cp_is_dbg_mode : coverpoint isacov.rvfi.dbg_mode {
+  cp_is_dbg_mode : coverpoint isacov.instr.rvfi.dbg_mode {
     bins dbg_mode = {1};
   }
 
@@ -101,15 +101,15 @@ covergroup cg_inhibit_mix (int idx)
 
   `per_instance_fcov
 
-  cp_inhibit_mcycle : coverpoint isacov.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[0];
-  cp_inhibit_minstret : coverpoint isacov.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[2];
+  cp_inhibit_mcycle : coverpoint isacov.instr.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[0];
+  cp_inhibit_minstret : coverpoint isacov.instr.rvfi.csrs["mcountinhibit"].get_csr_retirement_data()[2];
   cp_is_csr_read : coverpoint (isacov.instr.group == CSR_GROUP) && (isacov.instr.rd != 0) {
     bins is_csr_read = {1};
   }
-  cp_is_event_cycles : coverpoint isacov.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
+  cp_is_event_cycles : coverpoint isacov.instr.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
     bins event_cycles = {1};  // selector CYCLES is bit 0
   }
-  cp_is_event_instr : coverpoint isacov.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
+  cp_is_event_instr : coverpoint isacov.instr.rvfi.csrs[$sformatf("mhpmevent%0d", idx)].get_csr_retirement_data() {
     bins event_instr = {2};  // selector INSTR is bit 1
   }
   cp_is_mhpm_idx : coverpoint (isacov.instr.csr == (uvma_isacov_pkg::MCYCLE + idx)) {

--- a/cv32e40x/env/uvme/cov/uvme_exceptions_covg.sv
+++ b/cv32e40x/env/uvme/cov/uvme_exceptions_covg.sv
@@ -21,10 +21,10 @@ covergroup cg_exceptions
 
   `per_instance_fcov
 
-  cp_trap : coverpoint isacov.rvfi.trap {
+  cp_trap : coverpoint isacov.instr.rvfi.trap {
     bins trap = {1};
   }
-  cp_intr : coverpoint isacov.rvfi.intr {
+  cp_intr : coverpoint isacov.instr.rvfi.intr {
     bins intr = {1};
   }
   cp_imm12 : coverpoint isacov.instr.csr_val {
@@ -38,10 +38,10 @@ covergroup cg_exceptions
   cp_is_ebreak : coverpoint (isacov.instr.name inside {EBREAK, C_EBREAK}) {
     bins is_ebreak = {1};
   }
-  cp_no_ebreakm : coverpoint (isacov.rvfi.csrs["dcsr"].get_csr_retirement_data()[15]) {
+  cp_no_ebreakm : coverpoint (isacov.instr.rvfi.csrs["dcsr"].get_csr_retirement_data()[15]) {
     bins no_ebreakm = {0};
   }
-  cp_mcause : coverpoint isacov.rvfi.csrs["mcause"].get_csr_retirement_data() {
+  cp_mcause : coverpoint isacov.instr.rvfi.csrs["mcause"].get_csr_retirement_data() {
     bins reset               = {0};
     bins ins_acc_fault       = {1};
     bins illegal_ins         = {2};
@@ -51,10 +51,10 @@ covergroup cg_exceptions
     bins ecall               = {11};
     bins ins_bus_fault       = {48};
   }
-  cp_pcr_mtvec : coverpoint (isacov.rvfi.pc_rdata[31:2] == isacov.rvfi.csrs["mtvec"].get_csr_retirement_data()[31:2]) {
+  cp_pcr_mtvec : coverpoint (isacov.instr.rvfi.pc_rdata[31:2] == isacov.instr.rvfi.csrs["mtvec"].get_csr_retirement_data()[31:2]) {
     bins one = {1};
   }
-  cp_pcw_mtvec : coverpoint (isacov.rvfi.pc_wdata[31:2] == isacov.rvfi.csrs["mtvec"].get_csr_retirement_data()[31:2]) {
+  cp_pcw_mtvec : coverpoint (isacov.instr.rvfi.pc_wdata[31:2] == isacov.instr.rvfi.csrs["mtvec"].get_csr_retirement_data()[31:2]) {
     bins one = {1};
   }
 

--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -301,7 +301,7 @@ covergroup cg_rtype_lr_w(
     ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
   }
 
-  cp_align_word: coverpoint (instr.mem_addr[1:0]) {
+  cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -355,7 +355,7 @@ covergroup cg_rtype_sc_w (
 
   cross_rs1_rs2_value: cross cp_rs1_value, cp_rs2_value;
 
-  cp_align_word: coverpoint (instr.mem_addr[1:0]) {
+  cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -403,7 +403,7 @@ covergroup cg_rtype_amo (
     ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
   }
 
-  cp_align_word: coverpoint (instr.mem_addr[1:0]) {
+  cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -645,13 +645,13 @@ covergroup cg_itype_load (
   `ISACOV_CP_BITWISE_11_0(cp_imm1_toggle, instr.immi, 1)
   `ISACOV_CP_BITWISE(cp_rd_toggle,   instr.rd_value,  1)
 
-  cp_align_halfword: coverpoint (instr.mem_addr[0]) {
+  cp_align_halfword: coverpoint (instr.rvfi.mem_addr[0]) {
     ignore_bins IGN_OFF = {[0:$]} with (!align_halfword);
     bins ALIGNED  = {0};
     bins UNALIGNED = {1};
   }
 
-  cp_align_word: coverpoint (instr.mem_addr[1:0]) {
+  cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
     ignore_bins IGN_OFF = {[0:$]} with (!align_word);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
@@ -781,13 +781,13 @@ covergroup cg_stype(
   `ISACOV_CP_BITWISE(cp_rs2_toggle, instr.rs2_value, 1)
   `ISACOV_CP_BITWISE_11_0(cp_imms_toggle, instr.imms, 1)
 
-  cp_align_halfword: coverpoint (instr.mem_addr[0]) {
+  cp_align_halfword: coverpoint (instr.rvfi.mem_addr[0]) {
     ignore_bins IGN_OFF = {[0:$]} with (!align_halfword);
     bins ALIGNED  = {0};
     bins UNALIGNED = {1};
   }
 
-  cp_align_word: coverpoint (instr.mem_addr[1:0]) {
+  cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
     ignore_bins IGN_OFF = {[0:$]} with (!align_word);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
@@ -2369,7 +2369,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
 
   logic have_sampled = 0;
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_i_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_i_supported) begin
     have_sampled = 1;
     case (instr.name)
       LUI:   rv32i_lui_cg.sample(instr);
@@ -2425,7 +2425,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_m_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_m_supported) begin
     have_sampled = 1;
     case (instr.name)
       MUL:     rv32m_mul_cg.sample(instr);
@@ -2453,7 +2453,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_c_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_c_supported) begin
     have_sampled = 1;
     case (instr.name)
       C_ADDI:     rv32c_addi_cg.sample(instr);
@@ -2496,7 +2496,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zicsr_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zicsr_supported) begin
     have_sampled = 1;
     case (instr.name)
       CSRRW:   rv32zicsr_csrrw_cg.sample(instr);
@@ -2509,7 +2509,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zifencei_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zifencei_supported) begin
     have_sampled = 1;
     case (instr.name)
       FENCE_I: rv32zifencei_fence_i_cg.sample(instr);
@@ -2517,7 +2517,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_a_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_a_supported) begin
     have_sampled = 1;
     case (instr.name)
       LR_W:      rv32a_lr_w_cg.sample(instr);
@@ -2535,7 +2535,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zba_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zba_supported) begin
     have_sampled = 1;
     case (instr.name)
       SH1ADD:  rv32zba_sh1add_cg.sample(instr);
@@ -2545,7 +2545,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zbb_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zbb_supported) begin
     have_sampled = 1;
     case (instr.name)
       CLZ:     rv32zbb_clz_cg.sample(instr);
@@ -2570,7 +2570,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zbc_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zbc_supported) begin
     have_sampled = 1;
     case (instr.name)
       CLMUL:   rv32zbc_clmul_cg.sample(instr);
@@ -2580,7 +2580,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && cfg.core_cfg.ext_zbs_supported) begin
+  if (!have_sampled && !instr.trap && cfg.core_cfg.ext_zbs_supported) begin
     have_sampled = 1;
     case (instr.name)
       BSET:    rv32zbs_bset_cg.sample(instr);
@@ -2595,7 +2595,7 @@ function void uvma_isacov_cov_model_c::sample (uvma_isacov_instr_c instr);
     endcase
   end
 
-  if (!have_sampled && !instr.illegal && instr.name != UNKNOWN) begin
+  if (!have_sampled && !instr.trap && instr.name != UNKNOWN) begin
     `uvm_error("ISACOV", $sformatf("Could not sample instruction: %s", instr.name.name()));
   end
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon_trn.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon_trn.sv
@@ -16,19 +16,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
 
-class uvma_isacov_mon_trn_c #(int ILEN=DEFAULT_ILEN,
-                              int XLEN=DEFAULT_XLEN) extends uvml_trn_mon_trn_c;
+class uvma_isacov_mon_trn_c#(int ILEN=DEFAULT_ILEN,
+                             int XLEN=DEFAULT_XLEN) extends uvml_trn_mon_trn_c;
 
-  `uvm_object_utils(uvma_isacov_mon_trn_c)
+  `uvm_object_param_utils(uvma_isacov_mon_trn_c)
 
-  uvma_isacov_instr_c instr;
-  uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) rvfi;
+  uvma_isacov_instr_c#(ILEN, XLEN) instr;
 
   extern function new(string name = "uvma_isacov_mon_trn");
 
   extern function string convert2string();
-endclass : uvma_isacov_mon_trn_c
 
+endclass : uvma_isacov_mon_trn_c
 
 function uvma_isacov_mon_trn_c::new(string name = "uvma_isacov_mon_trn");
 
@@ -37,5 +36,7 @@ function uvma_isacov_mon_trn_c::new(string name = "uvma_isacov_mon_trn");
 endfunction : new
 
 function string uvma_isacov_mon_trn_c::convert2string();
+
   return instr.convert2string();
+
 endfunction : convert2string


### PR DESCRIPTION
add trap and illegal concepts into the isacov instr class for better reuse amongst different coverage models

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>