### PR TITLE
gitlab-ci: show test fail in dashboard

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -139,11 +139,13 @@ pub_smoke:
     matrix:
       - DV_SIMULATORS: ["veri-testharness,spike","vcs-testharness,spike","vcs-uvm,spike" ]
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Smoke test $DV_SIMULATORS" "Short tests to challenge most architectures with most testbenchs configurations" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source cva6/regress/smoke-tests.sh
-    - mkdir -p artifacts/reports
-    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Smoke test $DV_SIMULATORS" "In this section we challenge all target architecture with all simulator" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Smoke test $DV_SIMULATORS" "Short tests to challenge some architectures with most testbenchs configurations" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - artifacts/reports/*.yml
 
@@ -160,6 +162,8 @@ pub_hwconfig:
         DV_HWCONFIG_OPTS: ["--default_config=cv32a60x --isa=rv32imac --a_ext=1",
                            "--default_config=cv32a60x --isa=rv32imc --RenameEn=1"]
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "HW config $DV_SIMULATORS $DV_HWCONFIG_OPTS" "Short tests to challenge target configurations" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source ./cva6/regress/hwconfig_tests.sh
 
@@ -176,11 +180,13 @@ pub_compliance:
   variables:
     DV_SIMULATORS: "veri-testharness,spike"
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Compliance $DV_TARGET" "Compliance regression suite" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source cva6/regress/dv-riscv-compliance.sh
-    - mkdir -p artifacts/reports
-    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Compliance" "This is the regression Compliance" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Compliance $DV_TARGET" "Compliance regression suite" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/*.yml"
 
@@ -199,11 +205,13 @@ pub_tests-v:
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-v.yaml"
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Riscv-test $DV_TARGET (virtual)" "Riscv-test regression suite (virtual)" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source cva6/regress/dv-riscv-tests.sh
-    - mkdir -p artifacts/reports
-    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Riscv-test V" "This is the regression riscv-test (virtual)" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Riscv-test $DV_TARGET (virtual)" "Riscv-test regression suite (virtual)" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/*.yml"
 
@@ -222,11 +230,13 @@ pub_tests-p:
     DV_SIMULATORS: "veri-testharness,spike"
     DV_TESTLISTS: "../tests/testlist_riscv-tests-$DV_TARGET-p.yaml"
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Riscv-test $DV_TARGET (physical)" "Riscv-test regression suite (physical)" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
     - source cva6/regress/dv-riscv-tests.sh
-    - mkdir -p artifacts/reports
-    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Riscv-test P" "This is the regression riscv-test (physical)" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Riscv-test $DV_TARGET (physical)" "Riscv-test regression suite (physical)" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/*.yml"
 
@@ -248,6 +258,8 @@ pub_synthesis:
     INPUT_DELAY: "0.46"
     OUTPUT_DELAY: "0.11"
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "ASIC Synthesis $TARGET" "Synthesis indicator with specific Techno" "artifacts/reports/$CI_JOB_NAME.yml"
     #ack trick to manage float gitlab-ci variables that seems to support only string or integer
     - echo $(echo $SYNTH_PERIOD)
     - echo $(echo $INPUT_DELAY)
@@ -260,11 +272,11 @@ pub_synthesis:
     - source ./cva6/regress/install-cva6.sh
     - echo $SYN_DCSHELL_BASHRC; source $SYN_DCSHELL_BASHRC
     - make -C core-v-cores/cva6/pd/synth cva6_synth PERIOD=$(echo $PERIOD) NAND2_AREA=$(echo $NAND2_AREA) FOUNDRY_PATH=$FOUNDRY_PATH TECH_NAME=$TECH_NAME INPUT_DELAY=$(echo $INPUT_DELAY) OUTPUT_DELAY=$(echo $OUTPUT_DELAY) TARGET=$TARGET
-    - mkdir -p artifacts/reports
     - mv core-v-cores/cva6/pd/synth/ariane_synth_modified.v artifacts/ariane_synth_modified_$TARGET.v
     - mv core-v-cores/cva6/pd/synth/ariane_synth.v artifacts/ariane_synth_$TARGET.v
-    - python3 .gitlab-ci/scripts/report_synth.py core-v-cores/cva6/pd/synth/ariane/reports/$PERIOD/ariane_$(echo $TECH_NAME)_synth_area.rpt "ASIC Synthesis" "Synthesis indicator with specific Techno" "$NAND2_AREA" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_synth.py core-v-cores/cva6/pd/synth/ariane/reports/$PERIOD/ariane_$(echo $TECH_NAME)_synth_area.rpt "ASIC Synthesis $TARGET" "Synthesis indicator with specific Techno" "$NAND2_AREA" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - artifacts/ariane_synth_modified_$TARGET.v
       - artifacts/ariane_synth_$TARGET.v
@@ -281,6 +293,8 @@ pub_smoke-gate:
     - job: pub_synthesis
       artifacts: true
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Smoke Gate $DV_TARGET" "Simple test to check netlist from ASIC synthesis" "artifacts/reports/$CI_JOB_NAME.yml"
     - echo $LIB_VERILOG
     - source ./cva6/regress/install-cva6.sh
     - source ./cva6/regress/install-riscv-dv.sh
@@ -292,9 +306,9 @@ pub_smoke-gate:
     - make vcs_clean_all
     - python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv64a6_imafdc_sv39-p.yaml --test rv64ui-p-ld --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=spike,vcs-gate $DV_OPTS
     - cd ../..
-    - mkdir -p artifacts/reports
-    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Smoke Gate" "Just one test to check netlist" "artifacts/reports/$CI_JOB_NAME.yml"
+    - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log "Smoke Gate $DV_TARGET" "Simple test to check netlist from ASIC synthesis" "artifacts/reports/$CI_JOB_NAME.yml"
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/*.yml"
 
@@ -307,10 +321,16 @@ pub_benchmarks:
     DV_SIMULATORS: "veri-testharness,spike"
   needs: []
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "BenchMark $DV_TARGET" "Performance indicator of some benchmark" "artifacts/reports/$CI_JOB_NAME.yml"
     - source ./cva6/regress/install-cva6.sh
     - source ./cva6/regress/install-riscv-dv.sh
     - source ./cva6/regress/install-riscv-tests.sh
     - source ./cva6/regress/benchmark.sh
+  artifacts:
+    when: always
+    paths:
+      - "artifacts/reports/*.yml"
 
 pub_wb_dcache:
   stage: three
@@ -318,12 +338,18 @@ pub_wb_dcache:
     - .template_job_always_manual
   needs: []
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Writeback Data Cache test" "Test of IP wb_dcache" "artifacts/reports/$CI_JOB_NAME.yml"
     - source ./cva6/regress/install-cva6.sh
     - cd core-v-cores/cva6
     - source ci/make-tmp.sh
     - source ci/build-riscv-tests.sh
     - cd ../../../
     - make run-asm-tests-verilator defines=WB_DCACHE
+  artifacts:
+    when: always
+    paths:
+      - "artifacts/reports/*.yml"
 
 pub_linux:
   stage: three
@@ -333,8 +359,14 @@ pub_linux:
     - job: pub_compliance
       artifacts: false
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "Linux Test" "Simulation of Boot Linux" "artifacts/reports/$CI_JOB_NAME.yml"
     - source cva6/regress/linux.sh
   timeout: 2h 30m
+  artifacts:
+    when: always
+    paths:
+      - "artifacts/reports/*.yml"
 
 
 pub_fpga-build:
@@ -345,9 +377,15 @@ pub_fpga-build:
     - job: pub_compliance
       artifacts: false
   script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py "FPGA Build" "Test of FPGA build flow" "artifacts/reports/$CI_JOB_NAME.yml"
     - source $VIVADO_SETUP
     - source cva6/regress/install-cva6.sh
     - make -C core-v-cores/cva6 fpga
+  artifacts:
+    when: always
+    paths:
+      - "artifacts/reports/*.yml"
 
 
 merge_report:
@@ -358,9 +396,11 @@ merge_report:
       when: always
     - when: never
   script:
+    - mkdir -p artifacts/reports
     - ls -al artifacts/reports
     - python3 .gitlab-ci/scripts/merge_job_reports.py artifacts/reports pipeline_report_$CI_PIPELINE_ID.yml
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/pipeline_report_$CI_PIPELINE_ID.yml"
 

--- a/.gitlab-ci/scripts/report_fail.py
+++ b/.gitlab-ci/scripts/report_fail.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Thales DIS design services SAS
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Yannick Casamatta (yannick.casamatta@thalesgroup.com)
+
+import re
+from pprint import pprint
+import yaml
+import datetime
+import sys
+
+global_pass = "pass"
+
+report = {'title': sys.argv[1],
+          'description': sys.argv[2],
+          'token': 'YC' + str(datetime.datetime.now().timestamp()).replace('.', ''),
+          'status': "fail",
+          'label': "FAIL",
+          'metrics': [{'display_name': '',
+              'type': 'table_status',
+              'status': "fail",
+              'value': [{
+                  'status': 'fail',
+                  'label': 'FAIL',
+                  'col': ['Job has fail before end of script'],
+              }],
+          }],
+         }
+
+pprint(report)
+
+filename = re.sub('[^\w\.\\\/]', '_', sys.argv[3])
+print(filename)
+
+with open(filename, 'w+') as f:
+    yaml.dump(report, f)


### PR DESCRIPTION
Related to gitlab-ci dashboard management

Currently, the report of each test is created at the end of the script of each job.
The problem is that if one of the commands of the job returns a non-zero error code, then no report exists for the job and nothing mentions in the dashboard that the job is failed.

Ideally, jobs should not return a zero error code even in case of fail. The fault should be seen and generated by the script that generates the report for the job.

To fix the problem, this PR adds a script ran at the beginning of each job. That generates a "fail" report, and if the job is OK, it will be overwritten by the real report at the end.

Some descriptions in the CI has also been changed