### PR TITLE
New docker image

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -7,109 +7,109 @@
     "list": [
       {
         "name":     "uvmt_cv32e40p",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40p_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_num_mhpmcounter_29",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_1",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_2",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_3",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_4",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_5",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_num_mhpmcounter_29",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_1",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_2",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_3",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_4",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_5",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20210621.16.0-04Nov2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       }


### PR DESCRIPTION
New docker image for MetricsCI with dsim 20211122.2.0 and riscv32-embecosm-gcc-ubun…tu1804-20211128 toolchain.   This is the same update for the e40x/dev branch was just pushed to e40p/dev (#1053).

Signed-off-by: Mike Thompson <mike@openhwgroup.org>