### PR TITLE
fix issue 969 runaway debug tests in e40s

### DIFF
--- a/cv32e40s/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
+++ b/cv32e40s/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
@@ -23,13 +23,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define RND_STALL_REG *(volatile int *)0x1000
+extern volatile uint32_t test_debugger_entry;
 
 #define MACHINE 3
 int main(int argc, char *argv[])
 {
     unsigned int check_reg;
-    check_reg = RND_STALL_REG;
+    check_reg = test_debugger_entry;
 
     printf("Debug reg = %08x\n", check_reg);
     // Debug code will write 0xff to this register

--- a/cv32e40s/tests/programs/custom/debug_test_boot_set/debugger.S
+++ b/cv32e40s/tests/programs/custom/debug_test_boot_set/debugger.S
@@ -25,7 +25,6 @@
 .section .debugger, "ax"
 .global _debugger_start
 .set test_fail, 0x1
-.set test_debugger_entry, 0x1000
 .set test_debugger_ok, 0xa5
 
 _debugger_start:
@@ -39,7 +38,7 @@ _debugger_start:
     // We don't have any globals or pointers
     // at this time, so we must rely on
     // memory (hopefully) not being used
-    li a0, test_debugger_entry
+    la a0, test_debugger_entry
     li t0, test_debugger_ok
     sw t0, 0(a0)
     dret
@@ -49,3 +48,8 @@ _debugger_error:
     li t0, test_fail
     sw t0, 0(a0)
     dret
+
+.section .data
+.global test_debugger_entry
+test_debugger_entry:
+    .word 0

--- a/cv32e40s/tests/programs/custom/debug_test_reset/debug_test_reset.c
+++ b/cv32e40s/tests/programs/custom/debug_test_reset/debug_test_reset.c
@@ -1,19 +1,19 @@
 /*
 **
 ** Copyright 2020 OpenHW Group
-** 
+**
 ** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
 ** You may obtain a copy of the License at
-** 
+**
 **     https://solderpad.org/licenses/
-** 
+**
 ** Unless required by applicable law or agreed to in writing, software
 ** distributed under the License is distributed on an "AS IS" BASIS,
 ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
-** 
+**
 *******************************************************************************
 ** Basic debugger test. Needs more work and bugs fixed
 ** It will launch a debug request and have debugger code execute (debugger.S)
@@ -23,13 +23,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define RND_STALL_REG *(volatile int *)0x1000
+extern volatile uint32_t test_debugger_entry;
 
 #define MACHINE 3
 int main(int argc, char *argv[])
 {
     unsigned int check_reg;
-    check_reg = RND_STALL_REG;
+    check_reg = test_debugger_entry;
 
     printf("Debug reg = %08x\n", check_reg);
     // Debug code will write 0xff to this register

--- a/cv32e40s/tests/programs/custom/debug_test_reset/debugger.S
+++ b/cv32e40s/tests/programs/custom/debug_test_reset/debugger.S
@@ -2,43 +2,44 @@
 /*
 **
 ** Copyright 2020 OpenHW Group
-** 
+**
 ** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
 ** You may obtain a copy of the License at
-** 
+**
 **     https://solderpad.org/licenses/
-** 
+**
 ** Unless required by applicable law or agreed to in writing, software
 ** distributed under the License is distributed on an "AS IS" BASIS,
 ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
-** 
+**
 *******************************************************************************
 ** Debugger code
 *******************************************************************************
 */
+#include "corev_uvmt.h"
+
 
 .section .debugger, "ax"
 .global _debugger_start
-.set test_ret_val, 0x20000000
+
 .set test_fail, 0x1
-.set test_debugger_entry, 0x1000
 .set test_debugger_ok, 0xa5
-        
-_debugger_start:        
+
+_debugger_start:
     // No code should have been run before this
     // check dpc == boot_addr == 0x80
     csrr t1, dpc
-    li t2, 0x80 # Boot addr 
+    li t2, 0x80 # Boot addr
     bne t1, t2, _debugger_error
 
-    // Write known value to memory@0x1000
+    // Write known value to memory
     // We don't have any globals or pointers
-    // at this time, so we must rely on 
+    // at this time, so we must rely on
     // memory (hopefully) not being used
-    li a0, test_debugger_entry
+    la a0, test_debugger_entry
     li t0, test_debugger_ok
     sw t0, 0(a0)
 
@@ -65,12 +66,12 @@ _debugger_trigger_regs_access:
     # functional coverage
     # TDATA1, CSRRSI
     csrr t1, 0x7A1
-    csrrsi t0, 0x7A1, 0x4 # Set bit 2 
+    csrrsi t0, 0x7A1, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A1
     li t1, 2<<28 | 1<<27 | 1<<12 | 1<<6 | 1<<2
     bne t0, t1, _debugger_error
-   
+
     # TDATA1, CSRRCI
     csrr t1, 0x7A1
     csrrci t0, 0x7A1, 0x4 # Clear bit 2
@@ -82,12 +83,12 @@ _debugger_trigger_regs_access:
     # TDATA1, CSRRS
     csrr t1, 0x7A1
     li t0, 0x4
-    csrrs t0, 0x7A1, t0 # Set bit 2 
+    csrrs t0, 0x7A1, t0 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A1
     li t1, 2<<28 | 1<<27 | 1<<12 | 1<<6 | 1<<2
     bne t0, t1, _debugger_error
-   
+
     # TDATA1, CSRRC
     csrr t1, 0x7A1
     li t0, 0x4
@@ -96,7 +97,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A1
     li t1, 2<<28 | 1<<27 | 1<<12 | 1<<6 | 0<<2
     bne t0, t1, _debugger_error
-     
+
     # TDATA1, CSRRWI
     csrr t1, 0x7A1
     csrrwi t0, 0x7A1, 0x4 # Set bit 2
@@ -117,12 +118,12 @@ _debugger_trigger_regs_access:
     # TDATA2, CSRRSI
     csrw 0x7A2, x0 # clear before test
     csrr t1, 0x7A2
-    csrrsi t0, 0x7A2, 0x4 # Set bit 2 
+    csrrsi t0, 0x7A2, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A2
     li t1,  1<<2
     bne t0, t1, _debugger_error
-   
+
     # TDATA2, CSRRCI
     csrr t1, 0x7A2
     csrrci t0, 0x7A2, 0x4 # Clear bit 2
@@ -139,7 +140,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A2
     li t1,  0xa5a5a5a5
     bne t0, t1, _debugger_error
-   
+
     # TDATA2, CSRRC
     csrr t1, 0x7A2
     li t0, 0xFFFFFFFF
@@ -148,7 +149,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A2
     li t1,  0x0
     bne t0, t1, _debugger_error
-     
+
     # TDATA2, CSRRWI
     csrr t1, 0x7A2
     csrrwi t0, 0x7A2, 0x4 # Set bit 2
@@ -160,12 +161,12 @@ _debugger_trigger_regs_access:
     # TDATA3, CSRRSI
     csrw 0x7A3, x0 # clear before test
     csrr t1, 0x7A3
-    csrrsi t0, 0x7A3, 0x4 # Set bit 2 
+    csrrsi t0, 0x7A3, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A3
     li t1, 0
     bne t0, t1, _debugger_error
-   
+
     # TDATA3, CSRRCI
     csrr t1, 0x7A3
     csrrci t0, 0x7A3, 0x4 # Clear bit 2
@@ -182,7 +183,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A3
     li t1,  0x0
     bne t0, t1, _debugger_error
-   
+
     # TDATA3, CSRRC
     csrr t1, 0x7A3
     li t0, 0xFFFFFFFF
@@ -191,7 +192,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A3
     li t1,  0x0
     bne t0, t1, _debugger_error
-     
+
     # TDATA3, CSRRWI
     csrr t1, 0x7A3
     csrrwi t0, 0x7A3, 0x4 # Set bit 2
@@ -203,12 +204,12 @@ _debugger_trigger_regs_access:
     # TINFO, CSRRSI
     csrw 0x7A4, x0 # clear before test
     csrr t1, 0x7A4
-    csrrsi t0, 0x7A4, 0x4 # Set bit 2 
+    csrrsi t0, 0x7A4, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
     li t1, 4
     bne t0, t1, _debugger_error
-   
+
     # TINFO, CSRRCI
     csrr t1, 0x7A4
     csrrci t0, 0x7A4, 0x4 # Clear bit 2
@@ -225,7 +226,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A4
     li t1,  4
     bne t0, t1, _debugger_error
-   
+
     # TINFO, CSRRC
     csrr t1, 0x7A4
     li t0, 0xFFFFFFFF
@@ -234,7 +235,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A4
     li t1,  4
     bne t0, t1, _debugger_error
-     
+
     # TINFO, CSRRWI
     csrr t1, 0x7A4
     csrrwi t0, 0x7A4, 0x4 # Set bit 2
@@ -246,12 +247,12 @@ _debugger_trigger_regs_access:
     # TSELECT, CSRRSI
     csrw 0x7A0, x0 # clear before test
     csrr t1, 0x7A0
-    csrrsi t0, 0x7A0, 0x4 # Set bit 2 
+    csrrsi t0, 0x7A0, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A0
     li t1, 0
     bne t0, t1, _debugger_error
-   
+
     # TSELECT, CSRRCI
     csrr t1, 0x7A0
     csrrci t0, 0x7A0, 0x4 # Clear bit 2
@@ -268,7 +269,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A0
     li t1,  0
     bne t0, t1, _debugger_error
-   
+
     # TSELECT, CSRRC
     csrr t1, 0x7A0
     li t0, 0xFFFFFFFF
@@ -277,7 +278,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7A0
     li t1,  0
     bne t0, t1, _debugger_error
-     
+
     # TSELECT, CSRRWI
     csrr t1, 0x7A0
     csrrwi t0, 0x7A0, 0x4 # Set bit 2
@@ -291,12 +292,12 @@ _debugger_trigger_regs_access:
     # DSCRATCH0, CSRRSI
     csrw 0x7B2, x0 # clear before test
     csrr t1, 0x7B2
-    csrrsi t0, 0x7B2, 0x4 # Set bit 2 
+    csrrsi t0, 0x7B2, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7B2
     li t1, 4
     bne t0, t1, _debugger_error
-   
+
     # DSCRATCH0, CSRRCI
     csrr t1, 0x7B2
     csrrci t0, 0x7B2, 0x4 # Clear bit 2
@@ -313,7 +314,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B2
     li t1,  0xa5a5a5a5
     bne t0, t1, _debugger_error
-   
+
     # DSCRATCH0, CSRRC
     csrr t1, 0x7B2
     li t0, 0xFFFFFFFF
@@ -322,7 +323,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B2
     li t1,  0
     bne t0, t1, _debugger_error
-     
+
     # DSCRATCH0, CSRRWI
     csrr t1, 0x7B2
     csrrwi t0, 0x7B2, 0x4 # Set bit 2
@@ -330,7 +331,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B2
     li t1,  0x4
     bne t0, t1, _debugger_error
-    # Restore dscratch0    
+    # Restore dscratch0
     csrw 0x7B2, t2
 
     # Store dscratch1
@@ -338,12 +339,12 @@ _debugger_trigger_regs_access:
     # DSCRATCH1, CSRRSI
     csrw 0x7B3, x0 # clear before test
     csrr t1, 0x7B3
-    csrrsi t0, 0x7B3, 0x4 # Set bit 2 
+    csrrsi t0, 0x7B3, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7B3
     li t1, 4
     bne t0, t1, _debugger_error
-   
+
     # DSCRATCH1, CSRRCI
     csrr t1, 0x7B3
     csrrci t0, 0x7B3, 0x4 # Clear bit 2
@@ -360,7 +361,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B3
     li t1,  0xa5a5a5a5
     bne t0, t1, _debugger_error
-   
+
     # DSCRATCH1, CSRRC
     csrr t1, 0x7B3
     li t0, 0xFFFFFFFF
@@ -369,7 +370,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B3
     li t1,  0
     bne t0, t1, _debugger_error
-     
+
     # DSCRATCH1, CSRRWI
     csrr t1, 0x7B3
     csrrwi t0, 0x7B3, 0x4 # Set bit 2
@@ -385,12 +386,12 @@ _debugger_trigger_regs_access:
     # DPC, CSRRSI
     csrw 0x7B1, x0 # clear before test
     csrr t1, 0x7B1
-    csrrsi t0, 0x7B1, 0x4 # Set bit 2 
+    csrrsi t0, 0x7B1, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7B1
     li t1, 4
     bne t0, t1, _debugger_error
-   
+
     # DPC, CSRRCI
     csrr t1, 0x7B1
     csrrci t0, 0x7B1, 0x4 # Clear bit 2
@@ -407,7 +408,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B1
     li t1,  0xfffffff0
     bne t0, t1, _debugger_error
-   
+
     # DPC, CSRRC
     csrr t1, 0x7B1
     li t0, 0xFFFFFFFF
@@ -416,7 +417,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B1
     li t1,  0
     bne t0, t1, _debugger_error
-     
+
     # DPC, CSRRWI
     csrr t1, 0x7B1
     csrrwi t0, 0x7B1, 0x4 # Set bit 2
@@ -424,7 +425,7 @@ _debugger_trigger_regs_access:
     csrr t0, 0x7B1
     li t1,  0x4
     bne t0, t1, _debugger_error
-    
+
     # Restore dpc
     csrw 0x7B1, t2
 
@@ -433,12 +434,12 @@ _debugger_trigger_regs_access:
     # DCSR, CSRRSI
     csrw dcsr, x0 # clear before test
     csrr t1, dcsr
-    csrrsi t0, dcsr, 0x4 # Set bit 2 
+    csrrsi t0, dcsr, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, dcsr
     addi t1, t2, 0x4
     bne t0, t1, _debugger_error
-   
+
     # DCSR, CSRRCI
     csrr t1, dcsr
     csrrci t0, dcsr, 0x4 # Clear bit 2
@@ -455,7 +456,7 @@ _debugger_trigger_regs_access:
     csrr t0, dcsr
     addi t1, t2, 0x4
     bne t0, t1, _debugger_error
-   
+
     # DCSR, CSRRC
     csrr t1, dcsr
     li t0, 0x4
@@ -463,7 +464,7 @@ _debugger_trigger_regs_access:
     bne t0, t1, _debugger_error
     csrr t0, dcsr
     bne t0, t2, _debugger_error
-     
+
     # DCSR, CSRRWI
     csrr t1, dcsr
     csrrwi t0, dcsr, 0x4 # Set bit 2
@@ -471,13 +472,18 @@ _debugger_trigger_regs_access:
     csrr t0, dcsr
     addi t1, t2, 0x4
     bne t0, t1, _debugger_error
-    
+
     # Restore dpc
     csrw dcsr, t2
     dret
 
 _debugger_error:
-    li a0, test_ret_val
+    li a0, CV_VP_STATUS_FLAGS_BASE
     li t0, test_fail
     sw t0, 0(a0)
     dret
+
+.section .data
+.global test_debugger_entry
+test_debugger_entry:
+    .word 0


### PR DESCRIPTION
Fixing this issue in debug tests:
https://github.com/openhwgroup/core-v-verif/issues/969

