### PR TITLE
Fixed PMA region configs wrong order

### DIFF
--- a/cv32e40x/env/corev-dv/ldgen/cv32e40x_ldgen.sv
+++ b/cv32e40x/env/corev-dv/ldgen/cv32e40x_ldgen.sv
@@ -348,7 +348,7 @@ function void cv32e40x_ldgen_c::create_pma_section_file(string filepath);
         $fdisplay(fhandle_pma, { indent(L1), ".region_", $sformatf("%0d %0s", i, section_location), ":" });
         $fdisplay(fhandle_pma, { indent(L1), "{" });
         $fdisplay(fhandle_pma, { indent(L2), "KEEP(*(.region_", $sformatf("%0d", i), "));" });
-        $fdisplay(fhandle_pma, { indent(L1), "} > region_", $sformatf("%0d", i) });
+        $fdisplay(fhandle_pma, { indent(L1), "}"});
       end
     end
     $fdisplay(fhandle_pma, "}");
@@ -480,7 +480,7 @@ function void cv32e40x_ldgen_c::create_fixed_addr_section_file(string filepath);
   $fdisplay(fhandle_fix, "{");
   $fdisplay(fhandle_fix, { indent(L1), "/* CORE-V: interrupt vectors */" });
   $fdisplay(fhandle_fix, { indent(L1), "PROVIDE(__vector_start = ", $sformatf("0x%08x", mtvec_addr), ");" });
-  $fdisplay(fhandle_fix, { indent(L1), ".mtvec_bootstrap :" });
+  $fdisplay(fhandle_fix, { indent(L1), ".mtvec_bootstrap (__vector_start) :" });
   $fdisplay(fhandle_fix, { indent(L1), "{" });
   $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.mtvec_bootstrap));" });
   $fdisplay(fhandle_fix, { indent(L1), "}", mtvec_memory_area, "\n" });

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_constants.sv
@@ -86,82 +86,82 @@
    `elsif PMA_TEST_CFG_2
       const string pma_cfg_name = "pma_test_cfg_2";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 7;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h1FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h2000_0000>>2, word_addr_high : 32'h3FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h4000_0000>>2, word_addr_high : 32'h5FFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h6000_0000>>2, word_addr_high : 32'h9FFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'hA000_0000>>2, word_addr_high : 32'hDFFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
+        '{word_addr_low : 32'hE010_0000>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
         '{word_addr_low : 32'hE000_0000>>2, word_addr_high : 32'hE00F_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'hE010_0000>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1}
+        '{word_addr_low : 32'hA000_0000>>2, word_addr_high : 32'hDFFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h6000_0000>>2, word_addr_high : 32'h9FFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h4000_0000>>2, word_addr_high : 32'h5FFF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h2000_0000>>2, word_addr_high : 32'h3FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h1FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1}
         };
    `elsif PMA_TEST_CFG_3
       const string pma_cfg_name = "pma_test_cfg_3";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 16;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
-        '{word_addr_low : 32'h4800_0000>>2, word_addr_high : 32'h49FF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h4400_0000>>2, word_addr_high : 32'h4BFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h3ACE_0000>>2, word_addr_high : 32'h4ABC_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h3600_A000>>2, word_addr_high : 32'h4F99_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h3420_C854>>2, word_addr_high : 32'h5000_ABFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h3100_FCAB>>2, word_addr_high : 32'h5000_BCCA>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h3000_1353>>2, word_addr_high : 32'h5140_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h2C5A_3200>>2, word_addr_high : 32'h52FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h2A00_0000>>2, word_addr_high : 32'h56FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h2340_000A>>2, word_addr_high : 32'h600F_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h2000_0000>>2, word_addr_high : 32'h63FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h13AC_AA55>>2, word_addr_high : 32'h7FFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h1000_00F1>>2, word_addr_high : 32'h82FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
+        '{word_addr_low : 32'h0000_A000>>2, word_addr_high : 32'hFFFE_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h0200_0000>>2, word_addr_high : 32'hEFFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
         '{word_addr_low : 32'h0500_0000>>2, word_addr_high : 32'h8459_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0200_0000>>2, word_addr_high : 32'hEFFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_A000>>2, word_addr_high : 32'hFFFE_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1}
+        '{word_addr_low : 32'h1000_00F1>>2, word_addr_high : 32'h82FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h13AC_AA55>>2, word_addr_high : 32'h7FFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h2000_0000>>2, word_addr_high : 32'h63FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h2340_000A>>2, word_addr_high : 32'h600F_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h2A00_0000>>2, word_addr_high : 32'h56FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h2C5A_3200>>2, word_addr_high : 32'h52FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h3000_1353>>2, word_addr_high : 32'h5140_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h3100_FCAB>>2, word_addr_high : 32'h5000_BCCA>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h3420_C854>>2, word_addr_high : 32'h5000_ABFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h3600_A000>>2, word_addr_high : 32'h4F99_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h3ACE_0000>>2, word_addr_high : 32'h4ABC_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h4400_0000>>2, word_addr_high : 32'h4BFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h4800_0000>>2, word_addr_high : 32'h49FF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1}
         };
    `elsif PMA_TEST_CFG_4
       const string pma_cfg_name = "pma_test_cfg_4";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 16;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
-        '{word_addr_low : 32'h0001_0000>>2, word_addr_high : 32'h001F_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h0030_0000>>2, word_addr_high : 32'h04FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h1000_0000>>2, word_addr_high : 32'h1001_0000>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h1800_1234>>2, word_addr_high : 32'h18FF_AB21>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h2020_0010>>2, word_addr_high : 32'h2FFF_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h3100_A000>>2, word_addr_high : 32'h32FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h3440_0000>>2, word_addr_high : 32'h3800_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h4AAA_F000>>2, word_addr_high : 32'h4C00_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'h4D00_5555>>2, word_addr_high : 32'h4FFF_ABCD>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h5100_0000>>2, word_addr_high : 32'h52FF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h5400_0000>>2, word_addr_high : 32'h5FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
-        '{word_addr_low : 32'h6300_0000>>2, word_addr_high : 32'h6700_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'hA000_0000>>2, word_addr_high : 32'hAFFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'hBC00_0000>>2, word_addr_high : 32'hBCFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
+        '{word_addr_low : 32'hE700_EF00>>2, word_addr_high : 32'hE9FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
         '{word_addr_low : 32'hC000_0000>>2, word_addr_high : 32'hDFFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
-        '{word_addr_low : 32'hE700_EF00>>2, word_addr_high : 32'hE9FF_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1}
+        '{word_addr_low : 32'hBC00_0000>>2, word_addr_high : 32'hBCFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'hA000_0000>>2, word_addr_high : 32'hAFFF_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h6300_0000>>2, word_addr_high : 32'h6700_FFFF>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h5400_0000>>2, word_addr_high : 32'h5FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h5100_0000>>2, word_addr_high : 32'h52FF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h4D00_5555>>2, word_addr_high : 32'h4FFF_ABCD>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h4AAA_F000>>2, word_addr_high : 32'h4C00_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h3440_0000>>2, word_addr_high : 32'h3800_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h3100_A000>>2, word_addr_high : 32'h32FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h2020_0010>>2, word_addr_high : 32'h2FFF_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1},
+        '{word_addr_low : 32'h1800_1234>>2, word_addr_high : 32'h18FF_AB21>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h1000_0000>>2, word_addr_high : 32'h1001_0000>>2, main : 1'b0, bufferable : 1'b1, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0030_0000>>2, word_addr_high : 32'h04FF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h0001_0000>>2, word_addr_high : 32'h001F_FFFF>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b1}
         };
    `elsif PMA_TEST_CFG_5
       const string pma_cfg_name = "pma_test_cfg_5";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 16;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h5555_5555>>2, word_addr_high : 32'h5555_5555>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'hAAAA_AAAA>>2, word_addr_high : 32'hAAAA_AAAA>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'hCCCC_CCCC>>2, word_addr_high : 32'hCCCC_CCCC>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'hE38E_E38E>>2, word_addr_high : 32'hE38E_E38E>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'hFFFF_FFFF>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h9249_2492>>2, word_addr_high : 32'h9249_2492>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1},
+        '{word_addr_low : 32'h1249_2492>>2, word_addr_high : 32'h1249_2492>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
         '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
         '{word_addr_low : 32'hDB6D_B6DB>>2, word_addr_high : 32'hDB6D_B6DB>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
         '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h1249_2492>>2, word_addr_high : 32'h1249_2492>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
-        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, atomic : 1'b1}
+        '{word_addr_low : 32'h9249_2492>>2, word_addr_high : 32'h9249_2492>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'hFFFF_FFFF>>2, word_addr_high : 32'hFFFF_FFFF>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'hE38E_E38E>>2, word_addr_high : 32'hE38E_E38E>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'hCCCC_CCCC>>2, word_addr_high : 32'hCCCC_CCCC>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'hAAAA_AAAA>>2, word_addr_high : 32'hAAAA_AAAA>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h5555_5555>>2, word_addr_high : 32'h5555_5555>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0},
+        '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h0000_0000>>2, main : 1'b0, bufferable : 1'b0, cacheable : 1'b0, atomic : 1'b0}
         };
    `elsif PMA_TEST_CFG_X1 // Used for memory layout generator debug
       const string pma_cfg_name = "pma_test_cfg_x1";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 5;
-      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
+      parameter cv32e40x_pkg::pma_region_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
         '{word_addr_low : 32'h00000000>>2, word_addr_high : 32'h20000000>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
         '{word_addr_low : 32'h30000000>>2, word_addr_high : 32'h40000000>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},
         '{word_addr_low : 32'h50000000>>2, word_addr_high : 32'h60000000>>2, main : 1'b1, bufferable : 1'b0, cacheable : 1'b1, atomic : 1'b1},

--- a/cv32e40x/tests/cfg/pma_test_cfg_3.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_3.yaml
@@ -4,8 +4,8 @@ compile_flags:
    +define+PMA_TEST_CFG_3
 plusargs:
    +enable_pma=1
-   +boot_addr=0xA080
-   +mtvec_addr=0xA000
-   +nmi_addr=0x48000000
+   +boot_addr=0x48000080
+   +mtvec_addr=0x48000000
+   +nmi_addr=0x48100000
    +enable_large_mem_support=0
    +fix_sp=1

--- a/lib/mem_region_gen/pma_adapted_mem_region_gen.sv
+++ b/lib/mem_region_gen/pma_adapted_mem_region_gen.sv
@@ -71,10 +71,10 @@ class pma_adapted_memory_regions_c;
   * and initializes FSM
   */
   function new(pma_region_t pma_region[]);
-    foreach (pma_region[i]) begin
+    for (int i = pma_region.size() - 1; i >= 0; i--) begin
       // Skip zero-length regions
       if (pma_region[i].word_addr_low < pma_region[i].word_addr_high) begin
-        add_region(pma_region[i], i, UNCHECKED);
+        add_region(pma_region[i], pma_region.size() - i, UNCHECKED);
       end
     end
     state      = S_INIT;
@@ -96,7 +96,7 @@ class pma_adapted_memory_regions_c;
   */
   virtual function void divide_region_in_half(ref classified_region_t region[$]);
     bit require_min_two_region = 1;
-    if (region.size == 1 && require_min_two_region) begin
+    if (region.size() == 1 && require_min_two_region) begin
       region.push_back(region[0]);
       region[1].cfg.word_addr_low  = region[0].cfg.word_addr_high / 2;
       region[0].cfg.word_addr_high = region[1].cfg.word_addr_low  - 1;


### PR DESCRIPTION
Coverage analysis revealed a problem with the parsing of the PMA configs (parsed in reverse order), leading the configs to not capture the original test intent. This introduced the need for bug fixes in the linker and corev-dv memory region generation as well. 

Additionally, some regions were changed to main memory to fix lacking coverage. 