### PR TITLE
Typo + veri-testharness as default simulator

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -153,7 +153,7 @@ pub_compliance:
     matrix:
       - DV_TARGET: [cv64a6_imafdc_sv39, cv32a6_imac_sv0]
   variables:
-    DV_SIMULATOR: "veri-testharness,spike"
+    DV_SIMULATORS: "veri-testharness,spike"
   script:
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source cva6/regress/dv-riscv-compliance.sh
@@ -170,7 +170,7 @@ pub_tests-v:
     matrix:
       - DV_TARGET: [cv64a6_imafdc_sv39, cv32a6_imac_sv0]
   variables:
-    DV_SIMULATOR: "veri-testharness,spike"
+    DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
   script:
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
@@ -188,7 +188,7 @@ pub_tests-p:
     matrix:
       - DV_TARGET: [cv64a6_imafdc_sv39, cv32a6_imac_sv0]
   variables:
-    DV_SIMULATOR: "veri-testharness,spike"
+    DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
   script:
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC

--- a/cva6/regress/dv-riscv-compliance.sh
+++ b/cva6/regress/dv-riscv-compliance.sh
@@ -23,7 +23,7 @@ if ! [ -n "$DV_TARGET" ]; then
 fi
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=veri-core,spike
+  DV_SIMULATORS=veri-testharness,spike
 fi
 
 cd cva6/sim

--- a/cva6/regress/dv-riscv-tests.sh
+++ b/cva6/regress/dv-riscv-tests.sh
@@ -23,7 +23,7 @@ if ! [ -n "$DV_TARGET" ]; then
 fi
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=veri-core,spike
+  DV_SIMULATORS=veri-testharness,spike
 fi
 
 if ! [ -n "$DV_TESTLISTS" ]; then


### PR DESCRIPTION
Just a small fix and change default simulators to vcs-testharness since veri-core does no longer exist. @JeanRochCoulon 