### PR TITLE
connect nmip CSR RVFI to ISS NMI signal

### DIFF
--- a/cv32e40x/env/uvme/uvme_cv32e40x_core_sb.sv
+++ b/cv32e40x/env/uvme/uvme_cv32e40x_core_sb.sv
@@ -349,8 +349,9 @@ function void uvme_cv32e40x_core_sb_c::check_csr(uvma_rvfi_instr_seq_item_c#(ILE
                                                  uvma_rvvi_state_seq_item_c#(ILEN,XLEN) rvvi_state);
 
    foreach (rvfi_instr.csrs[i]) begin
-      string csr = rvfi_instr.csrs[i].csr;
       bit[XLEN-1:0] exp_csr_value;
+      bit[XLEN-1:0] csr_mask = {XLEN{1'b1}};
+      string        csr = rvfi_instr.csrs[i].csr;
 
       // Skip disabled CSR checks from configuration object
       if (cfg.is_csr_check_disabled(csr)) continue;
@@ -360,17 +361,24 @@ function void uvme_cv32e40x_core_sb_c::check_csr(uvma_rvfi_instr_seq_item_c#(ILE
          `uvm_fatal("CORESB", $sformatf("CSR %s from RVFI does not exist in RVVI state interface", csr));
       end
 
+      // Adjust CSR mask
+      // Skip dcsr.nmip check in non-debug mode
+      if (csr == "dcsr" && !rvfi_instr.dbg_mode) begin
+         csr_mask[3] = 0;
+      end
+
       csr_checked_cnt++;
 
       exp_csr_value = rvfi_instr.csrs[i].get_csr_retirement_data();
 
-      if (exp_csr_value != rvvi_state.csr[csr]) begin
-         `uvm_error("CORESB", $sformatf("CSR Mismatch, order: %0d, pc: 0x%08x, csr: %s, rvfi = 0x%08x, rvvi = 0x%08x",
+      if ((exp_csr_value & csr_mask) != rvvi_state.csr[csr]) begin
+         `uvm_error("CORESB", $sformatf("CSR Mismatch, order: %0d, pc: 0x%08x, csr: %s, rvfi = 0x%08x, rvvi = 0x%08x, mask = 0x%08x",
                                         rvfi_instr.order,
                                         rvfi_instr.pc_rdata,
                                         csr,
                                         exp_csr_value,
-                                        rvvi_state.csr[csr]));
+                                        rvvi_state.csr[csr],
+                                        csr_mask));
       end
    end
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -36,12 +36,16 @@ class uvma_rvfi_instr_mon_c#(int ILEN=DEFAULT_ILEN,
    // TLM
    uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN))  ap;
 
+   // State of monitor
+   bit                last_dcsr_nmip = 0;
+
    string log_tag = "RVFIMONLOG";
 
    `uvm_component_utils_begin(uvma_rvfi_instr_mon_c)
-      `uvm_field_int(nret_id, UVM_DEFAULT)
-      `uvm_field_object(cfg  , UVM_DEFAULT)
-      `uvm_field_object(cntxt, UVM_DEFAULT)
+      `uvm_field_int(nret_id,        UVM_DEFAULT)
+      `uvm_field_int(last_dcsr_nmip, UVM_DEFAULT)
+      `uvm_field_object(cfg,         UVM_DEFAULT | UVM_REFERENCE)
+      `uvm_field_object(cntxt,       UVM_DEFAULT | UVM_REFERENCE)
    `uvm_component_utils_end
 
    /**
@@ -197,7 +201,11 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
          end
 
          // In debug mode, detect NMIP event
-         if (cfg.nmi_handler_enabled && mon_trn.csrs["dcsr"].wmask[3] && mon_trn.csrs["dcsr"].wdata[3]) begin
+         if (cfg.nmi_handler_enabled &&
+             mon_trn.dbg_mode &&
+             !last_dcsr_nmip &&
+             mon_trn.csrs["dcsr"].get_csr_retirement_data()[3]) begin
+            `uvm_info("RVFIMON", $sformatf("Debug NMIP"), UVM_LOW);
             mon_trn.insn_nmi = 1;
          end
 
@@ -207,6 +215,8 @@ task uvma_rvfi_instr_mon_c::monitor_rvfi_instr();
              mon_trn.csrs["mcause"].get_csr_retirement_data() == cfg.insn_bus_fault_cause) begin
             mon_trn.insn_bus_fault = 1;
          end
+
+         last_dcsr_nmip = mon_trn.csrs["dcsr"].get_csr_retirement_data()[3];
 
          `uvm_info(log_tag, $sformatf("%s", mon_trn.convert2string()), UVM_HIGH);
 


### PR DESCRIPTION
Enables data bus errors in debug mode to be properly signaled for NMI pending.
