### PR TITLE
Added VP details to cva6_tb.sv and cva6_core_tb_sram.sv

### DIFF
--- a/cva6/tb/core/cva6_tb.sv
+++ b/cva6/tb/core/cva6_tb.sv
@@ -31,7 +31,13 @@ module cva6_core_only_tb #(
 ) (
   input  logic verilator_clk_i,
   input  logic verilator_rstn_i,
-  output wire  tb_exit_o
+  output wire  tb_exit_o,
+//added for VP
+  output logic        tests_passed,
+  output logic        tests_failed,
+  output logic [31:0] exit_value,
+  output logic        exit_valid
+
 );
 
   localparam CLK_REPORT_COUNT  =  100;
@@ -146,7 +152,12 @@ module cva6_core_only_tb #(
     .addr_i     ( addr[$clog2(NUM_WORDS)-1+$clog2(AXI_DATA_WIDTH/8):$clog2(AXI_DATA_WIDTH/8)] ),
     .wdata_i    ( wdata                                                                       ),
     .be_i       ( be                                                                          ),
-    .rdata_o    ( rdata                                                                       )
+    .rdata_o    ( rdata                                                                       ),
+//added for VP
+    .tests_passed_o ( tests_passed                            ),
+    .tests_failed_o ( tests_failed                            ),
+    .exit_valid_o   ( exit_valid                              ),
+    .exit_value_o   ( exit_value                              )
   );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -205,5 +216,24 @@ module cva6_core_only_tb #(
       end
     end
   end
+
+// check if we succeded
+    always_ff @(posedge tb_clk, negedge tb_rstn) begin
+        if (tests_passed) begin
+            $display("ALL TESTS PASSED");
+            $finish;
+        end
+        if (tests_failed) begin
+            $display("TEST(S) FAILED!");
+            $finish;
+        end
+        if (exit_valid) begin
+            if (exit_value == 0)
+                $display("%m @ %0t: EXIT SUCCESS", $time);
+            else
+                $display("%m @ %0t: EXIT FAILURE: %d", exit_value, $time);
+            $finish;
+        end
+    end
 
 endmodule

--- a/cva6/tb/core/tb_components/cva6_core_tb_sram.sv
+++ b/cva6/tb/core/tb_components/cva6_core_tb_sram.sv
@@ -54,7 +54,13 @@ module cva6_core_tb_sram #(
    input  logic [$clog2(NUM_WORDS)-1:0]  addr_i,
    input  logic [DATA_WIDTH-1:0]         wdata_i,
    input  logic [(DATA_WIDTH+7)/8-1:0]   be_i,
-   output logic [DATA_WIDTH-1:0]         rdata_o
+   output logic [DATA_WIDTH-1:0]         rdata_o,
+//added for VP
+   output logic                         tests_passed_o,
+   output logic                         tests_failed_o,
+   output logic                         exit_valid_o,
+   output logic [31:0]                  exit_value_o
+
 );
 
 localparam DATA_WIDTH_ALIGNED = ((DATA_WIDTH+63)/64)*64;
@@ -63,6 +69,97 @@ localparam BE_WIDTH_ALIGNED   = (((DATA_WIDTH+7)/8+7)/8)*8;
 logic [DATA_WIDTH_ALIGNED-1:0]  wdata_aligned;
 logic [BE_WIDTH_ALIGNED-1:0]    be_aligned;
 logic [DATA_WIDTH_ALIGNED-1:0]  rdata_aligned;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+//Addition of Virtual Peripheral details for CVA6:START
+////////////////////////////////////////////////////////////////////////////////
+
+
+    localparam int                        MMADDR_PRINT      = 32'h5000_0000;
+    localparam int                        MMADDR_TESTSTATUS = 32'h6000_0000;
+   // localparam int                        MMADDR_EXIT       = 32'h6000_0004;
+   // localparam int                        MMADDR_SIGBEGIN   = 32'h6000_0008;
+   // localparam int                        MMADDR_SIGEND     = 32'h6000_000C;
+   // localparam int                        MMADDR_SIGDUMP    = 32'h6000_0010;
+   // localparam int                        MMADDR_TIMERREG   = 32'h5500_0000;
+   // localparam int                        MMADDR_TIMERVAL   = 32'h5500_0004;
+   // localparam int                        MMADDR_DBG        = 32'h5500_0008;
+   // localparam int                        MMADDR_RNDSTALL   = 16'h5600;
+   // localparam int                        MMADDR_RNDNUM     = 32'h5500_1000;
+   // localparam int                        MMADDR_TICKS      = 32'h5500_1004;
+
+/* Memory used in e40 
+
+    localparam int                        MMADDR_PRINT      = 32'h1000_0000;
+    localparam int                        MMADDR_TESTSTATUS = 32'h2000_0000;
+    localparam int                        MMADDR_EXIT       = 32'h2000_0004;
+    localparam int                        MMADDR_SIGBEGIN   = 32'h2000_0008;
+    localparam int                        MMADDR_SIGEND     = 32'h2000_000C;
+    localparam int                        MMADDR_SIGDUMP    = 32'h2000_0010;
+    localparam int                        MMADDR_TIMERREG   = 32'h1500_0000;
+    localparam int                        MMADDR_TIMERVAL   = 32'h1500_0004;
+    localparam int                        MMADDR_DBG        = 32'h1500_0008;
+    localparam int                        MMADDR_RNDSTALL   = 16'h1600;
+    localparam int                        MMADDR_RNDNUM     = 32'h1500_1000;
+    localparam int                        MMADDR_TICKS      = 32'h1500_1004;
+
+*/
+
+
+// signals to print peripheral
+    logic [31:0]                   print_wdata;
+    logic                          print_valid;
+
+ // handle the mapping of read and writes to either memory or pseudo
+    // peripherals (currently just a redirection of writes to stdout)
+    always_comb begin
+        tests_passed_o      = '0;
+        tests_failed_o      = '0;
+        exit_value_o        =  0;
+        exit_valid_o        = '0;
+       //transaction         = T_PER;
+
+	   if (we_i) begin
+		if (addr_i == MMADDR_PRINT) begin
+                    print_wdata = wdata_i;
+                    print_valid = '1;
+		end else if (addr_i == MMADDR_TESTSTATUS) begin
+                    if (wdata_i == 123456789)
+                        tests_passed_o = '1;
+                    else if (wdata_i == 1)
+                        tests_failed_o = '1;
+           end
+        end
+    end
+
+
+
+ // print to stdout pseudo peripheral
+    always_ff @(posedge clk_i, negedge rstn_i) begin: print_peripheral
+        if(print_valid) begin
+            if ($test$plusargs("verbose")) begin
+                if (32 <= print_wdata && print_wdata < 128)
+                    $display("OUT: '%c'", print_wdata[7:0]);
+                else
+                    $display("OUT: %3d", print_wdata);
+
+            end else begin
+                $write("%c", print_wdata[7:0]);
+`ifndef VERILATOR
+                $fflush();
+`endif
+            end
+        end
+    end
+
+
+////////////////////////////////////////////////////////////////////////////////
+//Addition of Virtual Peripheral details for CVA6:END
+////////////////////////////////////////////////////////////////////////////////
+
+
 
 // align to 64 bits for inferrable macro below
 always_comb begin : p_align


### PR DESCRIPTION
Added Simulation stop scenario and outputs signals  tests_passed, tests_failed, exit_value, exit_valid to **cva6_tb.sv** and **cva6_core_tb_sram.sv**