### PR TITLE
cva6.yaml: add missing target argument for vcs-uvm

### DIFF
--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -101,7 +101,7 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   precmd: >
-    make -f Makefile vcs_uvm_comp cov=${cov} user-define="+define+WT_CACHE"
+    make -f Makefile vcs_uvm_comp target=<target> cov=${cov} user-define="+define+WT_CACHE"
   cmd: >
     make -f Makefile vcs_uvm_run elf-bin=<elf> cov=${cov}
   postcmd: >


### PR DESCRIPTION
without this argument, all vcs-uvm simulations are using cv64a6_imafdc_sv39 configuration

fix 887a396