### PR TITLE
Fixed bit-width warnings

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -115,7 +115,7 @@ module uvmt_cv32e40x_tb;
                                                                    .rvfi_insn(rvfi_i.rvfi_insn[uvme_cv32e40x_pkg::ILEN*0+:uvme_cv32e40x_pkg::ILEN]),
                                                                    .rvfi_trap(rvfi_i.rvfi_trap[11:0]),
                                                                    .rvfi_halt(rvfi_i.rvfi_halt[0]),
-                                                                   .rvfi_intr(rvfi_i.rvfi_intr[0]),
+                                                                   .rvfi_intr(rvfi_i.rvfi_intr.intr),
                                                                    .rvfi_dbg(rvfi_i.rvfi_dbg),
                                                                    .rvfi_dbg_mode(rvfi_i.rvfi_dbg_mode),
                                                                    .rvfi_nmip(rvfi_i.rvfi_nmip),
@@ -384,7 +384,7 @@ module uvmt_cv32e40x_tb;
       .wb_buffer_state    (core_i.load_store_unit_i.write_buffer_i.state),
 
       .rvfi_valid         (rvfi_i.rvfi_valid),
-      .rvfi_intr          (rvfi_i.rvfi_intr),
+      .rvfi_intr          (rvfi_i.rvfi_intr.intr),
       .rvfi_dbg_mode      (rvfi_i.rvfi_dbg_mode),
 
       .*
@@ -474,7 +474,7 @@ module uvmt_cv32e40x_tb;
 
       .rvfi_valid             (rvfi_i.rvfi_valid),
       .rvfi_insn              (rvfi_i.rvfi_insn),
-      .rvfi_intr              (rvfi_i.rvfi_intr),
+      .rvfi_intr              (rvfi_i.rvfi_intr.intr),
       .rvfi_dbg               (rvfi_i.rvfi_dbg),
       .rvfi_dbg_mode          (rvfi_i.rvfi_dbg_mode),
       .rvfi_pc_wdata          (rvfi_i.rvfi_pc_wdata),


### PR DESCRIPTION
Fixed bit-width warnings for rvfi_intr struct connection.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>