### PR TITLE
[skip ci] Fix curly braces

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
@@ -22,7 +22,7 @@
 -f ${DV_UVML_LOGS_PATH}/uvml_logs_pkg.flist
 -f ${DV_UVML_SB_PATH}/uvml_sb_pkg.flist
 -f ${DV_UVML_MEM_PATH}/uvml_mem_pkg.flist
--f $(DV_SVLIB_PATH)/svlib_pkg.flist
+-f ${DV_SVLIB_PATH}/svlib_pkg.flist
 
 // Agents
 -f ${DV_UVMA_CORE_CNTRL_PATH}/uvma_core_cntrl_pkg.flist


### PR DESCRIPTION
This was caught by a prospective member of the OpenHW Group who is using Synopsys VCS.  Apparently both dsim and xrun accept both curley braces and round braces around variable names in manifests and VCS does not.  Who knew?

Signed-off-by: Mike Thompson <mike@openhwgroup.org>