### PR TITLE
remove seed hack in vManager to increment index

### DIFF
--- a/bin/templates/regress_vsif.j2
+++ b/bin/templates/regress_vsif.j2
@@ -76,9 +76,8 @@ group {{project}} {
 {{indent}}        timeout: 3600;
 {{indent}}        test run {
 {{indent}}            sv_seed: gen_random;
-{{indent}}            seed: [0..{{t.num-1}}];
 {{indent}}            count: {{t.num}};
-{{indent}}            run_script: 'cd {{t.abs_dir}} && {{t.cmd}} COMP=0 CV_SIM_PREFIX= CV_CORE={{project}} {{toolchain|upper}}=1 CFG={{build.cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=$RUN_ENV(BRUN_SEED) GEN_START_INDEX=$RUN_ENV(BRUN_SEED) RNDSEED=$RUN_ENV(BRUN_SV_SEED) {{regress_macros.cv_results(results)}} {{makeargs}} {{t.makearg}}';
+{{indent}}            run_script: 'cd {{t.abs_dir}} && {{t.cmd}} COMP=0 CV_SIM_PREFIX= CV_CORE={{project}} {{toolchain|upper}}=1 CFG={{build.cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=$RUN_ENV(BRUN_RUN_ID) GEN_START_INDEX=$RUN_ENV(BRUN_SEED) RNDSEED=$RUN_ENV(BRUN_SV_SEED) {{regress_macros.cv_results(results)}} {{makeargs}} {{t.makearg}}';
 {% if simulator == 'vsim' %}
 {{indent}}            scan_script: 'vm_scan.pl {{filter_dir}}/corev_uvm.flt {{filter_dir}}/vsim_run.flt';
 {% endif %}


### PR DESCRIPTION
- this debug broke some features with vManager-Jenkins integration
- has no real functional effect other than RUN_INDEX of all Jenkins runs will match the overall jenkins ID instead of always being an incrementing index per job

