### PR TITLE
(temporarily) disable SVA for the E40S

### DIFF
--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -38,7 +38,12 @@ DSIM_FILE_LIST         ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
 DSIM_COMPILE_ARGS      += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 
-DSIM_USER_COMPILE_ARGS ?=
+ifeq ($(CV_CORE_UC),CV32E40S)
+DSIM_USER_COMPILE_ARGS = -no-sva
+else
+DSIM_USER_COMPILE_ARGS =
+endif
+
 ifeq ($(USE_ISS),YES)
 	DSIM_RUN_FLAGS     += +USE_ISS
 else


### PR DESCRIPTION
Several of the latest updates to the CV32E40S environment inadvertently trip over the DSIM issue mentioned in #1389.  This means MetricsCI is currently failing for that core.

Rather than continue to issue PRs similar to #1383 (and then have to back them out later), this PR will disable SVA compilation by DSIM (and only DSIM) for the CV32E40S (and only the CV32E40S).

Signed-off-by: Mike Thompson <mike@openhwgroup.org>