### PR TITLE
add lwdgen flag to Xcelium compiles to generate lightweight database …

### DIFF
--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -40,10 +40,16 @@ IMC               = $(CV_SIM_PREFIX) imc
 XRUN_UVMHOME_ARG     ?= CDNS-1.2-ML
 
 # Flags
-XRUN_COMP_FLAGS  ?= -64bit -disable_sem2009 -access +rwc \
+XRUN_COMP_FLAGS  ?= -64bit \
+					-disable_sem2009 \
+					-access +rwc \
                     -nowarn UEXPSC \
-                    -sv -uvm -uvmhome $(XRUN_UVMHOME_ARG) \
-                    $(TIMESCALE) $(SV_CMP_FLAGS)
+					-lwdgen \
+                    -sv \
+					-uvm \
+					-uvmhome $(XRUN_UVMHOME_ARG) \
+                    $(TIMESCALE) \
+					$(SV_CMP_FLAGS)
 
 XRUN_LDGEN_COMP_FLAGS ?= -64bit -disable_sem2009 -access +rwc \
 												 -nowarn UEXPSC \


### PR DESCRIPTION
…for Indago users

Should be completely innocuous to all Xcelium users unless they are using an extremely old Xcelium/Incisive.
