### PR TITLE
cva6.py: return FAIL when test compare is failed

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -744,6 +744,7 @@ def save_regr_report(report):
     failed_details = run_cmd("sed -e 's,.*_sim/,,' %s | grep '\(csv\|matched\)' | uniq | sed -e 'N;s/\\n/ /g' | grep '\[FAILED\]'" % report).strip()
     logging.info(failed_details)
     run_cmd(("echo %s >> %s" % (failed_details, report)))
+    sys.exit(RET_FAIL)
   logging.info("ISS regression report is saved to %s" % report)
 
 


### PR DESCRIPTION
Exit regression with RET_FAIL code error when a test from the testlist fails.
