### PR TITLE
Changing Makefile name in line 66 as is in ../ directory for 40x

### DIFF
--- a/cv32e40x/sim/core/Makefile
+++ b/cv32e40x/sim/core/Makefile
@@ -63,7 +63,7 @@ TEST         ?= hello-world
 ###############################################################################
 # Common Makefiles:
 #  -Variables for RTL and other dependencies (e.g. RISCV-DV)
-include ../Common.mk
+include ../ExternalRepos.mk
 #  -Core Firmware and the RISCV GCC Toolchain (SDK)
 include $(CORE_V_VERIF)/mk/Common.mk
 


### PR DESCRIPTION
##Change makefile name called in another makefile for 40x

https://github.com/Nicolas-Gaudin/core-v-verif/blob/a13787838c108f9e6d55af308a2bc1b70acd6419/cv32e40x/sim/core/Makefile#L66

Change in l66 of cv32e40x/sim/core/Makefile

include ../Common.mk

into

include ../ExternalRepos.mk

As is in ../ directory