### PR TITLE
Rename Mem_init.txt to expected name for vcs_core and vcs_gate target

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -61,7 +61,9 @@ vcs_core_comp:
 	cd $(VCS_WORK_DIR) && vcs $(ALL_VCS_FLAGS) work.cva6_core_only_tb
 
 vcs_core_run:
-	$(VCS_WORK_DIR)/simv $(if $(VERDI), -verdi,)
+	cp $(TESTNAME).txt $(VCS_WORK_DIR)/Mem_init.txt
+	cd $(VCS_WORK_DIR) && $(VCS_WORK_DIR)/simv $(if $(VERDI), -verdi,)
+	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
 
 export CVA6_UVMT_DIR          = $(CORE_V_VERIF)/cva6/tb/uvmt
 export CVA6_UVMT_PATH         = $(CORE_V_VERIF)/cva6/tb/uvmt
@@ -127,7 +129,7 @@ vcs_gate_comp:
 	cd $(VCS_WORK_DIR) && vcs $(ALL_VCS_FLAGS) -f $(FLIST_CORE)_gate -f $(FLIST_TB)
 
 vcs_gate_run:
-	cp Mem_init.txt $(VCS_WORK_DIR)/
+	cp $(TESTNAME).txt $(VCS_WORK_DIR)/Mem_init.txt
 	cd $(VCS_WORK_DIR)/ && $(VCS_WORK_DIR)/simv
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
 
@@ -170,7 +172,7 @@ veri_clean_all:
 ###############################################################################
 
 clean_all: vcs_clean_all veri_clean_all
-	rm -f Mem_init.txt
+	rm -f *.txt
 	rm -f trace*.log
 	rm -f trace*.dasm
 

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -81,7 +81,7 @@
   precmd: >
     make -f Makefile vcs_core_comp target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    make -f Makefile vcs_core_run
+    make -f Makefile vcs_core_run elf-bin=<elf>
   postcmd: >
     <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
 
@@ -92,7 +92,7 @@
   precmd: >
     make -f Makefile vcs_gate_comp target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    make -f Makefile vcs_gate_run
+    make -f Makefile vcs_gate_run elf-bin=<elf>
   postcmd: >
     <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
 


### PR DESCRIPTION
Just a small fix : Mem_init.txt has been renamed to $(TESTNAME).txt in PR #1108. 
I have updated vcs_core and vcs_gate target so it would work with this PR.