### PR TITLE
uncomment temporarily disabled tests in 40x rel_check

### DIFF
--- a/cv32e40x/regress/cv32e40x_rel_check.yaml
+++ b/cv32e40x/regress/cv32e40x_rel_check.yaml
@@ -67,12 +67,11 @@ tests:
     dir: cv32e40x/sim/uvmt
     cmd: make test TEST=generic_exception_test
 
-  # TODO:ropeders Comment back in when merge procedure is done
-  #illegal_instr_test:
-  #  build: uvmt_cv32e40x
-  #  description: Illegal instruction test
-  #  dir: cv32e40x/sim/uvmt
-  #  cmd: make test TEST=illegal_instr_test
+  illegal_instr_test:
+    build: uvmt_cv32e40x
+    description: Illegal instruction test
+    dir: cv32e40x/sim/uvmt
+    cmd: make test TEST=illegal_instr_test
 
   requested_csr_por:
     build: uvmt_cv32e40x
@@ -266,13 +265,12 @@ tests:
     cmd: make gen_corev-dv test TEST=corev_rand_debug_single_step
     num: 1
 
-  # TODO:ropeders Comment back in when merge procedure is done
-  #corev_rand_debug_ebreak:
-  #  build: uvmt_cv32e40x
-  #  description: debug random test with ebreaks from ROM
-  #  dir: cv32e40x/sim/uvmt
-  #  cmd: make gen_corev-dv test TEST=corev_rand_debug_ebreak
-  #  num: 2
+  corev_rand_debug_ebreak:
+    build: uvmt_cv32e40x
+    description: debug random test with ebreaks from ROM
+    dir: cv32e40x/sim/uvmt
+    cmd: make gen_corev-dv test TEST=corev_rand_debug_ebreak
+    num: 2
 
   corev_rand_interrupt_wfi:
     build: uvmt_cv32e40x


### PR DESCRIPTION
This PR re-enables some tests that were commented out in relation to the merge procedure and known problems.

The tests actually did pass now, but that should not be a criteria for re-enabling them anyway.
Passes ci_check (this change shouldn't impact ci_check anyway, but for good measures).