### PR TITLE
install-riscv-compliance.sh: use main branch

### DIFF
--- a/cva6/regress/install-riscv-compliance.sh
+++ b/cva6/regress/install-riscv-compliance.sh
@@ -9,7 +9,7 @@
 
 if ! [ -n "$COMPLIANCE_REPO" ]; then
   COMPLIANCE_REPO="https://github.com/riscv/riscv-compliance.git"
-  COMPLIANCE_BRANCH="master"
+  COMPLIANCE_BRANCH="main"
   COMPLIANCE_HASH="220e78542da4510e40eac31e31fdd4e77cdae437"
   COMPLIANCE_PATCH="../../../cva6/regress/riscv-compliance.patch"
 fi


### PR DESCRIPTION
as master branch was replaced by main branch on 2022-05-13
in riscv-compliance/riscv-arch-test repository

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>