### PR TITLE
.gitlab-ci/cva6.yml: add always for fpga boot artifact

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -454,6 +454,7 @@ pub_fpga-boot:
     - cd -
     - python3 .gitlab-ci/scripts/report_fpga_boot.py core-v-cores/cva6/corev_apu/fpga/scripts/fpga_boot.rpt
   artifacts:
+    when: always
     paths:
       - "artifacts/reports/*.yml"
 


### PR DESCRIPTION
Always creates artifacts for pub_fgpa-boot job.

@JeanRochCoulon 