### PR TITLE
Fixed wrong cfg used for mhmpcounter29_csr_access tests

### DIFF
--- a/cv32e40x/regress/cv32e40x_full.yaml
+++ b/cv32e40x/regress/cv32e40x_full.yaml
@@ -77,126 +77,108 @@ builds:
 # List of tests
 tests:
   hello-world:
-    build: uvmt_cv32e40x
     description: uvm_hello_world_test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hello-world
 
   csr_instructions:
-    build: uvmt_cv32e40x
     description: CSR instruction test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   generic_exception_test:
-    build: uvmt_cv32e40x
     description: Generic exception test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=generic_exception_test
 
   illegal_instr_test:
-    build: uvmt_cv32e40x
     description: Illegal instruction test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=illegal_instr_test
 
   branch_zero:
-    build: uvmt_cv32e40x
     description: Branch test with zero offsets
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=branch_zero
 
   cv32e40x_csr_access_test:
-    build: uvmt_cv32e40x
     description: CSR Access Mode Test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=cv32e40x_csr_access_test
 
   cv32e40x_readonly_csr_access_test:
-    build: uvmt_cv32e40x
     description: CSR Read-only Access Mode Test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=cv32e40x_readonly_csr_access_test
 
   requested_csr_por:
-    build: uvmt_cv32e40x
     description: CSR PoR test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=requested_csr_por
 
   modeled_csr_por:
-    build: uvmt_cv32e40x
     description: Modeled CSR PoR test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=modeled_csr_por
 
   csr_instr_asm:
-    build: uvmt_cv32e40x
     description: CSR instruction assembly test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=csr_instr_asm
 
   perf_counters_instructions:
-    build: uvmt_cv32e40x
     description: Performance counter test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=perf_counters_instructions
 
   mhpmcounter29_csr_access_test_1:
-    build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 1
     builds: [ uvmt_cv32e40x_num_mhpmcounter_29 ]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_1
 
   mhpmcounter29_csr_access_test_2:
-    build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 2
     builds: [ uvmt_cv32e40x_num_mhpmcounter_29 ]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_2
 
   hpmcounter_basic_test:
-    build: uvmt_cv32e40x
     description: Hardware performance counter basic test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_test
 
   hpmcounter_basic_nostall_test:
-    build: uvmt_cv32e40x
     description: Hardware performance counter basic test with no random stalls
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_nostall_test
 
   hpmcounter_hazard_test:
-    build: uvmt_cv32e40x
     description: Hardware performance counter hazard test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=hpmcounter_hazard_test
 
   riscv_ebreak_test_0:
-    build: uvmt_cv32e40x
     description: Static corev-dv ebreak
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=riscv_ebreak_test_0
 
   riscv_arithmetic_basic_test_0:
-    build: uvmt_cv32e40x
     description: Static riscv-dv arithmetic test 0
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -204,7 +186,6 @@ tests:
     num: 1
 
   riscv_arithmetic_basic_test_1:
-    build: uvmt_cv32e40x
     description: Static riscv-dv arithmetic test 1
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -212,7 +193,6 @@ tests:
     num: 1
 
   corev_rand_arithmetic_base_test:
-    build: uvmt_cv32e40x
     description: Generated corev-dv arithmetic test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -220,7 +200,6 @@ tests:
     num: 4
 
   corev_rand_instr_test:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -228,7 +207,6 @@ tests:
     num: 5
 
   corev_rand_instr_long_stall:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test with long stalls
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -236,7 +214,6 @@ tests:
     num: 2
 
   corev_rand_illegal_instr_test:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random instruction test with illegal instructions
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -244,7 +221,6 @@ tests:
     num: 5
 
   corev_rand_jump_stress_test:
-    build: uvmt_cv32e40x
     description: Generated corev-dv jump stress test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -252,7 +228,6 @@ tests:
     num: 5
 
   corev_rand_interrupt:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -260,7 +235,6 @@ tests:
     num: 5
 
   corev_rand_debug:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random debug test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -268,7 +242,6 @@ tests:
     num: 5
 
   corev_rand_debug_single_step:
-    build: uvmt_cv32e40x
     description: debug random test with single-stepping
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -276,7 +249,6 @@ tests:
     num: 5
 
   corev_rand_debug_ebreak:
-    build: uvmt_cv32e40x
     description: debug random test with ebreaks from ROM
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -284,7 +256,6 @@ tests:
     num: 5
 
   corev_rand_interrupt_wfi:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt WFI test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -292,21 +263,20 @@ tests:
     num: 5
 
   corev_rand_fencei:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random fence,i test
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_fencei
     num: 2
 
   corev_rand_interrupt_wfi_mem_stress:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with memory stress
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi_mem_stress
     num: 5
 
   corev_rand_interrupt_debug:
-    build: uvmt_cv32e40x
     description: Generated corev-dv random interrupt WFI test with debug
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -314,105 +284,97 @@ tests:
     num: 5
 
   corev_rand_interrupt_exception:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with exceptions
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_exception
     num: 5
 
   corev_rand_interrupt_nested:
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with random nested interrupts
+    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_nested
     num: 5
 
   corev_rand_pma_test:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
     description: Generated corev-dv random PMA test
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pma_test
     num: 3
 
   corev_rand_instr_obi_err:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI instruction bus error test
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err
     num: 6
 
   corev_rand_instr_obi_err_debug:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI instruction bus error test with debug
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err_debug
     num: 6
 
   corev_rand_data_obi_err:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI data bus error test
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err
     num: 6
 
   corev_rand_data_obi_err_debug:
-    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     description: Random OBI data bus error test with debug
+    builds: [ uvmt_cv32e40x_pma_1, uvmt_cv32e40x_pma_2, uvmt_cv32e40x_pma_3, uvmt_cv32e40x_pma_4, uvmt_cv32e40x_pma_5, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err_debug
     num: 6
 
   illegal:
-    build: uvmt_cv32e40x
     description: Illegal-riscv-tests
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=illegal
 
   fibonacci:
-    build: uvmt_cv32e40x
     description: Fibonacci test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=fibonacci
 
   misalign:
-    build: uvmt_cv32e40x
     description: Misalign test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=misalign
 
   dhrystone:
-    build: uvmt_cv32e40x
     description: Dhrystone test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=dhrystone
 
   debug_test:
-    build: uvmt_cv32e40x
     description: Debug Test 1
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test
 
   debug_test_reset:
-    build: uvmt_cv32e40x
     description: Debug reset test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_reset
 
   debug_test_trigger:
-    build: uvmt_cv32e40x
     description: Debug trigger test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=debug_test_trigger
 
   debug_test_boot_set:
-    build: uvmt_cv32e40x
     description: Debug test target debug_req at BOOT_SET
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
@@ -420,56 +382,50 @@ tests:
     num: 10
 
   interrupt_bootstrap:
-    build: uvmt_cv32e40x
     description: Interrupt bootstrap test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=interrupt_bootstrap
 
   interrupt_test:
-    build: uvmt_cv32e40x
     description: Interrupt test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=interrupt_test
 
   isa_fcov_holes:
-    build: uvmt_cv32e40x
     description: ISA function coverage test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   instr_bus_error:
-    build: uvmt_cv32e40x
     description: Directed instruction bus error test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=instr_bus_error
 
   data_bus_error:
-    build: uvmt_cv32e40x
     description: Directed data bus error test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=data_bus_error
 
   load_store_rs1_zero:
-    build: uvmt_cv32e40x
     description: Directed rs1 coverage test
     builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=load_store_rs1_zero
 
   pma:
-    build: uvmt_cv32e40x_pma
     description: ISA function coverage test
+    builds: [ uvmt_cv32e40x_pma]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   b_ext_test:
-    builds: [uvmt_cv32e40x_b_ext_abs, uvmt_cv32e40x_b_ext_all]
     description: Directed Zb extension test
+    builds: [ uvmt_cv32e40x_b_ext_abs, uvmt_cv32e40x_b_ext_all]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=b_ext_test
 

--- a/cv32e40x/regress/cv32e40x_full.yaml
+++ b/cv32e40x/regress/cv32e40x_full.yaml
@@ -156,14 +156,14 @@ tests:
   mhpmcounter29_csr_access_test_1:
     build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 1
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
+    builds: [ uvmt_cv32e40x_num_mhpmcounter_29 ]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_1
 
   mhpmcounter29_csr_access_test_2:
     build: uvmt_cv32e40x_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 2
-    builds: [ uvmt_cv32e40x, uvmt_cv32e40x_no_bitmanip]
+    builds: [ uvmt_cv32e40x_num_mhpmcounter_29 ]
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_2
 

--- a/cv32e40x/tests/cfg/num_mhpmcounter_29.yaml
+++ b/cv32e40x/tests/cfg/num_mhpmcounter_29.yaml
@@ -1,8 +1,12 @@
 name: num_mhpmcounters_29
 description: Configuration for CV32E40X simulations with NUM_MHPMCOUNTER set to 29
 compile_flags:
+    +define+ZBA_ZBB_ZBC_ZBS
     +define+SET_NUM_MHPMCOUNTERS=29
-ovpsim: >
-    --override root/cpu/misa_Extensions=0x001104
-    --override root/cpu/marchid=20
-cflags: >
+plusargs: >
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+cv_sw_march: >
+    rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/cfg/num_mhpmcounter_29.yaml
+++ b/cv32e40x/tests/cfg/num_mhpmcounter_29.yaml
@@ -8,5 +8,7 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
+    +DISABLE_CSR_CHECK=mcountinhibit
+    # FIXME: Remove the DISABLE_CSR_CHECK when correct reset value is implemented in the ISS
 cv_sw_march: >
     rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_1/mhpmcounter29_csr_access_test_1.S
+++ b/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_1/mhpmcounter29_csr_access_test_1.S
@@ -23,6 +23,9 @@
 #     Notes:
 #       1. This test requires NUM_MHPMCOUNTERS set to 29.
 #       2. Does not test function - just access.
+#       3. FIXME: ISS currently does not set mcountinhibit correctly on reset
+#          for non-default number of registers, RVVI and RVFI will mismatch if
+#          sb checking is enabled.
 ###############################################################################
 #include "corev_uvmt.h"
 

--- a/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_1/test.yaml
+++ b/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_1/test.yaml
@@ -1,4 +1,4 @@
 name: mhpmcounter29_csr_access_test_1
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
-    CSR access test with NUM_MHPMCOUNTER = 29 (can run with ISS)
+    CSR access test with NUM_MHPMCOUNTER = 29 (FIXME ISS does not set correct reset value for mcountinhibit)

--- a/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
+++ b/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/mhpmcounter29_csr_access_test_2.S
@@ -23,7 +23,9 @@
 #     Notes:
 #       1. This test requires NUM_MHPMCOUNTERS set to 29.
 #       2. Does not test function - just access.
-#       3. Cannot run with the ISS.
+#       3. FIXME: ISS currently does not set mcountinhibit correctly on reset
+#          for non-default number of registers, RVVI and RVFI will mismatch if
+#          sb checking is enabled.
 ###############################################################################
 #include "corev_uvmt.h"
 

--- a/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/test.yaml
+++ b/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/test.yaml
@@ -1,4 +1,4 @@
 name: mhpmcounter29_csr_access_test_2
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
-    CSR access test with NUM_MHPMCOUNTER = 29 (CANNOT run with ISS)
+  CSR access test with NUM_MHPMCOUNTER = 29 (FIXME ISS does not set correct reset value for mcountinhibit)

--- a/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/test.yaml
+++ b/cv32e40x/tests/programs/custom/mhpmcounter29_csr_access_test_2/test.yaml
@@ -2,4 +2,3 @@ name: mhpmcounter29_csr_access_test_2
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
     CSR access test with NUM_MHPMCOUNTER = 29 (CANNOT run with ISS)
-


### PR DESCRIPTION
The mhpmcounter29_csr_access_test_* should be run with NUM_MHPMCOUNTERS=29.

Full regression changed to use the num_hpmcounter_29 config for these tests,  
and added support for bitmanip instructions to this cfg.

Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>