### PR TITLE
cva6_tb.sv: remove .SIM_FINISH as replaced by time_out

### DIFF
--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -36,7 +36,7 @@ export NUM_JOBS=24
 if ! [ -n "$CVA6_REPO" ]; then
   CVA6_REPO="https://github.com/openhwgroup/cva6.git"
   CVA6_BRANCH="master"
-  CVA6_HASH="010eed815bca4ed30a33aa758d0e3333af331eb0"
+  CVA6_HASH="5c5c704d1d14190ec349fae12fe39fbe025456ae"
   CVA6_PATCH=
 fi
 echo $CVA6_REPO

--- a/cva6/tb/core/cva6_tb.sv
+++ b/cva6/tb/core/cva6_tb.sv
@@ -83,7 +83,6 @@ module cva6_core_only_tb #(
   //----------------------------------------------------------------------------
 
   rvfi_tracer  #(
-    .SIM_FINISH(2000000),
     .HART_ID(8'h0),
     .DEBUG_START(0),
     .DEBUG_STOP(0),


### PR DESCRIPTION
use of $plusargs in CVA6 (see 5c5c704d1d14190ec349fae12fe39fbe025456ae)

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>