### PR TITLE
Use vcs-uvm Makefile target in vcs-gate iss

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -160,23 +160,9 @@ vcs-uvm:
 generate_cov_dash:
 	urg -dir $(VCS_WORK_DIR)/simv.vdb
 
-vcs_gate_comp:
-	@echo "[VCS] Building Model"
-	mkdir -p $(VCS_WORK_DIR)
-	cd $(VCS_WORK_DIR) && vcs $(ALL_VCS_FLAGS) -f $(FLIST_CORE)_gate -f $(FLIST_TB) $(isscomp_opts)
-
-vcs_gate_run:
-	cd $(VCS_WORK_DIR)/ && $(VCS_WORK_DIR)/simv $(issrun_opts)
-	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/
-
 vcs_clean_all:
 	@echo "[VCS] Cleanup (entire vcs_work dir)"
 	rm -rf $(CORE_V_VERIF)/cva6/sim/vcs_results/ verdiLog/ simv* *.daidir *.vpd *.db csrc ucli.key vc_hdrs.h novas* inter.fsdb uart
-
-vcs-gate:
-	make vcs_gate_comp
-	make vcs_gate_run
-	$(tool_path)/spike-dasm < ./trace_rvfi_hart_00.dasm > $(log)
 
 ###############################################################################
 # Common targets and rules

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -42,7 +42,7 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   cmd: >
-    make vcs-gate target=<target> cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
+    make vcs-uvm target=<target>_gate cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 - iss: vcs-uvm
   path_var: RTL_PATH


### PR DESCRIPTION
Hello,

This PR fixes the vcs-gate target which was broken since the removal of the core only testbench. 
vcs-gate now uses vcs-uvm testbench to run post synthesis simulation. 

We can directly use vcs-uvm Makefile targets and remove old vcs-gate targets.

Guillaume