### PR TITLE
cva6.py: save cva6/sim path to go back to it after generating config

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -896,9 +896,10 @@ def load_config(args, cwd):
       args.mabi = "lp64"
       args.isa  = "rv64imc"
     elif args.target == "hwconfig":
+      current_path = os.getcwd()
       os.chdir(os.getcwd()+"/../../core-v-cores/cva6")
       [args.isa,args.mabi, args.target, args.hwconfig_opts] = generate_config(args.hwconfig_opts.split())
-      os.chdir(os.getcwd()+"/../../cva6/sim")
+      os.chdir(current_path)
     else:
       sys.exit("Unsupported pre-defined target: %0s" % args.target)
     args.core_setting_dir = cwd + "/dv" + "/target/"+ args.isa


### PR DESCRIPTION
Small fix in order to use hwconfig regression from cva6 repository via Thales-CI

@JeanRochCoulon or @yanicasa can you review it ?

Guillaume