### PR TITLE
[CI]: cva6.yml: fix for wb_dcache job

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -396,7 +396,8 @@ pub_wb_dcache:
     - source ci/build-riscv-tests.sh
     - cd ../../../
     - make run-asm-tests-verilator defines=WB_DCACHE
-    - python3 ../../.gitlab-ci/scripts/report_pass.py
+    - cd ../..
+    - python3 .gitlab-ci/scripts/report_pass.py
   artifacts:
     when: always
     paths:


### PR DESCRIPTION
Fix for continuous integration
report_pass.py needs to be used from core-v-verif directory, not cva6 one. Thir PR fixes that.

@JeanRochCoulon @zchamski can you look at that ?

Guillaume