### PR TITLE
Hotfix for store_fencei_exec stream located as first stream in program

### DIFF
--- a/cv32e40x/env/corev-dv/cv32e40x_fencei_instr_lib.sv
+++ b/cv32e40x/env/corev-dv/cv32e40x_fencei_instr_lib.sv
@@ -190,10 +190,10 @@ class corev_store_fencei_exec_instr_stream extends riscv_load_store_rand_instr_s
     )
     case (instr.instr_name)
       JAL: begin
-        instr.imm_str = "0b";
+        instr.imm_str = "1b";
       end
       BEQ, BNE, BLT, BGE, BLTU, BGEU: begin
-        instr.imm_str = "0b";
+        instr.imm_str = "1b";
         instr.branch_assigned = 1'b1;
       end
     endcase


### PR DESCRIPTION
Hotfix for the case where the store_fencei_exec stream is the first instruction in the stream (first stream gets its label changed from 0: to main: ) leading to compilation failure - changed jump/branch target to 1: instead. The exact symbol is not important as it is never executed, but it needs to exist for compilation to succeed