### PR TITLE
Add memory preloading support for vcs-testharness

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -104,7 +104,7 @@ vcs_uvm_run:
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"
-	rm -rf $(CORE_V_VERIF)/cva6/sim/vcs_results/ simv* *.daidir *.vpd *.db csrc ucli.key vc_hdrs.h
+	rm -rf $(CORE_V_VERIF)/cva6/sim/vcs_results/ verdiLog/ simv* *.daidir *.vpd *.db csrc ucli.key vc_hdrs.h novas* inter.fsdb uart
 
 ###############################################################################
 # Verilator

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -68,10 +68,11 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   precmd: >
+    make -C <path_var> vcs_build target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    make -C <path_var> vcs elf-bin=<elf> target=<target> user-define="+define+WT_CACHE"
+    <path_var>/work-vcs/simv ${VERDI:+-verdi} +permissive -sv_lib <path_var>/work-dpi/ariane_dpi +debug_disable=1 +PRELOAD=<elf> +permissive-off ++<elf>
   postcmd: >
-    <tool_path>/spike-dasm < <path_var>/trace_rvfi_hart_00.dasm > log
+    <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
 
 - iss: vcs-core
   path_var: RTL_PATH


### PR DESCRIPTION
Hello @MikeOpenHWGroup,

To make simulation faster, i added memory preloading support for vcs-testharness. `cva6.yaml` takes the right commands to preload memory using the makefile in the cva6 repository.

This PR is highly dependent on the PR n°772 i did in the cva6 repository. (https://github.com/openhwgroup/cva6/pull/772)

I recommend to wait for the CVA6 PR to be merged before merging this one.