### PR TITLE
Remove redundant use of always for a_dmhaltaddr_stable

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
@@ -550,7 +550,7 @@ module uvmt_cv32e40x_debug_assert
     end
     a_dmhaltaddr_stable : assert property (
         fetch_enable_i_sticky
-        |=>
+        |->
         $stable(cov_assert_if.dm_halt_addr_i)
         ) else `uvm_error(info_tag, "dm_halt_addr_i changed after fetch_enable_i");
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
@@ -543,12 +543,12 @@ module uvmt_cv32e40x_debug_assert
     a_dmhaltaddr_stable : assert property (
         (cov_assert_if.fetch_enable_i && cov_assert_if.rst_ni)
         |=>
-        always $stable(cov_assert_if.dm_halt_addr_i)
+        $stable(cov_assert_if.dm_halt_addr_i)
         ) else `uvm_error(info_tag, "TODO");
 
     // Should be word-aligned
     a_dmhaltaddr_aligned : assert property (
-        cov_assert_if.dm_halt_addr_i[1:0] == 2'b 00
+        cov_assert_if.dm_halt_addr_i[1:0] == 2'b00
         ) else `uvm_error(info_tag, "TODO");
 
 

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
@@ -540,11 +540,19 @@ module uvmt_cv32e40x_debug_assert
     // Check that "dm_halt_addr_i" is correct
 
     // Should be stable after "fetch_enable_i"
+    logic fetch_enable_i_sticky;
+    always @(posedge cov_assert_if.clk_i or negedge cov_assert_if.rst_ni) begin
+        if (!cov_assert_if.rst_ni) begin
+            fetch_enable_i_sticky <= 0;
+        end else if (cov_assert_if.fetch_enable_i) begin
+            fetch_enable_i_sticky <= 1;
+        end
+    end
     a_dmhaltaddr_stable : assert property (
-        (cov_assert_if.fetch_enable_i && cov_assert_if.rst_ni)
+        fetch_enable_i_sticky
         |=>
         $stable(cov_assert_if.dm_halt_addr_i)
-        ) else `uvm_error(info_tag, "TODO");
+        ) else `uvm_error(info_tag, "dm_halt_addr_i changed after fetch_enable_i");
 
     // Should be word-aligned
     a_dmhaltaddr_aligned : assert property (


### PR DESCRIPTION
For reasons unknown, the addition of `a_dmhaltaddr_stable` cause Metrics DSIM simulations of some (but not all) testcases to drastically slow down. For example, "make test TEST=interrupt_test" goes from ~8.5 minutes to more than 87 minutes.  Oddly, the simulation runs correctly, it just takes a very long time.   I have raised a support issue with Metrics.

The code that causes this issue is changed in this PR.  A redundant whitespace (`2'b 00`) is also fixed, but that is of no consequence to either xrun or dsim.  Please have a look and satisfy yourself that I have not broken anything.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>