### PR TITLE
cva6.yaml: add timeout to benchmarks + fix in wb_dcache job

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -353,6 +353,7 @@ pub_smoke-gate:
 
 pub_benchmarks:
   stage: three
+  timeout: 2 hours
   extends:
     - .template_job_always_manual
   variables:
@@ -395,7 +396,7 @@ pub_wb_dcache:
     - source ci/build-riscv-tests.sh
     - cd ../../../
     - make run-asm-tests-verilator defines=WB_DCACHE
-    - python3 .gitlab-ci/scripts/report_pass.py
+    - python3 ../../.gitlab-ci/scripts/report_pass.py
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
Hello,

Two fixes in this PR:

- add timeout to benchmarks job which takes around 1h30 in CI
- fix path in wb_dcache job to find report_pass.py script

Guillaume
