### PR TITLE
rvfi_trap changed to struct

### DIFF
--- a/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
+++ b/cv32e40x/tb/uvmt/uvmt_cv32e40x_tb.sv
@@ -113,7 +113,7 @@ module uvmt_cv32e40x_tb;
                                                                    .rvfi_valid(rvfi_i.rvfi_valid[0]),
                                                                    .rvfi_order(rvfi_i.rvfi_order[uvma_rvfi_pkg::ORDER_WL*0+:uvma_rvfi_pkg::ORDER_WL]),
                                                                    .rvfi_insn(rvfi_i.rvfi_insn[uvme_cv32e40x_pkg::ILEN*0+:uvme_cv32e40x_pkg::ILEN]),
-                                                                   .rvfi_trap(rvfi_i.rvfi_trap[11:0]),
+                                                                   .rvfi_trap(rvfi_i.rvfi_trap),
                                                                    .rvfi_halt(rvfi_i.rvfi_halt[0]),
                                                                    .rvfi_intr(rvfi_i.rvfi_intr),
                                                                    .rvfi_dbg(rvfi_i.rvfi_dbg),

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -34,7 +34,7 @@ interface uvma_rvfi_instr_if
     input logic                      rvfi_valid,
     input logic [ORDER_WL-1:0]       rvfi_order,
     input logic [ILEN-1:0]           rvfi_insn,
-    input logic [TRAP_WL-1:0]        rvfi_trap,
+    input rvfi_trap_t                rvfi_trap,
     input logic                      rvfi_halt,
     input logic [RVFI_DBG_WL-1:0]    rvfi_dbg,
     input logic                      rvfi_dbg_mode,

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
@@ -32,6 +32,15 @@ typedef struct packed {
   logic        intr;
 } rvfi_intr_t;
 
+typedef struct packed {
+   logic [1:0]  cause_type;
+   logic [2:0]  debug_cause;
+   logic [5:0]  exception_cause;
+   logic        debug;
+   logic        exception;
+   logic        trap;
+} rvfi_trap_t;
+
 function string get_mode_str(uvma_rvfi_mode mode);
    case (mode)
       UVMA_RVFI_U_MODE: return "U";


### PR DESCRIPTION
Switched rvfi_trap in the tb if definition to the struct matching the core rvfi"

Signed-off-by: Marton Teilgard <mateilga@silabs.com>