### PR TITLE
Move uvm_component_utils to top of file

### DIFF
--- a/GitCheats.md
+++ b/GitCheats.md
@@ -91,18 +91,12 @@ $ git push --set-upstream origin master<br>
 \# git remote set-url origin git@github.com:username/your-repository.git<br>
 $ git clone git@github.com:openhwgroup/core-v-verif.git master<br>
 
-### Metrics CI Cheat Sheet
-#### Add GitLab Metrics remote
-$ git remote add metrics git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git
+## Force your fork/branch to match the origin
+$ git fetch upstream
+$ git reset --hard upstream/<branch>
+$ git push origin <branch> --force
 
-#### Check to see if you have the Metrics remote added
-$ git remote -v<br>
-  \> metrics	git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git (fetch)<br>
-  \> metrics	git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git (push)<br>
-  \> origin	https://github.com/openhwgroup/core-v-verif (fetch)<br>
-  \> origin	https://github.com/openhwgroup/core-v-verif (push)<br>
-
-### Rebasing a previous commit
+## Rebasing a previous commit
 \# https://stackoverflow.com/questions/3042437/how-to-change-the-commit-author-for-one-specific-commit<br>
 \# https://docs.github.com/en/github/getting-started-with-github/about-git-rebase#an-example-of-using-git-rebase<br>
 $ cd \<working_dir\><br>
@@ -116,3 +110,16 @@ $ git commit --amend --author="Jean-Roch Coulon <jean-roch.coulon@invia.fr>" --n
 $ git rebase --continue<br>
 $ git remote -v<br>
 $ git push -f<br>
+
+
+### Metrics CI Cheat Sheet
+#### Add GitLab Metrics remote
+$ git remote add metrics git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git
+
+#### Check to see if you have the Metrics remote added
+$ git remote -v<br>
+  \> metrics git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git (fetch)<br>
+  \> metrics git@gitlab.openhwgroup.metrics.ca:cv32e40p_verif/cv32e40p_verif.git (push)<br>
+  \> origin  https://github.com/openhwgroup/core-v-verif (fetch)<br>
+  \> origin  https://github.com/openhwgroup/core-v-verif (push)<br>
+

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -35,12 +35,12 @@
  */
 class uvmt_cv32e40p_firmware_test_c extends uvmt_cv32e40p_base_test_c;
 
+   `uvm_component_utils_begin(uvmt_cv32e40p_firmware_test_c)
+   `uvm_object_utils_end
+
    constraint test_type_cons {
      test_cfg.tpt == PREEXISTING_SELFCHECKING;
    }
-
-   `uvm_component_utils_begin(uvmt_cv32e40p_firmware_test_c)
-   `uvm_object_utils_end
 
    /**
     */


### PR DESCRIPTION
This is an easy one - I wanted to add something to `GitCheats` and took advantage by sneaking in a trivial fix of a [lint error](https://dvteclipse.com/core5verif-verissimo/1/reports/run/cdf7ee911e6f2268cf98f2bc6e0f7e484a7f396d/index.html).

@YoannPruvost, I am going to start adding you as a reviewer for all pull-requests to cv32e40p branches.

Signed-off-by: Mike Thompson <mike@openhwgroup.org>