### PR TITLE
Add code coverage and riscv-dv random tests

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -29,6 +29,19 @@ VERDI          ?=
 user-define    ?= +define+WT_CACHE
 USERDEFINE      = +define+RVFI_TRACE $(user-define)
 
+TESTNAME := $(shell basename -s .o $(elf-bin))
+#######################################################################################
+#                   Code Coverage
+#######################################################################################
+#code coverage is deactivated by default
+#To activate the code coverage: define the env variable cov with: (export cov=value) , to deactivate it: (unset cov) OR (export cov= )
+ifdef cov
+	cov-comp-opt = -cm line+cond+fsm+tgl+assert
+	cov-run-opt  = -cm line+cond+fsm+tgl+assert -cm_name $(TESTNAME)
+else
+	cov-comp-opt =
+	cov-run-opt  =
+endif
 ###############################################################################
 # Synopsys VCS specific commands, variables
 ###############################################################################
@@ -91,14 +104,19 @@ vcs_uvm_comp:
 	cd $(VCS_WORK_DIR) && vcs $(ALL_UVM_FLAGS) \
 	  -f $(FLIST_CORE) -f $(FLIST_TB) \
 	  -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
+	  $(cov-comp-opt) \
 	  -top uvmt_cva6_tb
 
 vcs_uvm_run:
 	cp Mem_init.txt $(VCS_WORK_DIR)/
 	cd $(VCS_WORK_DIR)/ && \
 	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
-	++$(elf-bin)
+	++$(elf-bin) \
+	$(cov-run-opt) && \
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
+
+generate_cov_dash:
+	urg -dir $(VCS_WORK_DIR)/simv.vdb
 
 vcs_gate_comp:
 	@echo "[VCS] Building Model"

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -110,7 +110,7 @@ vcs_uvm_comp:
 	  -top uvmt_cva6_tb
 
 vcs_uvm_run:
-	cp Mem_init.txt $(VCS_WORK_DIR)/
+	cp $(TESTNAME).txt $(VCS_WORK_DIR)/Mem_init.txt
 	cd $(VCS_WORK_DIR)/ && \
 	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
 	++$(elf-bin) \
@@ -154,6 +154,10 @@ veri_comp:
 		$(CVA6_TB_DIR)/cva6_tb_verilator.cpp
 	@echo "[VERILATOR] Compiling Model"
 	$(MAKE) -C $(VERILATOR_WORK_DIR) -f Vcva6_core_only_tb.mk
+
+veri_run:
+	cp $(TESTNAME).txt Mem_init.txt
+	$(VERILATOR_WORK_DIR)/Vcva6_core_only_tb
 
 veri_clean_all:
 	@echo "[VERILATOR] Cleanup (both work and results dirs)"

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -35,8 +35,10 @@ TESTNAME := $(shell basename -s .o $(elf-bin))
 #######################################################################################
 #code coverage is deactivated by default
 #To activate the code coverage: define the env variable cov with: (export cov=value) , to deactivate it: (unset cov) OR (export cov= )
+cov-exclude-list ?= $(root-dir)/cov-exclude-mod.lst
+
 ifdef cov
-	cov-comp-opt = -cm line+cond+fsm+tgl+assert
+	cov-comp-opt = -cm line+cond+fsm+tgl+assert -cm_hier $(cov-exclude-list)
 	cov-run-opt  = -cm line+cond+fsm+tgl+assert -cm_name $(TESTNAME)
 else
 	cov-comp-opt =

--- a/cva6/sim/cov-exclude-mod.lst
+++ b/cva6/sim/cov-exclude-mod.lst
@@ -1,0 +1,12 @@
+// Copyright 2021 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+
+
+-tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.instr_tracer_i
+-tree uvmt_cva6_tb.cva6_dut_wrap.cva6_tb_wrapper_i.i_cva6.tracer_if

--- a/cva6/sim/cva6-simulator.yaml
+++ b/cva6/sim/cva6-simulator.yaml
@@ -1,0 +1,107 @@
+# Copyright Google LLC
+# Copyright 2021 Thales DIS Design Services SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+- tool: vcs
+  compile:
+    cmd:
+      - "vcs -file <cwd>/dv/vcs.compile.option.f
+              +incdir+<setting>
+              +incdir+<user_extension>
+             -f <cwd>/dv/files.f -full64
+             -l <out>/compile.log
+             -LDFLAGS '-Wl,--no-as-needed'
+             -Mdir=<out>/vcs_simv.csrc
+             -o <out>/vcs_simv <cmp_opts> <cov_opts> "
+    cov_opts: >
+      -cm_dir <out>/test.vdb
+  sim:
+    cmd: >
+      <out>/vcs_simv +vcs+lic+wait gen="true" <sim_opts> +ntb_random_seed=<seed> <cov_opts>
+    cov_opts: >
+      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>
+
+- tool: ius
+  compile:
+    cmd:
+      - "irun -64bit -access +rwc -f <cwd>/dv/files.f
+              +incdir+<setting>
+              +incdir+<user_extension>
+              -q -sv -uvm -vlog_ext +.vh -I.
+              -uvmhome CDNS-1.2
+              -elaborate
+              -l <out>/compile.log <cmp_opts>"
+  sim:
+    cmd: >
+      irun -R <sim_opts> -svseed <seed> -svrnc rand_struct
+
+- tool: questa
+  compile:
+    cmd:
+      - "vmap mtiUvm $QUESTA_HOME/questasim/uvm-1.2"
+      - "vlog -64
+        +incdir+<setting>
+        +incdir+<user_extension>
+        -access=rwc
+        -f <cwd>/dv/files.f
+        -sv
+        -mfcu -cuname design_cuname
+        +define+UVM_REGEX_NO_DPI
+        -writetoplevels <out>/top.list
+        -l <out>/compile.log <cmp_opts>"
+      - "vopt -64 -debug
+        +designfile -f <out>/top.list
+        -l <out>/optimize.log <cmp_opts>
+        -o design_opt"
+  sim:
+    cmd: >
+      vsim -64 -c <cov_opts> -do <cwd>/dv/questa_sim.tcl design_opt <sim_opts>  -sv_seed <seed>
+    cov_opts: >
+      -do "coverage save -onexit <out>/cov.ucdb;"
+
+- tool: dsim
+  env_var: DSIM,DSIM_LIB_PATH
+  compile:
+    cmd:
+      - "mkdir -p <out>/dsim"
+      - "<DSIM> -sv -work <out>/dsim
+                -genimage image
+                +incdir+$UVM_HOME/src
+                $UVM_HOME/src/uvm_pkg.sv
+                +define+DSIM
+                -suppress EnumMustBePositive
+                +incdir+<setting>
+                +incdir+<user_extension>
+                -f <cwd>/dv/files.f
+                -l <out>/dsim/compile.log <cmp_opts>"
+  sim:
+    cmd: >
+      <DSIM> <sim_opts> -sv_seed <seed> -pli_lib <DSIM_LIB_PATH>/libuvm_dpi.so +acc+rwb -image image -work <out>/dsim
+
+- tool: qrun
+  compile:
+    cmd:
+      - "qrun -f <cwd>/dv/qrun_option.f
+        +incdir+<setting>
+        +incdir+<user_extension>
+        -f <cwd>/dv/files.f <cmp_opts>
+        -l <out>/qrun_compile_optimize.log
+        -outdir <out>/qrun.out"
+  sim:
+    cmd: >
+      qrun -64 -simulate -snapshot design_opt -c <cov_opts> <sim_opts> -sv_seed <seed> -outdir <out>/qrun.out
+    cov_opts: >
+      -coverage -ucdb <out>/cov.ucdb

--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -283,6 +283,8 @@ def do_simulate(sim_cmd, test_list, cwd, sim_opts, seed_yaml, seed, csr_file,
   if sim_seed:
     with open(('%s/seed.yaml' % os.path.abspath(output_dir)) , 'w') as outfile:
       yaml.dump(sim_seed, outfile, default_flow_style=False)
+    with open(('seedlist.yaml') , 'a') as seedlist:
+      yaml.dump(sim_seed, seedlist, default_flow_style=False)
   if lsf_cmd:
     run_parallel_cmd(cmd_list, timeout_s, check_return_code = check_return_code,
                      debug_cmd = debug_cmd)

--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -21,6 +21,8 @@ import os
 import re
 import sys
 import logging
+import time
+import datetime
 
 from dv.scripts.lib import *
 from verilator_log_to_trace_csv import *
@@ -405,7 +407,8 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
   report = ("%s/iss_regr.log" % output_dir).rstrip()
   asm = re.sub(r"^.*\/", "", asm_test)
   asm = re.sub(r"\.S$", "", asm)
-  prefix = ("%s/directed_asm_tests/%s"  % (output_dir, asm))
+  asm = asm + "-" + str(datetime.datetime.now().isoformat()) #to have unique name for tests output files
+  prefix = ("%s/directed_asm_tests/%s" % (output_dir, asm))
   elf = prefix + ".o"
   binary = prefix + ".bin"
   iss_list = iss_opts.split(",")

--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -333,7 +333,8 @@ def elf2bin(elf, binary, debug_cmd):
   cmd = ("%s -O binary %s %s" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd), elf, binary))
   run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
   logging.info("Converting to Mem_init.txt")
-  cmd = ("%s -O verilog --change-addresses -0x80000000 %s Mem_init.txt" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd), elf))
+  Mem_init =  os.path.splitext(os.path.basename(elf))[0]
+  cmd = ("%s -O verilog --change-addresses -0x80000000 %s %s.txt" % (get_env_var("RISCV_OBJCOPY", debug_cmd = debug_cmd), elf, Mem_init))
   run_cmd_output(cmd.split(), debug_cmd = debug_cmd)
 
 

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -101,8 +101,8 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   precmd: >
-    make -f Makefile vcs_uvm_comp user-define="+define+WT_CACHE"
+    make -f Makefile vcs_uvm_comp cov=${cov} user-define="+define+WT_CACHE"
   cmd: >
-    make -f Makefile vcs_uvm_run elf-bin=<elf>
+    make -f Makefile vcs_uvm_run elf-bin=<elf> cov=${cov}
   postcmd: >
     <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -41,7 +41,7 @@
   precmd: >
     make -f Makefile veri_comp target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    ./verilator_work/Vcva6_core_only_tb
+    make -f Makefile veri_run elf-bin=<elf>
   postcmd: >
     <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
 


### PR DESCRIPTION
- to support code coverage, test output files need to have a unique name (add timestamp to the filename)
- provide a way to exclude some modules from coverage (e.g. rvfi_tracer module)
- to support riscv-dv random tests, use unique name for program file to be loaded (no more Mem_init.txt)