### PR TITLE
Add more pmp configs

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -32,16 +32,29 @@
    `elsif PMP_ENABLE_64
      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
      parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
+   `elsif PMP_G0R0
+     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+     parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
+   `elsif PMP_G0R16
+     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+     parameter int CORE_PARAM_PMP_NUM_REGIONS = 16;
    `elsif PMP_G1R5
      parameter int CORE_PARAM_PMP_GRANULARITY = 1;
      parameter int CORE_PARAM_PMP_NUM_REGIONS = 5;
+   `elsif PMP_G2R6
+     parameter int CORE_PARAM_PMP_GRANULARITY = 2;
+     parameter int CORE_PARAM_PMP_NUM_REGIONS = 6;
    `elsif PMP_G3R3
      parameter int CORE_PARAM_PMP_GRANULARITY = 3;
      parameter int CORE_PARAM_PMP_NUM_REGIONS = 3;
+   `elsif PMP_G27R64
+     parameter int CORE_PARAM_PMP_GRANULARITY = 27;
+     parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
    `else
      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
      parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
    `endif
+
 
    `ifdef PMA_CUSTOM_CFG
       const string pma_cfg_name = "pma_custom_cfg";


### PR DESCRIPTION
As the title says, this PR adds more PMP configs.
Adding these configs because we wanted more variation in regressions (specifically G = {0, 1, >1} to stimulate generate blocks).
The other configs are picked semi-arbitrarily, with regards to PMA configs and the nature of PMP behavior and CSRs etc.