### PR TITLE
Fix incorrect Python import (fixes issue #1341.)

### DIFF
--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -18,7 +18,7 @@ from tkinter.filedialog import asksaveasfilename
 import tkinter.colorchooser
 from inspect import ismethod
 import pickle
-from typing import OrderedDict
+from collections import OrderedDict
 
 # import cPickle as pickle
 # Configuration (env + Python + Yaml) is imported indirectly via vp_pack.


### PR DESCRIPTION
This PR fixes an incorrect import in VPTOOL python code which caused issue #1341.

Files changed:

* tools/vptool/vptool/vp.py (OrderedDict): Import from 'collections', not from 'typing'.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>