### PR TITLE
Address multiple lint errors

### DIFF
--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
@@ -1,31 +1,35 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Silicon Labs, Inc.
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 `ifndef __UVME_CV32E40P_RANDOM_DEBUG__
 `define __UVME_CV32E40P_RANDOM_DEBUG__
 
 class uvme_cv32e40p_random_debug_c extends uvme_cv32e40p_base_vseq_c;
 
-    
+    rand int dly;
+
     `uvm_object_utils_begin(uvme_cv32e40p_random_debug_c)
     `uvm_object_utils_end
 
-    extern function new(string name="uvme_cv32e40p_random_debug");
+    constraint default_dly_c {
+        dly inside {[1:10000]};
+    }
 
+    extern function new(string name="uvme_cv32e40p_random_debug");
     extern virtual task body();
     extern virtual task rand_delay();
 endclass : uvme_cv32e40p_random_debug_c
@@ -35,8 +39,11 @@ function uvme_cv32e40p_random_debug_c::new(string name="uvme_cv32e40p_random_deb
 endfunction : new
 
 task uvme_cv32e40p_random_debug_c::rand_delay();
-    #($urandom_range(10000, 1));
-endtask : rand_delay      
+    if (!this.randomize()) begin
+        `uvm_error("RAND_DELAY", "Cannot randomize uvme_cv32e40p_random_debug_c")
+    end
+    #(dly);
+endtask : rand_delay
 
 task uvme_cv32e40p_random_debug_c::body();
     fork

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
@@ -40,7 +40,7 @@ endfunction : new
 
 task uvme_cv32e40p_random_debug_c::rand_delay();
     if (!this.randomize()) begin
-        `uvm_error("RAND_DELAY", "Cannot randomize uvme_cv32e40p_random_debug_c")
+        `uvm_fatal("RAND_DELAY", "Cannot randomize uvme_cv32e40p_random_debug_c")
     end
     #(dly);
 endtask : rand_delay

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_rand_num_seq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_vp_rand_num_seq.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Silicon Labs
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 `ifndef __UVME_CV32E40P_VP_RAND_NUM_SEQ_SV__
 `define __UVME_CV32E40P_VP_RAND_NUM_SEQ_SV__
@@ -32,12 +32,12 @@ class uvme_cv32e40p_vp_rand_num_seq_c extends uvma_obi_memory_vp_base_seq_c;
 
    `uvm_object_utils_begin(uvme_cv32e40p_vp_rand_num_seq_c)
    `uvm_object_utils_end
-      
+
    /**
     * Default constructor.
     */
    extern function new(string name="uvme_cv32e40p_vp_rand_num_seq_c");
-   
+
    /**
     * Implement number of peripherals
     */
@@ -52,9 +52,9 @@ endclass : uvme_cv32e40p_vp_rand_num_seq_c
 
 
 function uvme_cv32e40p_vp_rand_num_seq_c::new(string name="uvme_cv32e40p_vp_rand_num_seq_c");
-   
+
    super.new(name);
-   
+
 endfunction : new
 
 function int unsigned uvme_cv32e40p_vp_rand_num_seq_c::get_num_words();
@@ -64,17 +64,19 @@ function int unsigned uvme_cv32e40p_vp_rand_num_seq_c::get_num_words();
 endfunction  : get_num_words
 
 task uvme_cv32e40p_vp_rand_num_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_trn);
-   
+
    uvma_obi_memory_slv_seq_item_c  slv_rsp;   
 
    `uvm_create(slv_rsp)
-   
-   slv_rsp.orig_trn = mon_trn;   
-   slv_rsp.rdata = $urandom();
+
+   slv_rsp.orig_trn = mon_trn;
+   // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+   // Waived because it is very unlikely we'd ever need to control this value.
+   slv_rsp.rdata = $urandom(); //@DVT_LINTER_WAIVER "MT20211214_10" disable SVTB.29.1.3.1
    slv_rsp.err = 1'b0;
 
    `uvm_info("VPRNDSEQ", $sformatf("Issuing a random number: 0x%08x", slv_rsp.rdata), UVM_HIGH);
-   
+
    // Temporary hack to write the random number into ISS memory so that ISS can "see" the random number GPR register load as the RTL
    cv32e40p_cntxt.rvvi_memory_vif.mem[mon_trn.address >> 2] = slv_rsp.rdata;
 

--- a/cv32e40p/tb/core/tb_riscv/riscv_gnt_stall.sv
+++ b/cv32e40p/tb/core/tb_riscv/riscv_gnt_stall.sv
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 //
 // riscv_gnt_stall.sv
 //
@@ -113,7 +113,7 @@ always @(posedge clk_i or negedge rst_ni) begin
 
     // When request is removed, randomize gnt
     if (!req_core_i) begin
-      grant_core_o <= $urandom;
+      grant_core_o <= $urandom; //@DVT_LINTER_WAIVER "MT20211214_2" disable SVTB.29.1.3.1
     end
 
     // New request coming in

--- a/cv32e40p/tb/core/tb_riscv/riscv_rvalid_stall.sv
+++ b/cv32e40p/tb/core/tb_riscv/riscv_rvalid_stall.sv
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
 //
 // riscv_rvalid_stall.sv
 //
@@ -95,7 +95,7 @@ function logic [FIFO_DELAY_WL-1:0] get_random_delay();
     else if (stall_mode_i == perturbation_defines::STANDARD)
         get_random_delay = valid_stall_i;
     else if (stall_mode_i == perturbation_defines::RANDOM)
-        get_random_delay = $urandom_range(max_stall_i, 0);
+        get_random_delay = $urandom_range(max_stall_i, 0); //@DVT_LINTER_WAIVER "MT20211214_3" disable SVTB.29.1.3.1
     else
         get_random_delay = 0;
 endfunction : get_random_delay

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
@@ -93,8 +93,7 @@ module uvmt_cv32e40p_iss_wrap
                 break;
          end
          if (i==0 ) begin
-            $display("ERROR not : found in split '%0s'", in_s);
-            $finish(-1);
+            `uvm_fatal("ERROR not : found in split '%0s'", in_s);
          end
          s1 = in_s.substr(0,i-1);
          s2 = in_s.substr(i+1,in_s.len()-1);

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_pkg.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_pkg.sv
@@ -1,20 +1,21 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// 
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 `ifndef __UVMT_CV32E40P_PKG_SV__
 `define __UVMT_CV32E40P_PKG_SV__
@@ -33,29 +34,30 @@
  * CV32E40P RTL design.
  */
 package uvmt_cv32e40p_pkg;
-   
+
    import uvm_pkg::*;
    import uvme_cv32e40p_pkg::*;
    import uvml_hrtbt_pkg::*;
-   import uvml_logs_pkg::*;   
-   
+   import uvml_logs_pkg::*;
+
    // Constants / Structs / Enums
    `include "uvmt_cv32e40p_constants.sv"
    `include "uvmt_cv32e40p_tdefs.sv"
-   
+
    // Virtual sequence library
    // TODO Add virtual sequences
    //      Ex: `include "uvmt_cv32e40p_sanity_vseq.sv"
    `include "uvmt_cv32e40p_vseq_lib.sv"
-   
+
    // Base test case
    `include "uvmt_cv32e40p_test_cfg.sv"
+   `include "uvmt_cv32e40p_test_randvars.sv"
    `include "uvmt_cv32e40p_base_test.sv"  // all testcases should extend from this testcase
    //`include "uvmt_cv32e40p_smoke_test.sv" // smoke test has multile XMRs that are illegal according to the LRM
 
    // Compilance tests
    `include "uvmt_cv32e40p_firmware_test.sv"
-   
+
 endpackage : uvmt_cv32e40p_pkg
 
 // All Interfaces used by the CV32E40P TB are here

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
@@ -406,7 +406,7 @@ module uvmt_cv32e40p_step_compare
         3. Compare RTL <-> OVP
     */
     event ev_compare;
-    static integer instruction_count = 0;
+    static int instruction_count = 0;
 
     typedef enum {
         INIT,

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -15,6 +15,7 @@
 // limitations under the License.
 //
 
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 
 `ifndef __UVMT_CV32E40P_BASE_TEST_SV__
@@ -30,11 +31,12 @@
 class uvmt_cv32e40p_base_test_c extends uvm_test;
 
    // Objects
-   rand uvmt_cv32e40p_test_cfg_c   test_cfg ;
-   rand uvme_cv32e40p_cfg_c        env_cfg  ;
-   rand uvme_cv32e40p_cntxt_c      env_cntxt;
-   uvml_logs_rs_text_c             rs       ;
-   uvml_logs_reg_logger_cbs_c      reg_cbs  ;
+   rand uvmt_cv32e40p_test_cfg_c      test_cfg      ;
+   rand uvmt_cv32e40p_test_randvars_c test_randvars ;
+   rand uvme_cv32e40p_cfg_c           env_cfg       ;
+   rand uvme_cv32e40p_cntxt_c         env_cntxt     ;
+   uvml_logs_rs_text_c                rs            ;
+   uvml_logs_reg_logger_cbs_c         reg_cbs       ;
 
    // Components
    uvme_cv32e40p_env_c   env       ;
@@ -50,9 +52,10 @@ class uvmt_cv32e40p_base_test_c extends uvm_test;
 
 
    `uvm_component_utils_begin(uvmt_cv32e40p_base_test_c)
-      `uvm_field_object(test_cfg , UVM_DEFAULT)
-      `uvm_field_object(env_cfg  , UVM_DEFAULT)
-      `uvm_field_object(env_cntxt, UVM_DEFAULT)
+      `uvm_field_object(test_cfg      , UVM_DEFAULT)
+      `uvm_field_object(test_randvars , UVM_DEFAULT)
+      `uvm_field_object(env_cfg       , UVM_DEFAULT)
+      `uvm_field_object(env_cntxt     , UVM_DEFAULT)
    `uvm_component_utils_end
 
 

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_test_randvars.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_test_randvars.sv
@@ -1,0 +1,49 @@
+// Copyright 2021 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+`ifndef __UVMT_CV32E40P_TEST_RANDVARS_SV__
+`define __UVMT_CV32E40P_TEST_RANDVARS_SV__
+
+
+/**
+ * Object of randomizable variables
+ */
+class uvmt_cv32e40p_test_randvars_c extends uvm_object;
+
+   rand int unsigned  random_int;
+   rand logic [31:0]  random_logic32;
+   rand logic         random_logic_bit;
+
+   `uvm_object_utils_begin(uvmt_cv32e40p_test_randvars_c)
+      `uvm_field_int(random_int,       UVM_DEFAULT)
+      `uvm_field_int(random_logic32,   UVM_DEFAULT)
+      `uvm_field_int(random_logic_bit, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+
+   extern function new(string name="uvmt_cv32e40p_test_randvars");
+
+endclass : uvmt_cv32e40p_test_randvars_c
+
+
+function uvmt_cv32e40p_test_randvars_c::new(string name="uvmt_cv32e40p_test_randvars");
+
+   super.new(name);
+
+endfunction : new
+
+
+`endif // __UVMT_CV32E40P_TEST_RANDVARS_SV__

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -138,7 +138,7 @@ task uvmt_cv32e40p_firmware_test_c::reset_debug();
     @(negedge env_cntxt.clknrst_cntxt.vif.reset_n);
 
     if (!debug_vseq.randomize()) begin
-        `uvm_error("TEST", "Cannot randomize the debug sequence!")
+        `uvm_fatal("TEST", "Cannot randomize the debug sequence!")
     end
     debug_vseq.start(vsequencer);
 
@@ -152,12 +152,12 @@ task uvmt_cv32e40p_firmware_test_c::bootset_debug();
 
     // Delay debug_req_i by up to 35 cycles.Should hit BOOT_SET
     if (!test_randvars.randomize() with { random_int inside {[1:35]}; }) begin
-        `uvm_error("TEST", "Cannot randomize test_randvars for debug_req_delay!")
+        `uvm_fatal("TEST", "Cannot randomize test_randvars for debug_req_delay!")
     end
     repeat(test_randvars.random_int) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
 
     if (!debug_vseq.randomize()) begin
-        `uvm_error("TEST", "Cannot randomize the debug sequence!")
+        `uvm_fatal("TEST", "Cannot randomize the debug sequence!")
     end
     debug_vseq.start(vsequencer);
 
@@ -171,7 +171,7 @@ task uvmt_cv32e40p_firmware_test_c::random_debug();
         repeat (100) @(env_cntxt.debug_cntxt.vif.mon_cb);
         debug_vseq = uvme_cv32e40p_random_debug_c::type_id::create("random_debug_vseqr", vsequencer);
         if (!debug_vseq.randomize()) begin
-           `uvm_error("TEST", "Cannot randomize the debug sequence!")
+           `uvm_fatal("TEST", "Cannot randomize the debug sequence!")
         end
         debug_vseq.start(vsequencer);
         break;

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -16,6 +16,7 @@
 // limitations under the License.
 //
 
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 
 `ifndef __UVMT_CV32E40P_FIRMWARE_TEST_SV__
@@ -34,18 +35,12 @@
  */
 class uvmt_cv32e40p_firmware_test_c extends uvmt_cv32e40p_base_test_c;
 
-   //constraint env_cfg_cons {
-   //   env_cfg.enabled         == 1;
-   //   env_cfg.is_active       == UVM_ACTIVE;
-   //   env_cfg.trn_log_enabled == 1;
-   //}
-
    constraint test_type_cons {
      test_cfg.tpt == PREEXISTING_SELFCHECKING;
    }
 
-
-   `uvm_component_utils(uvmt_cv32e40p_firmware_test_c)
+   `uvm_component_utils_begin(uvmt_cv32e40p_firmware_test_c)
+   `uvm_object_utils_end
 
    /**
     */
@@ -142,7 +137,9 @@ task uvmt_cv32e40p_firmware_test_c::reset_debug();
     `uvm_info("TEST", "Applying debug_req_i at reset", UVM_NONE);
     @(negedge env_cntxt.clknrst_cntxt.vif.reset_n);
 
-    void'(debug_vseq.randomize());
+    if (!debug_vseq.randomize()) begin
+        `uvm_error("TEST", "Cannot randomize the debug sequence!")
+    end
     debug_vseq.start(vsequencer);
 
 endtask
@@ -154,9 +151,14 @@ task uvmt_cv32e40p_firmware_test_c::bootset_debug();
     @(negedge env_cntxt.clknrst_cntxt.vif.reset_n);
 
     // Delay debug_req_i by up to 35 cycles.Should hit BOOT_SET
-    repeat($urandom_range(35,1)) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
+    if (!test_randvars.randomize() with { random_int inside {[1:35]}; }) begin
+        `uvm_error("TEST", "Cannot randomize test_randvars for debug_req_delay!")
+    end
+    repeat(test_randvars.random_int) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
 
-    void'(debug_vseq.randomize());
+    if (!debug_vseq.randomize()) begin
+        `uvm_error("TEST", "Cannot randomize the debug sequence!")
+    end
     debug_vseq.start(vsequencer);
 
 endtask
@@ -196,6 +198,10 @@ task uvmt_cv32e40p_firmware_test_c::random_fetch_toggle();
     int unsigned fetch_assert_cycles;
     int unsigned fetch_deassert_cycles;
 
+    // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+    // Waive for performance reasons.
+    //@DVT_LINTER_WAIVER_START "MT20211214_4" disable SVTB.29.1.3.1
+
     // Randomly assert for a random number of cycles
     randcase
       9: fetch_assert_cycles = $urandom_range(100_000, 100);
@@ -210,6 +216,8 @@ task uvmt_cv32e40p_firmware_test_c::random_fetch_toggle();
       3: fetch_deassert_cycles = $urandom_range(100, 1);
       1: fetch_deassert_cycles = $urandom_range(3, 1);
     endcase
+    //@DVT_LINTER_WAIVER_END "MT20211214_4"
+
     repeat (fetch_deassert_cycles) @(core_cntrl_vif.drv_cb);
     core_cntrl_vif.go_fetch();
   end

--- a/docs/CodingStyleGuidelines.md
+++ b/docs/CodingStyleGuidelines.md
@@ -20,19 +20,36 @@
 --->
 
 
-# Suggested Coding Guidelines
+# CORE-V-VERIF Coding Guidelines for SystemVerilog/UVM code
 
 > "Code is read much more often than it is written"
 >
 > ~ pep8
 
-Every company—even a company of one—should have a set of coding guidelines if for no other reason than to maintain consistency and readability. Whether a company chooses something different from what is described here, or picks and chooses from the list below, is entirely up to the company’s needs. The following guidelines have been in use since 2011 at Cavium, and every effort has been made to ensure that the code samples in this text abide by them.
+Every organization — even a company of one — should have a set of coding guidelines if for no other reason than to maintain consistency and readability.
+These guidelines are specific to code developed for design verification using SystemVerilog and the Universal Verification Methodology.
+For RTL code, the OpenHW Group uses the [the lowRISC Verilog coding style guide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md),
+and this may also be used for CORE-V-VERIF code when implementing testbench components from SystemVerilog modules.
+
+The original text of these guidlines is extracted, with permission, from *Advanced UVM*, (c) 2015, 2016 Brian Hunter, who owns all the rights thereto.
 
 1. **General Conventions**
+
+This document uses specific verbs to have specific meaning that is similar, but not identical to, that which is used by the [IEEE Standards Style Manaul](https://mentor.ieee.org/myproject/Public/mytools/draft/styleman.pdf) (section 9).<br>
+* **Shall** indicates a mandatory requirement.
+* **Should** indicates a recommendation may be used interchangibly with the verb **Recommended**.
+* **May** indicates a permissible action, and is sometimes used to suggest ways to fulfill a recommendation.
+* **Can** indicates possibility and/or a capability.
 
 1.1. **Common Header**
 
 1.1.1. All files shall begin with a common header. The initial author, filename, and a brief description shall be filled out as basic documentation.
+All headers shall have an SPDX-License-Identifier comment line such as below:
+```
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+```
+Please contract the OpenHW Group for a list of licenses we can accept.
+
 
 1.2. **Indentation**
 
@@ -212,7 +229,14 @@ For example:
   *************************************************************************/
 ```
 
+1.10. **Code blocks**
+
+All code blocks shall be delimited with begin..end keywords.
+
 2. **Verification Kits**
+
+Note: the concept if `Verification Kits` as defined in the `Advanced UVM` textbook is not explicitly supported in CORE-V-VERIF.
+A future reversion of these guidelines will update this section to explain how vkits are implemented in this repo.
 
 2.1. **Organization**
 
@@ -743,7 +767,8 @@ The `UVM_COMPONENT` macro is configured with `UVM_NOCOPY`, `UVM_NOCOMPARE`, and 
 
 A testbench's random configuration variables may control how the testbench is built out, how the DUT is configured, and how random traffic is generated.
 
-Testbench random configuration variables should take advantage of SystemVerilog's powerful constraints and functional coverage as much as possible. They should also be consistently declared from testbench to testbench.
+Testbench random configuration variables should take advantage of SystemVerilog's powerful constraints and functional coverage as much as possible.
+They should also be consistently declared from testbench to testbench.
 
 Tests should constrain random variables through inheritance. Child tests can then control the environment with minimal effort.
 
@@ -798,9 +823,27 @@ class foo_agent_c extends uvm_agent;
 endclass : foo_agent_c
 ```
 
+5.1.7 Use of random number system functions and methods
+<br><br>
+Use of $urandom(), $urandom_range(), $random(), $dist_uniform(), $dist_normal(),
+$dist_exponential(), $dist_poisson(), $dist_chi_square(), $dist_t() and
+$dist_erlang() should be avoided because members randomized with these calls
+cannot be constrained.
+
+This rule may be waived if the randomization of a member using one of these system methods is controlled by a member that is constrainable.
+For example:
+
+```
+    if (cfg.drive_random_rdata) begin
+       slv_mp.drv_slv_cb.rdata <= $urandom();
+    end
+```
+
 5.2. **Test Constraints**
 
-Tests are greatly simplified and highly re-usable when they are primarily composed of configuration and constraint overrides. By instantiating the configuration class as a random field of the base test, derivative tests can add their own constraints and/or disable the base constraints. Disabling constraints is best done by overriding the `randomize_cfg()` function.
+Tests are greatly simplified and highly re-usable when they are primarily composed of configuration and constraint overrides.
+By instantiating the configuration class as a random field of the base test, derivative tests can add their own constraints and/or disable the base constraints.
+Disabling constraints is best done by overriding the `randomize_cfg()` function.
 
 ```v
 class my_test_c extends exer_test_c;
@@ -1075,9 +1118,6 @@ Note that adding `uvm_objects` to the configuration database in this fashion wil
 
 
 ---
-
-Original text extracted from *Advanced UVM*, (c) 2015, 2016 Brian Hunter, who owns all the rights thereto.
-
 
 
 [1]: http://www.naturaldocs.org.

--- a/docs/CodingStyleGuidelines.md
+++ b/docs/CodingStyleGuidelines.md
@@ -823,8 +823,16 @@ class foo_agent_c extends uvm_agent;
 endclass : foo_agent_c
 ```
 
-5.1.7 Use of random number system functions and methods
-<br><br>
+5.1.7 Randomization results shall be checked and failures shall result in a fatal error
+
+```v
+if (!my_vseq.randomize()) begin
+    `uvm_fatal("TEST", "Cannot randomize my sequence")
+end
+```
+
+5.1.8 Use of random number system functions and methods
+<br>
 Use of $urandom(), $urandom_range(), $random(), $dist_uniform(), $dist_normal(),
 $dist_exponential(), $dist_poisson(), $dist_chi_square(), $dist_t() and
 $dist_erlang() should be avoided because members randomized with these calls

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Datum Technology Corporation
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 
 `ifndef __UVMA_OBI_MEMORY_DRV_SV__
@@ -30,58 +30,56 @@ class uvma_obi_memory_drv_c extends uvm_driver#(
    .REQ(uvma_obi_memory_base_seq_item_c),
    .RSP(uvma_obi_memory_mon_trn_c      )
 );
-   
+
    // Objects
    uvma_obi_memory_cfg_c    cfg;
    uvma_obi_memory_cntxt_c  cntxt;
-   
+
    // TLM
    uvm_analysis_port     #(uvma_obi_memory_mstr_seq_item_c)  mstr_ap;
    uvm_analysis_port     #(uvma_obi_memory_slv_seq_item_c )  slv_ap ;
    uvm_tlm_analysis_fifo #(uvma_obi_memory_mon_trn_c      )  mon_trn_fifo;
-   
+
    // Handles to virtual interface modports
    virtual uvma_obi_memory_if.active_mstr_mp  mstr_mp;
    virtual uvma_obi_memory_if.active_slv_mp   slv_mp ;
-   
-   
+
    `uvm_component_utils_begin(uvma_obi_memory_drv_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
       `uvm_field_object(cntxt, UVM_DEFAULT)
    `uvm_component_utils_end
-   
-   
+
    /**
     * Default constructor.
     */
    extern function new(string name="uvma_obi_memory_drv", uvm_component parent=null);
-   
+
    /**
     * 1. Ensures cfg & cntxt handles are not null.
     * 2. Builds ap.
     */
    extern virtual function void build_phase(uvm_phase phase);
-   
+
    /**
     * Oversees driving, depending on the reset state, by calling drv_<pre|in|post>_reset() tasks.
     */
    extern virtual task run_phase(uvm_phase phase);
-   
+
    /**
     * Called by run_phase() while agent is in pre-reset state.
     */
    extern task drv_pre_reset();
-   
+
    /**
     * Called by run_phase() while agent is in reset state.
     */
    extern task drv_in_reset();
-   
+
    /**
     * Called by run_phase() while agent is in post-reset state.
     */
    extern task drv_post_reset();
-   
+
    /**
     * Drives the 'gnt' signal in response to 'req' being asserted.
     */
@@ -91,82 +89,82 @@ class uvma_obi_memory_drv_c extends uvm_driver#(
     * TODO Describe uvma_obi_drv::prep_req()
     */
    extern task prep_req(ref uvma_obi_memory_base_seq_item_c req);
-   
+
    /**
     * Drives the virtual interface's (cntxt.vif) signals using req's contents.
     */
    extern task drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
    /**
     * Drives the virtual interface's (cntxt.vif) signals using req's contents.
     */
    extern task drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
    /**
     * Drives the virtual interface's (cntxt.vif) signals using req's contents.
     */
    extern task drv_mstr_write_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
    /**
     * Drives the virtual interface's (cntxt.vif) signals using req's contents.
     */
    extern task drv_slv_req(ref uvma_obi_memory_slv_seq_item_c req);
-   
+
    /**
     * Drives the interface's signals using req's contents.
     */
    extern virtual task drv_slv_read_req(ref uvma_obi_memory_slv_seq_item_c req);
-   
+
    /**
     * Drives the interface's signals using req's contents.
     */
    extern virtual task drv_slv_write_req(ref uvma_obi_memory_slv_seq_item_c req);
-   
+
    /**
     * TODO Describe uvma_obi_memory_drv_c::wait_for_rsp()
     */
    extern task wait_for_rsp(output uvma_obi_memory_mon_trn_c rsp);
-   
+
    /**
     * TODO Describe uvma_obi_memory_drv_c::process_mstr_rsp()
     */
    extern task process_mstr_rsp(ref uvma_obi_memory_mstr_seq_item_c req, ref uvma_obi_memory_mon_trn_c rsp);
-   
+
    /**
     * TODO Describe uvma_obi_memory_drv_c::process_slv_rsp()
     */
    extern task process_slv_rsp(ref uvma_obi_memory_slv_seq_item_c rsp, ref uvma_obi_memory_mon_trn_c req);
-   
+
    /**
     * TODO Describe uvma_obi_memory_drv_c::drv_mstr_idle()
     */
    extern task drv_mstr_idle();
-   
+
    /**
     * Drive an idle response state onto the OBI (including rvalid == 0)
     */
    extern task drv_slv_idle();
-   
+
 endclass : uvma_obi_memory_drv_c
 
 
 function uvma_obi_memory_drv_c::new(string name="uvma_obi_memory_drv", uvm_component parent=null);
-   
+
    super.new(name, parent);
-   
+
 endfunction : new
 
 
 function void uvma_obi_memory_drv_c::build_phase(uvm_phase phase);
-   
+
    super.build_phase(phase);
-   
+
    void'(uvm_config_db#(uvma_obi_memory_cfg_c)::get(this, "", "cfg", cfg));
    if (cfg == null) begin
       `uvm_fatal("CFG", "Configuration handle is null")
    end
    uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "*", "cfg", cfg);
-   
+
    void'(uvm_config_db#(uvma_obi_memory_cntxt_c)::get(this, "", "cntxt", cntxt));
    if (cntxt == null) begin
       `uvm_fatal("CNTXT", "Context handle is null")
@@ -174,45 +172,45 @@ function void uvma_obi_memory_drv_c::build_phase(uvm_phase phase);
    uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "*", "cntxt", cntxt);
    mstr_mp = cntxt.vif.active_mstr_mp;
    slv_mp  = cntxt.vif.active_slv_mp ;
-   
+
    mstr_ap      = new("mstr_ap"     , this);
    slv_ap       = new("slv_ap"      , this);
    mon_trn_fifo = new("mon_trn_fifo", this);
-   
+
 endfunction : build_phase
 
 
 task uvma_obi_memory_drv_c::run_phase(uvm_phase phase);
-   
+
    super.run_phase(phase);
-   
+
    if (cfg.enabled && cfg.is_active) begin
       fork
-         begin : chan_a         
+         begin : chan_a
             forever begin
                drv_slv_gnt();
             end
          end
-         
+
          begin : chan_r
             forever begin
                case (cntxt.reset_state)
                   UVMA_OBI_MEMORY_RESET_STATE_PRE_RESET : drv_pre_reset ();
                   UVMA_OBI_MEMORY_RESET_STATE_IN_RESET  : drv_in_reset  ();
                   UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: drv_post_reset();
-                  
+
                   default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid reset_state: %0d", cntxt.reset_state))
                endcase
             end
          end
       join_none
    end
-   
+
 endtask : run_phase
 
 
 task uvma_obi_memory_drv_c::drv_pre_reset();
-   
+
    slv_mp.drv_slv_cb.gnt    <= 1'b0;
    slv_mp.drv_slv_cb.rvalid <= 1'b0;
    if (cfg.is_1p2_or_higher()) begin
@@ -223,41 +221,41 @@ task uvma_obi_memory_drv_c::drv_pre_reset();
    case (cfg.drv_mode)
       UVMA_OBI_MEMORY_MODE_MSTR: @(mstr_mp.drv_mstr_cb);
       UVMA_OBI_MEMORY_MODE_SLV : @(slv_mp .drv_slv_cb );
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
    endcase
-   
+
 endtask : drv_pre_reset
 
 
 task uvma_obi_memory_drv_c::drv_in_reset();
-   
+
    case (cfg.drv_mode)
       UVMA_OBI_MEMORY_MODE_MSTR: begin
          @(mstr_mp.drv_mstr_cb);
          drv_mstr_idle();
       end
-      
+
       UVMA_OBI_MEMORY_MODE_SLV : begin
          slv_mp.drv_slv_cb.rdata <= '0;
          @(slv_mp.drv_slv_cb);
          slv_mp.drv_slv_cb.rdata <= '0;
          drv_slv_idle();
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
    endcase
-   
+
 endtask : drv_in_reset
 
 
 task uvma_obi_memory_drv_c::drv_post_reset();
-   
+
    uvma_obi_memory_mstr_seq_item_c  mstr_req;
    uvma_obi_memory_slv_seq_item_c   slv_req;
    uvma_obi_memory_mon_trn_c        mstr_rsp;
    uvma_obi_memory_mon_trn_c        slv_rsp;
-   
+
    case (cfg.drv_mode)
       UVMA_OBI_MEMORY_MODE_MSTR: begin
          // 1. Get next req from sequence and drive it on the vif
@@ -268,16 +266,16 @@ task uvma_obi_memory_drv_c::drv_post_reset();
          end
          `uvm_info("OBI_MEMORY_DRV", $sformatf("Got mstr_req:\n%s", mstr_req.sprint()), UVM_HIGH)
          drv_mstr_req(mstr_req);
-         
+
          // 2. Wait for the monitor to send us the slv's rsp with the results of the req
          wait_for_rsp(slv_rsp);
          process_mstr_rsp(mstr_req, slv_rsp);
-         
+
          // 3. Send out to TLM and tell sequencer we're ready for the next sequence item
          mstr_ap.write(mstr_req);
          seq_item_port.item_done();
       end
-      
+
       UVMA_OBI_MEMORY_MODE_SLV: begin
          seq_item_port.try_next_item(req);
          if (req != null) begin
@@ -288,7 +286,7 @@ task uvma_obi_memory_drv_c::drv_post_reset();
             end
             `uvm_info("OBI_MEMORY_DRV", $sformatf("Got slv_req:\n%s", slv_req.sprint()), UVM_HIGH)
             drv_slv_req(slv_req);
-            
+
             // 2. Send out to TLM and tell sequencer we're ready for the next sequence item
             slv_ap.write(slv_req);
             seq_item_port.item_done();
@@ -298,18 +296,18 @@ task uvma_obi_memory_drv_c::drv_post_reset();
             @(slv_mp.drv_slv_cb);
          end
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
    endcase
-   
+
 endtask : drv_post_reset
 
 
 task uvma_obi_memory_drv_c::drv_slv_gnt();
-   
+
    case (cntxt.reset_state)
-      UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: begin         
-         
+      UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: begin
+
          // Pre-calculate the "next" latency
          int unsigned effective_latency = cfg.calc_random_gnt_latency();
 
@@ -329,13 +327,13 @@ task uvma_obi_memory_drv_c::drv_slv_gnt();
 
          // Advance the clock
          @(slv_mp.drv_slv_cb);
-         
+
          // Break out of this loop upon the next req and gnt
-         while (!(slv_mp.drv_slv_cb.req && slv_mp.drv_slv_cb.gnt)) begin            
+         while (!(slv_mp.drv_slv_cb.req && slv_mp.drv_slv_cb.gnt)) begin
             // Only count down a non-zero effective latency if someone is requesting (req asserted)
             if (effective_latency && slv_mp.drv_slv_cb.req)
                effective_latency--;
-            
+
             if (!effective_latency) begin
                slv_mp.drv_slv_cb.gnt <= 1'b1;
                if (cfg.is_1p2_or_higher()) begin
@@ -347,33 +345,33 @@ task uvma_obi_memory_drv_c::drv_slv_gnt();
          end
       end
       // If we are in another reset state, it is critical to advance time within the reset loop
-      default: @(slv_mp.drv_slv_cb);         
+      default: @(slv_mp.drv_slv_cb);
    endcase
-   
+
 endtask : drv_slv_gnt
 
 task uvma_obi_memory_drv_c::prep_req(ref uvma_obi_memory_base_seq_item_c req);
-   
+
    `uvml_hrtbt()
    req.cfg = cfg;
-   
+
 endtask : prep_req
 
 
 task uvma_obi_memory_drv_c::drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
    case (req.access_type)
       UVMA_OBI_MEMORY_ACCESS_READ: begin
          drv_mstr_read_req(req);
       end
-      
+
       UVMA_OBI_MEMORY_ACCESS_WRITE: begin
          drv_mstr_write_req(req);
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid access_type: %0d", req.access_type))
    endcase
-   
+
 endtask : drv_mstr_req
 
 
@@ -381,13 +379,13 @@ endtask : drv_mstr_req
 // address phases.  Rather than create a new method for the common code, the
 // waiver pragmas (@DVT) are placed to warn future maintainers of the situation.
 task uvma_obi_memory_drv_c::drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_c req);
-   
+
 //@DVT_LINTER_WAIVER_START "MT20211004_1" disable SVTB.33.1.0, SVTB.33.2.0
    // Req Latency cycles
    repeat (req.req_latency) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Address phase
    mstr_mp.drv_mstr_cb.req <= 1'b1;
    mstr_mp.drv_mstr_cb.we  <= req.access_type;
@@ -404,12 +402,12 @@ task uvma_obi_memory_drv_c::drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_
    for (int unsigned ii=0; ii<cfg.id_width; ii++) begin
       mstr_mp.drv_mstr_cb.aid[ii] <= req.id[ii];
    end
-   
+
    // Wait for grant
    while (mstr_mp.drv_mstr_cb.gnt !== 1'b1) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Wait for rvalid
    if (mstr_mp.drv_mstr_cb.rvalid !== 1'b1) begin
       while (mstr_mp.drv_mstr_cb.rvalid !== 1'b1) begin
@@ -419,7 +417,7 @@ task uvma_obi_memory_drv_c::drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_
    repeat (req.rready_latency) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Response phase
    mstr_mp.drv_mstr_cb.rready <= 1'b1;
    mstr_mp.drv_mstr_cb.req    <= 1'b0;
@@ -432,14 +430,14 @@ task uvma_obi_memory_drv_c::drv_mstr_read_req(ref uvma_obi_memory_mstr_seq_item_
    while (mstr_mp.drv_mstr_cb.rvalid === 1'b1) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Tail
    mstr_mp.drv_mstr_cb.rready <= 1'b0;
    drv_mstr_idle();
    repeat (req.tail_length) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
 endtask : drv_mstr_read_req
 
 
@@ -476,12 +474,12 @@ task uvma_obi_memory_drv_c::drv_mstr_write_req(ref uvma_obi_memory_mstr_seq_item
    for (int unsigned ii=0; ii<cfg.id_width; ii++) begin
       mstr_mp.drv_mstr_cb.aid[ii] <= req.id[ii];
    end
-   
+
    // Wait for grant
    while (mstr_mp.drv_mstr_cb.gnt !== 1'b1) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Wait for rvalid
    while (mstr_mp.drv_mstr_cb.rvalid !== 1'b1) begin
       @(mstr_mp.drv_mstr_cb);
@@ -489,7 +487,7 @@ task uvma_obi_memory_drv_c::drv_mstr_write_req(ref uvma_obi_memory_mstr_seq_item
    repeat (req.rready_latency) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Response phase
    mstr_mp.drv_mstr_cb.rready <= 1'b1;
    mstr_mp.drv_mstr_cb.req    <= 1'b0;
@@ -502,31 +500,31 @@ task uvma_obi_memory_drv_c::drv_mstr_write_req(ref uvma_obi_memory_mstr_seq_item
    while (mstr_mp.drv_mstr_cb.rvalid === 1'b1) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
    // Tail
    mstr_mp.drv_mstr_cb.rready <= 1'b0;
    drv_mstr_idle();
    repeat (req.tail_length) begin
       @(mstr_mp.drv_mstr_cb);
    end
-   
+
 endtask : drv_mstr_write_req
 
 
 task uvma_obi_memory_drv_c::drv_slv_req(ref uvma_obi_memory_slv_seq_item_c req);
-   
+
    case (req.access_type)
       UVMA_OBI_MEMORY_ACCESS_READ: begin
          drv_slv_read_req(req);
       end
-      
+
       UVMA_OBI_MEMORY_ACCESS_WRITE: begin
          drv_slv_write_req(req);
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid access_type: %0d", req.access_type))
    endcase
-   
+
 endtask : drv_slv_req
 
 
@@ -550,8 +548,7 @@ task uvma_obi_memory_drv_c::drv_slv_read_req(ref uvma_obi_memory_slv_seq_item_c 
    @(slv_mp.drv_slv_cb);
    `uvm_info("OBI_MEMORY_DRV", "drv_slv_read_req FIN", UVM_HIGH)
    drv_slv_idle();
-   
-   
+
 endtask : drv_slv_read_req
 
 
@@ -572,40 +569,40 @@ task uvma_obi_memory_drv_c::drv_slv_write_req(ref uvma_obi_memory_slv_seq_item_c
    @(slv_mp.drv_slv_cb);
    `uvm_info("OBI_MEMORY_DRV", "drv_slv_write_req FIN", UVM_HIGH)
    drv_slv_idle();
-   
+
 endtask : drv_slv_write_req
 
 
 task uvma_obi_memory_drv_c::wait_for_rsp(output uvma_obi_memory_mon_trn_c rsp);
-   
+
    mon_trn_fifo.get(rsp);
-   
+
 endtask : wait_for_rsp
 
 
 task uvma_obi_memory_drv_c::process_mstr_rsp(ref uvma_obi_memory_mstr_seq_item_c req, ref uvma_obi_memory_mon_trn_c rsp);
-   
+
    req.rdata       = rsp.data;
    req.__has_error = rsp.err ;
-   
+
 endtask : process_mstr_rsp
 
 
 task uvma_obi_memory_drv_c::process_slv_rsp(ref uvma_obi_memory_slv_seq_item_c rsp, ref uvma_obi_memory_mon_trn_c req);
-   
+
    rsp.orig_trn = req;
-   
+
 endtask : process_slv_rsp
 
 
 task uvma_obi_memory_drv_c::drv_mstr_idle();
-   
+
    mstr_mp.drv_mstr_cb.req    <= '0;
    mstr_mp.drv_mstr_cb.rready <= '0;
-   
+
    case (cfg.drv_idle)
       UVMA_OBI_MEMORY_DRV_IDLE_SAME: ;// Do nothing;
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_ZEROS: begin
          mstr_mp.drv_mstr_cb.addr  <= '0;
          mstr_mp.drv_mstr_cb.we    <= '0;
@@ -615,8 +612,11 @@ task uvma_obi_memory_drv_c::drv_mstr_idle();
          mstr_mp.drv_mstr_cb.wuser <= '0;
          mstr_mp.drv_mstr_cb.aid   <= '0;
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_RANDOM: begin
+         // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+         // Waive-abe because cfg.drv_idle is constrainable.
+         //@DVT_LINTER_WAIVER_START "MT20211214_5" disable SVTB.29.1.3.1
          mstr_mp.drv_mstr_cb.addr  <= $urandom();
          mstr_mp.drv_mstr_cb.we    <= $urandom();
          mstr_mp.drv_mstr_cb.be    <= $urandom();
@@ -624,8 +624,9 @@ task uvma_obi_memory_drv_c::drv_mstr_idle();
          mstr_mp.drv_mstr_cb.auser <= $urandom();
          mstr_mp.drv_mstr_cb.wuser <= $urandom();
          mstr_mp.drv_mstr_cb.aid   <= $urandom();
+         //@DVT_LINTER_WAIVER_END "MT20211214_5"
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_X: begin
          mstr_mp.drv_mstr_cb.addr  <= 'X;
          mstr_mp.drv_mstr_cb.we    <= 'X;
@@ -635,7 +636,7 @@ task uvma_obi_memory_drv_c::drv_mstr_idle();
          mstr_mp.drv_mstr_cb.wuser <= 'X;
          mstr_mp.drv_mstr_cb.aid   <= 'X;
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_Z: begin
          mstr_mp.drv_mstr_cb.addr  <= 'Z;
          mstr_mp.drv_mstr_cb.we    <= 'Z;
@@ -645,24 +646,24 @@ task uvma_obi_memory_drv_c::drv_mstr_idle();
          mstr_mp.drv_mstr_cb.wuser <= 'Z;
          mstr_mp.drv_mstr_cb.aid   <= 'Z;
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_idle: %0d", cfg.drv_idle))
    endcase
-   
+
 endtask : drv_mstr_idle
 
 
 task uvma_obi_memory_drv_c::drv_slv_idle();
-   
+
    slv_mp.drv_slv_cb.rvalid <= '0;
    if (cfg.is_1p2_or_higher()) begin
       slv_mp.drv_slv_cb.rvalidpar <= 1'b1;
    end
 
    case (cfg.drv_idle)
-   
+
       UVMA_OBI_MEMORY_DRV_IDLE_SAME: ;// Do nothing;
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_ZEROS: begin
          //`uvm_info("OBI_MEMORY_DRV", $sformatf("Invalid drv_zeros: %0d", cfg.drv_idle), UVM_NONE)
          slv_mp.drv_slv_cb.rdata <= '0;
@@ -670,15 +671,19 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.ruser <= '0;
          slv_mp.drv_slv_cb.rid   <= '0;
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_RANDOM: begin
          `uvm_info("OBI_MEMORY_DRV", $sformatf("Invalid drv_random: %0d", cfg.drv_idle), UVM_NONE)
+         // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+         // Waive-abe because cfg.drv_idle is constrainable.
+         //@DVT_LINTER_WAIVER_START "MT20211214_6" disable SVTB.29.1.3.1
          slv_mp.drv_slv_cb.rdata <= $urandom();
          slv_mp.drv_slv_cb.err   <= $urandom();
          slv_mp.drv_slv_cb.ruser <= $urandom();
          slv_mp.drv_slv_cb.rid   <= $urandom();
+         //@DVT_LINTER_WAIVER_END "MT20211214_6"
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_X: begin
          `uvm_info("OBI_MEMORY_DRV", $sformatf("Invalid drv_idle: %0d", cfg.drv_idle), UVM_NONE)
          slv_mp.drv_slv_cb.rdata <= 'X;
@@ -686,7 +691,7 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.ruser <= 'X;
          slv_mp.drv_slv_cb.rid   <= 'X;
       end
-      
+
       UVMA_OBI_MEMORY_DRV_IDLE_Z: begin
          `uvm_info("OBI_MEMORY_DRV", $sformatf("Invalid drv_Z: %0d", cfg.drv_idle), UVM_NONE)
          slv_mp.drv_slv_cb.rdata <= 'Z;
@@ -694,10 +699,10 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.ruser <= 'Z;
          slv_mp.drv_slv_cb.rid   <= 'Z;
       end
-      
+
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_idle: %0d", cfg.drv_idle))
    endcase
-   
+
 endtask : drv_slv_idle
 
 

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
@@ -268,7 +268,11 @@ function int unsigned uvma_obi_memory_cfg_c::calc_random_gnt_latency();
       UVMA_OBI_MEMORY_DRV_SLV_GNT_MODE_CONSTANT      : effective_latency = 0;
       UVMA_OBI_MEMORY_DRV_SLV_GNT_MODE_FIXED_LATENCY : effective_latency = drv_slv_gnt_fixed_latency;
       UVMA_OBI_MEMORY_DRV_SLV_GNT_MODE_RANDOM_LATENCY: begin
+         // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+         // Waive-abe because drv_slv_gnt_* are constrainable.
+         //@DVT_LINTER_WAIVER_START "MT20211214_7" disable SVTB.29.1.3.1
          effective_latency = $urandom_range(drv_slv_gnt_random_latency_min, drv_slv_gnt_random_latency_max);
+         //@DVT_LINTER_WAIVER_END "MT20211214_7"
       end
    endcase
 
@@ -284,7 +288,9 @@ function int unsigned uvma_obi_memory_cfg_c::calc_random_rvalid_latency();
       UVMA_OBI_MEMORY_DRV_SLV_RVALID_MODE_CONSTANT      : effective_latency = 0;
       UVMA_OBI_MEMORY_DRV_SLV_RVALID_MODE_FIXED_LATENCY : effective_latency = drv_slv_rvalid_fixed_latency;
       UVMA_OBI_MEMORY_DRV_SLV_RVALID_MODE_RANDOM_LATENCY: begin
+         //@DVT_LINTER_WAIVER_START "MT20211214_8" disable SVTB.29.1.3.1
          effective_latency = $urandom_range(drv_slv_rvalid_random_latency_min, drv_slv_rvalid_random_latency_max);
+         //@DVT_LINTER_WAIVER_END "MT20211214_8"
       end
    endcase
 

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_debug_control_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_debug_control_seq.sv
@@ -113,35 +113,40 @@ task uvma_obi_memory_vp_debug_control_seq_c::debug(bit dbg_req_value,
                                                    int unsigned dbg_pulse_duration,
                                                    int unsigned start_delay);
 
+   // SVTB.29.1.3.1 - Banned random number system functions and methods calls
+   // Waive-abe because we just do not need the fine tune control of
+   // constraints in this situation.
+   //@DVT_LINTER_WAIVER_START "MT20211214_9" disable SVTB.29.1.3.1
    fork
       begin
          if (rand_start_delay) begin
-            wait_n_clocks($urandom_range(start_delay, 0));            
+            wait_n_clocks($urandom_range(start_delay, 0));
          end
          else begin
             wait_n_clocks(start_delay);
          end
-         
+
          if (request_mode) begin
             set_debug_req(dbg_req_value);
-            
+
             if (rand_pulse_duration) begin
                if (dbg_pulse_duration == 0)
                   wait_n_clocks($urandom_range(128,1));
                else
-                  wait_n_clocks($urandom_range(dbg_pulse_duration, 1));               
+                  wait_n_clocks($urandom_range(dbg_pulse_duration, 1));
             end
             else begin
-               wait_n_clocks(dbg_pulse_duration);               
+               wait_n_clocks(dbg_pulse_duration);
             end
-            set_debug_req(!dbg_req_value);            
+            set_debug_req(!dbg_req_value);
          end
          else begin
-            set_debug_req(dbg_req_value);            
+            set_debug_req(dbg_req_value);
          end
       end
    join_none
-   
+   //@DVT_LINTER_WAIVER_END "MT20211214_9"
+
 endtask : debug
 
 `endif // __UVMA_OBI_MEMORY_VP_DEBUG_CONTROL_SEQ_SV__

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_rand_num_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_rand_num_seq.sv
@@ -68,10 +68,8 @@ task uvma_obi_memory_vp_rand_num_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_tr
    `uvm_create(slv_rsp)
 
    slv_rsp.orig_trn = mon_trn;
-   //slv_rsp.rdata = $urandom();
    if (!this.randomize()) begin
-      `uvm_error("VPRNDSEQ", "Failed to randomize")
-      slv_rsp.rdata = 32'h1234_5678;
+      `uvm_fatal("VPRNDSEQ", "Failed to randomize")
    end
    else begin
       slv_rsp.rdata = this.rdata;

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_rand_num_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_rand_num_seq.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2021 OpenHW Group
 // Copyright 2021 Silicon Labs
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
-// 
+//
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
 // not use this file except in compliance with the License, or, at your option,
 // the Apache License version 2.0. You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/SHL-2.1/
-// 
+//
 // Unless required by applicable law or agreed to in writing, any work
 // distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations
 // under the License.
-// 
+//
 
 `ifndef __UVMA_OBI_MEMORY_VP_RAND_NUM_SEQ_SV__
 `define __UVMA_OBI_MEMORY_VP_RAND_NUM_SEQ_SV__
@@ -26,14 +26,16 @@
  */
 class uvma_obi_memory_vp_rand_num_seq_c extends uvma_obi_memory_vp_base_seq_c;
 
+   rand uvma_obi_memory_data_b_t   rdata;
+
    `uvm_object_utils_begin(uvma_obi_memory_vp_rand_num_seq_c)
    `uvm_object_utils_end
-      
+
    /**
     * Default constructor.
     */
    extern function new(string name="uvma_obi_memory_vp_rand_num_seq_c");
-   
+
    /**
     * Implement number of peripherals
     */
@@ -48,9 +50,9 @@ endclass : uvma_obi_memory_vp_rand_num_seq_c
 
 
 function uvma_obi_memory_vp_rand_num_seq_c::new(string name="uvma_obi_memory_vp_rand_num_seq_c");
-   
+
    super.new(name);
-   
+
 endfunction : new
 
 function int unsigned uvma_obi_memory_vp_rand_num_seq_c::get_num_words();
@@ -60,17 +62,24 @@ function int unsigned uvma_obi_memory_vp_rand_num_seq_c::get_num_words();
 endfunction : get_num_words
 
 task uvma_obi_memory_vp_rand_num_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_trn);
-   
-   uvma_obi_memory_slv_seq_item_c  slv_rsp;   
+
+   uvma_obi_memory_slv_seq_item_c  slv_rsp;
 
    `uvm_create(slv_rsp)
-   
-   slv_rsp.orig_trn = mon_trn;   
-   slv_rsp.rdata = $urandom();
+
+   slv_rsp.orig_trn = mon_trn;
+   //slv_rsp.rdata = $urandom();
+   if (!this.randomize()) begin
+      `uvm_error("VPRNDSEQ", "Failed to randomize")
+      slv_rsp.rdata = 32'h1234_5678;
+   end
+   else begin
+      slv_rsp.rdata = this.rdata;
+   end
    slv_rsp.err = 1'b0;
 
    `uvm_info("VPRNDSEQ", $sformatf("Issuing a random number: 0x%08x", slv_rsp.rdata), UVM_HIGH);
-   
+
    add_r_fields(mon_trn, slv_rsp);
    `uvm_send(slv_rsp)
 

--- a/lib/uvm_libs/uvml_hrtbt/uvml_hrtbt_mon.sv
+++ b/lib/uvm_libs/uvml_hrtbt/uvml_hrtbt_mon.sv
@@ -280,7 +280,7 @@ function void uvml_hrtbt_mon_c::heartbeat(uvm_component owner, int unsigned id=0
          `uvm_warning("HRTBT_MON", $sformatf("Specified heartbeat ID (%0d) is already in use.  A new random ID will be picked.", id))
       end
       do begin
-         id = $urandom();
+         id = $urandom(); //@DVT_LINTER_WAIVER "MT20211214_12" disable SVTB.29.1.3.1
       end while (timestamps.exists(id));
       
       // Add entry

--- a/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
@@ -28,42 +28,42 @@ class uvml_logs_rs_json_c extends uvm_default_report_server;
 
    uvm_report_server  old_report_server;
    uvm_report_server  global_server;
-   
-   integer logfile_handle;
-   
-   
+
+   int logfile_handle;
+
+
    /**
-    * 
+    *
     */
    extern function new(string name="uvml_logs_rs_json", log_filename="log.json");
-   
+
    /**
-    * 
+    *
     */
    extern function void install_server();
-   
+
    /**
     * Helper function to convert verbosity value to appropriate string, based on uvm_verbosity enum if an equivalent level
     */
    extern function string convert_verbosity_to_string(int verbosity);
-   
+
    /**
     * Output standard XML header to log file
     */
    extern function void report_header(UVM_FILE file=0);
-   
+
    /**
     * Output XML closing tags to log file
     */
    extern function void report_footer(UVM_FILE file=0);
-   
+
    /**
     * tidy up logging and restore global report server
     */
    extern virtual function void report_summarize(UVM_FILE file=0);
-   
+
    /**
-    * 
+    *
     */
    extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name="");
 
@@ -71,29 +71,29 @@ endclass : uvml_logs_rs_json_c
 
 
 function uvml_logs_rs_json_c::new(string name="uvml_logs_rs_json", log_filename="log.json");
-   
+
    super.new(name);
-   
+
    global_server = uvm_report_server::get_server();
    install_server();
    logfile_handle = $fopen(log_filename, "w");
    report_header(logfile_handle);
-   
+
 endfunction : new
 
 
 function void uvml_logs_rs_json_c::install_server();
-   
+
    old_report_server = global_server;
    uvm_report_server::set_server(this);
-   
+
 endfunction : install_server
 
 
 function string uvml_logs_rs_json_c::convert_verbosity_to_string(int verbosity);
-   
+
    uvm_verbosity  l_verbosity;
-   
+
    if ($cast(l_verbosity, verbosity)) begin
       convert_verbosity_to_string = l_verbosity.name();
    end
@@ -102,47 +102,47 @@ function string uvml_logs_rs_json_c::convert_verbosity_to_string(int verbosity);
       l_str.itoa(verbosity);
       convert_verbosity_to_string = l_str;
    end
-   
+
 endfunction : convert_verbosity_to_string
 
 
 function void uvml_logs_rs_json_c::report_header(UVM_FILE file=0);
-   
+
    f_display(file, "[");
-   
+
 endfunction
 
 
 function void uvml_logs_rs_json_c::report_footer(UVM_FILE file=0);
-   
+
    f_display(file, "]");
-   
+
 endfunction
 
 
 function void uvml_logs_rs_json_c::report_summarize(UVM_FILE file=0);
-   
+
    report_footer(logfile_handle);
    global_server.set_server(old_report_server);
    $fclose(logfile_handle);
    old_report_server.report_summarize(file);
-   
+
 endfunction : report_summarize
 
 
 function string uvml_logs_rs_json_c::compose_report_message(uvm_report_message report_message, string report_object_name="");
-   
+
    string final_msg_str;
-   
+
    string severity_str;
    string verbosity_str;
-   
+
    uvm_severity temp_sev;
 
    temp_sev = report_message.get_severity();
    severity_str  = temp_sev.name();
    verbosity_str = convert_verbosity_to_string(report_message.get_verbosity());
-   
+
    final_msg_str = {"{",
       $sformatf("\"time\":\"%0t\","    , $realtime()                  ),
       $sformatf("\"id\":\"%s\","       , report_message.get_id()      ),
@@ -153,9 +153,9 @@ function string uvml_logs_rs_json_c::compose_report_message(uvm_report_message r
       $sformatf("\"line\":%0d,"        , report_message.get_line()    ),
       $sformatf("\"context\":\"%s\""   , report_message.get_context() ),
    "}"};
-   
+
    return final_msg_str;
-   
+
 endfunction : compose_report_message
 
 

--- a/lib/uvm_libs/uvml_mem/uvml_mem.sv
+++ b/lib/uvm_libs/uvml_mem/uvml_mem.sv
@@ -83,7 +83,7 @@ function reg[7:0] uvml_mem_c::read(bit[XLEN-1:0] addr);
          MEM_DEFAULT_0:      _mem[addr] = '0;
          MEM_DEFAULT_CONST:  _mem[addr] = mem_default_const_value;
          MEM_DEFAULT_INCR:   _mem[addr] = addr[7:0];
-         MEM_DEFAULT_RANDOM: _mem[addr] = $urandom();
+         MEM_DEFAULT_RANDOM: _mem[addr] = $urandom(); //@DVT_LINTER_WAIVER "MT20211214_11" disable SVTB.29.1.3.1
       endcase
    end
 


### PR DESCRIPTION
Hi @silabs-hfegran, this is a big PR in terms of files, but technically a bit of a softball.  All changes are one of three categories:
1. Fixing lint errors as reported by Verissimo.
2. Removal of unnecessary white-space (continuing an on-going effort started by Steve).
3. Update to the Coding Style guidelines as per the discussion in #926.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>