### PR TITLE
cva6.py: add time to output files juste in case of coverage activated

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -410,7 +410,8 @@ def run_assembly(asm_test, iss_yaml, isa, target, mabi, gcc_opts, iss_opts, outp
   report = ("%s/iss_regr.log" % output_dir).rstrip()
   asm = re.sub(r"^.*\/", "", asm_test)
   asm = re.sub(r"\.S$", "", asm)
-  asm = asm + "-" + str(datetime.datetime.now().isoformat()) #to have unique name for tests output files
+  if os.getenv('cov'):
+    asm = asm + "-" + str(datetime.datetime.now().isoformat())
   prefix = ("%s/directed_asm_tests/%s" % (output_dir, asm))
   elf = prefix + ".o"
   binary = prefix + ".bin"


### PR DESCRIPTION
Signed-off-by: Zineb El Kacimi <zineb.el-kacimi@external.thalesgroup.com>