### PR TITLE
Fix path for custom programs directory

### DIFF
--- a/cv32e40p/sim/core/README.md
+++ b/cv32e40p/sim/core/README.md
@@ -35,7 +35,7 @@ to run the default test (hello_world).
 
 Running your own Assembler programs
 -----------------------------
-If you have a C or assembly program in `../../tests/core/custom`
+If you have a C or assembly program in `../../tests/programs/custom`
 then the following will work with Verilator:<br>
 ```
 make veri-test TEST=dhrystone


### PR DESCRIPTION
We can see the path in the Makefile here: https://github.com/openhwgroup/core-v-verif/blob/55deb696e671451f4057d6be3b49c1f4f29c13d1/cv32e40p/sim/core/Makefile#L57