### PR TITLE
Set end_trampoline back to 80000000 and process 1st instruction

### DIFF
--- a/cva6/sim/verilator_log_to_trace_csv.py
+++ b/cva6/sim/verilator_log_to_trace_csv.py
@@ -114,7 +114,7 @@ def read_verilator_trace(path, full_trace):
   # true. Otherwise, we are in state EFFECT if instr is not None, otherwise we
   # are in state INSTR.
 
-  end_trampoline_re = re.compile(r'core.*: 0x0000000000010014 ')
+  end_trampoline_re = re.compile(r'core.*: 0x0000000080000000 ')
   start_debug_it_re = re.compile(r'core.*: 0x0000000000000800 ')
   stop_debug_it_re  = re.compile(r'core.*: 0x0000000000000890 ')
 
@@ -128,7 +128,6 @@ def read_verilator_trace(path, full_trace):
         # The TRAMPOLINE state
         if end_trampoline_re.match(line):
           in_trampoline = False
-        continue
 
       if not in_trampoline:
         if in_debug:


### PR DESCRIPTION
Hello, 

I set back end_trampoline back to 0x80000000 but suppress the continue statement to process instruction at 80000000.
We had issue with the UVM testbench which has no bootrom and start at 80000000. 
The script was not able to find instruction at address 10014 ( it doesn't exist in UVM tb) and didn't process the log correctly resulting in an empty csv.

The solution I propose solves this issue and still process the 1st instruction to match spike trace.