### PR TITLE
fix bug selecting the COREV toolchain

### DIFF
--- a/cv32e40x/tests/programs/custom/b_ext_test/test.yaml
+++ b/cv32e40x/tests/programs/custom/b_ext_test/test.yaml
@@ -6,7 +6,7 @@ description: >
 # Toolchain configurations
 riscv_march: rv32imc_zba0p93_zbb0p93
 gnu_march:   rv32imc_zba0p93_zbb0p93
-corev_not_supported: 1
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00
 pulp_not_supported: 1
-llvm_march:  rv32imc_zba0p93_zbb0p93_zbc0p93_zbs0p93
-llvm_cflags: -menable-experimental-extensions
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -306,7 +306,7 @@ RISCV_MARCH      = $(call RESOLVE_FLAG2,$(TEST_GNU_MARCH),$(GNU_MARCH))
 RISCV_CFLAGS     = $(call RESOLVE_FLAG2,$(TEST_GNU_CFLAGS),$(GNU_CFLAGS))
 endif
 
-ifeq ($(COREV_YES)),YES)
+ifeq ($(COREV_YES),YES)
 ifeq ($(call IS_YES,$(TEST_COREV_NOT_SUPPORTED)),YES)
 $(error test [$(TEST)] does not support the COREV toolchain)
 endif
@@ -340,6 +340,7 @@ RISCV_EXE_PREFIX = $(RISCV)/bin/$(RISCV_PREFIX)
 RISCV_CC         = $(LLVM_CC)
 RISCV_MARCH      = $(call RESOLVE_FLAG2,$(TEST_LLVM_MARCH),$(LLVM_MARCH))
 RISCV_CFLAGS     = $(call RESOLVE_FLAG2,$(TEST_LLVM_CFLAGS),$(LLVM_CFLAGS))
+RISCV_CFLAGS    += -menable-experimental-extensions
 endif
 
 CFLAGS ?= -Os -g -static -mabi=ilp32 -march=$(RISCV_MARCH) -Wall -pedantic


### PR DESCRIPTION
always enable experimental extensions in LLVM
update march strings for the latest top-of-tree releases of LLVM and corev toolchains

Signed-off-by: Steve Richmond <Steve.Richmond@silabs.com>