### PR TITLE
debug_assert: add checks for havereset/running/halted

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_debug_assert.sv
@@ -510,6 +510,33 @@ module uvmt_cv32e40x_debug_assert
         else `uvm_error(info_tag, "Debug mode not entered correctly at reset!");
 
 
+    // Debug vs reset
+
+    a_debug_state_onehot : assert property (
+      $onehot({cov_assert_if.debug_havereset, cov_assert_if.debug_running, cov_assert_if.debug_halted})
+      ) else `uvm_error(info_tag, "Should have exactly 1 of havereset/running/halted");
+
+    cov_havereset_to_running : cover property (
+      (cov_assert_if.debug_havereset  == 1)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 0)
+      #=#
+      (cov_assert_if.debug_havereset  == 0)
+      && (cov_assert_if.debug_running == 1)
+      && (cov_assert_if.debug_halted  == 0)
+      );
+
+    cov_havereset_to_halted : cover property (
+      (cov_assert_if.debug_havereset  == 1)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 0)
+      #=#
+      (cov_assert_if.debug_havereset  == 0)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 1)
+      );
+
+
     // Check that we cover the case where a debug_req_i
     // comes while flushing due to an illegal insn, causing
     // dpc to be set to the exception handler entry addr

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -397,7 +397,7 @@ module uvmt_cv32e40x_tb;
   // Instantiate debug assertions
 
   bind cv32e40x_wrapper
-    uvmt_cv32e40x_debug_cov_assert_if debug_cov_assert_if (
+    uvmt_cv32e40x_debug_cov_assert_if  debug_cov_assert_if (
       .id_valid               (core_i.id_stage_i.id_valid_o),
       .sys_fence_insn_i       (core_i.id_stage_i.decoder_i.sys_fencei_insn_o),
 
@@ -419,6 +419,10 @@ module uvmt_cv32e40x_tb;
 
       .ctrl_fsm_cs            (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
       .debug_req_i            (core_i.controller_i.controller_fsm_i.debug_req_i),
+      .debug_havereset        (core_i.debug_havereset_o),
+      .debug_running          (core_i.debug_running_o),
+      .debug_halted           (core_i.debug_halted_o),
+
       .debug_req_q            (core_i.controller_i.controller_fsm_i.debug_req_q),
       .pending_debug          (core_i.controller_i.controller_fsm_i.pending_debug),
       .pending_nmi            (core_i.controller_i.controller_fsm_i.pending_nmi),

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb_ifs.sv
@@ -150,6 +150,10 @@ interface uvmt_cv32e40x_debug_cov_assert_if
     // Debug signals
     input         debug_req_i, // From controller
     input         debug_req_q, // From controller
+    input         debug_havereset,
+    input         debug_running,
+    input         debug_halted,
+
     input         pending_debug, // From controller
     input         pending_nmi, // From controller
     input         nmi_allowed, // From controller


### PR DESCRIPTION
This PR adds 3 checks to see that [this](https://cv32e40x-user-manual.readthedocs.io/en/latest/debug.html#debug-state) part of the user manual holds true.
I initially just wanted to see for my self, but I think it makes sense to include in the debug_assert assertion set.
@silabs-oysteink do you agree with these assertions?
(I realized the first assert is redundant vs the core SVAs, so I can remove it if we want, but for completeness of the debug_assert module we could keep it.)