### PR TITLE
uvmt_cva6_dut_wrap.sv, uvmt_cva6_tb.sv: fix parameter declaration

### DIFF
--- a/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -27,10 +27,11 @@ module uvmt_cva6_dut_wrap # ( parameter int unsigned AXI_USER_WIDTH    = 1,
                             output ariane_rvfi_pkg::rvfi_port_t rvfi_o
                            );
 
-    cva6_tb_wrapper #(     .AXI_USER_WIDTH    (1),
-     .AXI_ADDRESS_WIDTH (64),
-     .AXI_DATA_WIDTH    (64),
-     .NUM_WORDS         (2**25)
+    cva6_tb_wrapper #(
+     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
+     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
+     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
+     .NUM_WORDS         (NUM_WORDS)
 )
     cva6_tb_wrapper_i        (
          .clk_i                  ( clknrst_if.clk                 ),

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -30,6 +30,11 @@ module uvmt_cva6_tb;
    import uvmt_cva6_pkg::*;
    import uvme_cva6_pkg::*;
 
+   localparam AXI_USER_WIDTH    = 1;
+   localparam AXI_ADDRESS_WIDTH = 64;
+   localparam AXI_DATA_WIDTH    = 64;
+   localparam NUM_WORDS         = 2**24;
+
    // ENV (testbench) parameters
    parameter int ENV_PARAM_INSTR_ADDR_WIDTH  = 32;
    parameter int ENV_PARAM_INSTR_DATA_WIDTH  = 32;
@@ -53,10 +58,10 @@ module uvmt_cva6_tb;
    */
 
    uvmt_cva6_dut_wrap #(
-     .AXI_USER_WIDTH    (1),
-     .AXI_ADDRESS_WIDTH (64),
-     .AXI_DATA_WIDTH    (64),
-     .NUM_WORDS         (2**25)
+     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
+     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
+     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
+     .NUM_WORDS         (NUM_WORDS)
    ) cva6_dut_wrap (
                     .clknrst_if(clknrst_if),
                     .cvxif_if  (cvxif_if),


### PR DESCRIPTION
Fix the uvm testbench parameter declaration. Down size the number from 2**25 downto 2**24 because verilog array cannot be greater than 2**24 

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>