### PR TITLE
Added Zba,Zbb,Zbc,Zbs-extension support to all tests.

### DIFF
--- a/cv32e40x/env/corev-dv/target/cv32e40x/riscv_core_setting.sv
+++ b/cv32e40x/env/corev-dv/target/cv32e40x/riscv_core_setting.sv
@@ -30,7 +30,7 @@ privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
 riscv_instr_name_t unsupported_instr[];
 
 // ISA supported by the processor
-riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C};
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C, RV32ZBA, RV32ZBB, RV32ZBC, RV32ZBS};
 
 // Interrupt mode support
 mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};

--- a/cv32e40x/regress/cv32e40x_compliance.yaml
+++ b/cv32e40x/regress/cv32e40x_compliance.yaml
@@ -8,10 +8,12 @@ description: Runs all RISCV compliance tests on the CV32E40X
 builds:
   uvmt_cv32e40x:
     cmd: make comp
+    cfg: no_bitmanip
     dir: cv32e40x/sim/uvmt
 
   uvmt_cv32e40x_compliance_build:
     cmd: make all_compliance
+    cfg: no_bitmanip
     dir: cv32e40x/sim/uvmt
 
 # List of tests

--- a/cv32e40x/regress/cv32e40x_full.yaml
+++ b/cv32e40x/regress/cv32e40x_full.yaml
@@ -69,113 +69,136 @@ builds:
     cfg: pma_test_cfg_5
     dir: cv32e40x/sim/uvmt
 
+  uvmt_cv32e40x_no_bitmanip:
+    cmd: make comp_corev-dv comp
+    cfg: no_bitmanip
+    dir: cv32e40x/sim/uvmt
+
 # List of tests
 tests:
   hello-world:
     build: uvmt_cv32e40x
     description: uvm_hello_world_test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hello-world
 
   csr_instructions:
     build: uvmt_cv32e40x
     description: CSR instruction test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   generic_exception_test:
     build: uvmt_cv32e40x
     description: Generic exception test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=generic_exception_test
 
   illegal_instr_test:
     build: uvmt_cv32e40x
     description: Illegal instruction test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=illegal_instr_test
 
   branch_zero:
     build: uvmt_cv32e40x
     description: Branch test with zero offsets
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=branch_zero
 
   cv32e40x_csr_access_test:
     build: uvmt_cv32e40x
     description: CSR Access Mode Test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=cv32e40x_csr_access_test
 
   cv32e40x_readonly_csr_access_test:
     build: uvmt_cv32e40x
     description: CSR Read-only Access Mode Test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=cv32e40x_readonly_csr_access_test
 
   requested_csr_por:
     build: uvmt_cv32e40x
     description: CSR PoR test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=requested_csr_por
 
   modeled_csr_por:
     build: uvmt_cv32e40x
     description: Modeled CSR PoR test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=modeled_csr_por
 
   csr_instr_asm:
     build: uvmt_cv32e40x
     description: CSR instruction assembly test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=csr_instr_asm
 
   perf_counters_instructions:
     build: uvmt_cv32e40x
     description: Performance counter test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=perf_counters_instructions
 
   mhpmcounter29_csr_access_test_1:
     build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 1
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_1
 
   mhpmcounter29_csr_access_test_2:
     build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 2
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_2
 
   hpmcounter_basic_test:
     build: uvmt_cv32e40x
     description: Hardware performance counter basic test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_test
 
   hpmcounter_basic_nostall_test:
     build: uvmt_cv32e40x
     description: Hardware performance counter basic test with no random stalls
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
-    cmd: make test COREV=YES TEST=hpmcounter_basic_nostall_test
+    cmd: make test TEST=hpmcounter_basic_nostall_test
 
   hpmcounter_hazard_test:
     build: uvmt_cv32e40x
     description: Hardware performance counter hazard test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hpmcounter_hazard_test
 
   riscv_ebreak_test_0:
     build: uvmt_cv32e40x
     description: Static corev-dv ebreak
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=riscv_ebreak_test_0
 
   riscv_arithmetic_basic_test_0:
     build: uvmt_cv32e40x
     description: Static riscv-dv arithmetic test 0
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_0
     num: 1
@@ -183,6 +206,7 @@ tests:
   riscv_arithmetic_basic_test_1:
     build: uvmt_cv32e40x
     description: Static riscv-dv arithmetic test 1
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_1
     num: 1
@@ -190,7 +214,7 @@ tests:
   corev_rand_arithmetic_base_test:
     build: uvmt_cv32e40x
     description: Generated corev-dv arithmetic test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_arithmetic_base_test
     num: 4
@@ -198,7 +222,7 @@ tests:
   corev_rand_instr_test:
     build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_test
     num: 5
@@ -206,7 +230,7 @@ tests:
   corev_rand_instr_long_stall:
     build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test with long stalls
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_long_stall
     num: 2
@@ -214,7 +238,7 @@ tests:
   corev_rand_illegal_instr_test:
     build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test with illegal instructions
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_illegal_instr_test
     num: 5
@@ -222,7 +246,7 @@ tests:
   corev_rand_jump_stress_test:
     build: uvmt_cv32e40x
     description: Generated corev-dv jump stress test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_jump_stress_test
     num: 5
@@ -230,7 +254,7 @@ tests:
   corev_rand_interrupt:
     build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
     num: 5
@@ -238,7 +262,7 @@ tests:
   corev_rand_debug:
     build: uvmt_cv32e40x
     description: Generated corev-dv random debug test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug
     num: 5
@@ -246,7 +270,7 @@ tests:
   corev_rand_debug_single_step:
     build: uvmt_cv32e40x
     description: debug random test with single-stepping
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug_single_step
     num: 5
@@ -254,7 +278,7 @@ tests:
   corev_rand_debug_ebreak:
     build: uvmt_cv32e40x
     description: debug random test with ebreaks from ROM
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug_ebreak
     num: 5
@@ -262,20 +286,20 @@ tests:
   corev_rand_interrupt_wfi:
     build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt WFI test
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi
     num: 5
 
   corev_rand_fencei:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random fence,i test
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_fencei
     num: 2
 
   corev_rand_interrupt_wfi_mem_stress:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with memory stress
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi_mem_stress
@@ -284,20 +308,20 @@ tests:
   corev_rand_interrupt_debug:
     build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt WFI test with debug
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_debug
     num: 5
 
   corev_rand_interrupt_exception:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with exceptions
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_exception
     num: 5
 
   corev_rand_interrupt_nested:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with random nested interrupts
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_nested
@@ -311,28 +335,28 @@ tests:
     num: 3
 
   corev_rand_instr_obi_err:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI instruction bus error test
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err
     num: 6
 
   corev_rand_instr_obi_err_debug:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI instruction bus error test with debug
     dir: cv32e40x/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_obi_err_debug
+    cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err_debug
     num: 6
 
   corev_rand_data_obi_err:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI data bus error test
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err
     num: 6
 
   corev_rand_data_obi_err_debug:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI data bus error test with debug
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err_debug
@@ -341,48 +365,56 @@ tests:
   illegal:
     build: uvmt_cv32e40x
     description: Illegal-riscv-tests
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=illegal
 
   fibonacci:
     build: uvmt_cv32e40x
     description: Fibonacci test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=fibonacci
 
   misalign:
     build: uvmt_cv32e40x
     description: Misalign test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=misalign
 
   dhrystone:
     build: uvmt_cv32e40x
     description: Dhrystone test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=dhrystone
 
   debug_test:
     build: uvmt_cv32e40x
     description: Debug Test 1
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test
 
   debug_test_reset:
     build: uvmt_cv32e40x
     description: Debug reset test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_reset
 
   debug_test_trigger:
     build: uvmt_cv32e40x
     description: Debug trigger test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_trigger
 
   debug_test_boot_set:
     build: uvmt_cv32e40x
     description: Debug test target debug_req at BOOT_SET
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_boot_set
     num: 10
@@ -390,42 +422,42 @@ tests:
   interrupt_bootstrap:
     build: uvmt_cv32e40x
     description: Interrupt bootstrap test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=interrupt_bootstrap
 
   interrupt_test:
     build: uvmt_cv32e40x
     description: Interrupt test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=interrupt_test
 
   isa_fcov_holes:
     build: uvmt_cv32e40x
     description: ISA function coverage test
-    dir: cv32e40x/sim/uvmt
-    cmd: make test TEST=isa_fcov_holes
-
-  pma:
-    build: uvmt_cv32e40x_pma
-    description: ISA function coverage test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   instr_bus_error:
     build: uvmt_cv32e40x
     description: Directed instruction bus error test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=instr_bus_error
 
   data_bus_error:
     build: uvmt_cv32e40x
     description: Directed data bus error test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=data_bus_error
 
   load_store_rs1_zero:
     build: uvmt_cv32e40x
     description: Directed rs1 coverage test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=load_store_rs1_zero
 
@@ -440,3 +472,4 @@ tests:
     description: Directed Zb extension test
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=b_ext_test
+

--- a/cv32e40x/sim/Common.mk
+++ b/cv32e40x/sim/Common.mk
@@ -15,16 +15,16 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40x
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= af71c0ec7754fd87ce25335ef584de605aa68ca9
+CV_CORE_HASH   ?= feaf14428b48321e7be3184b4924378917183323
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv
 RISCVDV_BRANCH  ?= master
-RISCVDV_HASH    ?= f255eac0e011a95f1ae9d510adb24458b98600f3
+RISCVDV_HASH    ?= 96c1ee6f371f2754c45b4831fcab95f6671689d9
 
 EMBENCH_REPO    ?= https://github.com/embench/embench-iot.git
 EMBENCH_BRANCH  ?= master
-EMBENCH_HASH	?= 6934ddd1ff445245ee032d4258fdeb9828b72af4
+EMBENCH_HASH    ?= 6934ddd1ff445245ee032d4258fdeb9828b72af4
 
 COMPLIANCE_REPO   ?= https://github.com/strichmo/riscv-arch-test.git
 COMPLIANCE_BRANCH ?= strichmo/pr/cv32e40x_initial_old_compliance

--- a/cv32e40x/tests/cfg/b_ext_abs.yaml
+++ b/cv32e40x/tests/cfg/b_ext_abs.yaml
@@ -1,9 +1,13 @@
-name: b_ext_abs 
+name: b_ext_abs
 description: Enables the B extensions ZBA_ZBB_ZBS in the cv32e40x
-compile_flags: 
+compile_flags:
     +define+ZBA_ZBB_ZBS
 ovpsim: >
 #    --showoverrides
 #    --trace --tracechange --traceshowicount --monitornets
 cflags: >
+riscv_march: rv32imc_zba1p00_zbb1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbs1p00
 

--- a/cv32e40x/tests/cfg/b_ext_all.yaml
+++ b/cv32e40x/tests/cfg/b_ext_all.yaml
@@ -6,4 +6,8 @@ ovpsim: >
 #    --showoverrides
 #    --trace --tracechange --traceshowicount --monitornets
 cflags: >
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
 

--- a/cv32e40x/tests/cfg/default.yaml
+++ b/cv32e40x/tests/cfg/default.yaml
@@ -1,8 +1,17 @@
 name: default
 description: Default configuration for CV32E40X simulations
 compile_flags:
+    +define+ZBA_ZBB_ZBC_ZBS
 ovpsim: >
     # --showoverrides
     # --trace --tracechange --traceshowicount --monitornets
 cflags: >
-
+plusargs: >
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/no_bitmanip.yaml
+++ b/cv32e40x/tests/cfg/no_bitmanip.yaml
@@ -1,0 +1,7 @@
+name: no_bitmanip
+description: Default configuration for CV32E40X simulations
+compile_flags: >
+ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
+cflags: >

--- a/cv32e40x/tests/cfg/pma_test_cfg_1.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_1.yaml
@@ -2,6 +2,15 @@ name: pma_test_cfg_1
 description: PMA configuration for the PMA_TEST_CFG_1 test case
 compile_flags:
    +define+PMA_TEST_CFG_1
+   +define+ZBA_ZBB_ZBC_ZBS
 plusargs:
    +enable_pma=1
    +fix_sp=1
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/pma_test_cfg_2.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_2.yaml
@@ -2,6 +2,15 @@ name: pma_test_cfg_2
 description: PMA configuration for the PMA_TEST_CFG_2 test case
 compile_flags:
    +define+PMA_TEST_CFG_2
+   +define+ZBA_ZBB_ZBC_ZBS
 plusargs:
    +enable_pma=1
    +fix_sp=1
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/pma_test_cfg_3.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_3.yaml
@@ -2,6 +2,7 @@ name: pma_test_cfg_3
 description: PMA configuration for the PMA_TEST_CFG_3 test case
 compile_flags:
    +define+PMA_TEST_CFG_3
+   +define+ZBA_ZBB_ZBC_ZBS
 plusargs:
    +enable_pma=1
    +boot_addr=0x48000080
@@ -9,3 +10,11 @@ plusargs:
    +nmi_addr=0x48100000
    +enable_large_mem_support=0
    +fix_sp=1
+   +enable_zba_extension=1
+   +enable_zbb_extension=1
+   +enable_zbc_extension=1
+   +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/pma_test_cfg_4.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_4.yaml
@@ -2,6 +2,7 @@ name: pma_test_cfg_4
 description: PMA configuration for the PMA_TEST_CFG_4 test case
 compile_flags:
    +define+PMA_TEST_CFG_4
+   +define+ZBA_ZBB_ZBC_ZBS
 plusargs:
    +enable_pma=1
    +boot_addr=0x10080
@@ -10,3 +11,11 @@ plusargs:
    +dm_halt_addr=0x32010000
    +dm_exception_addr=0x32010800
    +fix_sp=1
+   +enable_zba_extension=1
+   +enable_zbb_extension=1
+   +enable_zbc_extension=1
+   +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/pma_test_cfg_5.yaml
+++ b/cv32e40x/tests/cfg/pma_test_cfg_5.yaml
@@ -2,9 +2,18 @@ name: pma_test_cfg_5
 description: PMA configuration for the PMA_TEST_CFG_5 test case
 compile_flags:
    +define+PMA_TEST_CFG_5
+   +define+ZBA_ZBB_ZBC_ZBS
 plusargs:
    +enable_pma=1
    +boot_addr=0x80
    +fix_sp=1
    +dm_halt_addr=0x301000
    +dm_exception_addr=0x301800
+   +enable_zba_extension=1
+   +enable_zbb_extension=1
+   +enable_zbc_extension=1
+   +enable_zbs_extension=1
+riscv_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+gnu_march:   rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+corev_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+llvm_march:  rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/programs/corev-dv/corev_rand_instr_test/corev-dv.yaml
+++ b/cv32e40x/tests/programs/corev-dv/corev_rand_instr_test/corev-dv.yaml
@@ -16,5 +16,3 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +hint_instr_ratio=2
-    +enable_b_extension=1
-    +enable_bitmanip_groups=zbb

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -259,24 +259,24 @@ OVP_MODEL_DPI   = $(DV_OVPM_MODEL)/bin/Linux64/imperas_CV32.dpi.so
 #
 GNU_SW_TOOLCHAIN    ?= /opt/gnu
 GNU_VENDOR          ?= unknown
-GNU_MARCH           ?= rv32imc
+GNU_MARCH           ?= $(call RESOLVE_FLAG2,$(CFG_GNU_MARCH),rv32imc)
 GNU_CC              ?= gcc
 COREV_SW_TOOLCHAIN  ?= /opt/corev
 COREV_VENDOR        ?= corev
-COREV_MARCH         ?= rv32imc
+COREV_MARCH         ?= $(call RESOLVE_FLAG2,$(CFG_COREV_MARCH),rv32imc)
 COREV_CC            ?= gcc
 PULP_SW_TOOLCHAIN   ?= /opt/pulp
 PULP_VENDOR         ?= unknown
-PULP_MARCH          ?= rv32imcxpulpv2
+PULP_MARCH          ?= $(call RESOLVE_FLAG2,$(CFG_PULP_MARCH),rv32imcxpulpv2)
 PULP_CC             ?= gcc
 LLVM_SW_TOOLCHAIN   ?= /opt/clang
 LLVM_VENDOR         ?= unknown
-LLVM_MARCH          ?= rv32imc
+LLVM_MARCH          ?= $(call RESOLVE_FLAG2,$(CFG_LLVM_MARCH),rv32imc)
 LLVM_CC             ?= cc
 
-CV_SW_TOOLCHAIN  ?= /opt/riscv
-CV_SW_VENDOR     ?= unknown
-CV_SW_MARCH      ?= rv32imc
+CV_SW_TOOLCHAIN     ?= /opt/riscv
+CV_SW_VENDOR        ?= unknown
+CV_SW_MARCH         ?= $(call RESOLVE_FLAG2,$(CFG_CV_SW_MARCH),rv32imc)
 
 GNU_YES          = $(call IS_YES,$(GNU))
 PULP_YES         = $(call IS_YES,$(PULP))

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -206,6 +206,9 @@ XRUN_RUN_FLAGS  += -nowarn RNDNOXCEL
 # Probes
 XRUN_RUN_FLAGS  += -nowarn PRLDYN
 
+# Physical repository related to logical library in a cds.lib does not exist
+XRUN_COMP_FLAGS += -nowarn DLCPTH
+
 # Allow extra semicolons
 XRUN_COMP_FLAGS += -nowarn UEXPSC
 


### PR DESCRIPTION
    Added Zba,Zbb,Zbc,Zbs-extension support to all tests.
    
    Summary of changes:
      - Updated cv32e40x hash.
      - Updated riscv-dv hash (Now with support for bitmanip v1.0.0).
      - Updated supported march for corev-dv to include Zba,Zbb,Zbc,Zbs.
      - Added support for configuration-wide plusargs.
      - Updated test configurations to use bitmanip by default.
      - Added test configuration (no_bitmanip) without bitmanip support.
      - Expanded full regression to include a few non-bitmanip enabled tests.
      - Removed invocation of old Zbb extension in corev_rand_instr_test.
      - Removed duplicate pma-test entry in regression list.
      - Disabled DLCPTH-warning from xrun as it caused a lot of clutter in the log files.
      - Removed COREV=1 flag from two tests in regression that should have been removed previously.
      - Compliance test still uses the previous config (no_bitmanip) as I am not certain what changes are needed here.
