### PR TITLE
introduce isscom_opts, issrun_opts and isspostrun_opts

### DIFF
--- a/cva6/regress/linux.sh
+++ b/cva6/regress/linux.sh
@@ -25,10 +25,11 @@ source ./cva6/regress/install-cva6.sh
 source ./cva6/regress/install-riscv-dv.sh
 
 if ! [ -n "$DV_SIMULATORS" ]; then
-  DV_SIMULATORS=veri-testharness-linux
+  DV_SIMULATORS=veri-testharness
 fi
 
 cd cva6/sim
 cp $BBL_ROOT/bbl bbl.o
-python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --elf_tests bbl.o
+python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --elf_tests bbl.o\
+  --issrun_opts="+time_out=40000000 +debug_disable=1" --isspostrun_opts="ffffffe0005e5cd4"
 cd -

--- a/cva6/regress/smoke-tests.sh
+++ b/cva6/regress/smoke-tests.sh
@@ -28,7 +28,8 @@ python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-v.ya
 python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-add --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_custom.yaml --test custom_test_template --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
-python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c --gcc_opts "-g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld"
+python3 cva6.py --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c\
+  --gcc_opts "-g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld"
 make -C ../../core-v-cores/cva6 clean
 make clean_all
 python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a6_imac_sv0.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a6_imac_sv0 --iss=$DV_SIMULATORS $DV_OPTS

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -25,11 +25,24 @@ FLIST_TB   := $(CVA6_TB_DIR)/Flist.cva6_tb
 target     ?= cv64a6_imafdc_sv39
 FLIST_CORE := $(CVA6_REPO_DIR)/core/Flist.$(target)
 
-VERDI          ?=
-user-define    ?= +define+WT_CACHE
-USERDEFINE      = +define+RVFI_TRACE $(user-define)
+VERDI           ?=
+path-var        ?=
+tool_path       ?=
+isscomp_opts    ?=
+issrun_opts     ?=
+isspostrun_opts ?=
+log             ?=
+variant         ?=
 
 TESTNAME := $(shell basename -s .o $(elf-bin))
+
+ifeq ($(isspostrun_opts), "")
+grep_address:
+	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
+else
+grep_address:
+endif
+
 #######################################################################################
 #                   Code Coverage
 #######################################################################################
@@ -44,8 +57,31 @@ else
 	cov-comp-opt =
 	cov-run-opt  =
 endif
+
 ###############################################################################
-# Synopsys VCS specific commands, variables
+# Spike specific commands, variables
+###############################################################################
+spike:
+	$(tool_path)/spike --log-commits --isa=$(variant) -l $(elf)
+	cp $(log).iss $(log)
+
+###############################################################################
+# testharness specific commands, variables
+###############################################################################
+vcs-testharness:
+	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	$(path_var)/work-vcs/simv ${VERDI:+-verdi} +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
+	$(tool_path)/spike-dasm < ./trace_rvfi_hart_00.dasm > $(log)
+	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
+
+veri-testharness:
+	make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	$(path_var)/work-ver/Variane_testharness $(elf) $(issrun_opts)
+	$(tool_path)/spike-dasm < ./trace_rvfi_hart_00.dasm > $(log)
+	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
+
+###############################################################################
+# UVM specific commands, variables
 ###############################################################################
 ALL_VCS_FLAGS           = $(if $(VERDI), -kdb -debug_access+all -lca,) -sverilog -full64 -timescale=1ns/1ns
 VCS_WORK_DIR            = $(CORE_V_VERIF)/cva6/sim/vcs_results/default/vcs.d
@@ -84,7 +120,7 @@ ALL_UVM_FLAGS           = -lca -sverilog +incdir+/opt/synopsys/vcs-mx/O-2018.09-
 	  /opt/synopsys/vcs-mx/O-2018.09-SP1-1/etc/uvm/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_MEDIUM -ntb_opts uvm-1.2 -timescale=1ns/1ps \
 	  -assert svaext -race=all -ignore unique_checks -full64 -q +incdir+/opt/synopsys/vcs-mx/O-2018.09-SP1-1/etc/uvm/src \
 	  +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt \
-	  $(USERDEFINE) $(if $(VERDI), -debug_access+all -kdb,)
+	  $(if $(VERDI), -debug_access+all -kdb,)
 ALL_SIMV_UVM_FLAGS      = -licwait 20 -l +ntb_random_seed=1 \
 		-sv_lib $(CORE_V_VERIF)/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
 		+UVM_TESTNAME=uvmt_cva6_firmware_test_c $(if $(VERDI), -gui -do $(CORE_V_VERIF)/cva6/sim/init_uvm.do,)
@@ -103,17 +139,23 @@ vcs_uvm_comp: dpi_build
 	cd $(VCS_WORK_DIR) && vcs $(ALL_UVM_FLAGS) \
 	  -f $(FLIST_CORE) -f $(FLIST_TB) \
 	  -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
-	  $(cov-comp-opt) \
+	  $(cov-comp-opt) $(isscomp_opts)\
 	  -top uvmt_cva6_tb
 
 vcs_uvm_run:
 	cd $(VCS_WORK_DIR)/ && \
 	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
-	++$(elf-bin) \
-	+PRELOAD=$(elf-bin) \
+	++$(elf) \
+	+PRELOAD=$(elf) \
 	-sv_lib $(dpi-library)/ariane_dpi $(if $(DO_SIM), -ucli -do $(CORE_V_VERIF)/cva6/sim/sim.do,) \
-	$(cov-run-opt) && \
+	$(cov-run-opt) $(issrun_opts)&& \
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
+
+vcs-uvm:
+	make vcs_uvm_comp
+	make vcs_uvm_run
+	$(tool_path)/spike-dasm < ./trace_rvfi_hart_00.dasm > $(log)
+	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 generate_cov_dash:
 	urg -dir $(VCS_WORK_DIR)/simv.vdb
@@ -121,16 +163,20 @@ generate_cov_dash:
 vcs_gate_comp:
 	@echo "[VCS] Building Model"
 	mkdir -p $(VCS_WORK_DIR)
-	cd $(VCS_WORK_DIR) && vcs $(ALL_VCS_FLAGS) -f $(FLIST_CORE)_gate -f $(FLIST_TB)
+	cd $(VCS_WORK_DIR) && vcs $(ALL_VCS_FLAGS) -f $(FLIST_CORE)_gate -f $(FLIST_TB) $(isscomp_opts)
 
 vcs_gate_run:
-	cd $(VCS_WORK_DIR)/ && $(VCS_WORK_DIR)/simv
+	cd $(VCS_WORK_DIR)/ && $(VCS_WORK_DIR)/simv $(issrun_opts)
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
 
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"
 	rm -rf $(CORE_V_VERIF)/cva6/sim/vcs_results/ verdiLog/ simv* *.daidir *.vpd *.db csrc ucli.key vc_hdrs.h novas* inter.fsdb uart
 
+vcs-gate:
+	make vcs_gate_comp
+	make vcs_gate_run
+	$(tool_path)/spike-dasm < ./trace_rvfi_hart_00.dasm > $(log)
 
 ###############################################################################
 # Common targets and rules

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -14,11 +14,8 @@
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
-  precmd: >
   cmd: >
-    <tool_path>/spike --log-commits --isa=<variant> -l <elf>
-  postcmd: >
-    mv log.iss log
+    make spike variant=<variant> elf=<elf> tool_path=<tool_path> log=<log>
 
 ###############################################################################
 # Verilator
@@ -27,27 +24,8 @@
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
-  precmd: >
-    make -C <path_var> verilate target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    <path_var>/work-ver/Variane_testharness +debug_disable=1 <elf>
-  postcmd: >
-    <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
-
-- iss: veri-testharness-linux
-  path_var: RTL_PATH
-  tool_path: SPIKE_PATH
-  tb_path: TB_PATH
-  precmd: >
-    make -C <path_var> verilate target=<target> user-define="+define+WT_CACHE"
-  cmd: >
-    <path_var>/work-ver/Variane_testharness +time_out=40000000 +debug_disable=1 <elf>
-# Linux BBL is built out line to produce bbl.o
-#   The test consists in executing the first 40M cycles of bbl.o
-#   The grep command checks that "relocate" (vmlinux symbol) address is executed
-#   Of course, the address depends on thr bbl.o, to be added to the TODO list !
-  postcmd: >
-    grep "ffffffe0005e5cd4" ./trace_rvfi_hart_00.dasm
+    make veri-testharness target=<target> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 ###############################################################################
 # Synopsys VCS specific commands, variables
@@ -56,31 +34,19 @@
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
-  precmd: >
-    make -C <path_var> vcs_build target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    <path_var>/work-vcs/simv ${VERDI:+-verdi} +permissive -sv_lib <path_var>/work-dpi/ariane_dpi +debug_disable=1 +PRELOAD=<elf> +permissive-off ++<elf>
-  postcmd: >
-    <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
+    make vcs-testharness target=<target> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 - iss: vcs-gate
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
-  precmd: >
-    make -f Makefile vcs_gate_comp target=<target> user-define="+define+WT_CACHE"
   cmd: >
-    make -f Makefile vcs_gate_run elf-bin=<elf>
-  postcmd: >
-    <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
+    make vcs-gate target=<target> cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 - iss: vcs-uvm
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
-  precmd: >
-    make -f Makefile vcs_uvm_comp target=<target> cov=${cov} user-define="+define+WT_CACHE"
   cmd: >
-    make -f Makefile vcs_uvm_run elf-bin=<elf> cov=${cov}
-  postcmd: >
-    <tool_path>/spike-dasm < ./trace_rvfi_hart_00.dasm > log
+    make vcs-uvm target=<target> cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>


### PR DESCRIPTION
Before simulation compilation and run configuration was setup in several files (cva6.py, cva6.yaml, core-v-verif/cva6/sim/Makefile and cva6/Makefile, cva6.yaml). This modification makes the configuration accessible from cva6.py through isscomp_opts and issrun_opts. It leads to cva6.py, cva6.yaml simplification. 

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>