### PR TITLE
Add 64b Linux boot and 32b FPGA build jobs. Add report scripts for dashboard

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -412,28 +412,58 @@ pub_linux:
 
 
 pub_fpga-build:
-  stage: three
+  stage: two
   extends:
     - .template_job_short_ci
   needs:
-    - job: pub_compliance
+    - job: pub_smoke
       artifacts: false
   variables:
-    DASHBOARD_JOB_TITLE: "FPGA Build"
+    DASHBOARD_JOB_TITLE: "FPGA Build $TARGET"
     DASHBOARD_JOB_DESCRIPTION: "Test of FPGA build flow"
     DASHBOARD_JOB_CATEGORY: "Synthesis"
+  parallel:
+    matrix:
+      - TARGET: [cv64a6_imafdc_sv39, cv32a60x]
   script:
     - mkdir -p artifacts/reports
     - python3 .gitlab-ci/scripts/report_fail.py
     - source $VIVADO_SETUP
     - source cva6/regress/install-cva6.sh
-    - make -C core-v-cores/cva6 fpga
-    - python3 .gitlab-ci/scripts/report_pass.py
+    - make -C core-v-cores/cva6 fpga target=$TARGET
+    - mkdir -p artifacts/reports
+    - mv core-v-cores/cva6/corev_apu/fpga/work-fpga/ariane_xilinx.bit artifacts/ariane_xilinx_$TARGET.bit
+    - python3 .gitlab-ci/scripts/report_fpga.py core-v-cores/cva6/corev_apu/fpga/reports/ariane.utilization.rpt
   artifacts:
     when: always
     paths:
+      - "artifacts/ariane_xilinx_$TARGET.bit"
       - "artifacts/reports/*.yml"
 
+pub_fpga-boot:
+  stage: three
+  tags: [fpga,shell]
+  needs: [pub_fpga-build]
+  variables:
+    VERILATOR_ROOT: "/shares/tools/dummy/verilator" # to avoid install of verilator
+    SPIKE_ROOT: "/shares/tools/dummy/spike"  # to avoid install of spike
+    DASHBOARD_JOB_TITLE: "FPGA Linux64 Boot "
+    DASHBOARD_JOB_DESCRIPTION: "Test of Linux 64 bits boot on FPGA Genesys2"
+    DASHBOARD_JOB_CATEGORY: "Synthesis"
+  script:
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_fail.py
+    - source cva6/regress/install-cva6.sh
+    - source $VIVADO2022_SETUP
+    - mkdir -p core-v-cores/cva6/corev_apu/fpga/work-fpga
+    - mv artifacts/ariane_xilinx_cv64a6_imafdc_sv39.bit core-v-cores/cva6/corev_apu/fpga/work-fpga/ariane_xilinx.bit
+    - cd core-v-cores/cva6/corev_apu/fpga/scripts
+    - source check_fpga_boot.sh
+    - cd -
+    - python3 .gitlab-ci/scripts/report_fpga_boot.py core-v-cores/cva6/corev_apu/fpga/scripts/fpga_boot.rpt
+  artifacts:
+    paths:
+      - "artifacts/reports/*.yml"
 
 merge_report:
   stage: .post

--- a/.gitlab-ci/scripts/report_fpga.py
+++ b/.gitlab-ci/scripts/report_fpga.py
@@ -1,0 +1,78 @@
+# Copyright 2022 Thales Silicon Security
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume Chauvon(guillaume.chauvon@thalesgroup.com)
+
+import re
+from pprint import pprint
+import yaml
+import datetime
+import sys
+import os
+
+with open(str(sys.argv[1]), "r") as f:
+    log = f.read()
+
+global_pass = "pass"
+
+report = {
+    "title": os.environ["DASHBOARD_JOB_TITLE"],
+    "description": os.environ["DASHBOARD_JOB_DESCRIPTION"],
+    'category': os.environ["DASHBOARD_JOB_CATEGORY"],
+    'job_id': os.environ["CI_JOB_ID"],
+    'job_url': os.environ["CI_JOB_URL"],
+    'job_stage_name': os.environ["CI_JOB_STAGE"],
+    'job_started_at': int(datetime.datetime.strptime(os.environ['CI_JOB_STARTED_AT'], '%Y-%m-%dT%H:%M:%S%z').timestamp()),
+    'job_end_at': int(datetime.datetime.now().timestamp()),
+    'token': 'YC' + str(datetime.datetime.now().timestamp()).replace('.', ''),
+    'status': "pass",
+    'metrics': []
+}
+
+pattern = re.compile(
+    "\|(?P<ind> +)(?P<Instance>[\w()\[\].]+) +\| +(?P<Module>[\w()\[\].]+) \| +(?P<TotalLUTs>\d+) \| +(?P<LogicLUTs>\d+) \| +(?P<LUTRAMs>\d+) \| +(?P<SRLs>\d+) \| +(?P<FFs>\d+) \| +(?P<RAMB36>\d+) \| +(?P<RAMB18>\d+) \| +(?P<DSP48Blocks>\d+) \|"
+)
+
+data = []
+for line in pattern.finditer(log):
+    l = line.groupdict()
+    if l["Instance"] == "i_ariane_peripherals":
+        break
+    data.append(l)
+
+
+metric = {
+    "display_name": "Utilization Results",
+    "type": "table",
+    "status": "pass",
+    "value": [],
+}
+
+for i in data:
+    value = {"col": []}
+    if (i["ind"]).count(" ") < 10:
+        value["col"].append(i["Instance"])
+        if i["Instance"] == "ariane_xilinx":
+            report["label"] = i["TotalLUTs"] + " TotalLUTs"
+        value["col"].append(i["Module"])
+        value["col"].append(i["TotalLUTs"] + " TotalLUTs")
+        value["col"].append(i["LogicLUTs"] + " LogicLUTs")
+        value["col"].append(i["LUTRAMs"] + " LUTRAMs")
+        value["col"].append(i["SRLs"] + " SRLs")
+        value["col"].append(i["FFs"] + " FFs")
+        value["col"].append(i["RAMB36"] + " RAMB36")
+        value["col"].append(i["RAMB18"] + " RAMB18")
+        value["col"].append(i["DSP48Blocks"] + " DSP48Blocks")
+        metric["value"].append(value)
+
+report["metrics"].append(metric)
+
+filename = re.sub("[^\w\.\\\/]", "_", os.environ["CI_JOB_NAME"])
+print(filename)
+
+with open('artifacts/reports/'+filename+'.yml', 'w+') as f:
+    yaml.dump(report, f)

--- a/.gitlab-ci/scripts/report_fpga_boot.py
+++ b/.gitlab-ci/scripts/report_fpga_boot.py
@@ -1,0 +1,69 @@
+# Copyright 2022 Thales Silicon Security
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Guillaume Chauvon(guillaume.chauvon@thalesgroup.com)
+
+import re
+from pprint import pprint
+import yaml
+import datetime
+import sys
+import os
+
+with open(str(sys.argv[1]), "r") as f:
+    lastline = f.readlines()[-1]
+
+with open(str(sys.argv[1]), "r") as f:
+    log = f.read()
+
+global_pass = "pass"
+
+report = {
+    "title": os.environ["DASHBOARD_JOB_TITLE"],
+    "description": os.environ["DASHBOARD_JOB_DESCRIPTION"],
+    'category': os.environ["DASHBOARD_JOB_CATEGORY"],
+    'job_id': os.environ["CI_JOB_ID"],
+    'job_url': os.environ["CI_JOB_URL"],
+    'job_stage_name': os.environ["CI_JOB_STAGE"],
+    'job_started_at': int(datetime.datetime.strptime(os.environ['CI_JOB_STARTED_AT'], '%Y-%m-%dT%H:%M:%S%z').timestamp()),
+    'job_end_at': int(datetime.datetime.now().timestamp()),
+    'token': 'YC' + str(datetime.datetime.now().timestamp()).replace('.', ''),
+    'status': "pass",
+    'metrics': []
+}
+
+metric = {
+    "display_name": "Linux boot log",
+    "type": "table_status",
+    "status": "pass",
+    "value": [],
+}
+
+value = {}
+print(lastline)
+if not ("Linux buildroot" in lastline and "riscv" in lastline):
+    value["status"] = "fail"
+    value["label"] = "FAIL"
+    report["status"] = "fail"
+    report["label"] = "FAIL"
+    metric["status"] = "fail"
+else:
+    value["status"] = "pass"
+    value["label"] = "PASS"
+    report["status"] = "pass"
+    report["label"] = "PASS"
+
+value["col"] = [lastline]
+metric["value"].append(value)
+
+report["metrics"].append(metric)
+
+filename = re.sub("[^\w\.\\\/]", "_", os.environ["CI_JOB_NAME"])
+print(filename)
+
+with open('artifacts/reports/'+filename+'.yml', 'w+') as f:
+    yaml.dump(report, f)


### PR DESCRIPTION
Add 32 bits FPGA build of bitstream job.
Add 64 bits Linux boot on physical genesys2 FPGA.
Linux image is : `Linux buildroot 5.10.7 riscv64 GNU/Linux` generated via [CVA6-SDK](https://github.com/openhwgroup/cva6-sdk)

Add necessary report scripts to integrate those jobs to the dashboard.