### PR TITLE
Fixes for mtvec-related issues in regressions

### DIFF
--- a/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
@@ -30,6 +30,47 @@ class cv32e40s_asm_program_gen extends corev_asm_program_gen;
     super.new(name);
   endfunction
 
+  virtual function void trap_vector_init(int hart);
+    string instr[];
+    privileged_reg_t trap_vec_reg;
+    string tvec_name;
+    foreach(riscv_instr_pkg::supported_privileged_mode[i]) begin
+      case(riscv_instr_pkg::supported_privileged_mode[i])
+        MACHINE_MODE:    trap_vec_reg = MTVEC;
+        SUPERVISOR_MODE: trap_vec_reg = STVEC;
+        USER_MODE:       trap_vec_reg = UTVEC;
+        default: `uvm_info(`gfn, $sformatf("Unsupported privileged_mode %0s",
+                           riscv_instr_pkg::supported_privileged_mode[i]), UVM_LOW)
+      endcase
+      // Skip utvec init if trap delegation to u_mode is not supported
+      if ((riscv_instr_pkg::supported_privileged_mode[i] == USER_MODE) &&
+          !riscv_instr_pkg::support_umode_trap) continue;
+      if (riscv_instr_pkg::supported_privileged_mode[i] < cfg.init_privileged_mode) continue;
+      tvec_name = trap_vec_reg.name();
+      // mtvec_handler is not the actual symbol for the trap handler in our implementation
+      // This ensures that we load the intended mtvec addreses instead of where the mtvec
+      // address 0 jumps to.
+      if (tvec_name.tolower == "mtvec") begin
+        instr = {instr, $sformatf("la x%0d, __vector_start", cfg.gpr[0])};
+      end else begin
+        instr = {instr, $sformatf("la x%0d, %0s%0s_handler",
+                                  cfg.gpr[0], hart_prefix(hart), tvec_name.tolower())};
+      end
+      if (SATP_MODE != BARE && riscv_instr_pkg::supported_privileged_mode[i] != MACHINE_MODE) begin
+        // For supervisor and user mode, use virtual address instead of physical address.
+        // Virtual address starts from address 0x0, here only the lower 20 bits are kept
+        // as virtual address offset.
+        instr = {instr,
+                 $sformatf("slli x%0d, x%0d, %0d", cfg.gpr[0], cfg.gpr[0], XLEN - 20),
+                 $sformatf("srli x%0d, x%0d, %0d", cfg.gpr[0], cfg.gpr[0], XLEN - 20)};
+      end
+      instr = {instr, $sformatf("ori x%0d, x%0d, %0d", cfg.gpr[0], cfg.gpr[0], cfg.mtvec_mode)};
+      instr = {instr, $sformatf("csrw 0x%0x, x%0d # %0s",
+                                 trap_vec_reg, cfg.gpr[0], trap_vec_reg.name())};
+    end
+    gen_section(get_label("trap_vec_init", hart), instr);
+  endfunction : trap_vector_init
+
   virtual function void gen_illegal_instr_handler(int hart);
     string instr[$];
     string load_instr = (XLEN == 32) ? "lw" : "ld";

--- a/cv32e40s/env/corev-dv/cv32e40s_pma_instr_lib.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_pma_instr_lib.sv
@@ -43,6 +43,7 @@ virtual class corev_load_store_pma_base_stream extends riscv_load_store_rand_ins
   constraint valid_addr_reg_c {
     use_compressed -> (addr_reg inside {[S0:A5]});
     !use_compressed -> (addr_reg inside {[T0:T6]});
+    addr_reg inside {cfg.gpr};
   }
 
   constraint valid_index_c {
@@ -95,6 +96,8 @@ class corev_load_pma_instr_stream extends corev_load_store_pma_base_stream;
     use_compressed -> (dest_reg inside {[S0:A5]});
     !use_compressed -> (dest_reg inside {[T0:T6]});
     dest_reg != addr_reg;
+    dest_reg inside {cfg.gpr};
+    addr_reg inside {cfg.gpr};
   }
 
   `uvm_object_utils(corev_load_pma_instr_stream)
@@ -247,6 +250,8 @@ class corev_load_store_pma_mixed_instr_stream extends corev_load_store_pma_base_
     use_compressed -> (dest_reg inside {[S0:A5]});
     !use_compressed -> (dest_reg inside {[T0:T6]});
     dest_reg != addr_reg;
+    dest_reg inside {cfg.gpr};
+    addr_reg inside {cfg.gpr};
   }
 
   `uvm_object_utils(corev_load_store_pma_mixed_instr_stream)

--- a/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
+++ b/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
@@ -434,7 +434,7 @@ function void cv32e40s_ldgen_c::create_fixed_addr_section_file(string filepath);
     display_fatal($sformatf("Unable to open %s", filepath));
   end
   if (pma_adapted_memory.region.size == 0) begin
-    nmi_separate_region = 1;
+    nmi_separate_region = 0;
   end
 
   foreach (pma_adapted_memory.region[i]) begin
@@ -480,18 +480,25 @@ function void cv32e40s_ldgen_c::create_fixed_addr_section_file(string filepath);
   $fdisplay(fhandle_fix, "{");
   $fdisplay(fhandle_fix, { indent(L1), "/* CORE-V: interrupt vectors */" });
   $fdisplay(fhandle_fix, { indent(L1), "PROVIDE(__vector_start = ", $sformatf("0x%08x", mtvec_addr), ");" });
+  $fdisplay(fhandle_fix, { indent(L1), "mtvec_handler = DEFINED(vectored_mode) ? ABSOLUTE(", $sformatf("0x%08x", mtvec_addr), ") : mtvec_handler;"});
   $fdisplay(fhandle_fix, { indent(L1), ".mtvec_bootstrap (__vector_start) :" });
   $fdisplay(fhandle_fix, { indent(L1), "{" });
   $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.mtvec_bootstrap));" });
   $fdisplay(fhandle_fix, { indent(L1), "}", mtvec_memory_area, "\n" });
+
+  $fdisplay(fhandle_fix, { indent(L1), ".mtvec_handler (__vector_start) :" });
+  $fdisplay(fhandle_fix, { indent(L1), "{" });
+  $fdisplay(fhandle_fix, { indent(L2), "*(.mtvec*);" });
+  $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.mtvec_handler));" });
+  $fdisplay(fhandle_fix, { indent(L1), "}", mtvec_memory_area, "\n" });
+
   $fdisplay(fhandle_fix, { indent(L1), "/* CORE-V: we want a fixed entry point */" });
   $fdisplay(fhandle_fix, { indent(L1), "PROVIDE(__boot_address = ", $sformatf("0x%08x", boot_addr), ");\n" });
   $fdisplay(fhandle_fix, { indent(L1), "/* NMI interrupt handler fixed entry point */" });
-  $fdisplay(fhandle_fix, { indent(L1), "nmi_handler = ABSOLUTE(", $sformatf("0x%08x",  nmi_addr), ");" });
-  $fdisplay(fhandle_fix, { indent(L1), ".nmi (", $sformatf("0x%08x", nmi_addr), ") :" });
+  $fdisplay(fhandle_fix, { indent(L1), $sformatf(".nmi_bootstrap DEFINED(vectored_mode) ? (0x%08x) : .", nmi_addr), " :"});
   $fdisplay(fhandle_fix, { indent(L1), "{" });
-  $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.nmi));" });
-  $fdisplay(fhandle_fix, { indent(L1), "}", nmi_memory_area });
+  $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.nmi_bootstrap));" });
+  $fdisplay(fhandle_fix, { indent(L1), "}", nmi_memory_area, "\n" });
   $fdisplay(fhandle_fix, "}");
 
   $fclose(fhandle_fix);

--- a/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
+++ b/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
@@ -495,7 +495,7 @@ function void cv32e40s_ldgen_c::create_fixed_addr_section_file(string filepath);
   $fdisplay(fhandle_fix, { indent(L1), "/* CORE-V: we want a fixed entry point */" });
   $fdisplay(fhandle_fix, { indent(L1), "PROVIDE(__boot_address = ", $sformatf("0x%08x", boot_addr), ");\n" });
   $fdisplay(fhandle_fix, { indent(L1), "/* NMI interrupt handler fixed entry point */" });
-  $fdisplay(fhandle_fix, { indent(L1), $sformatf(".nmi_bootstrap DEFINED(vectored_mode) ? (0x%08x) : .", nmi_addr), " :"});
+  $fdisplay(fhandle_fix, { indent(L1), $sformatf(".nmi_bootstrap ABSOLUTE(0x%08x) ", nmi_addr), " :"});
   $fdisplay(fhandle_fix, { indent(L1), "{" });
   $fdisplay(fhandle_fix, { indent(L2), "KEEP(*(.nmi_bootstrap));" });
   $fdisplay(fhandle_fix, { indent(L1), "}", nmi_memory_area, "\n" });

--- a/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
+++ b/cv32e40s/env/corev-dv/ldgen/cv32e40s_ldgen.sv
@@ -118,11 +118,11 @@ import cv32e40s_pkg::pma_cfg_t;
       if (!($value$plusargs("boot_addr=0x%x", boot_addr))) begin
         boot_addr = BOOT_ADDR;
       end
-      if (!($value$plusargs("nmi_addr=0x%x", nmi_addr))) begin
-        nmi_addr = NMI_ADDR;
-      end
       if (!($value$plusargs("mtvec_addr=0x%x", mtvec_addr))) begin
         mtvec_addr = MTVEC_ADDR;
+      end
+      if (!($value$plusargs("nmi_addr=0x%x", nmi_addr))) begin
+        nmi_addr = mtvec_addr + 4*15;
       end
       if (!($value$plusargs("dm_halt_addr=0x%x", dbg_origin_addr))) begin
         dbg_origin_addr = DEBUG_ORIGIN;

--- a/cv32e40s/regress/cv32e40s_pma.yaml
+++ b/cv32e40s/regress/cv32e40s_pma.yaml
@@ -12,20 +12,72 @@ builds:
     cmd: make clean_bsp clean_test_programs
     dir: cv32e40s/sim/uvmt
 
+  corev-dv_pma_1:
+    cmd: make comp_corev-dv
+    cfg: pma_test_cfg_1
+    dir: cv32e40s/sim/uvmt
+
+  corev-dv_pma_2:
+    cmd: make comp_corev-dv
+    cfg: pma_test_cfg_2
+    dir: cv32e40s/sim/uvmt
+
+  corev-dv_pma_3:
+    cmd: make comp_corev-dv
+    cfg: pma_test_cfg_3
+    dir: cv32e40s/sim/uvmt
+
+  corev-dv_pma_4:
+    cmd: make comp_corev-dv
+    cfg: pma_test_cfg_4
+    dir: cv32e40s/sim/uvmt
+
+  corev-dv_pma_5:
+    cmd: make comp_corev-dv
+    cfg: pma_test_cfg_5
+    dir: cv32e40s/sim/uvmt
+
+  uvmt_cv32e40s_pma_1:
+    cmd: make comp
+    cfg: pma_test_cfg_1
+    dir: cv32e40s/sim/uvmt
+
+  uvmt_cv32e40s_pma_2:
+    cmd: make comp
+    cfg: pma_test_cfg_2
+    dir: cv32e40s/sim/uvmt
+
+  uvmt_cv32e40s_pma_3:
+    cmd: make comp
+    cfg: pma_test_cfg_3
+    dir: cv32e40s/sim/uvmt
+
+  uvmt_cv32e40s_pma_4:
+    cmd: make comp
+    cfg: pma_test_cfg_4
+    dir: cv32e40s/sim/uvmt
+
+  uvmt_cv32e40s_pma_5:
+    cmd: make comp
+    cfg: pma_test_cfg_5
+    dir: cv32e40s/sim/uvmt
+
   corev-dv:
     cmd: make clean_riscv-dv comp_corev-dv
     dir: cv32e40s/sim/uvmt
     cov: 0
-  uvmt_cv32e40s:
-    cmd: make comp
-    dir: cv32e40s/sim/uvmt
 
 
 # List of tests
 tests:
   corev_rand_pma_test:
-    build: uvmt_cv32e40s
     description: Generated corev-dv pma test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_pma_test
+    builds:
+      - uvmt_cv32e40s_pma_1
+      - uvmt_cv32e40s_pma_2
+      - uvmt_cv32e40s_pma_3
+      - uvmt_cv32e40s_pma_4
+      - uvmt_cv32e40s_pma_5
     num: 20

--- a/lib/corev-dv/corev_asm_program_gen.sv
+++ b/lib/corev-dv/corev_asm_program_gen.sv
@@ -36,9 +36,16 @@ class corev_asm_program_gen extends riscv_asm_program_gen;
     instr_stream.push_back(".section .text.start");
     instr_stream.push_back("");
 
-    instr_stream.push_back(".section .mtvec_bootstrap, \"ax\"");
-    instr_stream.push_back(".globl _mtvec_bootstrap");
-    instr_stream.push_back("    j mtvec_handler");
+    if (cfg.mtvec_mode == DIRECT) begin
+      instr_stream.push_back(".section .mtvec_bootstrap, \"ax\"");
+      instr_stream.push_back(".globl _mtvec_bootstrap");
+      instr_stream.push_back("    j mtvec_handler");
+    end else begin
+      instr_stream.push_back(".globl vectored_mode");
+      instr_stream.push_back(".section .mtvec_handler, \"ax\"");
+      instr_stream.push_back(".globl mtvec_handler");
+      instr_stream.push_back(".type mtvec_handler, @function");
+    end
     instr_stream.push_back("");
 
     instr_stream.push_back(".globl _start");

--- a/lib/corev-dv/corev_asm_program_gen.sv
+++ b/lib/corev-dv/corev_asm_program_gen.sv
@@ -40,6 +40,9 @@ class corev_asm_program_gen extends riscv_asm_program_gen;
       instr_stream.push_back(".section .mtvec_bootstrap, \"ax\"");
       instr_stream.push_back(".globl _mtvec_bootstrap");
       instr_stream.push_back("    j mtvec_handler");
+      instr_stream.push_back(".section .nmi_bootstrap, \"ax\"");
+      instr_stream.push_back(".globl _nmi_bootstrap");
+      instr_stream.push_back("    j nmi_handler");
     end else begin
       instr_stream.push_back(".globl vectored_mode");
       instr_stream.push_back(".section .mtvec_handler, \"ax\"");


### PR DESCRIPTION
Previous implementation for trap handler generation and nmis did not take vectored/non-vectored mode into account and used the wrong symbol as mtvec handler reference. 

This PR aims to solve these issues by:
- nmi is always located at mtvec + 4*15 (actual configured mtvec, not the address of mtvec_handler)
- vectored and direct mode interrupt should have different handlers, one using trampoline code to get to the right handler (leaving room for nmi at the correct offset), the other places the jump-instructions directly at mtvec (and includes a jump to the nmi handler at the correct location)

These changes should resolve most timeouts due to interrupt-related runaway code. 