### PR TITLE
fix issue 969 runaway debug tests in e40x

### DIFF
--- a/cv32e40x/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
+++ b/cv32e40x/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
@@ -23,13 +23,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define RND_STALL_REG *(volatile int *)0x1000
+extern volatile uint32_t test_debugger_entry;
 
 #define MACHINE 3
 int main(int argc, char *argv[])
 {
     unsigned int check_reg;
-    check_reg = RND_STALL_REG;
+    check_reg = test_debugger_entry;
 
     printf("Debug reg = %08x\n", check_reg);
     // Debug code will write 0xff to this register

--- a/cv32e40x/tests/programs/custom/debug_test_boot_set/debugger.S
+++ b/cv32e40x/tests/programs/custom/debug_test_boot_set/debugger.S
@@ -25,7 +25,6 @@
 .section .debugger, "ax"
 .global _debugger_start
 .set test_fail, 0x1
-.set test_debugger_entry, 0x1000
 .set test_debugger_ok, 0xa5
 
 _debugger_start:
@@ -39,7 +38,7 @@ _debugger_start:
     // We don't have any globals or pointers
     // at this time, so we must rely on
     // memory (hopefully) not being used
-    li a0, test_debugger_entry
+    la a0, test_debugger_entry
     li t0, test_debugger_ok
     sw t0, 0(a0)
     dret
@@ -49,3 +48,8 @@ _debugger_error:
     li t0, test_fail
     sw t0, 0(a0)
     dret
+
+.section .data
+.global test_debugger_entry
+test_debugger_entry:
+    .word 0

--- a/cv32e40x/tests/programs/custom/debug_test_reset/debug_test_reset.c
+++ b/cv32e40x/tests/programs/custom/debug_test_reset/debug_test_reset.c
@@ -23,13 +23,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define RND_STALL_REG *(volatile int *)0x1000
+extern volatile uint32_t test_debugger_entry;
 
 #define MACHINE 3
 int main(int argc, char *argv[])
 {
     unsigned int check_reg;
-    check_reg = RND_STALL_REG;
+    check_reg = test_debugger_entry;
 
     printf("Debug reg = %08x\n", check_reg);
     // Debug code will write 0xff to this register

--- a/cv32e40x/tests/programs/custom/debug_test_reset/debugger.S
+++ b/cv32e40x/tests/programs/custom/debug_test_reset/debugger.S
@@ -21,10 +21,11 @@
 */
 #include "corev_uvmt.h"
 
+
 .section .debugger, "ax"
 .global _debugger_start
+
 .set test_fail, 0x1
-.set test_debugger_entry, 0x1000
 .set test_debugger_ok, 0xa5
 
 _debugger_start:
@@ -34,11 +35,11 @@ _debugger_start:
     li t2, 0x80 # Boot addr
     bne t1, t2, _debugger_error
 
-    // Write known value to memory@0x1000
+    // Write known value to memory
     // We don't have any globals or pointers
     // at this time, so we must rely on
     // memory (hopefully) not being used
-    li a0, test_debugger_entry
+    la a0, test_debugger_entry
     li t0, test_debugger_ok
     sw t0, 0(a0)
 
@@ -481,3 +482,8 @@ _debugger_error:
     li t0, test_fail
     sw t0, 0(a0)
     dret
+
+.section .data
+.global test_debugger_entry
+test_debugger_entry:
+    .word 0


### PR DESCRIPTION
Fixing this issue in debug tests:
https://github.com/openhwgroup/core-v-verif/issues/969

