### PR TITLE
New version of DSIM resolves #1122

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -107,14 +107,12 @@
       {
         "name":     "uvmt_cv32e40s_pma_5",
         "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_compliance_build",
         "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       }

--- a/.metrics.json
+++ b/.metrics.json
@@ -10,108 +10,110 @@
     "list": [
       {
         "name":     "uvmt_cv32e40p",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40p_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40p/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_num_mhpmcounter_29",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_1",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_2",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_3",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_4",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_pma_5",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make corev-dv CV_CORE=cv32e40x CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40x CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40x_compliance_build",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40x/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40x DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_num_mhpmcounter_29",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=num_mhpmcounter_29 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=num_mhpmcounter_29 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_1",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_1 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_1 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_2",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_2 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_2 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_3",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_3 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_3 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_4",
-        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_4 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_4 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_pma_5",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=pma_test_cfg_5 DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s CFG=pma_test_cfg_5 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_compliance_build",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.2.0-7Dec2021",
         "cmd":      "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
         "wavesCmd": "cd cv32e40s/sim/uvmt; make all_compliance; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"

--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_interrupt_assert.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_interrupt_assert.sv
@@ -201,8 +201,7 @@ module uvmt_cv32e40x_interrupt_assert
   property p_irq_in_mtvec(irq, mtvec);
     s_irq_taken(irq) ##0 mtvec_mode_q == mtvec;
   endproperty
-// DSIM-specific workaround: see github issue #1122
-`ifndef DSIM
+
   generate for(genvar gv_i = 0; gv_i < NUM_IRQ; gv_i++) begin : gen_irq_cov
     if (VALID_IRQ_MASK[gv_i]) begin : gen_valid
       c_irq_masked: cover property(p_irq_masked(gv_i));
@@ -216,7 +215,6 @@ module uvmt_cv32e40x_interrupt_assert
     end
   end
   endgenerate
-`endif // DSIM
 
   // Detect arbitration of interrupt assertion
   always @* begin
@@ -429,8 +427,7 @@ module uvmt_cv32e40x_interrupt_assert
   property p_wfi_wake_mstatus_mie(irq, mie);
     $fell(in_wfi) ##0 irq_i[irq] ##0 mie_q[irq] ##0 mstatus_mie == mie;
   endproperty
-// DSIM-specific workaround: see github issue #1122
-`ifndef DSIM
+
   generate for(genvar gv_i = 0; gv_i < 32; gv_i++) begin : gen_wfi_cov
     if (VALID_IRQ_MASK[gv_i]) begin
       c_wfi_wake_mstatus_mie_0: cover property(p_wfi_wake_mstatus_mie(gv_i, 0));
@@ -438,6 +435,5 @@ module uvmt_cv32e40x_interrupt_assert
     end
   end
   endgenerate
-`endif //DSIM
 
 endmodule : uvmt_cv32e40x_interrupt_assert


### PR DESCRIPTION
This PR brings in an updated version of dsim that resolves #1122 (and removes the hack exclude the TB code that the previous dsim release didn't like).

For the record, the Metrics issue number for this is 1163 (that is not a GitHub issue number!).

This PR has a DO NOT MERGE lable on it as I just noticed a mistake with the .metrics.json that will impact the cv32e40s.  I will fix it before removing the label.