### PR TITLE
Resolve or waive linter issues

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_iss_wrap.sv
@@ -86,7 +86,7 @@ module uvmt_cv32e40p_iss_wrap
        step_compare_if.ovp_cpu_state_cont  = cpu.control.state_cont;
    end
 
-    function void split(input string in_s, output string s1, s2);
+    function automatic void split(ref string in_s, ref string s1, s2);
         automatic int i;
         for (i=0; i<in_s.len(); i++) begin
             if (in_s.getc(i) == ":")

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_step_compare.sv
@@ -113,7 +113,8 @@ module uvmt_cv32e40p_step_compare
     end
   end
 
-  function void check_32bit(input string compared, input bit [31:0] expected, input logic [31:0] actual);
+                                                                                                          // Waiving Verissimo SVTB.32.2.0: Pass strings by reference unless otherwise needed
+  function void check_32bit(input string compared, input bit [31:0] expected, input logic [31:0] actual); //@DVT_LINTER_WAIVER "MT20211228_1" disable SVTB.32.2.0
       static int now = 0;
       if (now != $time) begin
         miscompare = 0;
@@ -384,7 +385,8 @@ module uvmt_cv32e40p_step_compare
     end
 
     // RTL->RM CSR : mcycle, minstret, mcycleh, minstreth
-    function automatic void pushRTL2RM(string message);
+                                                         // Waiving Verissimo SVTB.32.2.0: Pass strings by reference unless otherwise needed
+    function automatic void pushRTL2RM(string message);  //@DVT_LINTER_WAIVER "MT20211228_2" disable SVTB.32.2.0
         logic [ 5:0] gpr_addr;
         logic [31:0] gpr_value;
 

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -176,8 +176,9 @@ class uvmt_cv32e40p_base_test_c extends uvm_test;
 
    /**
     * Prints overlined and underlined text in uppercase.
+    * Waiving Verissimo SVTB.32.2.0: Pass strings by reference unless otherwise needed
     */
-   extern function void print_banner(string text);
+   extern function void print_banner(string text); //@DVT_LINTER_WAIVER "MT20211228_3" disable SVTB.32.2.0
 
    /**
     * Fatals out after watchdog_timeout has elapsed.

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -349,9 +349,10 @@ task uvma_obi_memory_drv_c::prep_req(ref uvma_obi_memory_base_seq_item_c req);
 endtask : prep_req
 
 // Both Master READ and WRITE transactions are handled here because the signalling is almost identical.
+// TODO: this task is yet to be fully tested as the CV32E4 cores are always the OBI bus master.
 task uvma_obi_memory_drv_c::drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req);
 
-   if (req.access_type != UVMA_OBI_MEMORY_ACCESS_READ || req.access_type != UVMA_OBI_MEMORY_ACCESS_WRITE) begin
+   if (req.access_type != UVMA_OBI_MEMORY_ACCESS_READ && req.access_type != UVMA_OBI_MEMORY_ACCESS_WRITE) begin
      `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid access_type: %0d", req.access_type))
    end
 

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
@@ -43,8 +43,9 @@ class uvma_obi_memory_slv_seq_c extends uvma_obi_memory_slv_base_seq_c;
 
    /**
     * Register sequences with a range of addresses on this OBI
+    * Waiving Verissimo SVTB.32.2.0: Pass strings by reference unless otherwise needed
     */
-   extern virtual function uvma_obi_memory_vp_base_seq_c register_vp_vseq(string name,
+   extern virtual function uvma_obi_memory_vp_base_seq_c register_vp_vseq(string name,                  //@DVT_LINTER_WAIVER "MT20211228_9" disable SVTB.32.2.0
                                                                           bit[31:0] start_address,
                                                                           uvm_object_wrapper seq_type);
 

--- a/lib/uvm_libs/uvml_logs/uvml_logs_mon_trn_logger.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_mon_trn_logger.sv
@@ -99,7 +99,8 @@ class uvml_logs_mon_trn_logger_c#(
    /**
     * Writes msg to disk
     */
-   extern function void fwrite(string msg);
+   // Waiving Verissimo linter SVTB.32.2.0: Pass strings by reference unless otherwise needed
+   extern function void fwrite(string msg); //@DVT_LINTER_WAIVER "MT20211228_8" disable SVTB.32.2.0
    
 endclass : uvml_logs_mon_trn_logger_c
 

--- a/lib/uvm_libs/uvml_logs/uvml_logs_reg_logger_cbs.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_reg_logger_cbs.sv
@@ -81,7 +81,8 @@ class uvml_logs_reg_logger_cbs_c extends uvm_reg_cbs;
    /**
     * Writes msg to disk
     */
-   extern function void fwrite(string msg);
+   // Waiving Verissimo linter SVTB.32.2.0: Pass strings by reference unless otherwise needed
+   extern function void fwrite(string msg); //@DVT_LINTER_WAIVER "MT20211228_7" disable SVTB.32.2.0
    
 endclass
 

--- a/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_rs_json.sv
@@ -65,7 +65,8 @@ class uvml_logs_rs_json_c extends uvm_default_report_server;
    /**
     *
     */
-   extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name="");
+   // Waiving Verissimo linter SVTB.32.2.0: Pass strings by reference unless otherwise needed
+   extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name=""); //@DVT_LINTER_WAIVER "MT20211228_6" disable SVTB.32.2.0
 
 endclass : uvml_logs_rs_json_c
 

--- a/lib/uvm_libs/uvml_logs/uvml_logs_rs_text.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_rs_text.sv
@@ -34,7 +34,8 @@ class uvml_logs_rs_text_c extends uvm_default_report_server;
    /**
     * 
     */
-   extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name="");
+   // Waiving Verissimo linter SVTB.32.2.0: Pass strings by reference unless otherwise needed
+   extern virtual function string compose_report_message(uvm_report_message report_message, string report_object_name=""); //@DVT_LINTER_WAIVER "MT20211228_5" disable SVTB.32.2.0
    
    /**
     * 

--- a/lib/uvm_libs/uvml_logs/uvml_logs_seq_item_logger.sv
+++ b/lib/uvm_libs/uvml_logs/uvml_logs_seq_item_logger.sv
@@ -98,8 +98,9 @@ class uvml_logs_seq_item_logger_c#(
    
    /**
     * Writes msg to disk
+    * Waiving Verissimo SVTB.32.2.0: Pass strings by reference unless otherwise needed
     */
-   extern function void fwrite(string msg);
+   extern function void fwrite(string msg); //@DVT_LINTER_WAIVER "MT20211228_4" disable SVTB.32.2.0
    
 endclass : uvml_logs_seq_item_logger_c
 


### PR DESCRIPTION
This PR resolves and/or waives two distinct linter errors identified by Verissimo:

1. Duplicated code in `lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv`.  Please look at this change carefully. The change is straightforward - two functions have been collapsed into a single function.  Having said that the OBI memory Agent is a critical component in our environments, so we want to be cautious about changes to it.
2. Dealing with `Verissimo SVTB.32.2.0` (Pass strings by reference).  For the most part, these have been waived.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>