### PR TITLE
Cv32e40x/merge rel to dev 15

### DIFF
--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -135,16 +135,16 @@ SIMV                    = ./simv
 DSIM                    = dsim
 DSIM_HOME               = /tools/Metrics/dsim
 DSIM_CMP_FLAGS          = +define+CORE_TB -timescale 1ns/1ps $(SV_CMP_FLAGS) -suppress MultiBlockWrite +define+CV32E40P_APU_TRACE
-DSIM_RUN_FLAGS          = -write-sql
+DSIM_RUN_FLAGS          =
 DSIM_UVM_ARGS           = +incdir+$(UVM_HOME)/src $(UVM_HOME)/src/uvm_pkg.sv
 DSIM_RESULTS           ?= $(PWD)/dsim_results
 DSIM_WORK              ?= $(DSIM_RESULTS)/dsim_work
 DSIM_IMAGE              = dsim.out
 
 ifneq (${WAVES}, 0)
-  DSIM_CMP_FLAGS += +acc+b
+  DSIM_CMP_FLAGS += +acc
   DSIM_DMP_FILE  ?= dsim.fst
-  DSIM_RUN_FLAGS += -waves $(DSIM_DMP_FILE) +disass +disass_display
+  DSIM_RUN_FLAGS += -waves $(DSIM_DMP_FILE)
 endif
 
 # xrun is the Cadence xcelium SystemVerilog simulator (https://cadence.com/)
@@ -313,8 +313,7 @@ dsim-test: dsim-comp $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 		-work $(DSIM_WORK) \
 		$(DSIM_RUN_FLAGS) \
 		-sv_lib $(UVM_HOME)/src/dpi/libuvm_dpi.so \
-		-sv_lib $(OVP_MODEL_DPI)  \
-		+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
+		+firmware=$(VERI_CUSTOM)/$(TEST)/$(TEST).hex
 
 # Metrics dsim cleanup
 .PHONY: dsim-clean
@@ -509,7 +508,8 @@ veri-test: verilate $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 	@echo "* Running with Verilator: logfile in $(SIM_TEST_RESULTS)/$(TEST).log"
 	@echo "$(BANNER)"
 	mkdir -p $(VERI_LOG_DIR)
-	./testbench_verilator $(VERI_FLAGS) \
+	$(SIM_TEST_RESULTS)/verilator_executable \
+		$(VERI_FLAGS) \
 		"+firmware=$(TEST_PROGRAM_RELPATH)/$(TEST)/$(TEST).hex" \
 		| tee $(VERI_LOG_DIR)/$(TEST).log
 

--- a/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
@@ -96,7 +96,7 @@ class uvme_cv32e40s_cfg_c extends uvma_core_cntrl_cfg_c;
       ext_f_supported        == 0;
       ext_d_supported        == 0;
 
-      if (b_ext == cv32e40s_pkg::NONE) {
+      if (b_ext == cv32e40s_pkg::B_NONE) {
          ext_zba_supported == 0;
          ext_zbb_supported == 0;
          ext_zbc_supported == 0;

--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -77,126 +77,108 @@ builds:
 # List of tests
 tests:
   hello-world:
-    build: uvmt_cv32e40s
     description: uvm_hello_world_test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hello-world
 
   csr_instructions:
-    build: uvmt_cv32e40s
     description: CSR instruction test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   generic_exception_test:
-    build: uvmt_cv32e40s
     description: Generic exception test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=generic_exception_test
 
   illegal_instr_test:
-    build: uvmt_cv32e40s
     description: Illegal instruction test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal_instr_test
 
   branch_zero:
-    build: uvmt_cv32e40s
     description: Branch test with zero offsets
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=branch_zero
 
   cv32e40s_csr_access_test:
-    build: uvmt_cv32e40s
     description: CSR Access Mode Test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=cv32e40s_csr_access_test
 
   cv32e40s_readonly_csr_access_test:
-    build: uvmt_cv32e40s
     description: CSR Read-only Access Mode Test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=cv32e40s_readonly_csr_access_test
 
   requested_csr_por:
-    build: uvmt_cv32e40s
     description: CSR PoR test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=requested_csr_por
 
   modeled_csr_por:
-    build: uvmt_cv32e40s
     description: Modeled CSR PoR test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=modeled_csr_por
 
   csr_instr_asm:
-    build: uvmt_cv32e40s
     description: CSR instruction assembly test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instr_asm
 
   perf_counters_instructions:
-    build: uvmt_cv32e40s
     description: Performance counter test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=perf_counters_instructions
 
   mhpmcounter29_csr_access_test_1:
-    build: uvmt_cv32e40s_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 1
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s_num_mhpmcounter_29 ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_1
 
   mhpmcounter29_csr_access_test_2:
-    build: uvmt_cv32e40s_num_mhpmcounter_29
     description: Hardware performance counter full access coverage test 2
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s_num_mhpmcounter_29 ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=mhpmcounter29_csr_access_test_2
 
   hpmcounter_basic_test:
-    build: uvmt_cv32e40s
     description: Hardware performance counter basic test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_test
 
   hpmcounter_basic_nostall_test:
-    build: uvmt_cv32e40s
     description: Hardware performance counter basic test with no random stalls
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_nostall_test
 
   hpmcounter_hazard_test:
-    build: uvmt_cv32e40s
     description: Hardware performance counter hazard test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_hazard_test
 
   riscv_ebreak_test_0:
-    build: uvmt_cv32e40s
     description: Static corev-dv ebreak
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_ebreak_test_0
 
   riscv_arithmetic_basic_test_0:
-    build: uvmt_cv32e40s
     description: Static riscv-dv arithmetic test 0
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -204,7 +186,6 @@ tests:
     num: 1
 
   riscv_arithmetic_basic_test_1:
-    build: uvmt_cv32e40s
     description: Static riscv-dv arithmetic test 1
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -212,7 +193,6 @@ tests:
     num: 1
 
   corev_rand_arithmetic_base_test:
-    build: uvmt_cv32e40s
     description: Generated corev-dv arithmetic test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -220,7 +200,6 @@ tests:
     num: 4
 
   corev_rand_instr_test:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random instruction test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -228,7 +207,6 @@ tests:
     num: 5
 
   corev_rand_instr_long_stall:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random instruction test with long stalls
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -236,7 +214,6 @@ tests:
     num: 2
 
   corev_rand_illegal_instr_test:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random instruction test with illegal instructions
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -244,7 +221,6 @@ tests:
     num: 5
 
   corev_rand_jump_stress_test:
-    build: uvmt_cv32e40s
     description: Generated corev-dv jump stress test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -252,7 +228,6 @@ tests:
     num: 5
 
   corev_rand_interrupt:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random interrupt test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -260,7 +235,6 @@ tests:
     num: 5
 
   corev_rand_debug:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random debug test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -268,7 +242,6 @@ tests:
     num: 5
 
   corev_rand_debug_single_step:
-    build: uvmt_cv32e40s
     description: debug random test with single-stepping
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -276,7 +249,6 @@ tests:
     num: 5
 
   corev_rand_debug_ebreak:
-    build: uvmt_cv32e40s
     description: debug random test with ebreaks from ROM
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -284,7 +256,6 @@ tests:
     num: 5
 
   corev_rand_interrupt_wfi:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random interrupt WFI test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -292,21 +263,20 @@ tests:
     num: 5
 
   corev_rand_fencei:
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Generated corev-dv random fence,i test
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_fencei
     num: 2
 
   corev_rand_interrupt_wfi_mem_stress:
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with memory stress
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi_mem_stress
     num: 5
 
   corev_rand_interrupt_debug:
-    build: uvmt_cv32e40s
     description: Generated corev-dv random interrupt WFI test with debug
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -314,105 +284,97 @@ tests:
     num: 5
 
   corev_rand_interrupt_exception:
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with exceptions
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_exception
     num: 5
 
   corev_rand_interrupt_nested:
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Generated corev-dv random interrupt WFI test with random nested interrupts
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_nested
     num: 5
 
   corev_rand_pma_test:
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5]
     description: Generated corev-dv random PMA test
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pma_test
     num: 3
 
   corev_rand_instr_obi_err:
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Random OBI instruction bus error test
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err
     num: 6
 
   corev_rand_instr_obi_err_debug:
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Random OBI instruction bus error test with debug
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err_debug
     num: 6
 
   corev_rand_data_obi_err:
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Random OBI data bus error test
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err
     num: 6
 
   corev_rand_data_obi_err_debug:
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     description: Random OBI data bus error test with debug
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err_debug
     num: 6
 
   illegal:
-    build: uvmt_cv32e40s
     description: Illegal-riscv-tests
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal
 
   fibonacci:
-    build: uvmt_cv32e40s
     description: Fibonacci test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=fibonacci
 
   misalign:
-    build: uvmt_cv32e40s
     description: Misalign test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=misalign
 
   dhrystone:
-    build: uvmt_cv32e40s
     description: Dhrystone test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=dhrystone
 
   debug_test:
-    build: uvmt_cv32e40s
     description: Debug Test 1
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test
 
   debug_test_reset:
-    build: uvmt_cv32e40s
     description: Debug reset test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_reset
 
   debug_test_trigger:
-    build: uvmt_cv32e40s
     description: Debug trigger test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_trigger
 
   debug_test_boot_set:
-    build: uvmt_cv32e40s
     description: Debug test target debug_req at BOOT_SET
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
@@ -420,56 +382,50 @@ tests:
     num: 10
 
   interrupt_bootstrap:
-    build: uvmt_cv32e40s
     description: Interrupt bootstrap test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=interrupt_bootstrap
 
   interrupt_test:
-    build: uvmt_cv32e40s
     description: Interrupt test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=interrupt_test
 
   isa_fcov_holes:
-    build: uvmt_cv32e40s
     description: ISA function coverage test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   instr_bus_error:
-    build: uvmt_cv32e40s
     description: Directed instruction bus error test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=instr_bus_error
 
   data_bus_error:
-    build: uvmt_cv32e40s
     description: Directed data bus error test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=data_bus_error
 
   load_store_rs1_zero:
-    build: uvmt_cv32e40s
     description: Directed rs1 coverage test
     builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=load_store_rs1_zero
 
   pma:
-    build: uvmt_cv32e40s_pma
     description: ISA function coverage test
+    builds: [ uvmt_cv32e40s_pma]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   b_ext_test:
-    builds: [uvmt_cv32e40s_b_ext_abs, uvmt_cv32e40s_b_ext_all]
     description: Directed Zb extension test
+    builds: [ uvmt_cv32e40s_b_ext_abs, uvmt_cv32e40s_b_ext_all]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=b_ext_test
 

--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 914849d18cf2088e89079b8f254c01f13b84d714
+CV_CORE_HASH	 ?= 0f58a811efffefaeed491ba3f2097c86be0159bf
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/sim/core/Makefile
+++ b/cv32e40s/sim/core/Makefile
@@ -63,7 +63,7 @@ TEST         ?= hello-world
 ###############################################################################
 # Common Makefiles:
 #  -Variables for RTL and other dependencies (e.g. RISCV-DV)
-include ../Common.mk
+include ../ExternalRepos.mk
 #  -Core Firmware and the RISCV GCC Toolchain (SDK)
 include $(CORE_V_VERIF)/mk/Common.mk
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -23,7 +23,7 @@
    `elsif ZBA_ZBB_ZBC_ZBS
       parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBC_ZBS;
    `else
-      parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::NONE;
+      parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::B_NONE;
    `endif
 
    `ifdef PMA_CUSTOM_CFG

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -510,12 +510,42 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "Debug mode not entered correctly at reset!");
 
 
+    // Debug vs reset
+
+    a_debug_state_onehot : assert property (
+      $onehot({cov_assert_if.debug_havereset, cov_assert_if.debug_running, cov_assert_if.debug_halted})
+      ) else `uvm_error(info_tag, "Should have exactly 1 of havereset/running/halted");
+
+    cov_havereset_to_running : cover property (
+      (cov_assert_if.debug_havereset  == 1)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 0)
+      #=#
+      (cov_assert_if.debug_havereset  == 0)
+      && (cov_assert_if.debug_running == 1)
+      && (cov_assert_if.debug_halted  == 0)
+      );
+
+    cov_havereset_to_halted : cover property (
+      (cov_assert_if.debug_havereset  == 1)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 0)
+      #=#
+      (cov_assert_if.debug_havereset  == 0)
+      && (cov_assert_if.debug_running == 0)
+      && (cov_assert_if.debug_halted  == 1)
+      );
+
+
     // Check that we cover the case where a debug_req_i
     // comes while flushing due to an illegal insn, causing
     // dpc to be set to the exception handler entry addr
+
+    // TODO We have excluded the case where an nmi is taken in the second stage of the antecedent. 
+    //      Make sure this is covered in a debug vs nmi assertion when it is written 
     sequence s_illegal_insn_debug_req_ante;  // Antecedent
         cov_assert_if.wb_illegal && cov_assert_if.wb_valid && !cov_assert_if.debug_mode_q
-        ##1 cov_assert_if.debug_req_i && !cov_assert_if.debug_mode_q;
+        ##1 cov_assert_if.debug_req_i && !cov_assert_if.debug_mode_q && !cov_assert_if.pending_nmi;
     endsequence
 
     sequence s_illegal_insn_debug_req_conse;  // Consequent

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -44,7 +44,7 @@ module uvmt_cv32e40s_dut_wrap
 
   #(// DUT (riscv_core) parameters.
     parameter NUM_MHPMCOUNTERS    =  1,
-    parameter cv32e40s_pkg::b_ext_e B_EXT  = cv32e40s_pkg::NONE,
+    parameter cv32e40s_pkg::b_ext_e B_EXT  = cv32e40s_pkg::B_NONE,
     parameter int          PMA_NUM_REGIONS =  0,
     parameter pma_region_t PMA_CFG[PMA_NUM_REGIONS-1 : 0] = '{default:PMA_R_DEFAULT},
     // Remaining parameters are used by TB components only

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -201,8 +201,6 @@ module uvmt_cv32e40s_interrupt_assert
   property p_irq_in_mtvec(irq, mtvec);
     s_irq_taken(irq) ##0 mtvec_mode_q == mtvec;
   endproperty
-// DSIM-specific workaround: see github issue #1122
-`ifndef DSIM
   generate for(genvar gv_i = 0; gv_i < NUM_IRQ; gv_i++) begin : gen_irq_cov
     if (VALID_IRQ_MASK[gv_i]) begin : gen_valid
       c_irq_masked: cover property(p_irq_masked(gv_i));
@@ -216,7 +214,6 @@ module uvmt_cv32e40s_interrupt_assert
     end
   end
   endgenerate
-`endif // DSIM
 
   // Detect arbitration of interrupt assertion
   always @* begin
@@ -429,8 +426,7 @@ module uvmt_cv32e40s_interrupt_assert
   property p_wfi_wake_mstatus_mie(irq, mie);
     $fell(in_wfi) ##0 irq_i[irq] ##0 mie_q[irq] ##0 mstatus_mie == mie;
   endproperty
-// DSIM-specific workaround: see github issue #1122
-`ifndef DSIM
+
   generate for(genvar gv_i = 0; gv_i < 32; gv_i++) begin : gen_wfi_cov
     if (VALID_IRQ_MASK[gv_i]) begin
       c_wfi_wake_mstatus_mie_0: cover property(p_wfi_wake_mstatus_mie(gv_i, 0));
@@ -438,6 +434,5 @@ module uvmt_cv32e40s_interrupt_assert
     end
   end
   endgenerate
-`endif //DSIM
 
 endmodule : uvmt_cv32e40s_interrupt_assert

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -397,7 +397,7 @@ module uvmt_cv32e40s_tb;
   // Instantiate debug assertions
 
   bind cv32e40s_wrapper
-    uvmt_cv32e40s_debug_cov_assert_if debug_cov_assert_if (
+    uvmt_cv32e40s_debug_cov_assert_if  debug_cov_assert_if (
       .id_valid               (core_i.id_stage_i.id_valid_o),
       .sys_fence_insn_i       (core_i.id_stage_i.decoder_i.sys_fencei_insn_o),
 
@@ -419,6 +419,10 @@ module uvmt_cv32e40s_tb;
 
       .ctrl_fsm_cs            (core_i.controller_i.controller_fsm_i.ctrl_fsm_cs),
       .debug_req_i            (core_i.controller_i.controller_fsm_i.debug_req_i),
+      .debug_havereset        (core_i.debug_havereset_o),
+      .debug_running          (core_i.debug_running_o),
+      .debug_halted           (core_i.debug_halted_o),
+
       .debug_req_q            (core_i.controller_i.controller_fsm_i.debug_req_q),
       .pending_debug          (core_i.controller_i.controller_fsm_i.pending_debug),
       .pending_nmi            (core_i.controller_i.controller_fsm_i.pending_nmi),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -150,6 +150,10 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     // Debug signals
     input         debug_req_i, // From controller
     input         debug_req_q, // From controller
+    input         debug_havereset,
+    input         debug_running,
+    input         debug_halted,
+
     input         pending_debug, // From controller
     input         pending_nmi, // From controller
     input         nmi_allowed, // From controller

--- a/docs/VerifStrat/source/quick_start.rst
+++ b/docs/VerifStrat/source/quick_start.rst
@@ -38,7 +38,7 @@ You will need:
    $ cd $CORE_V_VERIF/bin
    $ pip install -r requirements.txt
 
-3. A GCC cross-compiler (aka "the `Toolchain <https://github.com/openhwgroup/core-v-verif/blob/master/cv32e40p/sim/TOOLCHAIN.md#core-v-toolchain>`_").
+3. A GCC cross-compiler (aka "the `Toolchain <https://github.com/openhwgroup/core-v-verif/blob/master/mk/TOOLCHAIN.md#core-v-toolchain>`_").
    Even if you already have a toolchain, please do follow that link and read **TOOLCHAIN.md** for recommended ENV variables to point to it.
 4. `Verilator <https://veripool.org/guide/latest/install.html>`_.
 

--- a/mk/README.md
+++ b/mk/README.md
@@ -94,26 +94,33 @@ Makefiles
 -----------
 `Make` is used to generate the command-lines that compile and run simulations.<br>
 - `CV_CORE/sim/uvmt/Makefile` is the 'root' Makefile from which users can invoke simulations.
-This makefile includes the common uvmt simulation makefile at `mk/uvmt/uvmt.mk`
-which implements simulation execution targets (described below.)
+This Makefile is largely empty and include:
 - `CV_CORE/sim/ExternalRepos.mk` should be used to define variables to point to third-party libraries.
 This include the RTL repo to simulate; Google riscv-dv; RISCV compliance suite and other external repositories.
-- The common makefile in `mk/Common.mk` supports all common variables, rules
-and targets, including specific targets to clone the RTL from
-[cv32e40p](https://github.com/openhwgroup/cv32e40p). 
-- Simulator-specific Makefiles are used to build the command-line to run a specific test with a specific
+- `CORE-V-VERIF/mk/uvmt/uvmt.mk`, which implements simulation execution targets and:
+- `CORE-V-VERIF/mk/Common.mk` supports all common variables, rules and targets, including specific targets to clone the RTL.
+<br><br> 
+Simulator-specific Makefiles are used to build the command-line to run a specific test with a specific
 simulator.  These files are organized as shown below:
 ```
-     mk/
-      +--- Common.mk                        # Common variables and targets
-      +--- uvmt/
-              +--- uvmt.mk                  # Simulation makefile
-              +--- vcs.mk                   # Synopsys VCS
-              +--- vsim.mk                  # Mentor Questa
-              +--- dsim.mk                  # Metrics dsim
-              +--- xrun.mk                  # Cadance Xcelium
-              +--- riviera.mk               # Aldec Riviera-PRO
-              +--- <other_simulators>.mk
+CORE-V-VERIF/
+     |
+     +--- mk/
+     |     +--- Common.mk                       # Common variables and targets
+     |     +--- uvmt/
+     |            +--- uvmt.mk                  # Simulation makefile (includes ../Common.mk and simulator-specific mk)
+     |            +--- vcs.mk                   # Synopsys VCS
+     |            +--- vsim.mk                  # Mentor Questa
+     |            +--- dsim.mk                  # Metrics dsim
+     |            +--- xrun.mk                  # Cadance Xcelium
+     |            +--- riviera.mk               # Aldec Riviera-PRO
+     |            +--- <other_simulators>.mk
+     +--- CV_CORE/
+            +--- sim/
+                   +--- ExternalRepos.mk         # URLs, hashes to external repos (RTL, riscv-dv, etc.)
+                   +--- uvmt/
+                          +--- Makefile          # "root" Makefile
+                                                 # includes ../ExternalRepos.mk and CORE-V-VERIF/mk/uvmt/uvmt.mk
 ```
 The goal of this structure is to minimize the amount of redundant code in the
 Makefiles, maintain common look-and-feel across all cores and ease the maintance of a given simulator's specific variables,

--- a/mk/uvmt/dvt.mk
+++ b/mk/uvmt/dvt.mk
@@ -23,6 +23,11 @@
 # Usage: make SIMULATOR=<simulator> open_in_dvt_ide
 ###############################################################################
 
+# Start: shell and/or Makefile variables required by core-v-verif Makefiles; not used by DVT
+DPI_DASM_SPIKE_REPO   ?= https://github.com/riscv/riscv-isa-sim.git
+CV_SW_TOOLCHAIN       ?= /opt/riscv
+# End: shell and/or Makefile variables required by core-v-verif Makefiles; not used by DVT
+
 DVT_COMMAND=$(DVT_HOME)/bin/dvt_cli.sh createProject $(CORE_V_VERIF) -force -lang vlog -build default $(DVT_CLI_ARGS)
 DVT_BUILD_FILE_CONTENT_HEADER="+dvt_enable_elaboration +dvt_enable_elaboration_incremental+FULL"
 


### PR DESCRIPTION
Merge procedure "rel->dev" 40x.

Passes "rel_check" w/ Xcelium, except for the 4 failures below.

There are known failures:
`cv32e40x_csr_access_test`, `corev_rand_debug_ebreak` (both fail in "full" regression on "dev" already).
`debug_test`, `corev_rand_interrupt_debug` (both fail on the known debug_assert problem).

@silabs-hfegran , @silabs-mateilga , I want to point out the known failures above, so you are aware (and in case you want to object to the merge).