### PR TITLE
cva6.yml: Add timeout to 1h30 for FPGA build job

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -405,6 +405,7 @@ pub_wb_dcache:
 
 pub_fpga-build:
   stage: two
+  timeout: 90 minutes
   extends:
     - .template_job_short_ci
   needs:


### PR DESCRIPTION
FPGA build job take a little less than 1 hour to complete but sometimes it takes longer and fails due to timeout limit.

This should make that the job does not timeout anymore.

@JeanRochCoulon 