### PR TITLE
cva6.py: fix module import

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -26,7 +26,7 @@ import datetime
 
 from dv.scripts.lib import *
 from verilator_log_to_trace_csv import *
-from cva6 spike_log_to_trace_csv import *
+from cva6_spike_log_to_trace_csv import *
 from dv.scripts.ovpsim_log_to_trace_csv import *
 from dv.scripts.whisper_log_trace_csv import *
 from dv.scripts.sail_log_to_trace_csv import *


### PR DESCRIPTION
problem introduced in 5b43db03d8c9fae733e720c49293e3e2996bc0e1

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>