### PR TITLE
Update rtl hash for 40x

### DIFF
--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= bf832e774a8403c875c8a63db22d186da02d0446
+CV_CORE_HASH   ?= 30b56199fedea677050148b9cc160bdb7cc1192a
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv


### PR DESCRIPTION
Updates CV_CORE_HASH to the latest 40x.
There was initially a few problems, but they were fixed and merged in the 40x repo.
It now passes ci_check.