### PR TITLE
fix workaround to configure X core for B_EXT

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_dut_wrap.sv
@@ -147,11 +147,9 @@ module uvmt_cv32e40x_dut_wrap
 
     // --------------------------------------------
     // instantiate the core
-    defparam cv32e40x_wrapper_i.core_i.id_stage_i.B_EXT = B_EXT;
     cv32e40x_wrapper #(
                       .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS),
-                      // FIXME:strichmo:restore this when the issue with exposing B_EXT parameter is exposed to cv32e40x_wrapper and cv32e40x_core
-                      //.B_EXT            (B_EXT),
+                      .B_EXT            (B_EXT),
                       .PMA_NUM_REGIONS  (PMA_NUM_REGIONS),
                       .PMA_CFG          (PMA_CFG)
                       )


### PR DESCRIPTION
There was a hack to push B_EXT parameter deeper into the core to mask a parameter hierarchy issue.  The RTL is fixed so this undoes the hack.
