### PR TITLE
Fix bug in "store_fencei_load" test for 40x

### DIFF
--- a/cv32e40x/env/corev-dv/cv32e40x_fencei_instr_lib.sv
+++ b/cv32e40x/env/corev-dv/cv32e40x_fencei_instr_lib.sv
@@ -22,18 +22,15 @@
 class corev_store_fencei_load_instr_stream extends riscv_load_store_rand_instr_stream;
 
   rand bit [31:0]  addr;
-  rand riscv_reg_t addr_reg;
   rand riscv_reg_t data_reg;
 
   constraint dont_overwrite_data_reg {
-    addr_reg != data_reg;  // Don't overwrite the data that is to be written
+    data_reg != rs1_reg;  // Don't overwrite the data that is to be written
   }
   constraint dont_pollute_reserved_regs {
-    !(addr_reg inside {cfg.reserved_regs});
-    !(data_reg inside {cfg.reserved_regs});
+    !(data_reg inside {cfg.reserved_regs, reserved_rd});
   }
   constraint dont_store_in_x0 {
-    addr_reg != ZERO;
     data_reg != ZERO;
   }
 
@@ -45,59 +42,74 @@ class corev_store_fencei_load_instr_stream extends riscv_load_store_rand_instr_s
 
   function void post_randomize();
     riscv_instr instr;
+    riscv_instr instr_list_new[$];
+    int         idx_insert;
 
+    // Generate a default big chunk of instructions as a "substrate" to work on
+    super.post_randomize();
+
+    // The following instrs use "instr_list_new" to be merged into "instr_list" later
+
+/* TODO:ropeders not needed?
     // (Backup existing data)
     instr = riscv_instr::get_instr(LW);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
       instr_name == LW;
-      rs1 == addr_reg;
-      imm == addr[31:20];
+      rs1 == rs1_reg;
+      imm == offset[0];
       rd == data_reg;
       , "failed to randomize backup"
     )
     instr.comment = "store_fencei_load: backup existing";
-    instr_list.push_back(instr);
+    instr_list_new.push_back(instr);
+*/
 
     // Store
     instr = riscv_instr::get_rand_instr(.include_instr({SW, SH, SB}));
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
       instr_name inside {SW, SH, SB};
-      rs1 == addr_reg;
-      imm == addr[31:20];
+      rs1 == rs1_reg;
+      imm == offset[0];
       , "failed to randomize store"
     )
     instr.comment = "store_fencei_load: store";
-    instr_list.push_back(instr);
+    instr_list_new.push_back(instr);
 
     // Fence.i
     instr = riscv_instr::get_instr(FENCE_I);
     instr.comment = "store_fencei_load: fencei";
-    instr_list.push_back(instr);
+    instr_list_new.push_back(instr);
 
     // Load
     instr = riscv_instr::get_rand_instr(.include_instr({LW, LH, LHU, LB, LBU}));
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
       instr_name inside {LW, LH, LHU, LB, LBU};
-      rs1 == addr_reg;
-      imm == addr[31:20];
-      !(rd inside {addr_reg, data_reg});
+      rs1 == rs1_reg;
+      imm == offset[0];
+      !(rd inside {rs1_reg, data_reg});
       !(rd inside {cfg.reserved_regs});
       , "failed to randomize load"
     )
     instr.comment = "store_fencei_load: load";
-    instr_list.push_back(instr);
+    instr_list_new.push_back(instr);
 
+/* TODO:ropeders not needed?
     // (Restore previous data)
     instr = riscv_instr::get_instr(SW);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
       instr_name == SW;
-      rs1 == addr_reg;
-      imm == addr[31:20];
+      rs1 == rs1_reg;
+      imm == offset[0];
       rs2 == data_reg;
       , "failed to randomize restore"
     )
     instr.comment = "store_fencei_load: store previous";
-    instr_list.push_back(instr);
+    instr_list_new.push_back(instr);
+*/
+
+    // Combine the final instr list
+    idx_insert = $urandom_range(1, instr_list.size() - 1);  // Not before the LA
+    instr_list = {instr_list[0:idx_insert-1], instr_list_new, instr_list[idx_insert:$]};
 
     // Get a nice enumeration label for anything not labeled
     foreach (instr_list[i]) begin


### PR DESCRIPTION
This PR fixes a bug in the `corev_store_fencei_load_instr_stream` random test.

The problem was that I used a completely random addresses that were stored to and it led to iss mismatch when certain addresses were used that shouldn't have been used.
Fixed by reusing the methods in the parent class `riscv_load_store_rand_instr_stream` to get sensible addresses.

I have tested with 10 different seeds now and I have not seen any more problems.