### PR TITLE
corev_pma_rand_pma_test fixes for instruction corruption

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_core_sb.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_core_sb.sv
@@ -306,9 +306,11 @@ function void uvme_cv32e40x_core_sb_c::check_instr(uvma_rvfi_instr_seq_item_c#(I
    end
 
    // CHECK: insn
-   if (rvfi_instr.insn != rvvi_state.insn) begin
-      `uvm_error("CORESB", $sformatf("INSN Mismatch, order: %0d, rvfi.insn = 0x%08x, rvvi.insn = 0x%08x",
-                                     rvfi_instr.order, rvfi_instr.insn, rvvi_state.insn));
+   if (!rvfi_instr.trap) begin
+      if (rvfi_instr.insn != rvvi_state.insn) begin
+         `uvm_error("CORESB", $sformatf("INSN Mismatch, order: %0d, rvfi.pc = 0x%08x, rvfi.insn = 0x%08x, rvvi.insn = 0x%08x",
+                                       rvfi_instr.order, rvfi_instr.pc_rdata, rvfi_instr.insn, rvvi_state.insn));
+      end
    end
 
    // Heartbeat message


### PR DESCRIPTION
This PR fixes two major issues with the _corev_pma_rand_pma_test_ in cv32e40x regressions.

- OVPSIM does not seem to handle fetches from the _end_ of memory (i.e 0xffff_fffc) well.
- super.post_randomize() usage in many PMA instructions streams is cleaned up to avoid inserting instructions from super classes that are not properly constrained in accordance with the intended class.  This caused address generation for these instructions to be not-as-intended which could overwrite instructions in the flat memory space.
