### PR TITLE
Add test suite for issues found during CVA6 development.

### DIFF
--- a/cva6/regress/issue-tests.sh
+++ b/cva6/regress/issue-tests.sh
@@ -1,0 +1,34 @@
+# Copyright 2022 Thales DIS France
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
+
+# where are the tools
+if ! [ -n "$RISCV" ]; then
+  echo "Error: RISCV variable undefined"
+  return
+fi
+
+# install the required tools
+source ./cva6/regress/install-cva6.sh
+source ./cva6/regress/install-riscv-dv.sh
+source ./cva6/regress/install-riscv-compliance.sh
+source ./cva6/regress/install-riscv-tests.sh
+
+if ! [ -n "$DV_SIMULATORS" ]; then
+  DV_SIMULATORS=veri-testharness,spike
+fi
+
+cd cva6/sim/
+python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv64 --iss_yaml cva6.yaml --target cv64a6_imafdc_sv39 --iss=$DV_SIMULATORS $DV_OPTS
+make -C ../../core-v-cores/cva6 clean
+make clean_all
+python3 cva6.py --testlist=../tests/testlist_issues.yaml --test compressed-fpreg-commits-rv32 --iss_yaml cva6.yaml --target cv32a6_imafc_sv32 --iss=$DV_SIMULATORS $DV_OPTS
+make -C ../../core-v-cores/cva6 clean
+make clean_all
+
+cd -

--- a/cva6/tests/custom/issues/compressed-fpreg-commits-rv32.S
+++ b/cva6/tests/custom/issues/compressed-fpreg-commits-rv32.S
@@ -1,0 +1,32 @@
+# Copyright 2022 Thales DIS France
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
+
+#*****************************************************************************
+# compressed-fpregs-commits-rv32.S
+#-----------------------------------------------------------------------------
+#
+
+  .globl main
+main:
+  la      s1, tohost;
+  c.flw   fs0, 0(s1);
+  c.flwsp fs0, 0(sp);
+  xor     a2, a0, a0;  # trivial PASS...
+  beqz    a2, pass;
+
+fail:
+  # Failure post-processing; set retcode to 1.
+  li a0, 0x1;
+  jal exit;
+
+pass:
+  # Success post-processing: set retcode to 0.
+  li a0, 0x0;
+  jal exit;
+

--- a/cva6/tests/custom/issues/compressed-fpreg-commits-rv64.S
+++ b/cva6/tests/custom/issues/compressed-fpreg-commits-rv64.S
@@ -1,0 +1,32 @@
+# Copyright 2022 Thales DIS France
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
+
+#*****************************************************************************
+# compressed-fpreg-commits.S
+#-----------------------------------------------------------------------------
+#
+
+  .globl main
+main:
+  la s1, tohost;
+  c.fld  fs0, 0(s1);
+  c.fldsp fs1, 0(sp);
+  xor a2, a0, a0;  # trivial PASS...
+  beqz a2, pass;
+
+fail:
+  # Failure post-processing; set retcode to 1.
+  li a0, 0x1;
+  jal exit;
+
+pass:
+  # Success post-processing: set retcode to 0.
+  li a0, 0x0;
+  jal exit;
+

--- a/cva6/tests/testlist_issues.yaml
+++ b/cva6/tests/testlist_issues.yaml
@@ -1,0 +1,44 @@
+# Copyright Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ================================================================================
+#                  Regression test list format
+# --------------------------------------------------------------------------------
+# test            : Assembly test name
+# description     : Description of this test
+# gen_opts        : Instruction generator options
+# iterations      : Number of iterations of this test
+# no_iss          : Enable/disable ISS simulator (Optional)
+# gen_test        : Test name used by the instruction generator
+# asm_tests       : Path to directed, hand-coded assembly test file or directory
+# rtl_test        : RTL simulation test name
+# cmp_opts        : Compile options passed to the instruction generator
+# sim_opts        : Simulation options passed to the instruction generator
+# no_post_compare : Enable/disable comparison of trace log and ISS log (Optional)
+# compare_opts    : Options for the RTL & ISS trace comparison
+# gcc_opts        : gcc compile options
+# --------------------------------------------------------------------------------
+
+- test: compressed-fpreg-commits-rv64
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -misa-spec=2.2 -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld -lgcc"
+  asm_tests: <path_var>/custom/issues/compressed-fpreg-commits-rv64.S
+
+- test: compressed-fpreg-commits-rv32
+  iterations: 1
+  path_var: TESTS_PATH
+  gcc_opts: "-static -misa-spec=2.2 -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld -lgcc"
+  asm_tests: <path_var>/custom/issues/compressed-fpreg-commits-rv32.S
+


### PR DESCRIPTION
The `cva6/tests/custom/issues` test family is intended to exercise any issues found during CVA6 development - as opposed to upstream test suites.   The initial two tests exercise the proper formatting of writes into FP registers triggered by compressed instructions whereby an issue in the RTL tracer caused discrepancies between RTL logs and the output of Spike.

This PR supersedes #1388. 
 
Files changed/added:

* cva6/regress/issue-tests.sh: New.
* cva6/tests/custom/issues/compressed-fpreg-commits-rv32.S: Ditto.
* cva6/tests/custom/issues/compressed-fpreg-commits-rv64.S: Ditto.
* cva6/tests/testlist_issues.yaml: Ditto.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>