### PR TITLE
[VPTOOL] Clean up documentation and code.  Update copyright notice.

### DIFF
--- a/tools/vptool/VPTOOL-readme.txt
+++ b/tools/vptool/VPTOOL-readme.txt
@@ -61,7 +61,7 @@ The key Python variables are:
 * `PROJECT_NAME`: a free-form string that identifies the project targeted by the verification plan
 * `SAVED_DB_LOCATION`: path to the databases (either a file name, or a directory name).  It is constructed
   from the value of `PLATFORM_TOP_DIR` in `vptool/vp_config.py` so that it can be tailored to any
-  organizaion- or site-specific directory naming conventions.
+  organization- or site-specific directory naming conventions.
 * `SPLIT_SAVE`: if set to 'True', then verification plan data associated with each Feature is stored
   in separate `VP_IPnnn.pck` files in the directory designated by `SAVED_IP_LOCATION`.
   If `SPLIT_SAVE` is set to `False`, the verification plan data for **ALL** Features will be stored
@@ -84,11 +84,11 @@ shell script named `vptool-example.sh` which can be invoked from any location.
 - vptool                      the code of `VPTOOL`
 - vptool-example              an example of `VPTOOL` configuration with a verification database
   - runme.sh                  a shell script to run `VPTOOL` with the example database
-  - example_database          Verification Plan data and `VPTOOL` administrative files for the example
+  - example-database          Verification Plan data and `VPTOOL` administrative files for the example
     - vptool                  location of `VPTOOL` configuration and lock files
       - vp_config.py          `VPTOOL` configuration file for the example
-      - 
-    - ip_dir                  directory holding the verification Plan data
+      - locked_ip.pick        `VPTOOL` lock file (identifies which user has exclusive access to which feature)
+    - ip_dir                  directory holding the Verification Plan database
       - core-v                arbitrary subdirectory level (to accommodate site/organization conventions)
         - cva6                another arbitrary subdirectory level
           - VP_IP000.pck      database file of first feature
@@ -99,11 +99,11 @@ shell script named `vptool-example.sh` which can be invoked from any location.
 
 - Start VPTOOL:
 
-    sh vptool-example.sh
+    sh vptool-example/runme.sh
 
   This will load all per-feature Verification Plans present in the `SAVED_DB_LOCATION` variable.
-  The corresponding path is `vplan_database/ip_dir/*.pck` as defined in the configuration file
-  `vptool-0.8.0/vp_config.py`.
+  The corresponding path is `vptool-example/example-database/ip_dir/core-v/cva6/*.pck` as defined
+  in the configuration file `vptool-example/example-database/vptool/vp_config.py`.
 
   The New and Delete buttons at the bottom of the Feature, Sub-Feature and Verification Item selectors
   are greyed out except for the `New` button of the Feature selector.  This indicates that the user does

--- a/tools/vptool/vptool/vptool.yml
+++ b/tools/vptool/vptool/vptool.yml
@@ -1,29 +1,13 @@
 #############################################################################
+# Copyright (C) 2022 Thales DIS France SAS
 #
-# Copyright 2022 Thales
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#############################################################################
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0.
 #
 # Original Author: Zbigniew Chamski (zbigniew.chamski@thalesgroup.com)
-#
 #############################################################################
 
 gui:
   title: CORE-V Verification Plan tool
-  # On Thor, TTk says
-  ### Available themes: ['scidpink', 'scidgrey', 'classic', 'aquativo', 'scidgreen', 'itft1', 'scidblue', 'clearlooks', 'radiance', 'blue', 'scidmint', 'black', 'arc', 'plastik', 'scidsand', 'alt', 'default', 'scidpurple', 'elegance', 'clam', 'kroc', 'adapta', 'yaru', 'winxpblue', 'ubuntu', 'breeze', 'keramik', 'equilux', 'smog']
   theme: arc
   ip:
     label: Feature


### PR DESCRIPTION
Files changed:

* tools/vptool/VPTOOL-readme.txt (Configuration): Fix typo.
  (Directory structure): Fix names and descriptions of dirs/files.
  (Basic use): Fix incorrect paths.
* tools/vptool/vptool/vptool.yml (toplevel): Update copyright holder name.
  Refer to license text using SPDX identifier.
  (gui.title): Remove comment with a site-dependent list of themes.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>

@JeanRochCoulon @ASintzoff, please review.