### PR TITLE
CI Generated configuration

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -147,6 +147,22 @@ pub_smoke:
     paths:
       - artifacts/reports/*.yml
 
+pub_hwconfig:
+  stage: two
+  extends:
+    - .template_job_short_ci
+  needs:
+    - job: pub_smoke
+      artifacts: false
+  parallel:
+    matrix:
+      - DV_SIMULATORS: ["vcs-uvm,spike", "veri-testharness,spike"]
+        DV_HWCONFIG_OPTS: ["--default_config=cv64a6_imafdc_sv39 --isa=rv64imac --fpu=0",
+                           "--default_config=cv64a6_imafdc_sv39 --isa=rv64g --c_ext=0",
+                           "--default_config=cv64a6_imafdc_sv39 --isa=rv64gc --duser_en=1"]
+  script:
+    - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
+    - source ./cva6/regress/hwconfig_tests.sh
 
 pub_compliance:
   stage: two

--- a/cva6/regress/hwconfig_tests.sh
+++ b/cva6/regress/hwconfig_tests.sh
@@ -1,0 +1,30 @@
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume Chauvon (guillaume.chauvon@thalesgroup.com)
+
+# where are the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+# install the required tools
+source ./cva6/regress/install-cva6.sh
+source ./cva6/regress/install-riscv-dv.sh
+source ./cva6/regress/install-riscv-tests.sh
+
+if ! [ -n "$DV_SIMULATORS" ]; then
+  DV_SIMULATORS=veri-testharness,spike
+fi
+
+cd cva6/sim/
+python3 cva6.py --testlist=../tests/testlist_hwconfig.yaml --iss_yaml cva6.yaml --target hwconfig --hwconfig_opts="$DV_HWCONFIG_OPTS" --iss=$DV_SIMULATORS
+make -C ../../core-v-cores/cva6 clean
+make clean_all
+
+cd -

--- a/cva6/tests/testlist_hwconfig.yaml
+++ b/cva6/tests/testlist_hwconfig.yaml
@@ -1,0 +1,109 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+#- import: <riscv_dv_root>/target/rv64imc/testlist.yaml
+
+# ISA tests
+- test: rv64ui-p-add
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64ui/add.S
+
+- test: rv64ui-v-add
+  iterations: 1
+  needs:
+    - xlen: 64
+    - fpu: 1
+    - c_ext: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-DENTROPY=0x1 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ <path_var>/riscv-tests/env/v/entry.S <path_var>/riscv-tests/env/v/vm.c <path_var>/riscv-tests/env/v/string.c -I<path_var>/riscv-tests/env/v/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64ui/add.S
+
+- test: rv64ui-p-sw
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64ui/sw.S
+
+- test: rv64ui-p-lw
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64ui/lw.S
+
+- test: rv64um-p-div
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64um/div.S
+
+- test: rv64um-p-mul
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64um/mul.S
+
+- test: rv64uf-p-fcmp
+  iterations: 1
+  needs:
+    - xlen: 64
+    - fpu: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64uf/fcmp.S
+
+- test: rv64ua-p-amomax_d
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64ua/amomax_d.S
+
+- test: rv64mi-p-csr
+  iterations: 1
+  needs:
+    - xlen: 64
+  path_var: TESTS_PATH
+  gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-tests/isa/macros/scalar/ -I<path_var>/riscv-tests/env/p/ -I<path_var>/riscv-tests/riscv-target/spike/"
+  asm_tests: <path_var>/riscv-tests/isa/rv64mi/csr.S


### PR DESCRIPTION
Related to https://github.com/openhwgroup/cva6/pull/862#issue-1211045880

Hello,

I have integrated the use of custom configurations in our core-v-verif flow. It allow us to create CI on features that we don't check with our ISA tests. It also ease the creation and the use of configurations different from the 4 already existing configs in CVA6. 

I've also added a testlist and a script to be runned in CI. `testlist_config.yaml` has a field `needs` to check that the configuration we use can run the test.

@JeanRochCoulon @ASintzoff can you look at this ?
