### PR TITLE
Fix CEXes, interrupt_assert U-mode

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -42,7 +42,8 @@ module uvmt_cv32e40s_interrupt_assert
     input [31:0] uip,     // user interrupt pending
     input [31:0] mie_q,   // machine interrupt enable
     input [31:0] uie_q,   // user interrupt enable
-    input        mstatus_mie, // machine mode interrupt enable
+    input        mstatus_mie,  // machine mode interrupt enable
+    input        mstatus_tw,   // "timeout wait"
     input [1:0]  mtvec_mode_q, // machine mode interrupt vector mode
 
     // IF stage
@@ -343,6 +344,7 @@ module uvmt_cv32e40s_interrupt_assert
                   (wb_stage_instr_rdata_i == WFI_INSTR_DATA) &&
                   !branch_taken_ex                           &&
                   !wb_stage_instr_err_i                      &&
+                  !((priv_lvl == PRIV_LVL_U) && mstatus_tw)  &&
                   (wb_stage_instr_mpu_status == MPU_OK);
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -106,9 +106,9 @@ module uvmt_cv32e40s_interrupt_assert
 
   reg[31:0] expected_irq;
   logic     expected_irq_ack;
-  logic     is_mmode_mstatusmie = (priv_lvl == PRIV_LVL_M) && mstatus_mie;
-  logic     is_umode_uieuip     = (priv_lvl == PRIV_LVL_U) && (uie_q & uip);
-  logic     is_umode_miemip     = (priv_lvl == PRIV_LVL_U) && (mie_q & mip);
+  wire      is_mmode_mstatusmie = (priv_lvl == PRIV_LVL_M) && mstatus_mie;
+  wire      is_umode_uieuip     = (priv_lvl == PRIV_LVL_U) && (uie_q & uip);
+  wire      is_umode_miemip     = (priv_lvl == PRIV_LVL_U) && (mie_q & mip);
 
   reg[31:0] last_instr_rdata;
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -336,6 +336,7 @@ module uvmt_cv32e40s_tb;
       .mie_q        (cs_registers_i.mie_q),
       .uie_q        (cs_registers_i.uie_q),
       .mstatus_mie  (cs_registers_i.mstatus_q.mie),
+      .mstatus_tw   (cs_registers_i.mstatus_q.tw),
       .mtvec_mode_q (cs_registers_i.mtvec_q.mode),
 
       .if_stage_instr_req_o    (if_stage_i.m_c_obi_instr_if.s_req.req),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -332,9 +332,7 @@ module uvmt_cv32e40s_tb;
     uvmt_cv32e40s_interrupt_assert interrupt_assert_i(
       .mcause_n     ({cs_registers_i.mcause_n.irq, cs_registers_i.mcause_n.exception_code[4:0]}),
       .mip          (cs_registers_i.mip),
-      .uip          (cs_registers_i.uip),
       .mie_q        (cs_registers_i.mie_q),
-      .uie_q        (cs_registers_i.uie_q),
       .mstatus_mie  (cs_registers_i.mstatus_q.mie),
       .mstatus_tw   (cs_registers_i.mstatus_q.tw),
       .mtvec_mode_q (cs_registers_i.mtvec_q.mode),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -332,7 +332,9 @@ module uvmt_cv32e40s_tb;
     uvmt_cv32e40s_interrupt_assert interrupt_assert_i(
       .mcause_n     ({cs_registers_i.mcause_n.irq, cs_registers_i.mcause_n.exception_code[4:0]}),
       .mip          (cs_registers_i.mip),
+      .uip          (cs_registers_i.uip),
       .mie_q        (cs_registers_i.mie_q),
+      .uie_q        (cs_registers_i.uie_q),
       .mstatus_mie  (cs_registers_i.mstatus_q.mie),
       .mtvec_mode_q (cs_registers_i.mtvec_q.mode),
 


### PR DESCRIPTION
This PR fixes 4 CEXes in "interrupt_assert".

Passes ci_check (which includes some interrupt tests).
Passes formal on pma 3 and pma 1.

All the CEXes related to user mode not being handled by the assertions.