### PR TITLE
Fix errors in cv32e40p pulp_vectorial tests

### DIFF
--- a/cv32e40p/tests/programs/custom/pulp_vectorial_add_sub/pulp_vectorial_add_sub.S
+++ b/cv32e40p/tests/programs/custom/pulp_vectorial_add_sub/pulp_vectorial_add_sub.S
@@ -321,43 +321,43 @@ test36:
 test37:
     li x17, 0xf14b3729
     li x18, 0xa6dffa04
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
     li x20, 0x4c151896
     beq x20, x19, test38
     c.addi x15, 0x1
 test38:
     li x17, 0x615a3814
     li x18, 0x0b218a1d
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
     li x20, 0x363d6118
     beq x20, x19, test39
     c.addi x15, 0x1
 test39:
     li x17, 0x899b9daa
     li x18, 0xc799bf72
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
     li x20, 0x289a2e8e
     beq x20, x19, test40
     c.addi x15, 0x1
 test40:
     li x17, 0x784a98e3
     li x18, 0xa5385e64
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
-    li x20, 0x1d827ba3
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x0ec17ba3
     beq x20, x19, test41
     c.addi x15, 0x1
 test41:
     li x17, 0xa80f53e9
     li x18, 0xe3e07c1e
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
-    li x20, 0x45f77c1f
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x45f76803
     beq x20, x19, test42
     c.addi x15, 0x1
 test42:
     li x17, 0x721f17b7
     li x18, 0xca3256f2
-    .word 0x5d28b9d7    #pv.add.div2 x19, x17, x18
-    li x20, 0x1e286ea9
+    .word 0x7528a9d7    #pv.add.div2 x19, x17, x18
+    li x20, 0x1e283754
     beq x20, x19, test43
     c.addi x15, 0x1
 #tests43-48 test the pv.add.div4 instruction. values loaded in and compared to are expected output values
@@ -366,42 +366,42 @@ test42:
 test43:
     li x17, 0xf996c75d
     li x18, 0x6fcc0d8b
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x1a58353a
     beq x20, x19, test44
     c.addi x15, 0x1
 test44:
     li x17, 0x1ace57a3
     li x18, 0x5a105f37
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x1d372db6
     beq x20, x19, test45
     c.addi x15, 0x1
 test45:
     li x17, 0xa4a93062
     li x18, 0x2f1a9732
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x34f031e5
     beq x20, x19, test46
     c.addi x15, 0x1
 test46:
     li x17, 0x842aeebb
     li x18, 0xf8ec8340
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x1f451c7e
     beq x20, x19, test47
     c.addi x15, 0x1
 test47:
     li x17, 0xae2beb6d
     li x18, 0x2881cd1c
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x35ab2e22
     beq x20, x19, test48
     c.addi x15, 0x1
 test48:
     li x17, 0xe0de49ca
     li x18, 0xeda89810
-    .word 0x5d28c9d7    #pv.add.div4 x19, x17, x18
+    .word 0x7528c9d7    #pv.add.div4 x19, x17, x18
     li x20, 0x33a13876
     beq x20, x19, test49
     c.addi x15, 0x1
@@ -411,42 +411,42 @@ test48:
 test49:
     li x17, 0x00f0091b
     li x18, 0x04868a8f
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x00ae1275
     beq x20, x19, test50
     c.addi x15, 0x1
 test50:
     li x17, 0x349f1c44
     li x18, 0xde7a69e0
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x026310c4
     beq x20, x19, test51
     c.addi x15, 0x1
 test51:
     li x17, 0x453011b7
     li x18, 0x855ce1b1
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x19511e6d
     beq x20, x19, test52
     c.addi x15, 0x1
 test52:
     li x17, 0x4e544def
     li x18, 0xf63d2d7f
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x08920f6d
     beq x20, x19, test53
     c.addi x15, 0x1
 test53:
     li x17, 0x751ed585
     li x18, 0xed1fed20
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x0c471854
     beq x20, x19, test54
     c.addi x15, 0x1
 test54:
     li x17, 0x1b1b67d7
     li x18, 0xf758297f
-    .word 0x5d28e9d7    #pv.add.div8 x19, x17, x18
+    .word 0x7528e9d7    #pv.add.div8 x19, x17, x18
     li x20, 0x024e122a
     beq x20, x19, test55
     c.addi x15, 0x1

--- a/cv32e40p/tests/programs/custom/pulp_vectorial_bit_manip/pulp_vectorial_bit_manip.S
+++ b/cv32e40p/tests/programs/custom/pulp_vectorial_bit_manip/pulp_vectorial_bit_manip.S
@@ -217,42 +217,42 @@ test24:
 #pv.insert.h is of the form "pv.insert.h rD, rs1, rs2". rD[31:24] = rs1[31:24] >> rs2[7:0],
 #rD[23:16] = rs1[23:16] >> rs2[7:0], rD[15:8] = rs1[15:8] >> rs2[7:0], rD[7:0] = rs1[7:0] >> rs2[7:0]
 test25:
-    li x20, 0x626ef04f
+    li x19, 0x626ef04f
     li x17, 0x8ac2523d
     pv.insert.h x19, x17, 0x1
     li x20, 0x523df04f
     beq x20, x19, test26
     c.addi x15, 0x1
 test26:
-    li x20, 0x88fbb7a1
+    li x19, 0x88fbb7a1
     li x17, 0xd08380a0
     pv.insert.h x19, x17, 0x1
     li x20, 0x80a0b7a1
     beq x20, x19, test27
     c.addi x15, 0x1
 test27:
-    li x20, 0xbfbacff4
+    li x19, 0xbfbacff4
     li x17, 0xdc33ba16
     pv.insert.h x19, x17, 0x1
     li x20, 0xba16cff4
     beq x20, x19, test28
     c.addi x15, 0x1
 test28:
-    li x20, 0x990fc831
+    li x19, 0x990fc831
     li x17, 0x600419c0
     pv.insert.h x19, x17, 0x0
     li x20, 0x990f19c0
     beq x20, x19, test29
     c.addi x15, 0x1
 test29:
-    li x20, 0x044da5f9
+    li x19, 0x044da5f9
     li x17, 0x2cddf91e
     pv.insert.h x19, x17, 0x0
     li x20, 0x044df91e
     beq x20, x19, test30
     c.addi x15, 0x1
 test30:
-    li x20, 0x5a626f2a
+    li x19, 0x5a626f2a
     li x17, 0xe571bb0d
     pv.insert.h x19, x17, 0x0 #.word 0xb00889d7
     li x20, 0x5a62bb0d
@@ -262,42 +262,42 @@ test30:
 #pv.insert.b is of the form "pv.insert.b rD, rs1, Imm6". rD[31:24] = rs1[31:24] >> Imm6,
 #rD[23:16] = rs1[23:16] >> Imm6, rD[15:8] = rs1[15:8] >> Imm6, rD[7:0] = rs1[7:0] >> Imm6
 test31:
-    li x20, 0xe67cfd8a
+    li x19, 0xe67cfd8a
     li x17, 0xb589205f
     pv.insert.b x19, x17, 0x1
     li x20, 0xe67c5f8a
     beq x20, x19, test32
     c.addi x15, 0x1
 test32:
-    li x20, 0xef58b0a8
+    li x19, 0xef58b0a8
     li x17, 0x161409d6
     pv.insert.b x19, x17, 0x3
     li x20, 0xd658b0a8
     beq x20, x19, test33
     c.addi x15, 0x1
 test33:
-    li x20, 0x1d06993b
+    li x19, 0x1d06993b
     li x17, 0xfde810b0
     pv.insert.b x19, x17, 0x0
-    li x20, 0x1d06993b
+    li x20, 0x1d0699b0
     beq x20, x19, test34
     c.addi x15, 0x1
 test34:
-    li x20, 0xc536517f
+    li x19, 0xc536517f
     li x17, 0x8ffba9b9
     pv.insert.b x19, x17, 0x2
     li x20, 0xc5b9517f
     beq x20, x19, test35
     c.addi x15, 0x1
 test35:
-    li x20, 0xda47d50c
+    li x19, 0xda47d50c
     li x17, 0x8b13650e
     pv.insert.b x19, x17, 0x3
     li x20, 0x0e47d50c
     beq x20, x19, test36
     c.addi x15, 0x1
 test36:
-    li x20, 0x4724b9d9
+    li x19, 0x4724b9d9
     li x17, 0x8fdfaefe
     pv.insert.b x19, x17, 0x2 #.word 0xb02899d7
     li x20, 0x47feb9d9


### PR DESCRIPTION
Two of the cv32e40p pulp_vectorial_* tests were found to have minor errors when we used them to help verify the addition of the PULP_XPULP extension to the Imperas model:

### pulp_vectorial_add_sub.S:
1) The manual (using .word) encodings of the cv.add.div{2,4,8} instructions in pulp_vectorial_add_sub are incorrect. Specifically the funct5 field values do not match [the cv32e40p documentation](https://github.com/openhwgroup/cv32e40p/blob/master/docs/source/instruction_set_extensions.rst) for any of these instructions, and the funct3 values are incorrect for the cv.add.div2 instructions.
2) A few of the expected values defined in the tests for the cv.add.div2 instructions are not correct (missing shifts)

### pulp_vectorial_bit_manipulation.S
1) Incorrect register used for comparisons
2) One expected value was incorrect

See Issue #707 for more details.