### PR TITLE
Strichmo/pr/bitmanip 1 0 0

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_cfg.sv
@@ -124,7 +124,7 @@ class uvme_cv32e40x_cfg_c extends uvma_core_cntrl_cfg_c;
       unaligned_access_supported == 1;
       unaligned_access_amo_supported == 1;
 
-      bitmanip_version        == BITMANIP_VERSION_0P93;
+      bitmanip_version        == BITMANIP_VERSION_1P00;
 
       boot_addr_valid         == 1;
       mtvec_addr_valid        == 1;

--- a/cv32e40x/tests/programs/custom/b_ext_test/test.yaml
+++ b/cv32e40x/tests/programs/custom/b_ext_test/test.yaml
@@ -2,6 +2,11 @@ name: b_ext_test
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
     Simple sanity check for B extension instructions
+
+# Toolchain configurations
 riscv_march: rv32imc_zba0p93_zbb0p93
-llvm_march: rv32imc_zba0p93_zbb0p93_zbc0p93_zbs0p93
+gnu_march:   rv32imc_zba0p93_zbb0p93
+corev_not_supported: 1
+pulp_not_supported: 1
+llvm_march:  rv32imc_zba0p93_zbb0p93_zbc0p93_zbs0p93
 llvm_cflags: -menable-experimental-extensions

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -283,7 +283,7 @@ PULP_YES         = $(call IS_YES,$(PULP))
 COREV_YES        = $(call IS_YES,$(COREV))
 LLVM_YES         = $(call IS_YES,$(LLVM))
 
-ifeq ($(shell $(CORE_V_VERIF)/mk/toolchain_check.mk $(GNU_YES) $(PULP_YES) $(COREV_YES) $(LLVM_YES)),1)
+ifeq ($(shell $(CORE_V_VERIF)/mk/toolchain_check.sh $(GNU_YES) $(PULP_YES) $(COREV_YES) $(LLVM_YES)),1)
 $(error Multiple toolchains are enabled: GNU=${GNU_YES} PULP=${PULP_YES} COREV=${COREV_YES} LLVM=${LLVM_YES})
 endif
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -278,6 +278,15 @@ CV_SW_TOOLCHAIN  ?= /opt/riscv
 CV_SW_VENDOR     ?= unknown
 CV_SW_MARCH      ?= rv32imc
 
+GNU_YES          = $(call IS_YES,$(GNU))
+PULP_YES         = $(call IS_YES,$(PULP))
+COREV_YES        = $(call IS_YES,$(COREV))
+LLVM_YES         = $(call IS_YES,$(LLVM))
+
+ifeq ($(shell $(CORE_V_VERIF)/mk/toolchain_check.mk $(GNU_YES) $(PULP_YES) $(COREV_YES) $(LLVM_YES)),1)
+$(error Multiple toolchains are enabled: GNU=${GNU_YES} PULP=${PULP_YES} COREV=${COREV_YES} LLVM=${LLVM_YES})
+endif
+
 RISCV             = $(CV_SW_TOOLCHAIN)
 RISCV_PREFIX      = riscv32-$(CV_SW_VENDOR)-elf-
 RISCV_EXE_PREFIX  = $(RISCV)/bin/$(RISCV_PREFIX)
@@ -285,7 +294,10 @@ RISCV_CC          = gcc
 RISCV_MARCH       = $(call RESOLVE_FLAG2,$(TEST_RISCV_MARCH),$(CV_SW_MARCH))
 RISCV_CFLAGS      = $(TEST_RISCV_CFLAGS)
 
-ifeq ($(call IS_YES,$(GNU)),YES)
+ifeq ($(GNU_YES),YES)
+ifeq ($(call IS_YES,$(TEST_GNU_NOT_SUPPORTED)),YES)
+$(error test [$(TEST)] does not support the GNU toolchain)
+endif
 RISCV            = $(GNU_SW_TOOLCHAIN)
 RISCV_PREFIX     = riscv32-$(GNU_VENDOR)-elf-
 RISCV_EXE_PREFIX = $(RISCV)/bin/$(RISCV_PREFIX)
@@ -294,7 +306,10 @@ RISCV_MARCH      = $(call RESOLVE_FLAG2,$(TEST_GNU_MARCH),$(GNU_MARCH))
 RISCV_CFLAGS     = $(call RESOLVE_FLAG2,$(TEST_GNU_CFLAGS),$(GNU_CFLAGS))
 endif
 
-ifeq ($(call IS_YES,$(COREV)),YES)
+ifeq ($(COREV_YES)),YES)
+ifeq ($(call IS_YES,$(TEST_COREV_NOT_SUPPORTED)),YES)
+$(error test [$(TEST)] does not support the COREV toolchain)
+endif
 RISCV            = $(COREV_SW_TOOLCHAIN)
 RISCV_PREFIX     = riscv32-$(COREV_VENDOR)-elf-
 RISCV_EXE_PREFIX = $(RISCV)/bin/$(RISCV_PREFIX)
@@ -303,7 +318,10 @@ RISCV_MARCH      = $(call RESOLVE_FLAG2,$(TEST_COREV_MARCH),$(COREV_MARCH))
 RISCV_CFLAGS     = $(call RESOLVE_FLAG2,$(TEST_COREV_CFLAGS),$(COREV_CFLAGS))
 endif
 
-ifeq ($(call IS_YES,$(PULP)),YES)
+ifeq ($(PULP_YES),YES)
+ifeq ($(call IS_YES,$(TEST_PULP_NOT_SUPPORTED)),YES)
+$(error test [$(TEST)] does not support the PULP toolchain)
+endif
 RISCV            = $(PULP_SW_TOOLCHAIN)
 RISCV_PREFIX     = riscv32-$(PULP_VENDOR)-elf-
 RISCV_EXE_PREFIX = $(RISCV)/bin/$(RISCV_PREFIX)
@@ -312,7 +330,10 @@ RISCV_MARCH      = $(call RESOLVE_FLAG2,$(TEST_PULP_MARCH),$(PULP_MARCH))
 RISCV_CFLAGS     = $(call RESOLVE_FLAG2,$(TEST_PULP_CFLAGS),$(PULP_CFLAGS))
 endif
 
-ifeq ($(call IS_YES,$(LLVM)),YES)
+ifeq ($(LLVM_YES),YES)
+ifeq ($(call IS_YES,$(TEST_LLVM_NOT_SUPPORTED)),YES)
+$(error test [$(TEST)] does not support the LLVM toolchain)
+endif
 RISCV            = $(LLVM_SW_TOOLCHAIN)
 RISCV_PREFIX     = riscv32-$(LLVM_VENDOR)-elf-
 RISCV_EXE_PREFIX = $(RISCV)/bin/$(RISCV_PREFIX)

--- a/mk/toolchain_check.mk
+++ b/mk/toolchain_check.mk
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+###############################################################################
+#
+# Copyright 2021 OpenHW Group
+# Copyright 2021 Silicon Labs, Inc.
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+#
+# Helper bash script to determine when multiple build toolchains are configured
+# to diagnose toolchain test configuration issues with the COREV verification
+# testbench environment
+#
+###############################################################################
+#
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+# PERFORMANCE OF THIS SOFTWARE.
+#
+# Original Author: Robert Balas (balasr@iis.ee.ethz.ch)
+#
+###############################################################################
+
+GNU_YES=$1
+PULP_YES=$2
+COREV_YES=$3
+LLVM_YES=$4
+
+# Logic to return 1 if any two toolchains are enabled
+if [ ${GNU_YES} == "YES" -a ${PULP_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+if [ ${GNU_YES} == "YES" -a ${COREV_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+if [ ${GNU_YES} == "YES" -a ${LLVM_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+if [ ${PULP_YES} == "YES" -a ${COREV_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+if [ ${PULP_YES} == "YES" -a ${LLVM_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+if [ ${COREV_YES} == "YES" -a ${LLVM_YES} == "YES" ]; then
+	echo "1"
+	exit 0
+fi
+
+echo "0"
+

--- a/mk/toolchain_check.sh
+++ b/mk/toolchain_check.sh
@@ -26,23 +26,6 @@
 # testbench environment
 #
 ###############################################################################
-#
-#
-# Permission to use, copy, modify, and/or distribute this software for any
-# purpose with or without fee is hereby granted, provided that the above
-# copyright notice and this permission notice appear in all copies.
-#
-# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-# AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-# INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-# LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-# OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-# PERFORMANCE OF THIS SOFTWARE.
-#
-# Original Author: Robert Balas (balasr@iis.ee.ethz.ch)
-#
-###############################################################################
 
 GNU_YES=$1
 PULP_YES=$2


### PR DESCRIPTION
Fixes misa issue with https://github.com/openhwgroup/cv32e40x/issues/292 by reconfiguring OVPSIM

Adds some infrastructure checks for tests and toolchains:
- If the user specifies more than one toolchain, the makefile will error out
- Add optional YAML flags to restrict toolchains on which a test may run


