### PR TITLE
Verissimo waive vendor libs

### DIFF
--- a/vendor_lib/verissimo/waivers.xml
+++ b/vendor_lib/verissimo/waivers.xml
@@ -5,7 +5,7 @@
             <path>*/core-v-cores/*</path>
         </paths>
     </pre-waiver>
-    <pre-waiver apply-on="matched" name="Waive RTL source code">
+    <pre-waiver apply-on="matched" name="Waive third-party API source code">
         <paths regex="simple">
             <path>*/vendor_lib/*</path>
         </paths>


### PR DESCRIPTION
This PR adds another set of Verissimo waivers for all 3rd party vendor libs (including the newly added SVLIB library, imperas, etc).

For this we'll be using pre-waivers, which are faster for this purpose by not analyzing at all the matched paths.

> Pre-waivers are used to exclude from linting, parts of the code by the path or by the element types (modules, interfaces, ...) contained in the files. They are useful for excluding 3rd party IPs or libraries included in the compilation and will reduce the total linting time without affecting the correctness of the results in the non-waived code. Pre-waivers can also be added on a per-check basis inside the ruleset XML file.