### PR TITLE
corev-dv: add cvxif custom instructions, for cva6, to the Random Instruction Generator

### DIFF
--- a/cva6/env/corev-dv/README.md
+++ b/cva6/env/corev-dv/README.md
@@ -1,0 +1,40 @@
+Customize and Extend Generator
+==============================
+
+Add custom instructions
+-----------------------
+
+- To generate a test containing the cvxif custom instructions, run the commands below, in sim directory:
+  ```bash
+     cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
+     python3 cva6.py --testlist=dv/yaml/base_testlist.yaml --test riscv_arithmetic_basic_test --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=vcs-uvm
+     -cs ../env/corev-dv/target/rv64gc/ --mabi lp64 --isa rv64gc --sim_opts="+uvm_set_inst_override=riscv_asm_program_gen,cva6_asm_program_gen_c,'uvm_test_top.asm_gen'" --simulator_yaml ../env/corev-dv/simulator.yaml
+ ```
+  The command generates the riscv_arithmetic_basic_test described in dv/yaml/base_testlist.yaml, you can define your own testlist.yaml.
+
+- Supported targets: `rv64gc` and `rv32imc`
+
+- CUS_EXC, CUS_M_ADD, CUS_S_ADD, CUS_NOP_EXC and CUS_ISS_EXC instructions will not be generated, because they are not yet supported by CVA6/SPIKE.
+
+- To add new custom instructions:
+   - 1. Add the new instruction enum to `riscv_custom_instr_enum.sv`
+         .. code-block example:: verilog
+          CUSTOM_ADD,
+          CUSTOM_SUB,
+          ...
+   - 2. Add custom instruction definition to `rv32x_instr.sv` (or to another custom file.sv)
+         .. code-block example:: verilog
+          `DEFINE_CVXIF_CUSTOM_INSTR(CUSTOM_ADD, R_FORMAT, ARITHMETIC, RV32X)
+          `DEFINE_CVXIF_CUSTOM_INSTR(CUSTOM_SUB, R_FORMAT, ARITHMETIC, RV32X)`
+          ...
+   - 3. Add your macros to `cva6_defines.svh`
+         .. code-block example:
+         `define DEFINE_CVXIF_CUSTOM_INSTR(instr_n, instr_format, instr_category, instr_group, imm_tp = IMM)  \
+             class riscv_``instr_n``_instr extends cvxif_custom_instr;`  \
+                `INSTR_BODY(instr_n, instr_format, instr_category, instr_group, imm_tp)`
+         ...
+   - 4. If the instructions are related to cvxif: add the instr description to `cvxif_custom_instr` class
+        else: Extend `riscv_custom_instr.sv` and implement key functions like get_instr_name, convert2asm
+   - 5. Add RV32X to supported_isa in riscv_core_setting.sv
+   - 6. Add the instruction macros to `user_define.include` or `user_define.h`
+

--- a/cva6/env/corev-dv/custom/cvxif_custom_instr.sv
+++ b/cva6/env/corev-dv/custom/cvxif_custom_instr.sv
@@ -1,0 +1,121 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+`ifndef __CVXIF_CUSTOM_INSTR_SV__
+`define __CVXIF_CUSTOM_INSTR_SV__
+
+/**
+ * This class describe custom instructions used with the cvxif agent.
+ */
+class cvxif_custom_instr extends riscv_custom_instr;
+
+   rand riscv_reg_t rs1;
+   rand riscv_reg_t rs2;
+   rand riscv_reg_t rs3;
+
+   `uvm_object_utils(cvxif_custom_instr)
+   `uvm_object_new
+
+   virtual function string get_instr_name();
+      get_instr_name = instr_name.name();
+      return get_instr_name;
+   endfunction : get_instr_name
+
+   // Convert the instruction to assembly code
+   virtual function string convert2asm(string prefix = "");
+      string asm_str;
+      asm_str = format_string(get_instr_name(), MAX_INSTR_STR_LEN);
+      case (instr_name)
+         CUS_ADD:       asm_str = $sformatf("%0s %0s, %0s, %0s",      asm_str, rd.name(),  rs1.name(),  rs2.name());
+         CUS_ADD_MULTI: asm_str = $sformatf("%0s %0s, %0s, %0s",      asm_str, rd.name(),  rs1.name(),  rs2.name());
+         CUS_ADD_RS3:   asm_str = $sformatf("%0s %0s, %0s, %0s, %0s", asm_str, rd.name(),  rs1.name(),  rs2.name(), rs3.name());
+         CUS_NOP:       asm_str = "cus_nop";
+         /* following instructions are not yet supported by cva6 */
+         //CUS_EXC:       asm_str = $sformatf("%0s %0s, %0s, %0s", asm_str, rd.name(),  rs1.name(),  rs2.name());
+         //CUS_M_ADD:     asm_str = $sformatf("%0s %0s, %0s, %0s", asm_str, rd.name(),  rs1.name(),  rs2.name());
+         //CUS_S_ADD:     asm_str = $sformatf("%0s %0s, %0s, %0s", asm_str, rd.name(),  rs1.name(),  rs2.name());
+         //CUS_NOP_EXC:   asm_str = "cus_nop_exc";
+         //CUS_ISS_EXC:   asm_str = $sformatf("%0s %0s, %0s, %0s", asm_str, rd.name(),  rs1.name(),  rs2.name());
+      endcase
+      comment = {get_instr_name(), " ", comment};
+      if (comment != "") begin
+         asm_str = {asm_str, " #", comment};
+      end
+      return asm_str.tolower();
+   endfunction : convert2asm
+
+   virtual function void set_imm_len();
+      imm_len = 7;
+   endfunction : set_imm_len
+
+   function bit [6:0] get_opcode();
+      case (instr_name) inside
+         {CUS_ADD, CUS_ADD_MULTI, CUS_ADD_RS3, CUS_NOP}        : get_opcode = 7'b1111011;
+         // {CUS_ADD, CUS_ADD_MULTI, CUS_ADD_RS3, CUS_NOP, CUS_EXC, , CUS_NOP_EXC, CUS_ISS_EXC, CUS_M_ADD, CUS_S_ADD}   : get_opcode = 7'b1111011;
+         default : `uvm_fatal(`gfn, $sformatf("Unsupported instruction %0s", instr_name.name()))
+      endcase
+   endfunction
+
+   virtual function bit [2:0] get_func3();
+      case (instr_name) inside
+         {CUS_ADD, CUS_ADD_MULTI, CUS_ADD_RS3, CUS_NOP}        : get_func3 = 3'b000;
+         // {CUS_ADD, CUS_ADD_MULTI, CUS_ADD_RS3, CUS_NOP, CUS_EXC, CUS_NOP_EXC, CUS_ISS_EXC, CUS_M_ADD, CUS_S_ADD} : get_func3 = 3'b000;
+      endcase
+   endfunction
+
+   virtual function bit [6:0] get_func7();
+      case (instr_name)
+         CUS_ADD                    : get_func7 = 7'b0000000;
+         CUS_NOP                    : get_func7 = 7'b0000000;
+         CUS_ADD_MULTI              : get_func7 = 7'b0001000;
+         // CUS_EXC                 : get_func7 = 7'b1000000;
+         // CUS_M_ADD               : get_func7 = 7'b0000010;
+         // CUS_S_ADD               : get_func7 = 7'b0000110;
+         // CUS_NOP_EXC             : get_func7 = 7'b0100000;
+         // CUS_ISS_EXC             : get_func7 = 7'b1100000;
+      endcase
+   endfunction
+
+   virtual function bit [6:0] get_func2();
+      case (instr_name)
+         CUS_ADD_RS3                : get_func2 = 2'b01;
+      endcase
+   endfunction
+
+   virtual function void set_rand_mode();
+      /*case (instr_name) inside
+         "CUS_EXC", "CUS_ISS_EXC": begin
+            has_rd= 1'b0;
+            has_rs2= 1'b0;
+         end
+      endcase*/
+  endfunction
+
+   function void pre_randomize();
+      rd.rand_mode(has_rd);
+      rs2.rand_mode(has_rs2);
+   endfunction
+
+   constraint rd_c {
+      // if (instr_name inside {CUS_ADD_MULTI, CUS_ADD, CUS_ADD_RS3, CUS_M_ADD, CUS_S_ADD}) {
+      if (instr_name inside {CUS_ADD_MULTI, CUS_ADD, CUS_ADD_RS3}) {
+         rd!=0;
+      }
+  /* if (instr_name inside { CUS_EXC, CUS_ISS_EXC} ) {
+      rd == 0;
+      rs1 inside {[4:7], 13, 15};
+      rs2 == 0;
+    }*/
+  }
+
+endclass
+
+`endif // __CVXIF_CUSTOM_INSTR_SV__

--- a/cva6/env/corev-dv/custom/riscv_custom_instr_enum.sv
+++ b/cva6/env/corev-dv/custom/riscv_custom_instr_enum.sv
@@ -1,0 +1,22 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+// Add custom instruction name enum
+CUSTOM_1,
+CUS_ADD,
+CUS_ADD_MULTI,
+CUS_NOP,
+CUS_ADD_RS3,
+// CUS_EXC,
+// CUS_M_ADD,
+// CUS_S_ADD,
+// CUS_NOP_EXC,
+// CUS_ISS_EXC,

--- a/cva6/env/corev-dv/custom/rv32x_instr.sv
+++ b/cva6/env/corev-dv/custom/rv32x_instr.sv
@@ -1,0 +1,20 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+`DEFINE_CVXIF_CUSTOM_INSTR(CUS_ADD,        R_FORMAT,  ARITHMETIC, RV32X)
+`DEFINE_CVXIF_CUSTOM_INSTR(CUS_ADD_MULTI,  R_FORMAT,  ARITHMETIC, RV32X)
+`DEFINE_CVXIF_CUSTOM_INSTR(CUS_NOP,        R_FORMAT,  ARITHMETIC, RV32X)
+`DEFINE_CVXIF_CUSTOM_INSTR(CUS_ADD_RS3,    R4_FORMAT, ARITHMETIC, RV32X)
+// `DEFINE_CVXIF_CUSTOM_INSTR(CUS_EXC,        R_FORMAT,  ARITHMETIC, RV32X)
+// `DEFINE_CVXIF_CUSTOM_INSTR(CUS_M_ADD,      R_FORMAT,  ARITHMETIC, RV32X)
+// `DEFINE_CVXIF_CUSTOM_INSTR(CUS_S_ADD,      R_FORMAT,  ARITHMETIC, RV32X)
+// `DEFINE_CVXIF_CUSTOM_INSTR(CUS_NOP_EXC,    R_FORMAT,  ARITHMETIC, RV32X)
+// `DEFINE_CVXIF_CUSTOM_INSTR(CUS_ISS_EXC,    R_FORMAT,  ARITHMETIC, RV32X)

--- a/cva6/env/corev-dv/cva6-files.f
+++ b/cva6/env/corev-dv/cva6-files.f
@@ -1,0 +1,20 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+// HEADERS
++incdir+${CVA6_DV_ROOT}/
++incdir+${CVA6_DV_ROOT}/custom
++incdir+${CVA6_DV_ROOT}/user_extension
+
+// SOURCES
+${CVA6_DV_ROOT}/cva6_instr_pkg.sv
+${CVA6_DV_ROOT}/cva6_instr_test_pkg.sv
+

--- a/cva6/env/corev-dv/cva6_asm_program_gen.sv
+++ b/cva6/env/corev-dv/cva6_asm_program_gen.sv
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Google LLC
+ * Copyright 2020 Andes Technology Co., Ltd.
+ * Copyright 2020 OpenHW Group
+ * Copyright 2022 Thales DIS design services SAS
+ *
+ * Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+ *
+ * You may obtain a copy of the License at
+ *      https://solderpad.org/licenses/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+`ifndef __CVA6_ASM_PROGRAM_GEN_SV__
+`define __CVA6_ASM_PROGRAM_GEN_SV__
+
+//-----------------------------------------------------------------------------------------
+// CVA6 assembly program generator - extension of the RISC-V assembly program generator.
+//
+// Overrides gen_program_header()
+//-----------------------------------------------------------------------------------------
+
+class cva6_asm_program_gen_c extends riscv_asm_program_gen;
+
+   `uvm_object_utils(cva6_asm_program_gen_c)
+
+   function new (string name = "");
+      super.new(name);
+   endfunction
+
+   virtual function void gen_program_header();
+      string str[$];
+      instr_stream.push_back(".include \"user_define.include\"");
+      instr_stream.push_back(".globl _start");
+      instr_stream.push_back(".section .text");
+      if (cfg.disable_compressed_instr) begin
+         instr_stream.push_back(".option norvc;");
+      end
+      str = {"csrr x5, mhartid"};
+      for (int hart = 0; hart < cfg.num_of_harts; hart++) begin
+         str = {str, $sformatf("li x6, %0d", hart),
+                     $sformatf("beq x5, x6, %0df", hart)};
+      end
+      gen_section("_start", str);
+      for (int hart = 0; hart < cfg.num_of_harts; hart++) begin
+         instr_stream.push_back($sformatf("%0d: j h%0d_start", hart, hart));
+      end
+   endfunction
+
+endclass : cva6_asm_program_gen_c
+
+`endif // __CVA6_ASM_PROGRAM_GEN_SV__

--- a/cva6/env/corev-dv/cva6_defines.svh
+++ b/cva6/env/corev-dv/cva6_defines.svh
@@ -1,0 +1,15 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// -------------------------------------------------------------------------------------------
+
+// Custom extension instruction for CVXIF
+`define DEFINE_CVXIF_CUSTOM_INSTR(instr_n, instr_format, instr_category, instr_group, imm_tp = IMM)  \
+   class riscv_``instr_n``_instr extends cvxif_custom_instr;  \
+      `INSTR_BODY(instr_n, instr_format, instr_category, instr_group, imm_tp)

--- a/cva6/env/corev-dv/cva6_instr_pkg.sv
+++ b/cva6/env/corev-dv/cva6_instr_pkg.sv
@@ -1,0 +1,22 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+package cva6_instr_pkg;
+
+   import uvm_pkg::*;
+   `include "cva6_defines.svh"
+   import riscv_instr_pkg::*;
+   `include "cva6_asm_program_gen.sv"
+   `include "cvxif_custom_instr.sv"
+   `include "rv32x_instr.sv"
+   `include "riscv_core_setting.sv"
+
+endpackage

--- a/cva6/env/corev-dv/cva6_instr_test_pkg.sv
+++ b/cva6/env/corev-dv/cva6_instr_test_pkg.sv
@@ -1,0 +1,19 @@
+// Copyright 2022 Thales DIS design services SAS
+// Copyright 2022 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Zineb EL KACIMI (zineb.el-kacimi@external.thalesgroup.com)
+// ------------------------------------------------------------------------------ //
+
+package cva6_instr_test_pkg;
+
+   import uvm_pkg::*;
+   import riscv_instr_pkg::*;
+   import riscv_instr_test_pkg::*;
+   import cva6_instr_pkg::*;
+
+endpackage : cva6_instr_test_pkg;

--- a/cva6/env/corev-dv/simulator.yaml
+++ b/cva6/env/corev-dv/simulator.yaml
@@ -1,0 +1,39 @@
+# Copyright Google LLC
+# Copyright 2022 Thales DIS Design Services SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+###### This file is based on <cwd>/cva6-simuator.yaml
+
+- tool: vcs
+  compile:
+    cmd:
+      - "vcs -file <cwd>/dv/vcs.compile.option.f
+              +incdir+<setting>
+              +incdir+<user_extension>
+             -f <cwd>/dv/files.f
+             -f <cwd>/../env/corev-dv/cva6-files.f
+             -full64
+             -l <out>/compile.log
+             -LDFLAGS '-Wl,--no-as-needed'
+             -Mdir=<out>/vcs_simv.csrc
+             -o <out>/vcs_simv <cmp_opts> <cov_opts> "
+    cov_opts: >
+      -cm_dir <out>/test.vdb
+  sim:
+    cmd: >
+      <out>/vcs_simv +vcs+lic+wait gen="true" <sim_opts> +ntb_random_seed=<seed> <cov_opts>
+    cov_opts: >
+      -cm_dir <out>/test.vdb -cm_log /dev/null -cm_name test_<seed>_<test_id>

--- a/cva6/env/corev-dv/target/rv32imc/riscv_core_setting.sv
+++ b/cva6/env/corev-dv/target/rv32imc/riscv_core_setting.sv
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------
+// Processor feature configuration
+//-----------------------------------------------------------------------------
+// XLEN
+parameter int XLEN = 32;
+
+// Parameter for SATP mode, set to BARE if address translation is not supported
+parameter satp_mode_t SATP_MODE = BARE;
+
+// Supported Privileged mode
+privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
+
+// Unsupported instructions
+riscv_instr_name_t unsupported_instr[];
+
+// ISA supported by the processor
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C, RV32X};
+
+// Interrupt mode support
+mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+
+// The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
+// supported
+int max_interrupt_vector_num = 16;
+
+// Physical memory protection support
+bit support_pmp = 0;
+
+// Debug mode support
+bit support_debug_mode = 0;
+
+// Support delegate trap to user mode
+bit support_umode_trap = 0;
+
+// Support sfence.vma instruction
+bit support_sfence = 0;
+
+// Support unaligned load/store
+bit support_unaligned_load_store = 1'b1;
+
+// Parameter for vector extension
+parameter int VECTOR_EXTENSION_ENABLE = 0;
+parameter int VLEN = 512;
+parameter int ELEN = 64;
+parameter int SLEN = 64;
+
+// Number of harts
+parameter int NUM_HARTS = 1;
+
+// ----------------------------------------------------------------------------
+// Previleged CSR implementation
+// ----------------------------------------------------------------------------
+
+// Implemented previlieged CSR list
+`ifdef DSIM
+privileged_reg_t implemented_csr[] = {
+`else
+const privileged_reg_t implemented_csr[] = {
+`endif
+    // Machine mode mode CSR
+    MVENDORID,  // Vendor ID
+    MARCHID,    // Architecture ID
+    MIMPID,     // Implementation ID
+    MHARTID,    // Hardware thread ID
+    MSTATUS,    // Machine status
+    MISA,       // ISA and extensions
+    MIE,        // Machine interrupt-enable register
+    MTVEC,      // Machine trap-handler base address
+    MCOUNTEREN, // Machine counter enable
+    MSCRATCH,   // Scratch register for machine trap handlers
+    MEPC,       // Machine exception program counter
+    MCAUSE,     // Machine trap cause
+    MTVAL,      // Machine bad address or instruction
+    MIP         // Machine interrupt pending
+};
+
+// ----------------------------------------------------------------------------
+// Supported interrupt/exception setting, used for functional coverage
+// ----------------------------------------------------------------------------
+
+`ifdef DSIM
+interrupt_cause_t implemented_interrupt[] = {
+`else
+const interrupt_cause_t implemented_interrupt[] = {
+`endif
+    M_SOFTWARE_INTR,
+    M_TIMER_INTR,
+    M_EXTERNAL_INTR
+};
+
+`ifdef DSIM
+exception_cause_t implemented_exception[] = {
+`else
+const exception_cause_t implemented_exception[] = {
+`endif
+    INSTRUCTION_ACCESS_FAULT,
+    ILLEGAL_INSTRUCTION,
+    BREAKPOINT,
+    LOAD_ADDRESS_MISALIGNED,
+    LOAD_ACCESS_FAULT,
+    ECALL_MMODE
+};

--- a/cva6/env/corev-dv/target/rv64gc/riscv_core_setting.sv
+++ b/cva6/env/corev-dv/target/rv64gc/riscv_core_setting.sv
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------
+// Processor feature configuration
+//-----------------------------------------------------------------------------
+// XLEN
+parameter int XLEN = 64;
+
+// Parameter for SATP mode, set to BARE if address translation is not supported
+parameter satp_mode_t SATP_MODE = SV39;
+
+// Supported Privileged mode
+privileged_mode_t supported_privileged_mode[] = {USER_MODE, SUPERVISOR_MODE, MACHINE_MODE};
+
+// Unsupported instructions
+riscv_instr_name_t unsupported_instr[];
+
+// ISA supported by the processor
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV64I, RV64M, RV32C, RV64C, RV32A, RV64A,
+                                        RV32F, RV64F, RV32D, RV64D, RV32X};
+// Interrupt mode support
+mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+
+// The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
+// supported
+int max_interrupt_vector_num = 16;
+
+// Physical memory protection support
+bit support_pmp = 0;
+
+// Debug mode support
+bit support_debug_mode = 0;
+
+// Support delegate trap to user mode
+bit support_umode_trap = 0;
+
+// Support sfence.vma instruction
+bit support_sfence = 1;
+
+// Support unaligned load/store
+bit support_unaligned_load_store = 1'b1;
+
+// Parameter for vector extension
+parameter int VECTOR_EXTENSION_ENABLE = 0;
+parameter int VLEN = 512;
+parameter int ELEN = 64;
+parameter int SLEN = 64;
+
+// Number of harts
+parameter int NUM_HARTS = 1;
+
+// ----------------------------------------------------------------------------
+// Previleged CSR implementation
+// ----------------------------------------------------------------------------
+
+// Implemented previlieged CSR list
+`ifdef DSIM
+privileged_reg_t implemented_csr[] = {
+`else
+const privileged_reg_t implemented_csr[] = {
+`endif
+    // User mode CSR
+    USTATUS,    // User status
+    UIE,        // User interrupt-enable register
+    UTVEC,      // User trap-handler base address
+    USCRATCH,   // Scratch register for user trap handlers
+    UEPC,       // User exception program counter
+    UCAUSE,     // User trap cause
+    UTVAL,      // User bad address or instruction
+    UIP,        // User interrupt pending
+    // Supervisor mode CSR
+    SSTATUS,    // Supervisor status
+    SEDELEG,    // Supervisor exception delegation register
+    SIDELEG,    // Supervisor interrupt delegation register
+    SIE,        // Supervisor interrupt-enable register
+    STVEC,      // Supervisor trap-handler base address
+    SCOUNTEREN, // Supervisor counter enable
+    SSCRATCH,   // Scratch register for supervisor trap handlers
+    SEPC,       // Supervisor exception program counter
+    SCAUSE,     // Supervisor trap cause
+    STVAL,      // Supervisor bad address or instruction
+    SIP,        // Supervisor interrupt pending
+    SATP,       // Supervisor address translation and protection
+    // Machine mode mode CSR
+    MVENDORID,  // Vendor ID
+    MARCHID,    // Architecture ID
+    MIMPID,     // Implementation ID
+    MHARTID,    // Hardware thread ID
+    MSTATUS,    // Machine status
+    MISA,       // ISA and extensions
+    MEDELEG,    // Machine exception delegation register
+    MIDELEG,    // Machine interrupt delegation register
+    MIE,        // Machine interrupt-enable register
+    MTVEC,      // Machine trap-handler base address
+    MCOUNTEREN, // Machine counter enable
+    MSCRATCH,   // Scratch register for machine trap handlers
+    MEPC,       // Machine exception program counter
+    MCAUSE,     // Machine trap cause
+    MTVAL,      // Machine bad address or instruction
+    MIP,        // Machine interrupt pending
+    // Floating point CSR
+    FCSR        // Floating point control and status
+};
+
+// ----------------------------------------------------------------------------
+// Supported interrupt/exception setting, used for functional coverage
+// ----------------------------------------------------------------------------
+
+`ifdef DSIM
+interrupt_cause_t implemented_interrupt[] = {
+`else
+const interrupt_cause_t implemented_interrupt[] = {
+`endif
+    U_SOFTWARE_INTR,
+    S_SOFTWARE_INTR,
+    M_SOFTWARE_INTR,
+    U_TIMER_INTR,
+    S_TIMER_INTR,
+    M_TIMER_INTR,
+    U_EXTERNAL_INTR,
+    S_EXTERNAL_INTR,
+    M_EXTERNAL_INTR
+};
+
+`ifdef DSIM
+exception_cause_t implemented_exception[] = {
+`else
+const exception_cause_t implemented_exception[] = {
+`endif
+    INSTRUCTION_ACCESS_FAULT,
+    ILLEGAL_INSTRUCTION,
+    BREAKPOINT,
+    LOAD_ADDRESS_MISALIGNED,
+    LOAD_ACCESS_FAULT,
+    STORE_AMO_ADDRESS_MISALIGNED,
+    STORE_AMO_ACCESS_FAULT,
+    ECALL_UMODE,
+    ECALL_SMODE,
+    ECALL_MMODE,
+    INSTRUCTION_PAGE_FAULT,
+    LOAD_PAGE_FAULT,
+    STORE_AMO_PAGE_FAULT
+};

--- a/cva6/env/corev-dv/user_extension/user_define.h
+++ b/cva6/env/corev-dv/user_extension/user_define.h
@@ -1,0 +1,1 @@
+# Add user macros, routines in this file

--- a/cva6/env/corev-dv/user_extension/user_define.include
+++ b/cva6/env/corev-dv/user_extension/user_define.include
@@ -1,0 +1,68 @@
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# ------------------------------------------------------------------------------ #
+
+# Add user macros, routines in this file
+
+# Mappings of custom_* mnemonics to .insn pseudo-op of GAS
+
+
+# CUS_ADD rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x0, rd, rs1, rs2
+.macro  cus_add rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x0, \rd, \rs1, \rs2
+.endm
+
+# CUS_NOP -> .insn r CUSTOM_3, 0x0, 0x0, x0, x0, x0
+.macro  cus_nop
+    .insn r CUSTOM_3, 0x0, 0x0, x0, x0, x0
+.endm
+
+# CUS_NOP_EXC -> .insn r CUSTOM_3, 0x0, 0x20, x0, x0, x0
+.macro  cus_nop_exc
+    .insn r CUSTOM_3, 0x0, 0x20, x0, x0, x0
+.endm
+
+# CUS_ADD_RS3 rd, rs1, rs2, rs3 -> .insn r CUSTOM_3, 0x0, 0x1, rd, rs1, rs2, rs3
+.macro  cus_add_rs3 rd, rs1, rs2, rs3
+    .insn r CUSTOM_3, 0x0, 0x1, \rd, \rs1, \rs2, \rs3
+.endm
+
+# CUS_M_ADD rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x6, rd, rs1, rs2
+.macro  cus_m_add rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x6, \rd, \rs1, \rs2
+.endm
+
+# CUS_S_ADD rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x2, rd, rs1, rs2
+.macro  cus_s_add rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x2, \rd, \rs1, \rs2
+.endm
+
+# CUS_ADD_MULTI rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x8, rd, rs1, rs2
+.macro  cus_add_multi rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x8, \rd, \rs1, \rs2
+.endm
+
+# CUS_EXC rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x40, rd, rs1, rs2
+.macro  cus_exc rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x40, \rd, \rs1, \rs2
+.endm
+
+# CUS_ISS_EXC rd, rs1, rs2 -> .insn r CUSTOM_3, 0x0, 0x60, rd, rs1, rs2
+.macro  cus_iss_exc rd, rs1, rs2
+    .insn r CUSTOM_3, 0x0, 0x60, \rd, \rs1, \rs2
+.endm
+
+# CUS_LD rd, rs1, simm12 -> .insn i CUSTOM_3, 0x1, rd, rs1, simm12
+.macro  cus_ld rd, rs1, simm12
+    .insn i CUSTOM_3, 0x1, \rd, \rs1, \simm12
+.endm
+
+# CUS_SD rs2, simm12(rs1) -> .insn s CUSTOM_3, 0x2, rs2, simm12(rs1)
+.macro  cus_sd rs2, addr
+    .insn s CUSTOM_3, 0x2, \rs2, \addr
+.endm

--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -356,7 +356,7 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd):
       cmd = ("%s -static -mcmodel=medany \
              -fvisibility=hidden -nostdlib \
              -nostartfiles %s \
-             -I%s/dv/user_extension \
+             -I%s/../env/corev-dv/user_extension \
              -T%s/link.ld %s -o %s " % \
              (get_env_var("RISCV_GCC", debug_cmd = debug_cmd), asm, cwd, cwd, opts, elf))
       if 'gcc_opts' in test:
@@ -926,6 +926,7 @@ def main():
     isscomp_opts = "\""+args.isscomp_opts+"\""
     cwd = os.path.dirname(os.path.realpath(__file__))
     os.environ["RISCV_DV_ROOT"] = cwd + "/dv"
+    os.environ["CVA6_DV_ROOT"]  = cwd + "/../env/corev-dv"
     setup_logging(args.verbose)
     logg = logging.getLogger()
     # create file handler which logs even debug messages


### PR DESCRIPTION
Customize and Extend the Random Instruction Generator, to add cvxif custom instructions used by cvxif agent.

Signed-off-by: Zineb El Kacimi <zineb.el-kacimi@external.thalesgroup.com>