### PR TITLE
cva6/sim/Makefile: fix typo introduced in 6500c38

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -147,7 +147,7 @@ vcs_uvm_run:
 	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
 	++$(elf) \
 	+PRELOAD=$(elf) \
-	-sv_lib $(dpi-library)/ariane_dpi\
+	-sv_lib $(dpi-library)/ariane_dpi \
 	$(cov-run-opt) $(issrun_opts)&& \
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
 


### PR DESCRIPTION
when coverage is enabled, wrong dpi library is called due to missing space

Signed-off-by: André Sintzoff <andre.sintzoff@thalesgroup.com>