### PR TITLE
Clic assertions and necessary infrastructure updates

### DIFF
--- a/cv32e40s/env/uvme/uvme_cv32e40s_cntxt.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cntxt.sv
@@ -29,12 +29,14 @@ class uvme_cv32e40s_cntxt_c extends uvm_object;
    virtual uvmt_cv32e40s_debug_cov_assert_if debug_cov_vif;
    virtual uvmt_cv32e40s_vp_status_if        vp_status_vif; ///< Virtual interface for Virtual Peripherals
    virtual uvma_interrupt_if                 intr_vif     ; ///< Virtual interface for interrupts
+   virtual uvma_clic_if                      clic_vif     ; ///< Virtual interface for clic interrupts
    virtual uvma_debug_if                     debug_vif    ; ///< Virtual interface for debug
 
    // Agent context handles
    uvma_cv32e40s_core_cntrl_cntxt_c  core_cntrl_cntxt;
    uvma_clknrst_cntxt_c              clknrst_cntxt;
    uvma_interrupt_cntxt_c            interrupt_cntxt;
+   uvma_clic_cntxt_c                 clic_cntxt;
    uvma_debug_cntxt_c                debug_cntxt;
    uvma_obi_memory_cntxt_c           obi_memory_instr_cntxt;
    uvma_obi_memory_cntxt_c           obi_memory_data_cntxt;
@@ -53,6 +55,7 @@ class uvme_cv32e40s_cntxt_c extends uvm_object;
       `uvm_field_object(core_cntrl_cntxt,       UVM_DEFAULT)
       `uvm_field_object(clknrst_cntxt,          UVM_DEFAULT)
       `uvm_field_object(interrupt_cntxt,        UVM_DEFAULT)
+      `uvm_field_object(clic_cntxt,             UVM_DEFAULT)
       `uvm_field_object(debug_cntxt  ,          UVM_DEFAULT)
       `uvm_field_object(obi_memory_instr_cntxt, UVM_DEFAULT)
       `uvm_field_object(obi_memory_data_cntxt , UVM_DEFAULT)
@@ -85,6 +88,7 @@ function uvme_cv32e40s_cntxt_c::new(string name="uvme_cv32e40s_cntxt");
    debug_cntxt      = uvma_debug_cntxt_c::type_id::create("debug_cntxt");
    fencei_cntxt     = uvma_fencei_cntxt_c::type_id::create("fencei_cntxt");
    interrupt_cntxt  = uvma_interrupt_cntxt_c::type_id::create("interrupt_cntxt");
+   clic_cntxt       = uvma_clic_cntxt_c::type_id::create("clic_cntxt");
    obi_memory_data_cntxt  = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_data_cntxt" );
    obi_memory_instr_cntxt = uvma_obi_memory_cntxt_c::type_id::create("obi_memory_instr_cntxt");
    rvfi_cntxt       = uvma_rvfi_cntxt_c#(ILEN,XLEN)::type_id::create("rvfi_cntxt");

--- a/cv32e40s/env/uvme/uvme_cv32e40s_env.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_env.sv
@@ -42,6 +42,7 @@ class uvme_cv32e40s_env_c extends uvm_env;
    uvma_isacov_agent_c#(ILEN,XLEN)  isacov_agent;
    uvma_clknrst_agent_c             clknrst_agent;
    uvma_interrupt_agent_c           interrupt_agent;
+   uvma_clic_agent_c                clic_agent;
    uvma_debug_agent_c               debug_agent;
    uvma_obi_memory_agent_c          obi_memory_instr_agent;
    uvma_obi_memory_agent_c          obi_memory_data_agent ;
@@ -287,6 +288,13 @@ function void uvme_cv32e40s_env_c::retrieve_vifs();
       `uvm_info("VIF", $sformatf("Found intr_vif handle of type %s in uvm_config_db", $typename(cntxt.intr_vif)), UVM_DEBUG)
    end
 
+   if (!uvm_config_db#(virtual uvma_clic_if)::get(this, "", "clic_vif", cntxt.clic_vif)) begin
+      `uvm_fatal("VIF", $sformatf("Could not find clic_vif handle of type %s in uvm_config_db", $typename(cntxt.clic_vif)))
+   end
+   else begin
+      `uvm_info("VIF", $sformatf("Found clic_vif handle of type %s in uvm_config_db", $typename(cntxt.clic_vif)), UVM_DEBUG)
+   end
+
    if (!uvm_config_db#(virtual uvma_debug_if)::get(this, "", "debug_vif", cntxt.debug_vif)) begin
       `uvm_fatal("VIF", $sformatf("Could not find debug_vif handle of type %s in uvm_config_db", $typename(cntxt.debug_vif)))
    end
@@ -310,6 +318,7 @@ function void uvme_cv32e40s_env_c::assign_cfg();
    uvm_config_db#(uvma_debug_cfg_c)::set(this, "debug_agent", "cfg", cfg.debug_cfg);
    uvm_config_db#(uvma_fencei_cfg_c)::set(this, "fencei_agent", "cfg", cfg.fencei_cfg);
    uvm_config_db#(uvma_interrupt_cfg_c)::set(this, "*interrupt_agent", "cfg", cfg.interrupt_cfg);
+   uvm_config_db#(uvma_clic_cfg_c)::set(this, "*clic_agent", "cfg", cfg.clic_cfg);
    uvm_config_db#(uvma_isacov_cfg_c)::set(this, "*isacov_agent", "cfg", cfg.isacov_cfg);
    uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_data_agent",  "cfg", cfg.obi_memory_data_cfg);
    uvm_config_db#(uvma_obi_memory_cfg_c)::set(this, "obi_memory_instr_agent", "cfg", cfg.obi_memory_instr_cfg);
@@ -329,6 +338,7 @@ function void uvme_cv32e40s_env_c::assign_cntxt();
    uvm_config_db#(uvma_debug_cntxt_c)::set(this, "debug_agent", "cntxt", cntxt.debug_cntxt);
    uvm_config_db#(uvma_fencei_cntxt_c)::set(this, "fencei_agent", "cntxt", cntxt.fencei_cntxt);
    uvm_config_db#(uvma_interrupt_cntxt_c)::set(this, "interrupt_agent", "cntxt", cntxt.interrupt_cntxt);
+   uvm_config_db#(uvma_clic_cntxt_c)::set(this, "clic_agent", "cntxt", cntxt.clic_cntxt);
    uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_data_agent",  "cntxt", cntxt.obi_memory_data_cntxt);
    uvm_config_db#(uvma_obi_memory_cntxt_c)::set(this, "obi_memory_instr_agent", "cntxt", cntxt.obi_memory_instr_cntxt);
    uvm_config_db#(uvma_rvfi_cntxt_c#(ILEN,XLEN))::set(this, "rvfi_agent", "cntxt", cntxt.rvfi_cntxt);
@@ -339,17 +349,18 @@ endfunction: assign_cntxt
 
 function void uvme_cv32e40s_env_c::create_agents();
 
-   core_cntrl_agent = uvma_cv32e40s_core_cntrl_agent_c::type_id::create("core_cntrl_agent", this);
-   isacov_agent = uvma_isacov_agent_c#(ILEN,XLEN)::type_id::create("isacov_agent", this);
-   clknrst_agent = uvma_clknrst_agent_c::type_id::create("clknrst_agent", this);
-   interrupt_agent = uvma_interrupt_agent_c::type_id::create("interrupt_agent", this);
-   debug_agent = uvma_debug_agent_c::type_id::create("debug_agent", this);
+   core_cntrl_agent       = uvma_cv32e40s_core_cntrl_agent_c::type_id::create("core_cntrl_agent", this);
+   isacov_agent           = uvma_isacov_agent_c#(ILEN,XLEN)::type_id::create("isacov_agent", this);
+   clknrst_agent          = uvma_clknrst_agent_c::type_id::create("clknrst_agent", this);
+   interrupt_agent        = uvma_interrupt_agent_c::type_id::create("interrupt_agent", this);
+   clic_agent             = uvma_clic_agent_c::type_id::create("clic_agent", this);
+   debug_agent            = uvma_debug_agent_c::type_id::create("debug_agent", this);
    obi_memory_instr_agent = uvma_obi_memory_agent_c::type_id::create("obi_memory_instr_agent", this);
    obi_memory_data_agent  = uvma_obi_memory_agent_c::type_id::create("obi_memory_data_agent",  this);
-   rvfi_agent = uvma_rvfi_agent_c#(ILEN,XLEN)::type_id::create("rvfi_agent", this);
-   rvvi_agent = uvma_rvvi_ovpsim_agent_c#(ILEN,XLEN)::type_id::create("rvvi_agent", this);
-   fencei_agent = uvma_fencei_agent_c::type_id::create("fencei_agent", this);
-   pma_agent = uvma_pma_agent_c#(ILEN,XLEN)::type_id::create("pma_agent", this);
+   rvfi_agent             = uvma_rvfi_agent_c#(ILEN,XLEN)::type_id::create("rvfi_agent", this);
+   rvvi_agent             = uvma_rvvi_ovpsim_agent_c#(ILEN,XLEN)::type_id::create("rvvi_agent", this);
+   fencei_agent           = uvma_fencei_agent_c::type_id::create("fencei_agent", this);
+   pma_agent              = uvma_pma_agent_c#(ILEN,XLEN)::type_id::create("pma_agent", this);
 
 endfunction: create_agents
 
@@ -432,6 +443,7 @@ function void uvme_cv32e40s_env_c::connect_coverage_model();
    foreach (rvfi_agent.instr_mon_ap[i]) begin
       rvfi_agent.instr_mon_ap[i].connect(isacov_agent.monitor.rvfi_instr_export);
       rvfi_agent.instr_mon_ap[i].connect(cov_model.interrupt_covg.interrupt_mon_export);
+      //rvfi_agent.instr_mon_ap[i].connect(cov_model.clic_covg.clic_mon_export); // TODO: silabs-hfegran
       rvfi_agent.instr_mon_ap[i].connect(pma_agent.monitor.rvfi_instr_export);
    end
 
@@ -440,9 +452,10 @@ endfunction: connect_coverage_model
 
 function void uvme_cv32e40s_env_c::assemble_vsequencer();
 
-   vsequencer.clknrst_sequencer   = clknrst_agent.sequencer;
-   vsequencer.interrupt_sequencer = interrupt_agent.sequencer;
-   vsequencer.debug_sequencer     = debug_agent.sequencer;
+   vsequencer.clknrst_sequencer          = clknrst_agent.sequencer;
+   vsequencer.interrupt_sequencer        = interrupt_agent.sequencer;
+   vsequencer.clic_sequencer             = clic_agent.sequencer;
+   vsequencer.debug_sequencer            = debug_agent.sequencer;
    vsequencer.obi_memory_instr_sequencer = obi_memory_instr_agent.sequencer;
    vsequencer.obi_memory_data_sequencer  = obi_memory_data_agent .sequencer;
 

--- a/cv32e40s/env/uvme/uvme_cv32e40s_pkg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_pkg.sv
@@ -42,6 +42,7 @@ package uvme_cv32e40s_pkg;
    import uvma_core_cntrl_pkg::*;
    import uvma_isacov_pkg::*;
    import uvma_clknrst_pkg::*;
+   import uvma_clic_pkg::*;
    import uvma_interrupt_pkg::*;
    import uvma_debug_pkg::*;
    import uvma_obi_memory_pkg::*;
@@ -75,6 +76,7 @@ package uvme_cv32e40s_pkg;
    `include "uvme_cv32e40s_vp_status_flags_seq.sv"
    `include "uvme_cv32e40s_vp_fencei_tamper_seq.sv"
    `include "uvme_cv32e40s_interrupt_noise_vseq.sv"
+   `include "uvme_cv32e40s_clic_noise_vseq.sv"
    `include "uvme_cv32e40s_vseq_lib.sv"
    `include "uvme_cv32e40s_core_cntrl_base_seq.sv"
    `include "uvme_cv32e40s_core_cntrl_fetch_toggle_seq.sv"

--- a/cv32e40s/env/uvme/uvme_cv32e40s_vsqr.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_vsqr.sv
@@ -34,6 +34,7 @@ class uvme_cv32e40s_vsqr_c extends uvm_sequencer#(
    // Sequencer handles
    uvma_clknrst_sqr_c    clknrst_sequencer;
    uvma_interrupt_sqr_c  interrupt_sequencer;
+   uvma_clic_sqr_c       clic_sequencer;
    uvma_debug_sqr_c      debug_sequencer;
    uvma_obi_memory_sqr_c obi_memory_instr_sequencer;
    uvma_obi_memory_sqr_c obi_memory_data_sequencer ;

--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_clic_noise_vseq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_clic_noise_vseq.sv
@@ -1,0 +1,154 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVME_CV32E40S_CLIC_NOISE_SV__
+`define __UVME_CV32E40S_CLIC_NOISE_SV__
+
+/**
+ * Virtual sequence responsible for starting the system clock and issuing
+ * the initial reset pulse to the DUT.
+ */
+class uvme_cv32e40s_clic_noise_c extends uvme_cv32e40s_base_vseq_c;
+
+   rand int unsigned short_delay_wgt;
+   rand int unsigned med_delay_wgt;
+   rand int unsigned long_delay_wgt;
+   rand int unsigned initial_delay_assert_until_ack;
+   rand int unsigned initial_delay_assert;
+   rand int unsigned initial_delay_deassert;
+
+   rand bit [31:0]   reserved_irq_mask;
+
+   `uvm_object_utils_begin(uvme_cv32e40s_clic_noise_c)
+   `uvm_object_utils_end
+
+   constraint default_delay_c {
+     soft short_delay_wgt == 2;
+     soft med_delay_wgt == 5;
+     soft long_delay_wgt == 3;
+   }
+
+   constraint valid_delay_c {
+     short_delay_wgt != 0 || med_delay_wgt != 0 || long_delay_wgt != 0;
+   }
+
+   constraint valid_initial_delay_assert_until_ack_c {
+     initial_delay_assert_until_ack dist { 0 :/ 1,
+                                           [10:500] :/ 4,
+                                           [500:1000] :/ 3};
+   }
+
+   constraint valid_initial_delay_assert_c {
+     initial_delay_assert dist { 0 :/ 2,
+                                 [10:500] :/ 4,
+                                 [500:1000] :/ 3};
+   }
+
+   constraint valid_initial_delay_deassert_c {
+     initial_delay_deassert dist { 0 :/ 2,
+                                   [10:500] :/ 4,
+                                   [500:1000] :/ 3};
+   }
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvme_cv32e40s_clic_noise");
+
+   /**
+    * Starts the clock, waits, then resets the DUT.
+    */
+   extern virtual task body();
+   extern virtual task rand_delay();
+endclass : uvme_cv32e40s_clic_noise_c
+
+function uvme_cv32e40s_clic_noise_c::new(string name="uvme_cv32e40s_clic_noise");
+
+   super.new(name);
+
+endfunction : new
+
+task uvme_cv32e40s_clic_noise_c::rand_delay();
+  randcase
+    short_delay_wgt: repeat($urandom_range(100,1)) @(cntxt.clic_cntxt.vif.drv_cb);
+    med_delay_wgt: repeat($urandom_range(500,100)) @(cntxt.clic_cntxt.vif.drv_cb);
+    long_delay_wgt: repeat($urandom_range(10_000,5_000)) @(cntxt.clic_cntxt.vif.drv_cb);
+  endcase
+endtask : rand_delay
+
+task uvme_cv32e40s_clic_noise_c::body();
+
+  fork
+    begin : gen_assert_until_ack
+
+      repeat (initial_delay_assert_until_ack) @(cntxt.clic_cntxt.vif.drv_cb);
+
+      while(1) begin
+        uvma_clic_seq_item_c irq_req;
+
+        `uvm_create_on(irq_req, p_sequencer.clic_sequencer);
+        start_item(irq_req);
+        //irq_req.default_repeat_count_c.constraint_mode(0); // FIXME TODO
+        assert(irq_req.randomize() with {
+          action        == UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT_UNTIL_ACK;
+          repeat_count dist { 1 :/ 9, [2:3] :/ 1 };
+
+          //(irq_mask & local::reserved_irq_mask) == 0;
+        });
+        finish_item(irq_req);
+
+        rand_delay();
+
+      end
+    end
+
+    begin : gen_assert
+
+      repeat (initial_delay_assert) @(cntxt.clic_cntxt.vif.drv_cb);
+
+      while(1) begin
+        uvma_clic_seq_item_c irq_req;
+
+        `uvm_do_on_with(irq_req, p_sequencer.clic_sequencer, {
+          action        == UVMA_CLIC_SEQ_ITEM_ACTION_DEASSERT;
+          //(irq_mask & local::reserved_irq_mask) == 0;
+        })
+
+        rand_delay();
+
+      end
+    end
+
+    begin : gen_deassert
+
+      repeat (initial_delay_deassert) @(cntxt.clic_cntxt.vif.drv_cb);
+
+      while(1) begin
+        uvma_clic_seq_item_c irq_req;
+
+        `uvm_do_on_with(irq_req, p_sequencer.clic_sequencer, {
+          action        == UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT;
+          //(irq_mask & local::reserved_irq_mask) == 0;
+        })
+
+        rand_delay();
+
+      end
+    end
+  join
+endtask : body
+
+`endif // __UVME_CV32E40X_CLIC_NOISE_SV__

--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_interrupt_timer_seq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_interrupt_timer_seq.sv
@@ -49,7 +49,16 @@ endfunction : new
 
 task uvme_cv32e40s_vp_interrupt_timer_seq_c::set_interrupt();
 
-   cv32e40s_cntxt.interrupt_cntxt.vif.drv_cb.irq_drv <= interrupt_value;
+   if (cfg.clic_interrupts_enabled) begin
+     cv32e40s_cntxt.clic_cntxt.vif.drv_cb.clic_irq_drv       <= clic_value.irq;
+     cv32e40s_cntxt.clic_cntxt.vif.drv_cb.clic_irq_id_drv    <= clic_value.id;
+     cv32e40s_cntxt.clic_cntxt.vif.drv_cb.clic_irq_level_drv <= clic_value.level;
+     cv32e40s_cntxt.clic_cntxt.vif.drv_cb.clic_irq_priv_drv  <= clic_value.priv;
+     cv32e40s_cntxt.clic_cntxt.vif.drv_cb.clic_irq_shv_drv   <= clic_value.shv;
+   end
+   else if (cfg.basic_interrupts_enabled) begin
+     cv32e40s_cntxt.interrupt_cntxt.vif.drv_cb.irq_drv <= interrupt_value;
+   end
 
 endtask : set_interrupt
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
@@ -33,6 +33,7 @@
 -f ${DV_UVMA_PMA_PATH}/src/uvma_pma_pkg.flist
 -f ${DV_UVMA_CLKNRST_PATH}/uvma_clknrst_pkg.flist
 -f ${DV_UVMA_INTERRUPT_PATH}/uvma_interrupt_pkg.flist
+-f ${DV_UVMA_CLIC_PATH}/uvma_clic_pkg.flist
 -f ${DV_UVMA_DEBUG_PATH}/uvma_debug_pkg.flist
 -f ${DV_UVMA_RVVI_OVPSIM_PATH}/uvma_rvvi_ovpsim_pkg.flist
 -f ${DV_UVMA_FENCEI_PATH}/uvma_fencei_pkg.flist
@@ -67,6 +68,7 @@ ${DV_UVMT_PATH}/uvmt_cv32e40s_debug_assert.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_fencei_assert.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_integration_assert.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_interrupt_assert.sv
+${DV_UVMT_PATH}/uvmt_cv32e40s_clic_interrupt_assert.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_pmp_assert.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_pmp_model.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40s_pmprvfi_assert.sv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
@@ -1620,13 +1620,8 @@ module uvmt_cv32e40s_clic_interrupt_assert
     // in the current context
     // ------------------------------------------------------------------------
 
-    // FIXME: warning
-    always_comb begin
-      if (!rst_ni) begin
-        clic_oic <= '0;
-      end else if (irq_ack) begin
-        clic_oic <= clic_core;
-      end
+    always_latch begin
+      clic_oic = irq_ack ? clic_core : clic_oic;
     end
 
     sequence seq_irq_req_unchanged;

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
@@ -1,0 +1,2687 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+module uvmt_cv32e40s_clic_interrupt_assert
+  import uvm_pkg::*;
+  import cv32e40s_pkg::*;
+  import uvma_rvfi_pkg::*;
+  #(
+    parameter int   SMCLIC          = 0,
+    parameter int   SMCLIC_ID_WIDTH = 5,
+    parameter int   NUM_IRQ         = 32
+  )(
+    input logic                       clk,
+    input logic                       clk_i,
+    input logic                       rst_ni,
+    input logic                       fetch_enable,
+
+    // CSR interface
+    input logic [31:0]                dpc,
+    input logic [31:0]                mintstatus,
+    input logic [31:0]                mintthresh,
+    input logic [31:0]                mstatus,
+    input logic [31:0]                mtvec,
+    input logic [31:0]                mtvt,
+    input logic [31:0]                mepc,
+    input logic [31:0]                mie,
+    input logic [31:0]                mip,
+    input logic [31:0]                mnxti,
+    input logic [31:0]                mscratch,
+    input logic [31:0]                mscratchcsw,
+    input logic [31:0]                mscratchcswl,
+    input logic [31:0]                dcsr,
+
+    input logic [31:0]                rvfi_mepc_wdata,
+    input logic [31:0]                rvfi_mepc_wmask,
+    input logic                       rvfi_mepc_we,
+    input logic [31:0]                rvfi_mepc_rdata,
+    input logic [31:0]                rvfi_mepc_rmask,
+    input logic [31:0]                rvfi_dpc_rdata,
+    input logic [31:0]                rvfi_dpc_rmask,
+    input logic [31:0]                rvfi_mscratch_wdata,
+    input logic [31:0]                rvfi_mscratch_wmask,
+    input logic [31:0]                rvfi_mscratch_rdata,
+    input logic [31:0]                rvfi_mscratch_rmask,
+
+
+    input logic [31:0]                mcause,
+    input logic [31:0]                mclicbase,
+
+    input logic [31:0]                mtvec_addr_i,
+
+    input logic [NUM_IRQ-1:0]         irq_i,
+    input logic                       irq_ack,
+    input logic [1:0]                 current_priv_mode,
+
+    uvma_clic_if                      clic_if,
+
+    input logic [SMCLIC_ID_WIDTH-1:0] irq_id,
+    input logic [7:0]                 irq_level,
+    input logic [1:0]                 irq_priv,
+    input logic                       irq_shv,
+
+    input logic                       debug_mode,
+    input logic                       debug_req,
+    input logic                       debug_havereset,
+    input logic                       debug_running,
+    input logic [31:0]                debug_halt_addr,
+    input logic [31:0]                debug_exc_addr,
+
+    input logic                       obi_instr_req,
+    input logic                       obi_instr_gnt,
+    input logic                       obi_instr_rvalid,
+    input logic                       obi_instr_rready,
+    input logic [31:0]                obi_instr_addr,
+    input logic [31:0]                obi_instr_rdata,
+    input logic                       obi_instr_err,
+
+    input logic                       obi_data_req,
+    input logic                       obi_data_gnt,
+    input logic                       obi_data_we,
+    input logic [3:0]                 obi_data_be,
+    input logic                       obi_data_rvalid,
+    input logic                       obi_data_rready,
+    input logic [31:0]                obi_data_addr,
+    input logic [31:0]                obi_data_wdata,
+    input logic                       obi_data_err,
+
+    input logic [1:0]                 rvfi_mode,
+    input logic [31:0]                rvfi_insn,
+    input rvfi_intr_t                 rvfi_intr,
+    input logic [31:0]                rvfi_rs1_rdata,
+    input logic [31:0]                rvfi_rs2_rdata,
+    input logic [31:0]                rvfi_rd_wdata,
+    input logic                       rvfi_valid,
+    input rvfi_trap_t                 rvfi_trap,
+    input logic [31:0]                rvfi_pc_rdata,
+    input logic [31:0]                rvfi_pc_wdata,
+    input logic                       rvfi_dbg_mode,
+    input logic [2:0]                 rvfi_dbg,
+
+    input logic                       core_sleep_o
+  );
+
+  default clocking
+    @(posedge clk_i);
+  endclocking
+  default disable iff !rst_ni;
+
+  string info_tag = "CLIC_ASSERT";
+
+  // This needs changes for 0.5.0
+  localparam logic [31:0] NMI_OFFSET    = 15 * 4;
+
+  typedef struct packed {
+    logic                       irq;
+    logic [SMCLIC_ID_WIDTH-1:0] id;
+    logic [7:0]                 level;
+    logic [1:0]                 priv;
+    logic                       shv;
+  } clic_irq_bundle_t;
+
+  typedef struct packed {
+    logic [SMCLIC_ID_WIDTH-1:0] id;
+    logic [7:0]                 level;
+    logic [1:0]                 priv;
+    logic                       shv;
+  } internal_clic_irq_bundle_t;
+
+  typedef struct packed {
+    logic [31:24] mil;
+    logic [23:16] reserved;
+    logic [15:8]  sil;
+    logic [7:0]   uil;
+  } mintstatus_t;
+
+  typedef struct packed {
+    logic [31:8] reserved_0;
+    logic [7:0]  th;
+  } mintthresh_t;
+
+  typedef struct packed {
+    logic [31:31] sd;
+    logic [30:23] reserved_3;
+    logic [22:22] tsr;
+    logic [21:21] tw;
+    logic [20:20] tvm;
+    logic [19:19] mxr;
+    logic [18:18] sum;
+    logic [17:17] mprv;
+    logic [16:15] xs;
+    logic [14:13] fs;
+    logic [12:11] mpp;
+    logic [10:9]  vs;
+    logic [8:8]   spp;
+    logic [7:7]   mpie;
+    logic [6:6]   ube;
+    logic [5:5]   spie;
+    logic [4:4]   reserved_2;
+    logic [3:3]   mie;
+    logic [2:2]   reserved_1;
+    logic [1:1]   sie;
+    logic [0:0]   reserved_0;
+  } mstatus_t;
+
+  typedef struct packed {
+    logic [31:7] base_31_7;
+    logic [6:2]  base_6_2;
+    logic [1:0]  mode;
+  } mtvec_clic_t;
+
+  typedef struct packed {
+    logic [31:12] mclicbase;
+    logic [11:0]  reserved;
+  } mclicbase_t;
+
+  localparam N_MTVT = 2+SMCLIC_ID_WIDTH > 6 ? 2+SMCLIC_ID_WIDTH : 6;
+
+  typedef struct packed {
+    logic [31:N_MTVT]  base_31_n;
+    logic [N_MTVT-1:6] base_n_6;
+    logic [5:0]        reserved;
+  } mtvt_t;
+
+  typedef struct packed {
+    logic [31:1] m_exception_pc;
+    logic [0:0]  reserved;
+  } mepc_t;
+
+  typedef enum logic [10:0] {
+    INSTR_ACCESS_FAULT  = 11'd1,
+    ILLEGAL_INSTR       = 11'd2,
+    BREAKPOINT          = 11'd3,
+    LOAD_ACCESS_FAULT   = 11'd5,
+    STORE_ACCESS_FAULT  = 11'd7,
+    ECALL_U_MODE        = 11'd8,
+    ECALL_M_MODE        = 11'd11,
+    INSTR_BUS_FAULT     = 11'd48,
+    INSTR_PARITY_FAULT  = 11'd49,
+    NMI_LOAD            = 11'd1024,
+    NMI_STORE           = 11'd1025,
+    NMI_LOAD_PARITY     = 11'd1026,
+    NMI_STORE_PARITY    = 11'd1027
+  } exccode_t;
+
+  typedef struct packed {
+    logic [31:31] interrupt;
+    logic [30:30] minhv;
+    logic [29:28] mpp;
+    logic [27:27] mpie;
+    logic [26:24] reserved_1;
+    logic [23:16] mpil;
+    logic [15:12] reserved_0;
+    logic [11:11] exccode_11;
+    union packed {
+      logic [10:0]  exccode_10_0;
+      exccode_t     exccode_val;
+    }n;
+  } mcause_t;
+
+  typedef struct packed {
+    logic [31:28] debugver;
+    logic [27:18] reserved_27_18;
+    logic [17:17] ebreakvs;
+    logic [16:16] ebreakvu;
+    logic [15:15] ebreakm;
+    logic [14:14] reserved_14;
+    logic [13:13] ebreaks;
+    logic [12:12] ebreaku;
+    logic [11:11] stepie;
+    logic [10:10] stopcount;
+    logic [9:9]   stoptime;
+    logic [8:6]   cause;
+    logic [5:5]   v;
+    logic [4:4]   mprven;
+    logic [3:3]   nmip;
+    logic [2:2]   step;
+    logic [1:0]   prv;
+  } dcsr_t;
+
+  typedef enum logic [1:0] {
+    M_MODE = 2'b11,
+    I_MODE = 2'b10, // Illegal, reserved
+    S_MODE = 2'b01, // Not used in 40S/X
+    U_MODE = 2'b00
+  } priv_mode_t;
+
+  typedef enum logic [2:0] {
+    CSRRW = 3'b001,
+    CSRRS = 3'b010,
+    CSRRC = 3'b011,
+    CSRRWI = 3'b101,
+    CSRRSI = 3'b110,
+    CSRRCI = 3'b111
+  } csr_minor_opcode_t;
+
+  typedef enum logic [6:0] {
+    LOAD   = 7'b000_0011, LOAD_FP  = 7'b000_0111, CUS_0 = 7'b000_1011, MISC_MEM = 7'b000_1111, OP_IMM = 7'b001_0011, AUIPC = 7'b001_0111,OP_IMM_32 = 7'b001_1011,
+    STORE  = 7'b010_0011, STORE_FP = 7'b010_0111, CUS_1 = 7'b010_1011, AMO      = 7'b010_1111, OP     = 7'b011_0011, LUI   = 7'b011_0111,OP_32     = 7'b011_1011,
+    MADD   = 7'b100_0011, MSUB     = 7'b100_0111, NMSUB = 7'b100_1011, NMADD    = 7'b100_1111, OP_FP  = 7'b101_0011, RES_1 = 7'b101_0111,CUS_2     = 7'b101_1011,
+    BRANCH = 7'b110_0011, JALR     = 7'b110_0111, RES_0 = 7'b110_1011, JAL      = 7'b110_1111, SYSTEM = 7'b111_0011, RES_2 = 7'b111_0111,CUS_3     = 7'b111_1011
+  } major_opcode_t;
+
+  typedef enum logic [2:0] {
+    FUNCT3_LB  = 3'b000,
+    FUNCT3_LH  = 3'b001,
+    FUNCT3_LW  = 3'b010,
+    FUNCT3_LBU = 3'b100,
+    FUNCT3_LHU = 3'b101
+  } load_size_e;
+
+  typedef enum logic [2:0] {
+    FUNCT3_SB = 3'b000,
+    FUNCT3_SH = 3'b001,
+    FUNCT3_SW = 3'b010
+  } store_size_e;
+
+  typedef enum logic [4:0] {
+    X0  = 5'd0,
+    X1  = 5'd1,
+    X2  = 5'd2,
+    X3  = 5'd3,
+    X4  = 5'd4,
+    X5  = 5'd5,
+    X6  = 5'd6,
+    X7  = 5'd7,
+    X8  = 5'd8,
+    X9  = 5'd9,
+    X10 = 5'd10,
+    X11 = 5'd11,
+    X12 = 5'd12,
+    X13 = 5'd13,
+    X14 = 5'd14,
+    X15 = 5'd15,
+    X16 = 5'd16,
+    X17 = 5'd17,
+    X18 = 5'd18,
+    X19 = 5'd19,
+    X20 = 5'd20,
+    X21 = 5'd21,
+    X22 = 5'd22,
+    X23 = 5'd23,
+    X24 = 5'd24,
+    X25 = 5'd25,
+    X26 = 5'd26,
+    X27 = 5'd27,
+    X28 = 5'd28,
+    X29 = 5'd29,
+    X30 = 5'd30,
+    X31 = 5'd31
+  } gpr_t;
+
+  typedef enum logic [31:20] {
+    MSTATUS       = 12'h300,
+    MISA          = 12'h301,
+    MIE           = 12'h304,
+    MTVEC         = 12'h305,
+    MTVT          = 12'h307,
+    MSTATUSH      = 12'h310,
+    MCOUNTINHIBIT = 12'h320,
+    MHPMEVENT3    = 12'h323,
+    MHPMEVENT31   = 12'h33F,
+    MSCRATCH      = 12'h340,
+    MEPC          = 12'h341,
+    MCAUSE        = 12'h342,
+    MTVAL         = 12'h343,
+    MIP           = 12'h344,
+    MNXTI         = 12'h345,
+    MINTSTATUS    = 12'h346,
+    MINTTHRESH    = 12'h347,
+    MSCRATCHCSW   = 12'h348,
+    MSCRATCHCSWL  = 12'h349,
+    MCLICBASE     = 12'h34A,
+    TSELECT       = 12'h7A0,
+    TDATA1        = 12'h7A1,
+    TDATA2        = 12'h7A2,
+    TDATA3        = 12'h7A3,
+    TINFO         = 12'h7A4,
+    TCONTROL      = 12'h7A5,
+    DCSR          = 12'h7B0,
+    DPC           = 12'h7B1,
+    DSCRATCH0     = 12'h7B2,
+    DSCRATCH1     = 12'h7B3
+} csr_name_t;
+
+  typedef struct packed {
+    csr_name_t           csr;
+    union packed {
+      gpr_t              rs1;
+      logic [19:15]      uimm;
+    }n;
+    csr_minor_opcode_t funct3;
+    gpr_t          rd;
+    major_opcode_t opcode;
+  } csr_instr_t;
+
+  typedef struct packed {
+    logic [31:12]  imm;
+    gpr_t          rd;
+  }u_type;
+
+  typedef struct packed {
+    logic [31:12]  imm;
+    gpr_t          rd;
+  }j_type;
+
+  function logic[20:0] read_j_imm(logic[31:0] instr);
+    automatic logic [20:0] imm;
+    imm = instr >> 11;
+    return { imm[20], imm[10:1], imm[11], imm[18:12], 1'b0 };
+  endfunction : read_j_imm
+
+  typedef struct packed {
+    union packed {
+      struct packed {
+        logic [31:25]  funct7;
+        gpr_t          rs2;
+      }m;
+      logic [31:20]  funct12;
+    }n;
+    gpr_t          rs1;
+    logic [14:12]  funct3;
+    gpr_t          rd;
+  }r_type;
+
+  typedef struct packed {
+    gpr_t          rs3;
+    logic [26:25]  funct2;
+    gpr_t          rs2;
+    gpr_t          rs1;
+    logic [14:12]  funct3;
+    gpr_t          rd;
+  }r4_type;
+
+  typedef struct packed {
+    logic [31:20]  imm;
+    gpr_t          rs1;
+    logic [14:12]  funct3;
+    gpr_t          rd;
+  }i_type;
+
+  typedef struct packed {
+    logic [31:20]  imm;
+    gpr_t          rs1;
+    load_size_e    funct3;
+    gpr_t          rd;
+  }i_type_load;
+
+  typedef struct packed {
+    logic [31:25]  imm;
+    gpr_t          rs2;
+    gpr_t          rs1;
+    logic [14:12]  funct3;
+    gpr_t          rd;
+  }b_type;
+
+  function logic[11:0] read_b_imm(logic[31:0] instr);
+    automatic logic [11:0] imm;
+    imm = {instr[31], instr[7], instr[30:25], instr[11:8]};
+    return imm;
+  endfunction : read_b_imm
+
+  typedef struct packed {
+    logic [31:25]  imm_h;
+    gpr_t          rs2;
+    gpr_t          rs1;
+    store_size_e   funct3;
+    logic [11:7]   imm_l;
+  }s_type;
+
+  function logic[11:0] read_s_imm(logic[31:0] instr);
+    automatic logic [11:0] imm;
+    imm = {instr[31:25], instr[11:7]};
+    return imm;
+  endfunction : read_s_imm
+
+  typedef struct packed {
+    union packed {
+      logic [31:7]       raw;
+      i_type             i;
+      i_type_load        i_load;
+      j_type             j;
+      s_type             s;
+      r_type             r;
+      r4_type            r4;
+      b_type             b;
+      u_type             u;
+    }n;
+    major_opcode_t opcode;
+  } uncompressed_instr_t;
+
+  // Instruction name enum, add instructions as needed
+  typedef enum {
+    FENCEI,
+    MRET,
+    DRET,
+    ECALL,
+    EBREAK,
+    WFI,
+    SB,
+    SH,
+    SW,
+    LB,
+    LH,
+    LW,
+    LBU,
+    LHU,
+    // Compressed
+    CEBREAK,
+    // Pseudo name, class of instruction
+    STORE_INSN,
+    LOAD_INSN
+  } insn_names_e;
+
+  logic core_not_in_debug;
+  logic core_in_debug;
+  logic is_csr_access_instr;
+
+  logic [11:0] s_imm;
+  logic [11:0] b_imm;
+  logic [20:0] j_imm;
+  logic [11:0] i_imm;
+
+  uncompressed_instr_t mapped_instr;
+
+  clic_irq_bundle_t clic;
+  clic_irq_bundle_t clic_core;
+  clic_irq_bundle_t clic_oic;
+
+  csr_instr_t       csr_instr_raw;
+  csr_instr_t       csr_instr;
+  mintstatus_t      mintstatus_fields;
+  mstatus_t         mstatus_fields;
+  mtvec_clic_t      mtvec_fields;
+  mclicbase_t       mclicbase_fields;
+  mtvt_t            mtvt_fields;
+  mepc_t            mepc_fields;
+  mcause_t          mcause_fields;
+  mintthresh_t      mintthresh_fields;
+  dcsr_t            dcsr_fields;
+
+  logic is_mepc_access_instr;
+  logic is_mtvec_access_instr;
+  logic is_mtvt_access_instr;
+  logic is_mcause_access_instr;
+  logic is_mstatus_access_instr;
+  logic is_mnxti_access_instr;
+  logic is_mscratchcsw_access_instr;
+  logic is_mscratchcswl_access_instr;
+  logic is_csr_write;
+  logic is_csr_read;
+  logic is_mret_insn;
+  logic is_fencei_insn;
+  logic is_interrupt_allowed;
+  logic is_dret_insn;
+
+  logic is_load_insn;
+  logic is_store_insn;
+
+  logic is_valid_mnxti_write;
+  logic is_valid_mnxti_read;
+  logic is_wfi;
+
+  int   obi_in_flight;
+  int   obi_in_flight_n;
+  int   obi_data_in_flight;
+  int   obi_data_in_flight_n;
+  logic incr_data_obi;
+  logic decr_data_obi;
+
+  logic is_load_bus_fault;
+  logic is_store_bus_fault;
+  logic is_load_parity_fault;
+  logic is_store_parity_fault;
+  logic is_instr_access_fault;
+
+  logic is_interrupt_taken;
+  logic is_invalid_instr_word;
+  logic is_cause_nmi;
+  logic is_cause_interrupt;
+  logic is_trap_exception;
+  logic is_intr_ecall_ebreak;
+  logic is_intr_exception;
+
+  assign is_load_bus_fault     = (rvfi_intr.cause == NMI_LOAD           && rvfi_intr.intr == 1 && rvfi_intr.interrupt == 1);
+  assign is_store_bus_fault    = (rvfi_intr.cause == NMI_STORE          && rvfi_intr.intr == 1 && rvfi_intr.interrupt == 1);
+  assign is_load_parity_fault  = (rvfi_intr.cause == NMI_LOAD_PARITY    && rvfi_intr.intr == 1 && rvfi_intr.interrupt == 1);
+  assign is_store_parity_fault = (rvfi_intr.cause == NMI_STORE_PARITY   && rvfi_intr.intr == 1 && rvfi_intr.interrupt == 1);
+  assign is_cause_nmi          = (rvfi_intr.cause inside { NMI_LOAD, NMI_STORE, NMI_LOAD_PARITY, NMI_STORE_PARITY })
+                                  && rvfi_intr.intr
+                                  && rvfi_intr.interrupt;
+  assign is_cause_interrupt    = !( rvfi_intr.cause inside {NMI_LOAD, NMI_STORE, NMI_LOAD_PARITY, NMI_STORE_PARITY})
+                                 && rvfi_intr.intr
+                                 && rvfi_intr.interrupt;
+  assign is_interrupt_taken    = (rvfi_intr.intr == 1'b1 && rvfi_intr.interrupt == 1'b1);
+
+  assign is_instr_access_fault = (rvfi_trap.exception_cause == INSTR_ACCESS_FAULT && rvfi_trap.exception == 1 && rvfi_trap.trap == 1);
+  assign is_invalid_instr_word = ((   rvfi_trap.exception_cause == INSTR_ACCESS_FAULT
+                                   || rvfi_trap.exception_cause == INSTR_BUS_FAULT
+                                   || rvfi_trap.exception_cause == INSTR_PARITY_FAULT)
+                                  && rvfi_trap.exception == 1'b1 && rvfi_trap.trap == 1'b1);
+
+  assign is_trap_exception     = rvfi_trap.exception == 1'b1 && rvfi_trap.trap == 1'b1;
+  assign is_intr_exception     = rvfi_intr.exception == 1'b1 && rvfi_intr.intr == 1'b1;
+  assign is_intr_ecall_ebreak  = is_intr_exception
+                                 && (rvfi_intr.cause == ECALL_M_MODE
+                                  || rvfi_intr.cause == ECALL_U_MODE
+                                  || rvfi_intr.cause == BREAKPOINT);
+
+
+  assign s_imm = read_s_imm(rvfi_insn);
+  assign b_imm = read_b_imm(rvfi_insn);
+  assign j_imm = read_j_imm(rvfi_insn);
+  assign i_imm = mapped_instr.n.i.imm;
+
+  assign mapped_instr = uncompressed_instr_t'(rvfi_insn);
+
+  // Map csrs to bitfield representations
+  assign mintstatus_fields = mintstatus_t'(mintstatus);
+  assign mintthresh_fields = mintthresh_t'(mintthresh);
+  assign mstatus_fields    = mstatus_t'(mstatus);
+  assign mtvec_fields      = mtvec_clic_t'(mtvec);
+  assign mclicbase_fields  = mclicbase_t'(mclicbase);
+  assign mtvt_fields       = mtvt_t'(mtvt);
+  assign mepc_fields       = mepc_t'(mepc);
+  assign mcause_fields     = mcause_t'(mcause);
+  assign dcsr_fields       = dcsr_t'(dcsr);
+
+  always_comb begin
+    clic.irq   = clic_if.clic_irq;
+    clic.id    = clic_if.clic_irq_id;
+    clic.level = clic_if.clic_irq_level;
+    clic.priv  = clic_if.clic_irq_priv;
+    clic.shv   = clic_if.clic_irq_shv;
+  end
+
+  always_comb begin
+    if (!rst_ni) begin
+      clic_core.id    = '0;
+      clic_core.level = '0;
+      clic_core.priv  = '0;
+      clic_core.shv   = '0;
+    end else begin
+      clic_core.id    = irq_id;
+      clic_core.level = irq_level;
+      clic_core.priv  = irq_priv;
+      clic_core.shv   = irq_shv;
+    end
+  end
+
+  always @(posedge clk) begin
+    if (!rst_ni) begin
+      clic_core.irq <= 0;
+    end else begin
+      clic_core.irq <= clic.irq;
+    end
+  end
+
+
+  assign core_not_in_debug            = debug_running;
+  assign core_in_debug                = !core_not_in_debug;
+  assign csr_instr_raw                = csr_instr_t'(rvfi_insn);
+  assign is_csr_access_instr          = csr_instr_raw.opcode == SYSTEM
+                                        && (csr_instr_raw.funct3 inside { CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI }) ;
+  assign is_mnxti_access_instr        = is_csr_access_instr && rvfi_valid && csr_instr.csr == MNXTI;
+  assign is_mepc_access_instr         = is_csr_access_instr && rvfi_valid && csr_instr.csr == MEPC;
+  assign is_mtvec_access_instr        = is_csr_access_instr && rvfi_valid && csr_instr.csr == MTVEC;
+  assign is_mtvt_access_instr         = is_csr_access_instr && rvfi_valid && csr_instr.csr == MTVT;
+  assign is_mcause_access_instr       = is_csr_access_instr && rvfi_valid && csr_instr.csr == MCAUSE;
+  assign is_mstatus_access_instr      = is_csr_access_instr && rvfi_valid && csr_instr.csr == MSTATUS;
+  assign is_mscratchcsw_access_instr  = is_csr_access_instr && rvfi_valid && csr_instr.csr == MSCRATCHCSW;
+  assign is_mscratchcswl_access_instr = is_csr_access_instr && rvfi_valid && csr_instr.csr == MSCRATCHCSWL;
+
+  assign csr_instr = is_csr_access_instr ? csr_instr_raw : 32'h0000_0000;
+
+  assign is_valid_mnxti_write = is_mnxti_access_instr && is_csr_write && rvfi_valid;
+  assign is_valid_mnxti_read  = is_mnxti_access_instr && is_csr_read  && rvfi_valid;
+
+  // TODO replace with non-poking signal
+  assign is_interrupt_allowed = dut_wrap.cv32e40s_wrapper_i.core_i.controller_i.controller_fsm_i.interrupt_allowed;
+
+  function logic fun_is_csr_write(csr_instr_t instr);
+    if (instr.opcode == SYSTEM
+      && (instr.funct3 inside { CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI })) begin
+
+      case (instr.funct3)
+        CSRRW, CSRRWI : fun_is_csr_write = 1'b1;
+        CSRRS, CSRRC  : fun_is_csr_write = instr.n.rs1  ? 1'b1 : 1'b0;
+        CSRRSI, CSRRCI: fun_is_csr_write = instr.n.uimm ? 1'b1 : 1'b0;
+
+        // Should never be here
+        default       : fun_is_csr_write = 1'b0;
+      endcase
+    end else begin
+      fun_is_csr_write = 1'b0;
+    end
+  endfunction : fun_is_csr_write
+
+  function logic fun_is_csr_read(csr_instr_t instr);
+    if (instr.opcode == SYSTEM
+      && (instr.funct3 inside { CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI })) begin
+      case (instr.funct3)
+        CSRRW, CSRRWI : fun_is_csr_read  = instr.rd ? 1'b1 : 1'b0;
+        CSRRS, CSRRC  : fun_is_csr_read  = 1'b1;
+        CSRRSI, CSRRCI: fun_is_csr_read  = 1'b1;
+
+        // Should never be here
+        default       : fun_is_csr_read  = 1'b0;
+      endcase
+    end else begin
+      fun_is_csr_read = 1'b0;
+    end
+  endfunction : fun_is_csr_read
+
+  always_comb begin
+    if (is_csr_access_instr) begin
+      is_csr_write = fun_is_csr_write(csr_instr);
+      is_csr_read  = fun_is_csr_read(csr_instr);
+    end else begin
+      is_csr_write = 0;
+      is_csr_read  = 0;
+    end
+  end
+
+
+  function is_insn(uncompressed_instr_t insn, insn_names_e insn_type);
+    if (is_invalid_instr_word) begin
+      return 1'b0;
+    end
+
+    case (insn_type)
+      FENCEI : return (   (insn.opcode         == MISC_MEM)
+                       && (insn.n.i.rd         == 5'b0_0000)
+                       && (insn.n.i.funct3     == 3'b001)
+                       && (insn.n.i.rs1        == 5'b0_0000)
+                       && (insn.n.i.imm        == 12'h000));
+      ECALL  : return (   (insn.opcode         == SYSTEM)
+                       && (insn.n.i.imm        == 12'b0000_0000_0000));
+      EBREAK : return (   (insn.opcode         == SYSTEM)
+                       && (insn.n.i.imm        == 12'b0000_0000_0001));
+      CEBREAK: return (   (insn                == 32'b0000_0000_1001_0010)); // compressed
+      MRET   : return (   (insn.opcode         == SYSTEM)
+                       && (insn.n.r.rd         == 5'b0_0000)
+                       && (insn.n.r.n.m.funct7 == 12'b001_1000)
+                       && (insn.n.r.n.m.rs2    == 5'b0_0010)
+                       && (insn.n.r.rs1        == 5'b0_0000)
+                       && (insn.n.r.funct3     == 3'b000));
+      DRET   : return (   (insn.opcode         == SYSTEM)
+                       && (insn.n.r.n.funct12  == 12'b0111_1011_0010));
+      WFI    : return (   (insn.opcode         == SYSTEM)
+                       && (insn.n.r.rd         == 5'b0_0000)
+                       && (insn.n.r.funct3     == 3'b000)
+                       && (insn.n.r.rs1        == 5'b0_0000)
+                       && (insn.n.r.n.funct12  == 12'b0001_0000_0101));
+      SB     : return (   (insn.opcode         == STORE)
+                       && (insn.n.s.funct3     == FUNCT3_SB));
+      SH     : return (   (insn.opcode         == STORE)
+                       && (insn.n.s.funct3     == FUNCT3_SH));
+      SW     : return (   (insn.opcode         == STORE)
+                       && (insn.n.s.funct3     == FUNCT3_SW));
+      STORE_INSN : return (insn.opcode         == STORE)
+                       && (insn.n.s.funct3 inside { FUNCT3_SB, FUNCT3_SH, FUNCT3_SW });
+      LB     : return (   (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3     == FUNCT3_LB));
+      LH     : return (   (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3     == FUNCT3_LH));
+      LW     : return (   (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3     == FUNCT3_LW));
+      LBU    : return (   (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3     == FUNCT3_LBU));
+      LHU    : return (   (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3     == FUNCT3_LHU));
+      LOAD_INSN  : return (insn.opcode         == LOAD)
+                       && (insn.n.i.funct3 inside { FUNCT3_LB, FUNCT3_LH, FUNCT3_LW, FUNCT3_LBU, FUNCT3_LHU });
+    endcase
+  endfunction : is_insn
+
+  assign is_mret_insn   = rvfi_valid && is_insn(rvfi_insn, MRET);
+  assign is_dret_insn   = rvfi_valid && is_insn(rvfi_insn, DRET);
+  assign is_fencei_insn = rvfi_valid && is_insn(rvfi_insn, FENCEI);
+
+  assign is_store_insn  = rvfi_valid && is_insn(rvfi_insn, STORE_INSN);
+  assign is_load_insn   = rvfi_valid && is_insn(rvfi_insn, LOAD_INSN);
+
+  function logic is_store_insn_addr_in_mtvt_region(uncompressed_instr_t insn);
+    automatic logic [31:0] base   = 0;
+    automatic logic [11:0] offset = 0;
+    case (is_insn(insn, STORE_INSN))
+      1: offset = s_imm;
+      0: return 1'b0;
+    endcase
+    base = rvfi_rs1_rdata;
+    return base + offset inside { [mtvt : mtvt + ((2**SMCLIC_ID_WIDTH * 4))] } ? 1'b1 : 1'b0;
+  endfunction : is_store_insn_addr_in_mtvt_region
+
+  function logic is_load_insn_addr_in_mtvt_region(uncompressed_instr_t insn);
+    automatic logic [31:0] base = 0;
+    automatic logic [11:0] offset = 0;
+    case (is_insn(insn, LOAD_INSN))
+      1: offset = i_imm;
+      0: return 1'b0;
+    endcase
+    base = rvfi_rs1_rdata;
+    return base + offset inside { [mtvt : mtvt + ((2**SMCLIC_ID_WIDTH * 4))] } ? 1'b1 : 1'b0;
+  endfunction : is_load_insn_addr_in_mtvt_region
+
+  generate
+  if (SMCLIC) begin : gen_clic_assertions
+
+    // ------------------------------------------------------------------------
+    // mintstatus.mil resets to 0
+    // ------------------------------------------------------------------------
+
+    property p_mintstatus_mil_reset_to_zero;
+      $rose(rst_ni) |-> mintstatus_fields.mil == '0; // TODO add bitwidth
+    endproperty : p_mintstatus_mil_reset_to_zero
+
+    a_mintstatus_mil_reset_to_zero: assert property (p_mintstatus_mil_reset_to_zero)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mintstatus.mil non-zero reset value not allowed"));
+
+    // ------------------------------------------------------------------------
+    // mstatus.mie should reset to zero
+    // ------------------------------------------------------------------------
+
+    property p_mstatus_mie_reset_to_zero;
+      $rose(rst_ni) |-> mstatus_fields.mie == '0; // TODO add bitwidth
+    endproperty : p_mstatus_mie_reset_to_zero
+
+    a_mstatus_mie_reset_to_zero: assert property (p_mstatus_mie_reset_to_zero)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mstatus.mie non-zero reset value not allowed"));
+
+    // ------------------------------------------------------------------------
+    // mtvec reset value is correct
+    // ------------------------------------------------------------------------
+
+    property p_mtvec_reset_value_correct;
+      $rose(fetch_enable) |=> ##1
+        mtvec_fields.base_31_7 == mtvec_addr_i[31:7] &&
+        mtvec_fields.base_6_2  == 5'h00 &&
+        mtvec_fields.mode      == M_MODE;
+    endproperty : p_mtvec_reset_value_correct;
+
+    a_mtvec_reset_value_correct: assert property (p_mtvec_reset_value_correct)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mtvec reset value: 0x%08h, should have been 0x%08h",
+          mtvec_fields, mtvec_addr_i));
+
+    // ------------------------------------------------------------------------
+    // clic.priv should always be machine mode
+    // ------------------------------------------------------------------------
+
+    property p_clic_mode_only;
+      clic.priv == M_MODE;
+    endproperty : p_clic_mode_only
+
+    a_clic_mode_only: assert property (p_clic_mode_only)
+    else
+      `uvm_error(info_tag,
+        $sformatf("When clic is enabled, it should be the ONLY mode available"));
+
+    // ------------------------------------------------------------------------
+    // NMI address should be at the fifthteenth entry in the mtvec table
+    // ------------------------------------------------------------------------
+
+    // FIXME update when spec 0.5.0 for different offset
+    property p_nmi_to_mtvec_fifthteenth_entry;
+            is_cause_nmi
+         && rvfi_valid
+      |->
+            rvfi_pc_rdata == ({$past(mtvec_fields.base_31_7), $past(mtvec_fields.base_6_2), 2'b00} + NMI_OFFSET)
+      or
+            rvfi_pc_rdata == ({$past(mtvec_fields.base_31_7), $past(mtvec_fields.base_6_2), 2'b00} + NMI_OFFSET + 2)
+         && (mapped_instr.opcode[1:0] != 2'b11)
+      or
+            is_dret_insn
+        ##1 rvfi_valid[->1]
+        ##0 rvfi_pc_rdata == ({$past(mtvec_fields.base_31_7), $past(mtvec_fields.base_6_2), 2'b00} + NMI_OFFSET)
+         && !rvfi_dbg_mode
+      or
+        //    rvfi_valid[->1]
+        ##0 rvfi_pc_rdata == debug_halt_addr
+         && rvfi_dbg_mode
+      ;
+    endproperty : p_nmi_to_mtvec_fifthteenth_entry
+
+    a_nmi_to_mtvec_fifthteenth_entry: assert property (p_nmi_to_mtvec_fifthteenth_entry)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Taken nmi address wrong"));
+
+    // ------------------------------------------------------------------------
+    // SMCLIC_ID_WIDTH setting should be for 1-1024 interrupts
+    // ------------------------------------------------------------------------
+
+    property p_smclic_valid_setting;
+      SMCLIC_ID_WIDTH inside {[1:10]};
+    endproperty : p_smclic_valid_setting
+
+    a_smclic_valid_setting: assert property (p_smclic_valid_setting)
+    else
+      `uvm_error(info_tag,
+        $sformatf("SMCLIC_ID_WIDTH is invalid, is %0d, should be in range 1 .. 10",
+                  SMCLIC_ID_WIDTH));
+
+    // ------------------------------------------------------------------------
+    // irq_i[0:31] should be hardcoded zero
+    // ------------------------------------------------------------------------
+
+    for (genvar i = 0; i < NUM_IRQ; i++) begin : gen_non_clic_tieoff
+
+      property p_tieoff_zero_irq_i;
+        irq_i[i] == '0;
+      endproperty : p_tieoff_zero_irq_i;
+
+      a_tieoff_zero_irq_i : assert property (p_tieoff_zero_irq_i)
+      else
+        `uvm_error(info_tag,
+           $sformatf("irq_i[%0d] should be zero, is %0b",
+             i,
+             irq_i[i])
+        );
+    end
+
+    // ------------------------------------------------------------------------
+    // Enabled and pending interrupts should eventually be taken,
+    // assuming that the request is not retracted
+    // ------------------------------------------------------------------------
+
+    assign incr_data_obi = obi_data_req && obi_data_gnt && !obi_data_rvalid;
+    assign decr_data_obi = !(obi_data_req && obi_data_gnt) && obi_data_rvalid && (obi_data_in_flight > 0);
+
+
+    always @(posedge clk_i) begin
+      if (!rst_ni) begin
+        obi_data_in_flight <= 0;
+      end else begin
+        obi_data_in_flight <= obi_data_in_flight + incr_data_obi;
+        obi_data_in_flight <= obi_data_in_flight - decr_data_obi;
+      end
+    end
+
+    always @* begin
+      obi_data_in_flight_n <= obi_data_in_flight - decr_data_obi + incr_data_obi;
+    end
+
+    localparam MAX_STALL_CYCLES = 20;
+
+    property p_obi_instr_max_load_stalls;
+      obi_instr_req && obi_instr_gnt |-> !obi_instr_rvalid [*0:MAX_STALL_CYCLES] ##1 obi_instr_rvalid;
+    endproperty : p_obi_instr_max_load_stalls
+
+    property p_obi_data_max_load_stalls;
+      obi_data_req && obi_data_gnt |-> !obi_data_rvalid [*0:MAX_STALL_CYCLES] ##1 obi_data_rvalid;
+    endproperty : p_obi_data_max_load_stalls
+
+
+    localparam MAX_RVFI_VALID_DELAY = 64;
+
+    property p_instr_valid_delay;
+        !rvfi_valid |-> !rvfi_valid[*0:MAX_RVFI_VALID_DELAY] ##1 rvfi_valid;
+    endproperty
+
+
+    // TODO: fix
+    assign is_wfi = dut_wrap.cv32e40s_wrapper_i.rvfi_i.sys_wfi_insn_wb_i;
+
+
+    // Pending and enabled interrupts will eventually be taken if the conditions are right
+    // Excludes checking in blocking regions (debug, exception handlers, nmi)
+    property p_always_taken;
+      sync_accept_on(
+           core_in_debug
+        || rvfi_intr.exception
+        || rvfi_trap.exception
+      //            || dut_wrap.cv32e40s_wrapper_i.rvfi_i.nmi_pending_i
+        || is_cause_nmi
+        || !$stable(clic, @(posedge clk_i))
+        || !(irq_level_ok_valid || irq_priv_ok_valid)
+                )
+
+      irq_level_ok_valid || irq_priv_ok_valid
+      implies
+        s_eventually irq_ack;
+
+    endproperty : p_always_taken
+
+    a_always_taken: assert property(p_always_taken)
+    else
+      `uvm_error(info_tag,
+        $sformatf("TODO")); // TODO
+
+    // ------------------------------------------------------------------------
+    // irq_ack is always single cycle pulse
+    // ------------------------------------------------------------------------
+
+    property p_irq_ack_is_always_single_cycle_pulse;
+        irq_ack
+      |=>
+        !irq_ack;
+    endproperty : p_irq_ack_is_always_single_cycle_pulse
+
+    a_irq_ack_is_always_single_cycle_pulse: assert property (p_irq_ack_is_always_single_cycle_pulse)
+    else
+      `uvm_error(info_tag,
+        $sformatf("irq_ack not single cycle pulse"));
+
+    // ------------------------------------------------------------------------
+    // irq_ack should only be asserted on taken interrupts
+    // ------------------------------------------------------------------------
+
+    logic irq_level_ok_valid;
+    logic irq_priv_ok_valid;
+
+    logic [7:0] effective_clic_level;
+
+    always_comb begin
+      effective_clic_level = mintthresh_fields.th > mintstatus_fields.mil ? mintthresh_fields.th : mintstatus_fields.mil;
+    end
+
+    assign irq_level_ok_valid = mstatus_fields.mie
+                                && clic.irq
+                                && (clic.priv == current_priv_mode)
+                                && (clic.level > effective_clic_level);
+
+    assign irq_priv_ok_valid = clic.irq
+                               && (clic.priv > current_priv_mode)
+                               && (clic.level > 0);
+
+    property p_irq_ack_valid;
+        irq_ack
+      |->
+      /*either*/
+           mstatus_fields.mie
+        && $past(clic.irq)
+        && $past(clic.priv) == current_priv_mode
+        && $past(clic.level) > effective_clic_level
+
+      or
+           $past(clic.irq)
+        && $past(clic.priv) > current_priv_mode
+        && $past(clic.level) > 0
+      ;
+    endproperty : p_irq_ack_valid
+
+    a_irq_ack_valid: assert property (p_irq_ack_valid)
+    else
+      `uvm_error(info_tag,
+        $sformatf("irq ack prerequisites not met and ack occurred"));
+
+    // ------------------------------------------------------------------------
+    // There should be no irq_ack on taken nmi
+    // ------------------------------------------------------------------------
+
+    property p_nmi_taken_no_ack;
+        irq_ack
+      |->
+        (rvfi_valid && !is_cause_nmi)[->1];
+    endproperty : p_nmi_taken_no_ack
+
+    a_nmi_taken_no_ack: assert property (p_nmi_taken_no_ack)
+    else
+      `uvm_error(info_tag,
+        $sformatf("There should be no irq_ack for a taken nmi"));
+
+    // ------------------------------------------------------------------------
+    // Only one irq_ack per irq
+    // ------------------------------------------------------------------------
+
+    property p_only_one_ack_per_irq;
+        clic.irq
+      |->
+        irq_ack[=0:1] within $changed(clic)[->1];
+    endproperty : p_only_one_ack_per_irq
+
+    a_only_one_ack_per_irq: assert property (p_only_one_ack_per_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("There should only be one ack per interrupt request"));
+
+    // ------------------------------------------------------------------------
+    // Every irq_ack should be followed by an rvfi_intr
+    // ------------------------------------------------------------------------
+
+    property p_every_ack_followed_by_rvfi_intr;
+            irq_ack
+        ##1 rvfi_valid[->1]
+      |->
+            rvfi_intr.intr
+         && rvfi_intr.interrupt
+      or
+            rvfi_trap.debug
+      or
+            rvfi_trap.exception;
+    endproperty : p_every_ack_followed_by_rvfi_intr
+
+    a_every_ack_followed_by_rvfi_intr: assert property (p_every_ack_followed_by_rvfi_intr)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Every irq_ack should be followed by the corresponding rvfi_intr"));
+
+    // ------------------------------------------------------------------------
+    // mclicbase lower 12 bit should always be zero
+    // ------------------------------------------------------------------------
+
+    property p_mclicbase_lower_12_bits_zero;
+      mclicbase_fields.reserved == 12'h000;
+    endproperty : p_mclicbase_lower_12_bits_zero
+
+    a_mclicbase_lower_12_bits_zero: assert property (p_mclicbase_lower_12_bits_zero)
+    else
+      `uvm_error(info_tag,
+         $sformatf("mclicbase[11:0] should have been zero, is %012b",
+           mclicbase_fields.reserved));
+
+    // ------------------------------------------------------------------------
+    // mie is unused, and should be hard coded zero
+    // ------------------------------------------------------------------------
+
+    property p_mie_unused_hardcode_zero;
+      mie == 32'h0000_0000;
+    endproperty : p_mie_unused_hardcode_zero
+
+    a_mie_unused_hardcode_zero: assert property (p_mie_unused_hardcode_zero)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Mie is unused and should always read zero"));
+
+    // ------------------------------------------------------------------------
+    // mip is unused, and should be hard coded zero
+    // ------------------------------------------------------------------------
+
+    property p_mip_unused_hardcode_zero;
+      mip == 32'h0000_0000;
+    endproperty : p_mip_unused_hardcode_zero
+
+    a_mip_unused_hardcode_zero: assert property (p_mip_unused_hardcode_zero)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Mip is unused and should always read zero"));
+
+    // ------------------------------------------------------------------------
+    // mtvec should always be aligned to 128 bytes
+    // ------------------------------------------------------------------------
+
+    property p_mtvec_aligned_to_128_bytes;
+      mtvec_fields.base_6_2 == 5'b0_0000;
+    endproperty : p_mtvec_aligned_to_128_bytes;
+
+    a_mtvec_aligned_to_128_bytes: assert property (p_mtvec_aligned_to_128_bytes)
+    else
+      `uvm_error(info_tag,
+         $sformatf("mtvec[6:2] should have been zero (128 bytes alignment), was %05b",
+           mtvec_fields.base_6_2));
+
+    // ------------------------------------------------------------------------
+    // mtvec.mode should always be clic mode
+    // ------------------------------------------------------------------------
+
+    property p_mtvec_mode_always_clic;
+      mtvec_fields.mode == 2'b11;
+    endproperty : p_mtvec_mode_always_clic
+
+    a_mtvec_mode_always_clic: assert property (p_mtvec_mode_always_clic)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mtvec.mode should always be clic in clic mode, is %02b",
+          mtvec_fields.mode));
+
+    // ------------------------------------------------------------------------
+    // fencei guarantees that updated mtvt table values are fetched
+    // ------------------------------------------------------------------------
+
+    //arbitrary limit, 8 should be OK for now (by some margin) update as needed
+    localparam MAX_OBI_OUTSTANDING = 8;
+    logic [31:0] mtvt_write_offset;
+    logic [31:0] mtvt_read_offset;
+    logic [31:0] mtvt_table_value[0:(2**(SMCLIC_ID_WIDTH))-1];
+    logic is_mtvt_store_event;
+    logic no_mtvt_store_event_occurred;
+    int   items_in_obi_instr_fifo;
+    int   items_in_obi_data_wfifo;
+    logic obi_instr_pop;
+    logic obi_instr_push;
+    logic obi_data_pop;
+    logic obi_data_push;
+    logic [0:8][31:0] obi_instr_addr_fifo;
+    logic [0:8][31:0] obi_data_addr_fifo;
+
+    // Keep track of addresses v. data for obi reads on instr_if
+    always @(posedge clk_i) begin
+      if (!rst_ni) begin
+        items_in_obi_instr_fifo <= 0;
+        obi_instr_addr_fifo      <= '0;
+      end else begin
+        case (1)
+          obi_instr_pop && !obi_instr_push && items_in_obi_instr_fifo > 0: begin
+            items_in_obi_instr_fifo <= items_in_obi_instr_fifo - 1;
+            obi_instr_addr_fifo[0:8] <= items_in_obi_instr_fifo ? { obi_instr_addr_fifo[1:8], 32'b0}: obi_instr_addr_fifo[0:8];
+          end
+
+          obi_instr_pop && obi_instr_push: begin
+            case (items_in_obi_instr_fifo)
+              0: obi_instr_addr_fifo[0:8] <= {obi_instr_addr, obi_instr_addr_fifo[1:8]}; // ignore pop, no item in fifo
+              1: obi_instr_addr_fifo[0:8] <= {obi_instr_addr, obi_instr_addr_fifo[2:8], 32'h0};
+              2: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:1], obi_instr_addr, obi_instr_addr_fifo[3:8], 32'h0};
+              3: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:2], obi_instr_addr, obi_instr_addr_fifo[4:8], 32'h0};
+              4: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:3], obi_instr_addr, obi_instr_addr_fifo[5:8], 32'h0};
+              5: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:4], obi_instr_addr, obi_instr_addr_fifo[6:8], 32'h0};
+              6: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:5], obi_instr_addr, obi_instr_addr_fifo[7:8], 32'h0};
+              7: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[1:6], obi_instr_addr, obi_instr_addr_fifo[8:8], 32'h0};
+            endcase
+          end
+
+          !obi_instr_pop && obi_instr_push && items_in_obi_instr_fifo < MAX_OBI_OUTSTANDING : begin
+            case (items_in_obi_instr_fifo)
+              0: obi_instr_addr_fifo[0:8] <= {obi_instr_addr, obi_instr_addr_fifo[1:8]};
+              1: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:0], obi_instr_addr, obi_instr_addr_fifo[2:8]};
+              2: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:1], obi_instr_addr, obi_instr_addr_fifo[3:8]};
+              3: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:2], obi_instr_addr, obi_instr_addr_fifo[4:8]};
+              4: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:3], obi_instr_addr, obi_instr_addr_fifo[5:8]};
+              5: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:4], obi_instr_addr, obi_instr_addr_fifo[6:8]};
+              6: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:5], obi_instr_addr, obi_instr_addr_fifo[7:8]};
+              7: obi_instr_addr_fifo[0:8] <= {obi_instr_addr_fifo[0:6], obi_instr_addr, obi_instr_addr_fifo[8:8]};
+            endcase
+            items_in_obi_instr_fifo <= items_in_obi_instr_fifo + 1;
+          end
+        endcase
+      end
+    end
+
+    always @(posedge clk_i) begin
+      if (!rst_ni) begin
+        items_in_obi_data_wfifo <= 0;
+        obi_data_addr_fifo      <= '0;
+      end else begin
+        case (1)
+          obi_data_pop && !obi_data_push && items_in_obi_data_wfifo > 0: begin
+            items_in_obi_data_wfifo <= items_in_obi_data_wfifo - 1;
+            obi_data_addr_fifo[0:8] <= items_in_obi_data_wfifo ? { obi_data_addr_fifo[1:8], 32'b0}: obi_data_addr_fifo[0:8];
+          end
+
+          obi_data_pop && obi_data_push: begin
+            case (items_in_obi_data_wfifo)
+              0: obi_data_addr_fifo[0:8] <= {obi_data_addr, obi_data_addr_fifo[1:8]}; // ignore pop, no item in fifo
+              1: obi_data_addr_fifo[0:8] <= {obi_data_addr, obi_data_addr_fifo[2:8], 32'h0};
+              2: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:1], obi_data_addr, obi_data_addr_fifo[3:8], 32'h0};
+              3: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:2], obi_data_addr, obi_data_addr_fifo[4:8], 32'h0};
+              4: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:3], obi_data_addr, obi_data_addr_fifo[5:8], 32'h0};
+              5: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:4], obi_data_addr, obi_data_addr_fifo[6:8], 32'h0};
+              6: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:5], obi_data_addr, obi_data_addr_fifo[7:8], 32'h0};
+              7: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[1:6], obi_data_addr, obi_data_addr_fifo[8:8], 32'h0};
+            endcase
+          end
+
+          !obi_data_pop && obi_data_push && items_in_obi_data_wfifo < MAX_OBI_OUTSTANDING : begin
+            case (items_in_obi_data_wfifo)
+              0: obi_data_addr_fifo[0:8] <= {obi_data_addr, obi_data_addr_fifo[1:8]};
+              1: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:0], obi_data_addr, obi_data_addr_fifo[2:8]};
+              2: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:1], obi_data_addr, obi_data_addr_fifo[3:8]};
+              3: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:2], obi_data_addr, obi_data_addr_fifo[4:8]};
+              4: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:3], obi_data_addr, obi_data_addr_fifo[5:8]};
+              5: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:4], obi_data_addr, obi_data_addr_fifo[6:8]};
+              6: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:5], obi_data_addr, obi_data_addr_fifo[7:8]};
+              7: obi_data_addr_fifo[0:8] <= {obi_data_addr_fifo[0:6], obi_data_addr, obi_data_addr_fifo[8:8]};
+            endcase
+            items_in_obi_data_wfifo <= items_in_obi_data_wfifo + 1;
+          end
+        endcase
+
+      end
+    end
+
+
+    // New obi_instr read request
+    assign obi_instr_push = obi_instr_req && obi_instr_gnt;
+    // New obi_instr read fulfillment
+    assign obi_instr_pop  = obi_instr_rvalid && obi_instr_rready;
+
+    // New obi_data write request
+    assign obi_data_push = obi_data_req && obi_data_gnt && obi_data_we;
+    // New obi_data write fulfillment
+    assign obi_data_pop  = obi_data_rvalid && obi_data_rready;
+
+    logic is_read_mtvt_table_val_obi;
+    localparam logic [31:0] mtvt_max_offset = ((2**SMCLIC_ID_WIDTH)*4-1);
+
+    always_comb begin
+      if (!rst_ni) begin
+        is_read_mtvt_table_val_obi = 1'b0;
+      end
+      else begin
+        is_read_mtvt_table_val_obi = (obi_instr_addr inside { [mtvt:mtvt+mtvt_max_offset ]}) && obi_instr_req && obi_instr_gnt;
+      end
+    end
+
+    logic is_write_mtvt_table_val_obi;
+    always_comb begin
+      if (!rst_ni) begin
+        is_write_mtvt_table_val_obi <= 1'b0;
+      end
+      else begin
+        is_write_mtvt_table_val_obi <= (obi_data_addr inside { [mtvt:mtvt+mtvt_max_offset ]}) && obi_data_req && obi_data_gnt && obi_data_we;
+      end
+    end
+
+    logic [31:0] last_mtvt_table_read_addr;
+    always @(posedge clk) begin
+      if (!rst_ni) begin
+        last_mtvt_table_read_addr <= 0;
+      end else begin
+        if ($fell(is_read_mtvt_table_val_obi)) begin
+          last_mtvt_table_read_addr <= $past(obi_instr_addr);
+        end else begin
+          last_mtvt_table_read_addr <= last_mtvt_table_read_addr;
+        end
+      end
+    end
+
+    logic is_mtvt_load_event;
+    assign is_mtvt_store_event = is_store_insn_addr_in_mtvt_region(rvfi_insn) && !rvfi_trap.exception && rvfi_valid;
+    assign is_mtvt_load_event  = is_read_mtvt_table_val_obi;
+
+    always@* begin
+      if (!rst_ni) begin
+        no_mtvt_store_event_occurred = 1;
+      end
+      if (is_mtvt_store_event) begin
+        mtvt_write_offset                       <= rvfi_rs1_rdata + s_imm - mtvt;
+        mtvt_table_value[(SMCLIC_ID_WIDTH)'(mtvt_write_offset/'d4)] <= rvfi_rs2_rdata;
+        no_mtvt_store_event_occurred = 0;
+      end
+      else if (no_mtvt_store_event_occurred && is_mtvt_load_event) begin
+        mtvt_read_offset <= rvfi_rs1_rdata + i_imm - mtvt;
+        mtvt_table_value[(SMCLIC_ID_WIDTH)'(mtvt_read_offset/'d4)] <= rvfi_rd_wdata;
+      end
+    end
+
+    sequence s_store_mtvt_value;
+      is_mtvt_store_event;
+    endsequence : s_store_mtvt_value
+
+    property p_mtvt_table_read_equals_value_written;
+      obi_instr_pop && !obi_instr_err && obi_instr_addr_fifo[0] inside { [mtvt : mtvt + ((2**SMCLIC_ID_WIDTH)*4)-1] }
+      |->
+      obi_instr_rdata == mtvt_table_value[(SMCLIC_ID_WIDTH)'((obi_instr_addr_fifo[0] - mtvt)/4)];
+
+    endproperty : p_mtvt_table_read_equals_value_written
+
+    property p_fencei_guarantee_visible_mtvt_write;
+      accept_on(
+        // Assume that mtvt is not changed - otherwise complexity of assertion explodes
+        !$stable(mtvt, @(posedge clk_i))
+      )
+        s_store_mtvt_value
+        ##1 (is_fencei_insn && rvfi_valid)[->1]
+        ##1 (irq_ack && clic_core.shv)[->1]
+        ##1 rvfi_valid[->1]
+      |->
+        // past because oic.id might have taken a new interrupt here, with cleared lower bit
+        rvfi_pc_rdata == (($past(mtvt_table_value[clic_oic.id]) >> 1) << 1)
+      or
+        // Took debug instead, make sure dpc is correct
+        rvfi_dbg
+        && rvfi_pc_rdata == debug_halt_addr
+        && (rvfi_dpc_rdata & rvfi_dpc_rmask) == (($past(mtvt_table_value[clic_oic.id]) >> 1) << 1)
+      or
+        is_invalid_instr_word
+      or
+        is_cause_nmi
+      or
+        is_trap_exception
+      or
+      // This should not be necessary, but inconsistent rvfi signaling on shv traps necessitates this check
+        is_intr_exception
+      ;
+    endproperty : p_fencei_guarantee_visible_mtvt_write
+
+    a_fencei_guarantee_visible_mtvt_write: assert property (p_fencei_guarantee_visible_mtvt_write)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Fencei should _always_ make writes to mtvt visible to next taken shv interrupt"));
+
+    // ------------------------------------------------------------------------
+    // Function ptr reads treated as if fetch
+    // ------------------------------------------------------------------------
+
+    property p_mtvt_alignment_correct;
+      accept_on(N_MTVT <= 6) // Pass if field does not exist
+      mtvt_fields.base_n_6 == '0;
+    endproperty : p_mtvt_alignment_correct
+
+    a_mtvt_alignment_correct: assert property (p_mtvt_alignment_correct)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mtvt alignment should have been %d bytes, mtvt: %08x",
+          (2 ** N_MTVT),
+          mtvt));
+
+    // ------------------------------------------------------------------------
+    // mepc is always set correctly when taking an interrupt
+    // ------------------------------------------------------------------------
+
+    logic [31:0] next_pc;
+
+    // Formal tools generate warnings for latch behavior in assign statements, use explicit always_latch here
+    always_latch begin
+      next_pc = rvfi_valid ?  rvfi_pc_wdata : (!rst_ni) ?  0 : next_pc  ;
+    end
+
+    property p_mepc_set_correct_after_irq;
+      logic [31:0] sampled_next_pc;
+           // checks both csr_output and rvfi rdata
+           irq_ack
+       ##1 (1, sampled_next_pc    = rvfi_pc_wdata)
+       ##0 rvfi_valid[->1]
+      |->
+           // 1. Normal case
+           sampled_next_pc        == $past(next_pc) // should always match)
+        && rvfi_intr.cause         < 'h400 // no nmi
+        && rvfi_intr.exception    == 1'b0
+        && rvfi_mepc_rdata        == $past(next_pc) // does not match with nmi
+      or
+           // 2. Nmi occurred
+           sampled_next_pc        == $past(next_pc) // should always match
+        && rvfi_intr.cause        >= 'h400
+        && !(is_mepc_access_instr && is_csr_write)
+        && rvfi_mepc_rdata        == (mtvec_fields & ~32'b11)
+      or
+           // 3. Handler rewrites mtvec addr, and nmi occurred on new mtvec
+           sampled_next_pc        == $past(next_pc)
+        && is_cause_nmi
+        && is_mtvec_access_instr && is_csr_write
+      or
+           // 4. Handler rewrites mepc addr, and nmi occurred on new mepc
+           sampled_next_pc        == $past(next_pc)
+        && is_cause_nmi
+        && is_mepc_access_instr && is_csr_write
+      or
+           // 5. Hardware vectored interrupt, but with instruction access fault exception on mtvt
+           sampled_next_pc        == $past(next_pc)
+        && clic_oic.shv           == 1'b1
+        && rvfi_intr.cause        == 'h1
+        && rvfi_mepc_rdata        == (mtvec_fields & ~32'b11)
+      or
+           // 6. Hardware vectored interrupt, but with instruction access fault on mtvt target
+           sampled_next_pc        == $past(next_pc)
+        && clic_oic.shv           == 1'b1
+        && rvfi_intr.cause        == 'h1
+        && rvfi_mepc_rdata        == mtvt_fields + (4 * clic_oic.id)
+      or
+           // 7. Hardware vectored interrupt without instruction access fault
+           sampled_next_pc        == $past(next_pc)
+        && clic_oic.shv           == 1'b1
+        && rvfi_intr.exception    == 1'b0
+        && rvfi_mepc_rdata        == sampled_next_pc
+      or
+           // 8. Last instruction prior to irq_ack enables irq, shv-irq and first instruction in handler gets interrupted
+           // and this traps with instruction access fault
+           // irq_ack followed by irq ack
+           sampled_next_pc        == $past(next_pc)
+        && $changed(clic_oic)     == 1'b1
+        && $past(clic_oic.shv)    == 1'b1
+        && rvfi_intr.cause        == 1'h1
+        && rvfi_mepc_rdata        == mtvt_fields + (4 * $past(clic_oic.id))
+      or
+           // 9. Nested interrupt, with first being shv, second non-shv
+           sampled_next_pc        == $past(next_pc)
+        && $changed(clic_oic)     == 1'b1
+        && $past(clic_oic.shv)    == 1'b1
+        && clic_oic.shv           == 1'b0
+        && rvfi_intr.cause        == 1'h1
+        && rvfi_mepc_rdata        == mtvec_fields & ~32'b11
+      or
+           // 10. non-nested, mtvt fail with mtvt write
+           sampled_next_pc        == $past(next_pc)
+        && $stable(clic_oic)      == 1'b1
+        && clic_oic.shv           == 1'b1
+        && rvfi_intr.cause        == 1'h1
+        && is_mtvt_access_instr && is_csr_write
+        && rvfi_mepc_rdata        == $past(mtvt_fields) + (4 * clic_oic.id)
+      or
+           // 11. nested interrupts mtvt fail with mtvt write
+           sampled_next_pc        == $past(next_pc)
+        && $changed(clic_oic)     == 1'b1
+        && $past(clic_oic.shv)    == 1'b1
+        && rvfi_intr.cause        == 1'h1
+        && is_mtvt_access_instr && is_csr_write
+        && rvfi_mepc_rdata        == $past(mtvt_fields) + (4 * $past(clic_oic.id))
+      ;
+    endproperty : p_mepc_set_correct_after_irq;
+
+    a_mepc_set_correct_after_irq: assert property (p_mepc_set_correct_after_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Wrong mepc (0x%08x)",
+          mepc_fields));
+
+    // ------------------------------------------------------------------------
+    // mcause.interrupt is always set when taking an interrupt
+    // ------------------------------------------------------------------------
+
+    property p_mcause_interrupt_always_set_on_taken_irq;
+          irq_ack
+      |=>
+          mcause_fields.interrupt;
+    endproperty : p_mcause_interrupt_always_set_on_taken_irq
+
+    a_mcause_interrupt_always_set_on_taken_irq: assert property (p_mcause_interrupt_always_set_on_taken_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mcause.interrupt should be set on taken interrupts"));
+
+    // ------------------------------------------------------------------------
+    // mcause.cause is always set correctly after taking an interrupt
+    // ------------------------------------------------------------------------
+
+    property p_mcause_exccode_always_set_correctly_on_taken_irq;
+          irq_ack
+      |=>
+          mcause_fields.n.exccode_10_0 == $past(clic_core.id);
+    endproperty : p_mcause_exccode_always_set_correctly_on_taken_irq
+
+    a_mcause_exccode_always_set_correctly_on_taken_irq: assert property (p_mcause_exccode_always_set_correctly_on_taken_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mcause.exccode should be set on taken interrupts"));
+
+
+    // ------------------------------------------------------------------------
+    // mcause.mpil should reflect the previous privilege mode after taking
+    // an interrupt
+    // ------------------------------------------------------------------------
+
+    property p_mcause_mpil_reflects_previous_interrupt_lvl;
+      bit [7:0] il_prev;
+      (irq_ack, il_prev = mintstatus_fields.mil) |=> mcause_fields.mpil == il_prev;
+    endproperty : p_mcause_mpil_reflects_previous_interrupt_lvl
+
+    a_mcause_mpil_reflects_previous_interrupt_lvl: assert property (p_mcause_mpil_reflects_previous_interrupt_lvl)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mpil wrong, value: %0d",
+          mcause.mpil));
+
+    // ------------------------------------------------------------------------
+    // mcause.mpp should reflect the previous privilege mode after taking an
+    // interrupt
+    // ------------------------------------------------------------------------
+
+    property p_mcause_we_cover;
+      reject_on(rvfi_trap)
+           is_mcause_access_instr
+        && csr_instr.n.rs1 != 0
+        && csr_instr.rd != 0
+        && (~|rvfi_trap)
+        && rvfi_valid
+        ##1
+           rvfi_valid[=5];
+    endproperty : p_mcause_we_cover
+
+    property p_mstatus_we_cover;
+      reject_on(rvfi_trap)
+            is_mstatus_access_instr
+         && csr_instr.n.rs1 != 0
+         && csr_instr.rd != 0
+         && (~|rvfi_trap)
+         && rvfi_valid
+        ##1
+           rvfi_valid[=5];
+    endproperty : p_mstatus_we_cover
+
+    property p_mnxti_we_cover;
+      reject_on(rvfi_trap)
+            is_mnxti_access_instr
+         && csr_instr.n.rs1 != 0
+         && csr_instr.rd != 0
+         && (~|rvfi_trap)
+         && rvfi_valid
+        ##1
+            rvfi_valid[=5];
+    endproperty : p_mnxti_we_cover
+
+    property p_mstatus_mpp_neq_mcause_mpp;
+      mstatus_fields.mpp == mcause_fields.mpp;
+    endproperty : p_mstatus_mpp_neq_mcause_mpp
+
+    property p_mstatus_mpie_neq_mcause_mpie;
+      mstatus_fields.mpie == mcause_fields.mpie;
+    endproperty : p_mstatus_mpie_neq_mcause_mpie
+
+    p_mpp: assert property (p_mstatus_mpp_neq_mcause_mpp);
+    p_mpie: assert property (p_mstatus_mpie_neq_mcause_mpie);
+
+    weird_csr_access_cover_1 : cover property (
+      p_mcause_we_cover
+    );
+    weird_csr_access_cover_2 : cover property (
+      p_mstatus_we_cover
+    );
+    weird_csr_access_cover_3 : cover property (
+      p_mnxti_we_cover
+    );
+
+    property p_mcause_mpp_reflects_previous_privilege_mode;
+      bit [1:0] mode_prev = 2'b11;
+      irq_ack
+      |=>
+      mcause_fields.mpp == $past(current_priv_mode);
+    endproperty : p_mcause_mpp_reflects_previous_privilege_mode
+
+    a_mcause_mpp_reflects_previous_privilege_mode: assert property (p_mcause_mpp_reflects_previous_privilege_mode)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Previous privilege wrong, mpp value: %02b",
+          mcause_fields.mpp));
+
+    // ------------------------------------------------------------------------
+    // mcause.mpie should reflect the previous interrupt enable after taking
+    // an interrupt
+    // ------------------------------------------------------------------------
+
+    property p_mcause_mpie_reflects_previous_interrupt_enable;
+      bit mpie_prev;
+      (irq_ack, mpie_prev = mstatus_fields.mie) |=> mstatus_fields.mpie == mpie_prev;
+    endproperty  : p_mcause_mpie_reflects_previous_interrupt_enable
+
+    a_mcause_mpie_reflects_previous_interrupt_enable: assert property (p_mcause_mpie_reflects_previous_interrupt_enable)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mpie wrong, value: %0b",
+          mcause_fields.mpie));
+
+    // ------------------------------------------------------------------------
+    // mnxti should return the value of the currently taken interrupt
+    // if the pending interrupt in clic is the same as the interrupt id
+    // in the current context
+    // ------------------------------------------------------------------------
+
+    // FIXME: warning
+    always_comb begin
+      if (!rst_ni) begin
+        clic_oic <= '0;
+      end else if (irq_ack) begin
+        clic_oic <= clic_core;
+      end
+    end
+
+    sequence seq_irq_req_unchanged;
+      clic == clic_oic;
+    endsequence : seq_irq_req_unchanged
+
+    sequence seq_valid_irq_pending(s_clic);
+      clic_irq_bundle_t sampled_clic = s_clic;
+         sampled_clic.priv == M_MODE
+      && sampled_clic.level > mcause_fields.mpil
+      && sampled_clic.level > mintthresh_fields.th
+      && !sampled_clic.shv
+      && csr_instr.rd;
+    endsequence : seq_valid_irq_pending
+
+    property p_mnxti_case_1_irq_req_unchanged;
+      clic_irq_bundle_t sampled_clic;
+          (seq_irq_req_unchanged.triggered, sampled_clic = clic)
+        ##2
+            is_valid_mnxti_read && !irq_ack
+      |->
+            // Return pointer to current interrupt entry
+                (rvfi_rd_wdata == mtvt_fields + (clic_oic.id * 4))
+             && sampled_clic.priv == M_MODE
+             && sampled_clic.level > mcause_fields.mpil
+             && sampled_clic.level > mintthresh_fields.th
+             && !sampled_clic.shv
+             && csr_instr.rd
+      or
+        // Return 0 if not higher level, or shv, or previous mnxti updated the context such that the previous
+        // levels are no longer valid
+                rvfi_rd_wdata == 0
+             && !(sampled_clic.priv == M_MODE
+             && sampled_clic.level > mcause_fields.mpil
+             && sampled_clic.level > mintthresh_fields.th
+             && !sampled_clic.shv
+             && csr_instr.rd)
+      or
+                rvfi_trap.debug
+      or
+                rvfi_trap.exception
+      ;
+    endproperty : p_mnxti_case_1_irq_req_unchanged
+
+    a_mnxti_case_1_irq_req_unchanged: assert property (p_mnxti_case_1_irq_req_unchanged)
+    else
+      `uvm_error(info_tag,
+        $sformatf("No change on pending interrupt, mnxti incorrect result"));
+
+    // ------------------------------------------------------------------------
+    // mnxti should return the table entry for the new, higher level
+    // interrupt when this new interrupt has superceeded the initial
+    // interrupt.
+    // ------------------------------------------------------------------------
+
+    sequence seq_higher_lvl_nonshv_clic_taken;
+          clic.irq
+       && clic.level > mcause_fields.mpil
+       && clic.level > mintthresh_fields.th
+       && clic.priv == clic_oic.priv
+       && !clic.shv;
+    endsequence : seq_higher_lvl_nonshv_clic_taken
+
+    property p_mnxti_case_2_replaced_by_higher_level_non_shv_irq;
+      logic [SMCLIC_ID_WIDTH-1:0] sampled_clic_id;
+            (seq_higher_lvl_nonshv_clic_taken.triggered, sampled_clic_id = clic.id)
+        ##2
+            is_valid_mnxti_read
+      |->
+            // Return pointer to current interrupt entry
+            (rvfi_rd_wdata == mtvt_fields + (sampled_clic_id * 4))
+      or
+            // rvfi masks out reads that are written to x0
+            csr_instr.rd == X0
+         && rvfi_rd_wdata == 0
+      or
+            rvfi_trap.debug
+      or
+            rvfi_trap.exception;
+    endproperty : p_mnxti_case_2_replaced_by_higher_level_non_shv_irq
+
+
+    a_mnxti_case_2_replaced_by_higher_level_non_shv_irq: assert property (p_mnxti_case_2_replaced_by_higher_level_non_shv_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("interrupt replaced by higher level non-shv interrupt, mnxti incorrect result"));
+
+    // ------------------------------------------------------------------------
+    // mnxti should return the value of the lower leveled interrupt
+    // when the original interrupt is no longer present and the new
+    // interrupt has a level higher than the interrupted context
+    // already in clic
+    // ------------------------------------------------------------------------
+
+    sequence seq_lower_oic_no_longer_presesnt_lower_lvl_pending;
+          clic.irq
+       && clic.level > mcause_fields.mpil
+       && clic.level <= clic_oic.level
+       && clic.level > mintthresh_fields.th
+       && clic.priv == clic_oic.priv
+       && !clic.shv;
+    endsequence : seq_lower_oic_no_longer_presesnt_lower_lvl_pending
+
+    property p_mnxti_case_4_replaced_by_lower_level_irq;
+      logic [SMCLIC_ID_WIDTH-1:0] sampled_clic_id;
+        seq_higher_lvl_nonshv_clic_taken.triggered
+        ##2 is_valid_mnxti_write
+        ##1 (seq_lower_oic_no_longer_presesnt_lower_lvl_pending.triggered[->1], sampled_clic_id = clic.id)
+        ##2 is_valid_mnxti_read
+      |->
+        (rvfi_rd_wdata == mtvt_fields + (sampled_clic_id * 4))
+      or
+        csr_instr.rd  == X0
+        && rvfi_rd_wdata == 0
+      or
+        rvfi_trap.debug
+      or
+        rvfi_trap.exception;
+    endproperty : p_mnxti_case_4_replaced_by_lower_level_irq
+
+    a_mnxti_case_4_replaced_by_lower_level_irq: assert property (p_mnxti_case_4_replaced_by_lower_level_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("interrupt replaced by lower level interrupt, mnxti result incorrect"));
+
+    // ------------------------------------------------------------------------
+    // mnxti should read zero if the original interrupt is no longer asserted
+    // ------------------------------------------------------------------------
+
+    property p_mnxti_case_5_1_no_current_irq;
+          !clic.irq
+      ##2 is_valid_mnxti_read
+      |->
+          rvfi_rd_wdata == 32'h0000_0000;
+    endproperty : p_mnxti_case_5_1_no_current_irq
+
+    a_mnxti_case_5_1_no_current_irq : assert property (p_mnxti_case_5_1_no_current_irq)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mnxti should read zero when no irq is present"));
+
+    // ------------------------------------------------------------------------
+    // mnxti should read zero if the current pending interrupt has a
+    // level lower than mpil
+    // ------------------------------------------------------------------------
+
+    sequence seq_nonshv_lower_lvl_pending;
+           clic.irq
+       && !clic.shv
+       && (clic.level < mcause_fields.mpil);
+    endsequence : seq_nonshv_lower_lvl_pending
+
+    property p_mnxti_case_5_2_lvl_nonshv_pending;
+          seq_nonshv_lower_lvl_pending.triggered
+      ##2 is_valid_mnxti_read
+      |->
+          rvfi_rd_wdata == 32'h0000_0000;
+    endproperty : p_mnxti_case_5_2_lvl_nonshv_pending
+
+    a_mnxti_case_5_2_lvl_nonshv_pending : assert property (p_mnxti_case_5_2_lvl_nonshv_pending)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mnxti should read zero when irq is lower level and non-shv"));
+
+    // ------------------------------------------------------------------------
+    // mnxti should read zero if higher level shv interrupt has succeeded
+    // the initial interrerupt
+    // ------------------------------------------------------------------------
+
+    sequence seq_higher_lvl_shv_irq_pending;
+          clic.irq
+       && clic.shv
+       && clic.level > mintthresh_fields.th
+       && clic.level > mcause_fields.mpil;
+    endsequence : seq_higher_lvl_shv_irq_pending
+
+    property p_mnxti_case_6_higher_level_irq_superceed;
+          seq_higher_lvl_shv_irq_pending.triggered
+      ##2 is_valid_mnxti_read
+      |->
+          rvfi_rd_wdata == 32'h0000_0000;
+    endproperty : p_mnxti_case_6_higher_level_irq_superceed
+
+    a_mnxti_case_6_higher_level_irq_superceed: assert property (p_mnxti_case_6_higher_level_irq_superceed)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mnxti should read zero when a higher level shv interrupt is pending"));
+
+    // ------------------------------------------------------------------------
+    // mnxti CSR side effects on write
+    // ------------------------------------------------------------------------
+
+    sequence seq_pending_nonshv_irq;
+          clic.irq
+       && !clic.shv
+       && clic.level > mintthresh_fields.th
+       && clic.level > mcause_fields.mpil
+       && clic.priv == M_MODE;
+    endsequence : seq_pending_nonshv_irq
+
+    property p_mnxti_side_effects_on_write;
+      clic_irq_bundle_t sampled_clic;
+
+          (seq_pending_nonshv_irq.triggered, sampled_clic = clic)
+      ##2 is_valid_mnxti_write
+      |->
+          mintstatus_fields.mil         == sampled_clic.level
+          && mcause_fields.n.exccode_10_0 == sampled_clic.id
+          && mcause_fields.interrupt    == 1'b1
+      or
+          rvfi_trap.exception
+      or
+          rvfi_trap.debug;
+
+    endproperty : p_mnxti_side_effects_on_write
+
+    a_mnxti_side_effects_on_write: assert property (p_mnxti_side_effects_on_write)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Side effects on mnxti write wrong"));
+
+    property p_mnxti_no_side_effects_on_no_write;
+           !is_valid_mnxti_write
+        && is_mnxti_access_instr
+      |->
+           // no change unless trap (below)
+           $stable(mintstatus_fields)
+        && $stable(mcause_fields)
+      or
+           // mintstatus static if horizontal trap,
+           // mcause allowed to change
+           $stable(mintstatus_fields)
+        && rvfi_trap.exception
+        && rvfi_trap.trap
+       ##1
+           rvfi_valid[->1]
+       ##0
+           rvfi_intr.exception
+        && rvfi_intr.intr
+        && $stable(rvfi_mode)
+      or
+           // Clear mintstatus.mil for vertical traps
+           // mcause allowed to change
+            mintstatus_fields.mil == 'h0
+         && rvfi_trap.exception
+         && rvfi_trap.trap
+        ##1
+            rvfi_valid[->1]
+        ##0
+            rvfi_intr.exception
+         && rvfi_intr.intr
+         && $changed(rvfi_mode)
+      or
+        // NMI
+            //$stable(mintstatus_fields) // FIXME reintroduce to not overconstrain
+        ##1 rvfi_valid[->1]
+        ##0 rvfi_intr.interrupt
+        &&  rvfi_intr.cause >= 'h400
+      ;
+    endproperty :  p_mnxti_no_side_effects_on_no_write
+
+    a_mnxti_no_side_effects_on_no_write: assert property (p_mnxti_no_side_effects_on_no_write)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Should be no side effects on no mnxti write"));
+
+    // ------------------------------------------------------------------------
+    // Mintstatus should be updated on ISR handler entry
+    // ------------------------------------------------------------------------
+
+    property p_mintstatus_updated_on_isr_handler_entry;
+            clic.irq
+        ##1 irq_ack
+        |=>
+            mintstatus_fields.mil == clic_oic.level &&
+            mintstatus_fields.sil == 8'h00 &&
+            mintstatus_fields.uil == 8'h00;
+    endproperty : p_mintstatus_updated_on_isr_handler_entry
+
+    a_mintstatus_updated_on_isr_handler_entry: assert property(p_mintstatus_updated_on_isr_handler_entry)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Minstatus mismatch, read 0x%08h",
+          mintstatus_fields));
+
+    // ------------------------------------------------------------------------
+    // Minhv should be set when an shv interrupt is taken
+    // ------------------------------------------------------------------------
+
+    property p_mcause_minhv_set_at_hw_vectoring_start;
+          clic.shv
+      ##1 irq_ack
+        |=>
+          mcause_fields.minhv;
+    endproperty : p_mcause_minhv_set_at_hw_vectoring_start
+
+    a_mcause_minhv_set_at_hw_vectoring_start: assert property (p_mcause_minhv_set_at_hw_vectoring_start)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mcause.minhv not set at hw vectored ISR entry"));
+
+    // ------------------------------------------------------------------------
+    // Minhv should be cleared on successful pointer fetch
+    // ------------------------------------------------------------------------
+
+    property p_mcause_minhv_cleared_at_hw_vectoring_end;
+      $rose(mcause_fields.minhv)
+      && !(csr_instr.csr == MCAUSE)
+        |=>
+          rvfi_valid[->1]
+      ##0 mcause_fields.minhv == 1'b0
+      or
+          // minhv set by write to mcause
+          rvfi_valid[->1]
+      ##0 is_mcause_access_instr
+       && is_csr_write
+       && rvfi_rs1_rdata[30] == 1'b1
+      or
+          // vectored address failed
+          rvfi_valid[->1]
+      ##0 is_invalid_instr_word
+      ;
+    endproperty : p_mcause_minhv_cleared_at_hw_vectoring_end
+
+    a_mcause_minhv_cleared_at_hw_vectoring_end: assert property (p_mcause_minhv_cleared_at_hw_vectoring_end)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mcause.minhv not cleared at hw vectored fetch")
+      );
+
+    property p_mcause_minhv_not_cleared_at_hw_vectoring_failed;
+          $rose(mcause_fields.minhv)
+       && !(csr_instr.csr == MCAUSE)
+      ##1 rvfi_valid[->1]
+      ##0 is_invalid_instr_word
+        |->
+      mcause_fields.minhv == 1'b1
+      ;
+    endproperty : p_mcause_minhv_not_cleared_at_hw_vectoring_failed
+
+    a_mcause_minhv_not_cleared_at_hw_vectoring_failed: assert property (p_mcause_minhv_not_cleared_at_hw_vectoring_failed)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mcause.minhv should not have been cleared")
+      );
+    // ------------------------------------------------------------------------
+    // Cover: minhv cleared at hw vectoring end (successful pointer fetch)
+    // ------------------------------------------------------------------------
+
+    property cp_mcause_minhv_cleared_at_hw_vectoring_end;
+      strong(
+          $rose(mcause_fields.minhv)
+          && !(csr_instr.csr == MCAUSE)
+          ##1 $fell(mcause_fields.minhv)[->1]
+        and
+          1 ##1 rvfi_valid[->1]
+      );
+    endproperty : cp_mcause_minhv_cleared_at_hw_vectoring_end
+
+    cov_mcause_minhv_cleared_at_hw_vectoring_end: cover property(cp_mcause_minhv_cleared_at_hw_vectoring_end);
+
+    // ------------------------------------------------------------------------
+    // No prefetches between pointer fetch and final target
+    // ------------------------------------------------------------------------
+
+    property p_no_prefetches_between_ptr_fetch_and_final_target;
+      clic.shv
+      ##1 irq_ack
+      ##1 mcause_fields.minhv
+      && !(csr_instr.csr == MCAUSE)
+        |=>
+      (obi_instr_req && obi_instr_gnt)[->1]
+      ##0 $fell(mcause_fields.minhv)[->1];
+    endproperty : p_no_prefetches_between_ptr_fetch_and_final_target
+
+    a_no_prefetches_between_ptr_fetch_and_final_target: assert property (p_no_prefetches_between_ptr_fetch_and_final_target)
+    else
+      `uvm_error(info_tag,
+        $sformatf("There should be no prefeches between ptr fetch and final target"));
+
+    // ------------------------------------------------------------------------
+    // Cover: No prefetches between pointer fetch and final target
+    // ------------------------------------------------------------------------
+
+    property cp_no_prefetches_between_ptr_fetch_and_final_target;
+      reject_on(core_in_debug)
+      clic.shv
+      ##1 irq_ack
+      ##1 mcause_fields.minhv
+        && !(csr_instr.csr == MCAUSE)
+      #=#
+      (obi_instr_req && obi_instr_gnt)[->1]
+      ##0 $fell(mcause_fields.minhv)[->1];
+    endproperty : cp_no_prefetches_between_ptr_fetch_and_final_target
+
+    cov_no_prefetches_between_ptr_fetch_and_final_target: cover property (cp_no_prefetches_between_ptr_fetch_and_final_target);
+
+    // ------------------------------------------------------------------------
+    // PC should be set to the address fetched from the mtvt pointer after
+    // taking an shv interrupt
+    // ------------------------------------------------------------------------
+
+    logic incr_obi;
+    logic decr_obi;
+    assign incr_obi =   obi_instr_req && obi_instr_gnt && !obi_instr_rvalid;
+    assign decr_obi = !(obi_instr_req && obi_instr_gnt) && obi_instr_rvalid && (obi_in_flight > 0);
+
+    always @* begin
+      if (!rst_ni) begin
+        obi_in_flight_n <= 0;
+      end else begin
+        obi_in_flight_n <= obi_in_flight - decr_obi + incr_obi;
+      end
+    end
+
+    always @(posedge clk_i) begin
+      if (!rst_ni) begin
+        obi_in_flight <= 0;
+      end else begin
+        obi_in_flight <= obi_in_flight + incr_obi - decr_obi;
+      end
+    end
+
+    property p_pc_to_mtvt_for_taken_shv_interrupt;
+      logic [31:0] pointer_value = '0;
+      logic [31:0] pointer_addr = '0;
+      accept_on(
+           is_load_bus_fault
+        || is_store_bus_fault
+        || is_instr_access_fault
+        || (rvfi_trap.exception == 1)
+        || core_in_debug
+        || obi_instr_err
+      )
+      clic.irq && clic.shv
+      ##1 irq_ack
+      ##1 ((!mcause_fields.minhv)[->1],
+           pointer_value = $past(obi_instr_rdata, 2),
+           pointer_addr  = $past(obi_instr_addr,  1))
+      |->
+          rvfi_valid[->1]
+      ##0 rvfi_pc_rdata       == (pointer_value & ~1)
+       && rvfi_pc_rdata[31:2] == (pointer_addr[31:2])
+      or
+          rvfi_valid[->1]
+      ##0 is_cause_nmi // nmi-address verified in nmi-related assertions
+      or
+      // TODO: This should catch traps from shv-failures, but does not atm. pending rtl updates
+          rvfi_valid[->1]
+      ##0 is_invalid_instr_word
+       && rvfi_pc_rdata       == { $past(mtvec[31:7]), 7'h0 }
+      or
+          rvfi_valid[->1]
+      ##0 is_intr_exception
+       && rvfi_intr.cause == INSTR_ACCESS_FAULT
+      ;
+
+    endproperty : p_pc_to_mtvt_for_taken_shv_interrupt
+
+    a_pc_to_mtvt_for_taken_shv_interrupt: assert property (p_pc_to_mtvt_for_taken_shv_interrupt)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Pc should be at mtvt after taking an shv interrupt"));
+
+    // ------------------------------------------------------------------------
+    // PC should be set to mtvec for taken non-shv interrupt
+    // ------------------------------------------------------------------------
+
+    property p_pc_to_mtvec_for_taken_nonshv_interrupt;
+            clic.irq
+        &&  !clic.shv
+        ##1 irq_ack
+      |=>
+            // Need to use past here to avoid the case where mtvec is updated simultaneously
+            rvfi_valid[->1]
+        ##0 rvfi_pc_rdata[31:7] == $past(mtvec[31:7])
+      or
+            // Nmi, correct pc covered in a_nmi_to_mtvec_fifthteenth_entry
+            rvfi_valid[->1]
+        ##0 is_cause_nmi
+      or
+            rvfi_valid[->1]
+        ##0 is_instr_access_fault
+      or
+            rvfi_valid[->1]
+       ##0  rvfi_dbg_mode
+      ;
+    endproperty : p_pc_to_mtvec_for_taken_nonshv_interrupt
+
+    a_pc_to_mtvec_for_taken_nonshv_interrupt: assert property (p_pc_to_mtvec_for_taken_nonshv_interrupt)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Pc should be at mtvec after taking a non-shv interrupt"));
+
+    // ------------------------------------------------------------------------
+    // Correct alignment of the taken non-shv interrupt address
+    // ------------------------------------------------------------------------
+
+    property p_pc_alignment_of_taken_non_shv_interrupt;
+            irq_ack
+        &&  !clic_core.shv
+      |=>
+            // Exceptions/interrupts should jump to base address,
+            // and base addr. should be aligned
+            rvfi_valid[->1]
+        ##0 rvfi_pc_rdata[6:0] == 7'b000_0000
+         && !is_cause_nmi
+      or
+            rvfi_valid[->1]
+        ##0 is_cause_nmi
+         && rvfi_pc_rdata[6:0] == NMI_OFFSET // == all zeros + NMI_OFFSET in table
+      or
+            rvfi_valid[->1]
+        ##0 rvfi_dbg_mode
+      ;
+    endproperty : p_pc_alignment_of_taken_non_shv_interrupt
+
+    a_pc_alignment_of_taken_non_shv_interrupt: assert property (p_pc_alignment_of_taken_non_shv_interrupt)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Non-shv interrupt taken should have a PC aligned with bits 6:0 = 0"));
+
+    // ------------------------------------------------------------------------
+    // Interrupt taken if, and only if the following matches:
+    // ------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
+    // Higher level than mintthresh.th interrupts can preempt
+    // ------------------------------------------------------------------------
+    property p_higher_lvl_than_mintthresh_th_can_preempt;
+            clic.irq
+        ##1 ($past(clic.priv) == current_priv_mode)
+        &&  ($past(clic.level) > effective_clic_level)
+        &&  mstatus_fields.mie
+        &&  is_interrupt_allowed == 1'b1
+      |->
+            irq_ack
+      or
+            rvfi_valid[->1:2]
+        ##0 rvfi_dbg_mode
+      or
+            rvfi_valid[->1:2]
+        ##0 rvfi_intr.exception
+      or
+            rvfi_valid[->1:2]
+        ##0 rvfi_trap.exception
+      or
+            rvfi_valid[->1:2]
+        ##0 is_cause_nmi
+      ;
+    endproperty : p_higher_lvl_than_mintthresh_th_can_preempt
+
+    a_higher_lvl_than_mintthresh_th_can_preempt: assert property(p_higher_lvl_than_mintthresh_th_can_preempt)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Higher level than mintthresh should be able to interrupt"));
+
+    // ------------------------------------------------------------------------
+    // Lower level than mintthresh.th interrupts cannot preempt
+    // ------------------------------------------------------------------------
+    property p_lower_lvl_than_mintthresh_th_cannot_preempt;
+          clic.irq
+      ##1 $past(clic.level) < mintthresh_fields.th
+      &&  $past(clic.priv) == current_priv_mode
+      |->
+          !irq_ack;
+    endproperty : p_lower_lvl_than_mintthresh_th_cannot_preempt
+
+    a_lower_lvl_than_mintthresh_th_cannot_preempt: assert property (p_lower_lvl_than_mintthresh_th_cannot_preempt)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Lower than mintthresh.th level interrupts should not preempt"));
+
+    // ------------------------------------------------------------------------
+    // WFI wakeup required
+    // ------------------------------------------------------------------------
+    property p_wfi_wakeup_condition_valid;
+      clic_irq_bundle_t sampled_clic;
+      logic [7:0]       sampled_level;
+      priv_mode_t       sampled_priv;
+      core_sleep_o ##1 // first cycle $fell will fail out of reset
+            ($fell(core_sleep_o),
+              sampled_clic = clic,
+              sampled_priv = priv_mode_t'(current_priv_mode),
+              sampled_level = effective_clic_level)
+        ##1 rvfi_valid[->1]
+      |->
+            sampled_clic.irq
+         && sampled_clic.priv  == sampled_priv
+         && sampled_clic.level > sampled_level
+      or
+            sampled_clic.irq
+         && sampled_clic.priv  > sampled_priv
+         && sampled_clic.level > 0
+      or
+        ##1 rvfi_valid[->1]
+        ##0 rvfi_dbg_mode == 1'b1
+      ;
+    endproperty : p_wfi_wakeup_condition_valid
+
+    a_wfi_wakeup_condition_valid: assert property (p_wfi_wakeup_condition_valid)
+    else
+      `uvm_error(info_tag,
+        $sformatf("core should have woken up"));
+
+    // ------------------------------------------------------------------------
+    // WFI wakeup forbidden
+    // ------------------------------------------------------------------------
+    property p_wfi_wakeup_condition_not_valid;
+        core_sleep_o
+      ##1
+       !((  clic.irq
+         && clic.priv  == priv_mode_t'(current_priv_mode)
+         && clic.level > effective_clic_level)
+       ||
+        (   clic.irq
+         && clic.priv  > priv_mode_t'(current_priv_mode)
+         && clic.level > 0))
+      |->
+        $stable(core_sleep_o)
+      or
+            !core_sleep_o
+        ##0 rvfi_valid[->2]
+        ##0 rvfi_dbg_mode
+      ;
+    endproperty : p_wfi_wakeup_condition_not_valid
+
+    a_wfi_wakeup_condition_not_valid: assert property (p_wfi_wakeup_condition_not_valid)
+    else
+      `uvm_error(info_tag,
+        $sformatf("core should not have woken up"));
+
+    // ------------------------------------------------------------------------
+    // WFI entry causes core to stop
+    // ------------------------------------------------------------------------
+    property p_wfi_causes_core_to_stop;
+      core_sleep_o
+      |->
+        !rvfi_valid
+      ;
+    endproperty : p_wfi_causes_core_to_stop
+
+    a_wfi_causes_core_to_stop: assert property (p_wfi_causes_core_to_stop)
+    else
+      `uvm_error(info_tag,
+        $sformatf("core should not execute anything in wfi"));
+
+    // ------------------------------------------------------------------------
+    // WFI entry causes core clock to be gated
+    // ------------------------------------------------------------------------
+    property p_wfi_causes_clock_gating;
+      core_sleep_o
+      |->
+        $stable(clk)
+      ;
+    endproperty : p_wfi_causes_clock_gating
+
+    a_wfi_causes_clock_gating: assert property (p_wfi_causes_clock_gating)
+    else
+      `uvm_error(info_tag,
+        $sformatf("core clk should be gated in wfi"));
+
+    // ------------------------------------------------------------------------
+    // WFI: core_sleep_o only asserted during wfi
+    // ------------------------------------------------------------------------
+    property p_core_sleep_o_only_during_wfi;
+      core_sleep_o
+      |->
+            rvfi_valid[->1]
+        ##0 is_insn(rvfi_insn, WFI)
+      ;
+    endproperty : p_core_sleep_o_only_during_wfi
+
+    a_core_sleep_o_only_during_wfi: assert property (p_core_sleep_o_only_during_wfi)
+    else
+      `uvm_error(info_tag,
+        $sformatf("core_sleep_o should only be asserted during wfi"));
+
+    // ------------------------------------------------------------------------
+    // Correct state of core after mret
+    // Regular execution (excludes debug, exceptions etc...)
+    // ------------------------------------------------------------------------
+
+    logic irq_ack_occurred_between_valid;
+    logic minhv_high_between_valid;
+
+    always @(posedge clk) begin
+      if (!rst_ni || (rvfi_valid && !irq_ack)) begin
+        irq_ack_occurred_between_valid <= 1'b0;
+      end else begin
+        irq_ack_occurred_between_valid <= irq_ack_occurred_between_valid ? 1'b1 : irq_ack;
+      end
+    end
+
+    always @(posedge clk) begin
+      if (!rst_ni || rvfi_valid && !mcause_fields.minhv) begin
+        minhv_high_between_valid <= 1'b0;
+      end else begin
+        minhv_high_between_valid <= minhv_high_between_valid ? 1'b1 : mcause_fields.minhv;
+      end
+    end
+
+    property p_irq_ack_occurred_zero_out_of_reset;
+        !fetch_enable |-> irq_ack_occurred_between_valid == 1'b0;
+    endproperty : p_irq_ack_occurred_zero_out_of_reset
+
+
+    property p_execution_state_after_mret;
+      logic [1:0] sampled_mpp;
+      logic [31:0] sampled_pc_wdata;
+      logic sampled_irq_occurred;
+
+          // last cycle after mret, before new rvfi_valid
+          (rvfi_valid && is_last_mret_insn,
+           sampled_pc_wdata = rvfi_pc_wdata)
+       ##1 rvfi_valid[->1]
+      |->
+           // 1. Standard behavior
+           rvfi_pc_rdata == mepc_fields
+      or
+           // irq taken, mepc not written by retiring instruction
+           // address checked by mtvec/mtvt assertions
+           irq_ack_occurred_between_valid
+        && !(is_csr_write  == 1'b1
+        && is_mepc_access_instr == 1'b1)
+      or
+           // minhv bit set - no way to check destination address here.
+           minhv_high_between_valid
+      or
+           // irq taken, handler rewrites mepc
+           // only check mepc update, irq dest. addr checked by respective assertions
+           irq_ack_occurred_between_valid
+        && mepc_fields == rvfi_mepc_wdata & rvfi_mepc_wmask
+        && is_csr_write  == 1'b1
+        && is_mepc_access_instr == 1'b1
+      or
+           // debug gets taken, write effects of instruction on rvfi_valid should have no effect,
+           // but there might be an instruction fault
+           rvfi_dbg_mode == 1'b1
+        && rvfi_pc_rdata == { debug_halt_addr[31:2], 2'b00 }
+        && is_trap_exception
+      or
+           // Trap to debug and take exception
+           rvfi_dbg_mode == 1'b1
+        && rvfi_pc_rdata == { debug_exc_addr[31:2], 2'b00 }
+        && is_intr_exception
+      or
+           // Trap to debug and take ecall/ebreak
+           rvfi_dbg_mode == 1'b1
+        && rvfi_pc_rdata == { debug_halt_addr[31:2], 2'b00 }
+        && is_intr_ecall_ebreak
+
+      or
+           // Trap to debug
+           rvfi_dbg_mode == 1'b1
+        && rvfi_pc_rdata == { debug_halt_addr[31:2], 2'b00 }
+        && !is_intr_exception
+        && !is_trap_exception
+      or
+           // Write to mepc, need to check past mepc
+           !irq_ack_occurred_between_valid
+        && rvfi_pc_rdata == $past(mepc_fields)
+        && is_csr_write  == 1'b1
+        && is_mepc_access_instr == 1'b1
+      or
+           // nmi
+           rvfi_pc_rdata == { mtvec_fields[31:2], 2'b00 } + NMI_OFFSET
+        && is_cause_nmi  == 1'b1
+      or
+           // nmi with retired write to mtvec
+           rvfi_pc_rdata == { $past(mtvec_fields[31:2]), 2'b00 } + NMI_OFFSET
+        && is_cause_nmi  == 1'b1
+      ;
+       // TODO add mpil, mpie
+    endproperty : p_execution_state_after_mret
+
+    a_execution_state_after_mret: assert property (p_execution_state_after_mret)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mret result state incorrect"));
+
+    // ------------------------------------------------------------------------
+    // clic level should be the larger of mintthresh_th and prev. taken irq
+    // ------------------------------------------------------------------------
+    uncompressed_instr_t last_valid_instr;
+    csr_instr_t          last_valid_instr_csr;
+
+    // Formal tools generate warnings for latch behavior in assign statements, use explicit always_latch here
+    always_latch begin
+      last_valid_instr = rvfi_valid ? uncompressed_instr_t'(rvfi_insn) : last_valid_instr;
+    end
+
+    assign last_valid_instr_csr = csr_instr_t'(last_valid_instr);
+
+    logic is_last_mret_insn;
+    logic is_last_dret_insn;
+
+    property p_last_valid_instr_reset_state;
+        !fetch_enable |-> last_valid_instr == 'h0;
+    endproperty : p_last_valid_instr_reset_state
+
+    // Keep track of last retired instruction type
+    assign is_last_mret_insn   = is_insn(last_valid_instr, MRET);
+    assign is_last_dret_insn   = is_insn(last_valid_instr, DRET);
+
+    function logic[7:0] max_level(logic[7:0] a, logic[7:0] b);
+      max_level = a > b ? a : b;
+    endfunction : max_level
+
+    property p_clic_core_level_max_prev_irq_mintthresh_th;
+      // Evaluates to true false on second cycle, thus the duality of
+      // $past and present statements below. TODO: possible to simplify without leaving holes?
+      1 ##1 // out of reset fix
+      $changed(mintstatus_fields.mil)
+      |->
+          // first cycle ack, no mret, mpp machine mode
+          $past(irq_ack)
+       && !$past(is_mret_insn)
+       && $past(mcause_fields.mpp) == M_MODE
+       && mintstatus_fields.mil == clic_oic.level
+       && clic_oic.level > max_level($past(mintthresh_fields.th), $past(mintstatus_fields.mil))
+      or
+         // first cycle ack, no mret, mpp user mode
+          $past(irq_ack)
+       && !$past(is_mret_insn)
+       && $past(mcause_fields.mpp) == U_MODE
+       && mintstatus_fields.mil == clic_oic.level
+       && clic_oic.level > 0
+      or
+         // first cycle ack, no mret
+         // mret sets mil to mpil, but at next rvfi_valid this is replaced by
+         // the il of the taken interrupt
+          $past(irq_ack)
+       && $past(is_mret_insn)
+       && mintstatus_fields.mil == mcause_fields.mpil
+      ##1 mintstatus_fields.mil == clic_oic.level
+      or
+         // first cycle ack and mnxti write
+         // mnxti updated mil with pending interrupt
+         $past(irq_ack)
+      && $past(is_valid_mnxti_write)
+      && mintstatus_fields.mil == $past(clic.level, 3)
+      ##1 mintstatus_fields.mil == clic_oic.level
+       && clic_oic.level > max_level($past(mintthresh_fields.th), $past(mintstatus_fields.mil))
+      or
+          // first cycle ack, mret, mpp user mode
+          $past(irq_ack)
+       && $past(is_mret_insn)
+       && $past(mcause_fields.mpp) == U_MODE
+       && $past(mintstatus_fields.mil) == $past(mcause_fields.mpil)
+      ##1 mintstatus_fields.mil > 0
+       && clic_oic.level == mintstatus_fields.mil
+      or
+         // no taken interrupt and mret
+         // mret updates mil to mpil
+          !$past(irq_ack)
+       && $past(is_mret_insn)
+       && mintstatus_fields.mil == mcause_fields.mpil
+      or
+          // no taken interrupt but mnxti updated mil with pending interrupt
+          is_valid_mnxti_write
+       && mintstatus_fields.mil == $past(clic.level, 2)
+      or
+          // last instruction before taken interrupt is dret, with prv set to user mode
+          // vertical interrupt handling
+          (is_last_dret_insn || $past(is_dret_insn))
+       && $past(irq_ack)
+       && $past(dcsr_fields.prv) == U_MODE
+      ##1 mintstatus_fields.mil > 0
+       && clic_oic.level == mintstatus_fields.mil
+      or
+          // last instruction before taken interrupt is dret, with prv set to machine mode
+          // horizontal interrupt handling
+          (is_last_dret_insn || $past(is_dret_insn))
+       && $past(irq_ack)
+       && $past(dcsr_fields.prv) == M_MODE
+      ##1 clic_oic.level > max_level($past(mintthresh_fields.th), $past(mintstatus_fields.mil))
+       && clic_oic.level == mintstatus_fields.mil
+      or
+          // pure mret, no irq, no prior back to back instruction in wb
+          is_mret_insn
+       && !irq_ack
+       && mintstatus_fields.mil == mcause_fields.mpil
+      or
+           // mret retire immediately prior to ack, with mpp machine mode
+           irq_ack
+       &&  is_mret_insn
+       &&  mcause_fields.mpp == M_MODE
+       &&  mintstatus_fields.mil == mcause_fields.mpil
+      ##1  mintstatus_fields.mil == clic_oic.level
+       &&  clic_oic.level > max_level($past(mintthresh_fields.th), $past(mintstatus_fields.mil))
+      or
+           // mret retire immediately prior to ack, with mpp user mode
+           irq_ack
+       &&  is_mret_insn
+       &&  mcause_fields.mpp == U_MODE
+       &&  mintstatus_fields.mil == mcause_fields.mpil
+      ##1  mintstatus_fields.mil == clic_oic.level
+       &&  clic_oic.level > 0
+      or
+          // something wrong happened and instruction trapped
+          rvfi_valid[->1]
+      ##0 rvfi_trap
+      or
+          // nmi occurred
+          rvfi_valid[->1]
+      ##0 is_cause_nmi
+      ;
+    endproperty : p_clic_core_level_max_prev_irq_mintthresh_th
+
+    a_clic_core_level_max_prev_irq_mintthresh_th: assert property (p_clic_core_level_max_prev_irq_mintthresh_th)
+    else
+      `uvm_error(info_tag,
+        $sformatf("internal clic level error"));
+
+    // ------------------------------------------------------------------------
+    // Horizontal exception handling
+    // ------------------------------------------------------------------------
+
+    property p_horizontal_exception_service;
+            rvfi_mode == M_MODE
+         && rvfi_valid
+         && rvfi_trap.exception
+      |->
+        ##0 $stable(current_priv_mode,     @(posedge clk_i))
+         && $stable(mintstatus_fields.mil, @(posedge clk_i))
+      until_with rvfi_valid[->1];
+    endproperty : p_horizontal_exception_service
+
+    property p_stable_mode_lvl;
+      $stable(current_priv_mode) && $stable(mintstatus_fields.mil);
+    endproperty : p_stable_mode_lvl
+
+    a_horizontal_exception_service: assert property (p_horizontal_exception_service)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Horizontal exception service not handled correctly"));
+
+    // ------------------------------------------------------------------------
+    // Vertical exception handling
+    // ------------------------------------------------------------------------
+
+    property p_vertical_exception_service;
+            rvfi_valid
+        &&  rvfi_trap.exception
+        &&  rvfi_mode == U_MODE
+      |=>
+            // regular case
+            rvfi_valid[->1]
+        ##0 mintstatus_fields.mil == 0
+        &&  rvfi_mode == M_MODE
+      or
+            // mnxti overwriting expected mil, checked in mnxti assertions
+            rvfi_valid[->1]
+        ##0 is_mnxti_access_instr
+        &&  rvfi_mode == M_MODE
+      or
+            // first handler instruction is mret, level should not be changed
+            rvfi_valid[->1]
+        ##0 is_mret_insn
+        &&  rvfi_mode == M_MODE
+        &&  $stable(mintstatus_fields.mil)  // FIXME: Known issue, leaving comment to avoid debugging until fixed
+      ;
+    endproperty : p_vertical_exception_service
+
+    a_vertical_exception_service: assert property (p_vertical_exception_service)
+    else
+      `uvm_error(info_tag,
+        $sformatf("Vertical exception service not handled correctly"));
+
+    // ------------------------------------------------------------------------
+    // MEPC lsb should always be 0
+    // ------------------------------------------------------------------------
+    property p_mepc_lsb_always_zero;
+      mepc_fields.reserved == 1'b0;
+    endproperty : p_mepc_lsb_always_zero;
+
+    a_mepc_lsb_always_zero: assert property (p_mepc_lsb_always_zero)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mepc[0] should always be zero"));
+
+    // ------------------------------------------------------------------------
+    // Checks correct behavior of accesses to mscratchcsw
+    // ------------------------------------------------------------------------
+    // FIXME: Fails for undefined CSR instructions (needs defined behavior)
+    property p_mscratchcsw_value;
+           is_mscratchcsw_access_instr
+        && csr_instr.funct3    == CSRRW
+        && csr_instr.rd        != X0
+        && csr_instr.n.rs1     != X0
+      |->
+           rvfi_rd_wdata       == (csr_instr.rd != X0 ? rvfi_mscratch_rdata : 'b0)
+        && rvfi_mscratch_wdata == rvfi_rs1_rdata
+        && mstatus_fields.mpp  != rvfi_mode
+      or
+           rvfi_rd_wdata       == rvfi_rs1_rdata
+        && rvfi_mscratch_wmask == 'h0
+        && mstatus_fields.mpp  == rvfi_mode
+      or
+           rvfi_trap.exception
+      or
+           rvfi_trap.debug
+      ;
+    endproperty : p_mscratchcsw_value
+
+    a_mscratchcsw_value: assert property (p_mscratchcsw_value)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mscratchcsw value not as expected"));
+
+    // ------------------------------------------------------------------------
+    // Checks correct behavior of accesses to mscratchcswl
+    // ------------------------------------------------------------------------
+    // FIXME: Fails for undefined CSR instructions (needs defined behavior)
+    property p_mscratchcswl_value;
+           is_mscratchcswl_access_instr
+        && csr_instr.funct3    == CSRRW
+        && csr_instr.rd        != X0
+        && csr_instr.n.rs1     != X0
+      |->
+           rvfi_rd_wdata       == (csr_instr.rd != X0 ? rvfi_mscratch_rdata : 'b0)
+        && rvfi_mscratch_wdata == rvfi_rs1_rdata
+        && |mcause_fields.mpil  ^ |mintstatus_fields.mil
+      or
+           rvfi_rd_wdata       == rvfi_rs1_rdata
+        && rvfi_mscratch_wmask == 'h0
+        && |mcause_fields.mpil ^~ |mintstatus_fields.mil
+      or
+           rvfi_trap.exception
+      or
+           rvfi_trap.debug
+      ;
+    endproperty : p_mscratchcswl_value
+
+    a_mscratchcswl_value: assert property (p_mscratchcswl_value)
+    else
+      `uvm_error(info_tag,
+        $sformatf("mscratchcswl value not as expected"));
+
+    // ------------------------------------------------------------------------
+    // Formal verification constraints
+    // Gated due to some simulators not ignoring restrict keyword
+    // ------------------------------------------------------------------------
+
+    `ifdef FORMAL
+      r_fetch_enable_stable:                   restrict property (fetch_enable |-> $stable(mtvec_addr_i));
+      r_clic_mode_assume:                      restrict property (p_clic_mode_only);
+      r_irq_i:                                 restrict property (irq_i == 0);
+      r_mtvt_table_read_equals_value_written:  restrict property (p_mtvt_table_read_equals_value_written);
+      // Limit data and instr stalls for formal convergence, consider removing when assertion set matures
+      r_instr_load_stalls:                     restrict property (p_obi_instr_max_load_stalls);
+      r_data_load_stalls:                      restrict property (p_obi_data_max_load_stalls);
+      r_instr_valid_delay:                     restrict property (p_instr_valid_delay);
+      // prevents undefined latch value out of reset in formal
+      r_last_valid_init_state:                 restrict property (p_last_valid_instr_reset_state);
+      r_irq_ack_occurred_zero_out_of_of_reset: restrict property (p_irq_ack_occurred_zero_out_of_reset);
+      c_mtvt_table_read_equals_value_written:  cover property (p_mtvt_table_read_equals_value_written);
+    `endif
+
+  end
+
+  endgenerate
+endmodule : uvmt_cv32e40s_clic_interrupt_assert
+

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -19,9 +19,9 @@
 `define __UVMT_CV32E40S_CONSTANTS_SV__
 
    `ifdef SMCLIC_EN
-      parameter int SMCLIC = 1;
+      parameter int CORE_PARAM_SMCLIC = 1;
    `else
-      parameter int SMCLIC = 0;
+      parameter int CORE_PARAM_SMCLIC = 0;
    `endif
    // Add various clic configurations
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -18,6 +18,13 @@
 `ifndef __UVMT_CV32E40S_CONSTANTS_SV__
 `define __UVMT_CV32E40S_CONSTANTS_SV__
 
+   `ifdef SMCLIC_EN
+      parameter int SMCLIC = 1;
+   `else
+      parameter int SMCLIC = 0;
+   `endif
+   // Add various clic configurations
+
    `ifdef ZBA_ZBB_ZBS
       parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBS;
    `elsif ZBA_ZBB_ZBC_ZBS

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -41,13 +41,14 @@
  */
 module uvmt_cv32e40s_dut_wrap
   import cv32e40s_pkg::*;
-
-  #(// DUT (riscv_core) parameters.
+#(// DUT (riscv_core) parameters.
     parameter cv32e40s_pkg::b_ext_e B_EXT  = cv32e40s_pkg::B_NONE,
     parameter int          PMA_NUM_REGIONS =  0,
     parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1 : 0] = '{default:PMA_R_DEFAULT},
     parameter int          PMP_NUM_REGIONS = 0,
     parameter int          PMP_GRANULARITY = 0,
+    parameter logic        SMCLIC = 0,
+    parameter int          SMCLIC_ID_WIDTH = 5,
     // Remaining parameters are used by TB components only
               INSTR_ADDR_WIDTH    =  32,
               INSTR_RDATA_WIDTH   =  32,
@@ -56,6 +57,7 @@ module uvmt_cv32e40s_dut_wrap
   (
     uvma_clknrst_if              clknrst_if,
     uvma_interrupt_if            interrupt_if,
+    uvma_clic_if                 clic_if,
     uvmt_cv32e40s_vp_status_if   vp_status_if,
     uvme_cv32e40s_core_cntrl_if  core_cntrl_if,
     uvmt_cv32e40s_core_status_if core_status_if,
@@ -118,10 +120,15 @@ module uvmt_cv32e40s_dut_wrap
 
     // --------------------------------------------
     // Connect to uvma_interrupt_if
-    assign interrupt_if.clk                     = clknrst_if.clk;
-    assign interrupt_if.reset_n                 = clknrst_if.reset_n;
-    assign interrupt_if.irq_id                  = cv32e40s_wrapper_i.core_i.irq_id;
-    assign interrupt_if.irq_ack                 = cv32e40s_wrapper_i.core_i.irq_ack;
+    assign interrupt_if.clk         = clknrst_if.clk;
+    assign interrupt_if.reset_n     = clknrst_if.reset_n;
+    assign interrupt_if.irq_id      = cv32e40s_wrapper_i.core_i.irq_id;
+    assign interrupt_if.irq_ack     = cv32e40s_wrapper_i.core_i.irq_ack;
+
+    // --------------------------------------------
+    assign clic_if.clk              = clknrst_if.clk;
+    assign clic_if.reset_n          = clknrst_if.reset_n;
+    assign clic_if.irq_ack          = cv32e40s_wrapper_i.core_i.irq_ack;
 
     // --------------------------------------------
     // Connect to core_cntrl_if
@@ -182,7 +189,8 @@ assign rchk_lsu = {
                       .PMA_NUM_REGIONS  (PMA_NUM_REGIONS),
                       .PMA_CFG          (PMA_CFG),
                       .PMP_GRANULARITY  (PMP_GRANULARITY),
-                      .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+                      .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+                      .SMCLIC           (SMCLIC)
                       )
     cv32e40s_wrapper_i
         (
@@ -235,11 +243,11 @@ assign rchk_lsu = {
 
          .irq_i                  ( interrupt_if.irq               ),
          .wu_wfe_i               ( 1'b0                           ), // todo: hook up
-         .clic_irq_i             ( '0   /*todo: connect */        ),
-         .clic_irq_id_i          ( '0   /*todo: connect */        ),
-         .clic_irq_level_i       ( '0   /*todo: connect */        ),
-         .clic_irq_priv_i        ( '0   /*todo: connect */        ),
-         .clic_irq_shv_i         ( '0   /*todo: connect */        ),
+         .clic_irq_i             ( clic_if.clic_irq               ),
+         .clic_irq_id_i          ( clic_if.clic_irq_id            ),
+         .clic_irq_level_i       ( clic_if.clic_irq_level         ),
+         .clic_irq_priv_i        ( clic_if.clic_irq_priv          ),
+         .clic_irq_shv_i         ( clic_if.clic_irq_shv           ),
 
 
          .fencei_flush_req_o     ( fencei_if_i.flush_req          ),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -332,7 +332,6 @@ module uvmt_cv32e40s_interrupt_assert
     else if (wb_stage_instr_valid_i) begin
       last_instr_rdata <= wb_stage_instr_rdata_i;
     end
-  end
 
   // ---------------------------------------------------------------------------
   // WFI Checks
@@ -359,7 +358,6 @@ module uvmt_cv32e40s_interrupt_assert
       else if (|pending_enabled_irq || debug_req_i)
         in_wfi_wfe <= 1'b0;
     end
-  end
 
   assign pipeline_ready_for_wfi = (alignbuf_outstanding == 0) && !lsu_busy;
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -332,6 +332,7 @@ module uvmt_cv32e40s_interrupt_assert
     else if (wb_stage_instr_valid_i) begin
       last_instr_rdata <= wb_stage_instr_rdata_i;
     end
+  end
 
   // ---------------------------------------------------------------------------
   // WFI Checks
@@ -358,6 +359,7 @@ module uvmt_cv32e40s_interrupt_assert
       else if (|pending_enabled_irq || debug_req_i)
         in_wfi_wfe <= 1'b0;
     end
+  end
 
   assign pipeline_ready_for_wfi = (alignbuf_outstanding == 0) && !lsu_busy;
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_support_logic.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_support_logic.sv
@@ -21,7 +21,7 @@ module uvmt_cv32e40s_support_logic
   import cv32e40s_pkg::*;
   (
     uvma_rvfi_instr_if rvfi,
-    uvmt_cv32e40s_support_logic_if.write support_if
+    uvmt_cv32e40s_support_logic_if.master support_if
   );
 
     // ---------------------------------------------------------------------------

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -111,7 +111,7 @@ module uvmt_cv32e40s_tb;
                                                                    .rvfi_valid(rvfi_i.rvfi_valid[0]),
                                                                    .rvfi_order(rvfi_i.rvfi_order[uvma_rvfi_pkg::ORDER_WL*0+:uvma_rvfi_pkg::ORDER_WL]),
                                                                    .rvfi_insn(rvfi_i.rvfi_insn[uvme_cv32e40s_pkg::ILEN*0+:uvme_cv32e40s_pkg::ILEN]),
-                                                                   .rvfi_trap(rvfi_i.rvfi_trap[11:0]),
+                                                                   .rvfi_trap(rvfi_i.rvfi_trap),
                                                                    .rvfi_halt(rvfi_i.rvfi_halt[0]),
                                                                    .rvfi_intr(rvfi_i.rvfi_intr),
                                                                    .rvfi_dbg(rvfi_i.rvfi_dbg),
@@ -602,14 +602,6 @@ module uvmt_cv32e40s_tb;
       .*
     );
 
-<<<<<<< 5524721d4a2e70904534b020a7b33efe96ac0c2a
-
-||||||| merged common ancestors
-
-
-
-=======
->>>>>>> Clic assertions and necessary infrastructure updates
   // Core integration assertions
 
   bind cv32e40s_wrapper

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -479,7 +479,6 @@ module uvmt_cv32e40s_tb;
 
       .rvfi_mepc_wdata     (rvfi_i.rvfi_csr_mepc_wdata),
       .rvfi_mepc_wmask     (rvfi_i.rvfi_csr_mepc_wmask),
-      .rvfi_mepc_we        (rvfi_i.csr_mepc_we_i),
       .rvfi_mepc_rdata     (rvfi_i.rvfi_csr_mepc_rdata),
       .rvfi_mepc_rmask     (rvfi_i.rvfi_csr_mepc_rmask),
       .rvfi_dpc_rdata      (rvfi_i.rvfi_csr_dpc_rdata),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -52,6 +52,7 @@ module uvmt_cv32e40s_tb;
    uvma_clknrst_if              clknrst_if_iss();
    uvma_debug_if                debug_if();
    uvma_interrupt_if            interrupt_if();
+   uvma_clic_if                 clic_if();
    uvma_obi_memory_if           obi_instr_if_i(
      .clk(clknrst_if.clk),
      .reset_n(clknrst_if.reset_n)
@@ -87,7 +88,8 @@ module uvmt_cv32e40s_tb;
                              .PMP_NUM_REGIONS   (uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS),
                              .INSTR_ADDR_WIDTH  (ENV_PARAM_INSTR_ADDR_WIDTH),
                              .INSTR_RDATA_WIDTH (ENV_PARAM_INSTR_DATA_WIDTH),
-                             .RAM_ADDR_WIDTH    (ENV_PARAM_RAM_ADDR_WIDTH)
+                             .RAM_ADDR_WIDTH    (ENV_PARAM_RAM_ADDR_WIDTH),
+                             .SMCLIC            (uvmt_cv32e40s_pkg::SMCLIC)
                             )
                             dut_wrap (
                               .clknrst_if(clknrst_if),
@@ -98,6 +100,7 @@ module uvmt_cv32e40s_tb;
                               .obi_instr_if_i(obi_instr_if_i),
                               .obi_data_if_i(obi_data_if_i),
                               .fencei_if_i(fencei_if_i),
+                              .clic_if(clic_if),
                               .*);
 
   bind cv32e40s_wrapper
@@ -420,6 +423,7 @@ module uvmt_cv32e40s_tb;
     ) obi_data_memory_assert_i(.obi(obi_data_if_i));
 
   // Bind in verification modules to the design
+  `ifndef SMCLIC_EN
   bind cv32e40s_core
     uvmt_cv32e40s_interrupt_assert  interrupt_assert_i (
       .mcause_n     ({cs_registers_i.mcause_n.irq, cs_registers_i.mcause_n.exception_code[4:0]}),
@@ -449,6 +453,96 @@ module uvmt_cv32e40s_tb;
 
       .*
     );
+  `endif
+
+  `ifdef SMCLIC_EN
+  // CLIC assertions
+  bind cv32e40s_core
+    uvmt_cv32e40s_clic_interrupt_assert#(
+      .SMCLIC(uvmt_cv32e40s_pkg::SMCLIC)
+    ) clic_assert_i(
+      .dpc                 (cs_registers_i.dpc_rdata),
+      .mintstatus          (cs_registers_i.mintstatus_rdata),
+      .mintthresh          (cs_registers_i.mintthresh_rdata),
+      .mcause              (cs_registers_i.mcause_rdata),
+      .mtvec               (cs_registers_i.mtvec_rdata),
+      .mtvt                (cs_registers_i.mtvt_rdata),
+      .mclicbase           (cs_registers_i.mclicbase_rdata),
+      .mepc                (cs_registers_i.mepc_rdata),
+      .mip                 (cs_registers_i.mip_rdata),
+      .mie                 (cs_registers_i.mie_rdata),
+      .mnxti               (cs_registers_i.mnxti_rdata),
+      .mscratch            (cs_registers_i.mscratch_rdata),
+      .mscratchcsw         (cs_registers_i.mscratchcsw_rdata),
+      .mscratchcswl        (cs_registers_i.mscratchcswl_rdata),
+      .dcsr                (cs_registers_i.dcsr_rdata),
+
+      .rvfi_mepc_wdata     (rvfi_i.rvfi_csr_mepc_wdata),
+      .rvfi_mepc_wmask     (rvfi_i.rvfi_csr_mepc_wmask),
+      .rvfi_mepc_we        (rvfi_i.csr_mepc_we_i),
+      .rvfi_mepc_rdata     (rvfi_i.rvfi_csr_mepc_rdata),
+      .rvfi_mepc_rmask     (rvfi_i.rvfi_csr_mepc_rmask),
+      .rvfi_dpc_rdata      (rvfi_i.rvfi_csr_dpc_rdata),
+      .rvfi_dpc_rmask      (rvfi_i.rvfi_csr_dpc_rmask),
+      .rvfi_mscratch_rdata (rvfi_i.rvfi_csr_mscratch_rdata),
+      .rvfi_mscratch_rmask (rvfi_i.rvfi_csr_mscratch_rmask),
+      .rvfi_mscratch_wdata (rvfi_i.rvfi_csr_mscratch_wdata),
+      .rvfi_mscratch_wmask (rvfi_i.rvfi_csr_mscratch_wmask),
+
+      .irq_i               (core_i.irq_i),
+      .irq_ack             (core_i.irq_ack),
+      .fetch_enable        (core_i.fetch_enable),
+      .current_priv_mode   (core_i.priv_lvl),
+      .mtvec_addr_i        (core_i.mtvec_addr_i),
+      // External inputs
+      .clic_if             (dut_wrap.clic_if),
+      // Internal sampled   variants
+      .irq_id              (core_i.irq_id[SMCLIC_ID_WIDTH-1:0]),
+      .irq_level           (core_i.irq_level),
+      .irq_priv            (core_i.irq_priv),
+      .irq_shv             (core_i.irq_shv),
+
+      .obi_instr_req       (core_i.instr_req_o),
+      .obi_instr_gnt       (core_i.instr_gnt_i),
+      .obi_instr_rvalid    (core_i.instr_rvalid_i),
+      .obi_instr_addr      (core_i.instr_addr_o),
+      .obi_instr_rdata     (core_i.instr_rdata_i),
+      .obi_instr_rready    (1'b1),
+      .obi_instr_err       (core_i.instr_err_i),
+
+      .obi_data_addr       (core_i.data_addr_o),
+      .obi_data_wdata      (core_i.data_wdata_o),
+      .obi_data_we         (core_i.data_we_o),
+      .obi_data_be         (core_i.data_be_o),
+      .obi_data_req        (core_i.data_req_o),
+      .obi_data_gnt        (core_i.data_gnt_i),
+      .obi_data_rvalid     (core_i.data_rvalid_i),
+      .obi_data_rready     (1'b1),
+      .obi_data_err        (core_i.data_err_i),
+
+      .debug_mode          (controller_i.controller_fsm_i.debug_mode_q),
+      .debug_req           (core_i.debug_req_i),
+      .debug_havereset     (core_i.debug_havereset_o),
+      .debug_running       (core_i.debug_running_o),
+      .debug_halt_addr     (dut_wrap.cv32e40s_wrapper_i.dm_halt_addr_i),
+      .debug_exc_addr      (dut_wrap.cv32e40s_wrapper_i.dm_exception_addr_i),
+
+      .rvfi_mode           (rvfi_i.rvfi_mode),
+      .rvfi_insn           (rvfi_i.rvfi_insn),
+      .rvfi_intr           (rvfi_i.rvfi_intr),
+      .rvfi_rs1_rdata      (rvfi_i.rvfi_rs1_rdata),
+      .rvfi_rs2_rdata      (rvfi_i.rvfi_rs2_rdata),
+      .rvfi_rd_wdata       (rvfi_i.rvfi_rd_wdata),
+      .rvfi_valid          (rvfi_i.rvfi_valid),
+      .rvfi_pc_rdata       (rvfi_i.rvfi_pc_rdata),
+      .rvfi_pc_wdata       (rvfi_i.rvfi_pc_wdata),
+      .rvfi_trap           (rvfi_i.rvfi_trap),
+      .rvfi_dbg_mode       (rvfi_i.rvfi_dbg_mode),
+      .rvfi_dbg            (rvfi_i.rvfi_dbg),
+      .core_sleep_o        (core_i.core_sleep_o),
+      .*
+    );
+  `endif
 
   // User-mode assertions
 
@@ -507,7 +601,14 @@ module uvmt_cv32e40s_tb;
       .*
     );
 
+<<<<<<< 5524721d4a2e70904534b020a7b33efe96ac0c2a
 
+||||||| merged common ancestors
+
+
+
+=======
+>>>>>>> Clic assertions and necessary infrastructure updates
   // Core integration assertions
 
   bind cv32e40s_wrapper
@@ -699,15 +800,15 @@ module uvmt_cv32e40s_tb;
       .*
     );
 
-  bind cv32e40s_wrapper
-    uvmt_cv32e40s_support_logic_if support_logic_if (
 
-      .ctrl_fsm_o_i(core_i.controller_i.controller_fsm_i.ctrl_fsm_o),
-      .data_bus_req_i(obi_data_if_i.req),
-      .data_bus_gnt_i(obi_data_if_i.gnt),
+    bind cv32e40s_wrapper
+      uvmt_cv32e40s_support_logic_if support_logic_if ();
 
-      .*
-    );
+    // TODO find a better way
+    assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.ctrl_fsm_o_i   = dut_wrap.cv32e40s_wrapper_i.core_i.controller_i.controller_fsm_i.ctrl_fsm_o;
+    assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.data_bus_req_i = dut_wrap.cv32e40s_wrapper_i.core_i.m_c_obi_data_if.s_req.req;
+    assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.clk_i          = dut_wrap.cv32e40s_wrapper_i.core_i.clk_i;
+    assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.rst_ni         = dut_wrap.cv32e40s_wrapper_i.core_i.rst_ni;
 
 
     bind cv32e40s_pmp :
@@ -754,13 +855,13 @@ module uvmt_cv32e40s_tb;
       );
 
     bind cv32e40s_wrapper uvmt_cv32e40s_support_logic u_support_logic(.rvfi(rvfi_instr_if_0_i),
-                                                                      .support_if(support_logic_if.write)
+                                                                      .support_if(support_logic_if)
                                                                       );
 
     bind cv32e40s_wrapper uvmt_cv32e40s_debug_assert u_debug_assert(.cov_assert_if(debug_cov_assert_if));
 
     bind cv32e40s_wrapper uvmt_cv32e40s_zc_assert u_zc_assert(.rvfi(rvfi_instr_if_0_i),
-                                                              .support_if(support_logic_if.read)
+                                                              .support_if(support_logic_if)
                                                               );
 
 
@@ -792,19 +893,21 @@ module uvmt_cv32e40s_tb;
      $timeformat(-9, 3, " ns", 8);
 
      // Add interfaces handles to uvm_config_db
-     uvm_config_db#(virtual uvma_isacov_if              )::set(.cntxt(null), .inst_name("*.env.isacov_agent"), .field_name("vif"), .value(isacov_if));
-     uvm_config_db#(virtual uvma_debug_if               )::set(.cntxt(null), .inst_name("*.env.debug_agent"), .field_name("vif"), .value(debug_if));
-     uvm_config_db#(virtual uvma_clknrst_if             )::set(.cntxt(null), .inst_name("*.env.clknrst_agent"), .field_name("vif"),        .value(clknrst_if));
-     uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env.interrupt_agent"), .field_name("vif"),      .value(interrupt_if));
-     uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_instr_agent"), .field_name("vif"), .value(obi_instr_if_i) );
-     uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_data_agent"),  .field_name("vif"), .value(obi_data_if_i) );
-     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei"),     .field_name("vif"), .value(fencei_if_i));
-     uvm_config_db#(virtual uvma_rvfi_instr_if          )::set(.cntxt(null), .inst_name("*.env.rvfi_agent"), .field_name("instr_vif0"),.value(dut_wrap.cv32e40s_wrapper_i.rvfi_instr_if_0_i));
-     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei_agent"), .field_name("fencei_vif"),     .value(fencei_if_i)  );
-     uvm_config_db#(virtual uvmt_cv32e40s_vp_status_if  )::set(.cntxt(null), .inst_name("*"),                .field_name("vp_status_vif"),    .value(vp_status_if) );
-     uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env"),            .field_name("intr_vif"),         .value(interrupt_if) );
-     uvm_config_db#(virtual uvma_debug_if               )::set(.cntxt(null), .inst_name("*.env"),            .field_name("debug_vif"),        .value(debug_if)     );
-//     uvm_config_db#(virtual uvmt_cv32e40s_debug_cov_assert_if)::set(.cntxt(null), .inst_name("*.env"),       .field_name("debug_cov_vif"),    .value(debug_cov_assert_if));
+     uvm_config_db#(virtual uvma_isacov_if              )::set(.cntxt(null), .inst_name("*.env.isacov_agent"),           .field_name("vif"),           .value(isacov_if));
+     uvm_config_db#(virtual uvma_debug_if               )::set(.cntxt(null), .inst_name("*.env.debug_agent"),            .field_name("vif"),           .value(debug_if));
+     uvm_config_db#(virtual uvma_clknrst_if             )::set(.cntxt(null), .inst_name("*.env.clknrst_agent"),          .field_name("vif"),           .value(clknrst_if));
+     uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env.interrupt_agent"),        .field_name("vif"),           .value(interrupt_if));
+     uvm_config_db#(virtual uvma_clic_if                )::set(.cntxt(null), .inst_name("*.env.clic_agent"),             .field_name("vif"),           .value(clic_if));
+     uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_instr_agent"), .field_name("vif"),           .value(obi_instr_if_i) );
+     uvm_config_db#(virtual uvma_obi_memory_if          )::set(.cntxt(null), .inst_name("*.env.obi_memory_data_agent"),  .field_name("vif"),           .value(obi_data_if_i) );
+     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei"),                 .field_name("vif"),           .value(fencei_if_i));
+     uvm_config_db#(virtual uvma_rvfi_instr_if          )::set(.cntxt(null), .inst_name("*.env.rvfi_agent"),             .field_name("instr_vif0"),    .value(dut_wrap.cv32e40s_wrapper_i.rvfi_instr_if_0_i));
+     uvm_config_db#(virtual uvma_fencei_if              )::set(.cntxt(null), .inst_name("*.env.fencei_agent"),           .field_name("fencei_vif"),    .value(fencei_if_i)  );
+     uvm_config_db#(virtual uvmt_cv32e40s_vp_status_if  )::set(.cntxt(null), .inst_name("*"),                            .field_name("vp_status_vif"), .value(vp_status_if) );
+     uvm_config_db#(virtual uvma_interrupt_if           )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("intr_vif"),      .value(interrupt_if) );
+     uvm_config_db#(virtual uvma_clic_if                )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("clic_vif"),      .value(clic_if) );
+     uvm_config_db#(virtual uvma_debug_if               )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("debug_vif"),     .value(debug_if)     );
+//     uvm_config_db#(virtual uvmt_cv32e40s_debug_cov_assert_if)::set(.cntxt(null), .inst_name("*.env"),                 .field_name("debug_cov_vif"),    .value(debug_cov_assert_if));
      `RVFI_CSR_UVM_CONFIG_DB_SET(marchid)
      `RVFI_CSR_UVM_CONFIG_DB_SET(mcountinhibit)
      `RVFI_CSR_UVM_CONFIG_DB_SET(mstatus)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -89,7 +89,7 @@ module uvmt_cv32e40s_tb;
                              .INSTR_ADDR_WIDTH  (ENV_PARAM_INSTR_ADDR_WIDTH),
                              .INSTR_RDATA_WIDTH (ENV_PARAM_INSTR_DATA_WIDTH),
                              .RAM_ADDR_WIDTH    (ENV_PARAM_RAM_ADDR_WIDTH),
-                             .SMCLIC            (uvmt_cv32e40s_pkg::SMCLIC)
+                             .SMCLIC            (uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC)
                             )
                             dut_wrap (
                               .clknrst_if(clknrst_if),
@@ -459,7 +459,7 @@ module uvmt_cv32e40s_tb;
   // CLIC assertions
   bind cv32e40s_core
     uvmt_cv32e40s_clic_interrupt_assert#(
-      .SMCLIC(uvmt_cv32e40s_pkg::SMCLIC)
+      .SMCLIC(uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC)
     ) clic_assert_i(
       .dpc                 (cs_registers_i.dpc_rdata),
       .mintstatus          (cs_registers_i.mintstatus_rdata),
@@ -538,6 +538,8 @@ module uvmt_cv32e40s_tb;
       .rvfi_trap           (rvfi_i.rvfi_trap),
       .rvfi_dbg_mode       (rvfi_i.rvfi_dbg_mode),
       .rvfi_dbg            (rvfi_i.rvfi_dbg),
+
+      .wu_wfe              (dut_wrap.cv32e40s_wrapper_i.wu_wfe_i),
       .core_sleep_o        (core_i.core_sleep_o),
       .*
     );

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -806,6 +806,7 @@ module uvmt_cv32e40s_tb;
     // TODO find a better way
     assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.ctrl_fsm_o_i   = dut_wrap.cv32e40s_wrapper_i.core_i.controller_i.controller_fsm_i.ctrl_fsm_o;
     assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.data_bus_req_i = dut_wrap.cv32e40s_wrapper_i.core_i.m_c_obi_data_if.s_req.req;
+    assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.data_bus_gnt_i = dut_wrap.cv32e40s_wrapper_i.core_i.m_c_obi_data_if.s_gnt.gnt;
     assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.clk_i          = dut_wrap.cv32e40s_wrapper_i.core_i.clk_i;
     assign dut_wrap.cv32e40s_wrapper_i.support_logic_if.rst_ni         = dut_wrap.cv32e40s_wrapper_i.core_i.rst_ni;
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -107,7 +107,7 @@ endinterface : uvmt_cv32e40s_core_status_if
 
 
 // Interface to xsecure assertions and covergroups
-interface uvmt_cv32e40s_xsecure_if   
+interface uvmt_cv32e40s_xsecure_if
     import cv32e40s_pkg::*;
     import cv32e40s_rvfi_pkg::*;
     (
@@ -175,7 +175,7 @@ interface uvmt_cv32e40s_xsecure_if
 
     // WB stage
     input logic core_wb_stage_wb_valid_o
-      
+
 );
 
 
@@ -341,19 +341,16 @@ interface uvmt_cv32e40s_debug_cov_assert_if
 
 endinterface : uvmt_cv32e40s_debug_cov_assert_if
 
-interface uvmt_cv32e40s_support_logic_if
+interface uvmt_cv32e40s_support_logic_if;
    import cv32e40s_pkg::*;
    import uvma_rvfi_pkg::*;
-   (
-      input    clk_i,
-      input    rst_ni,
+   logic clk_i;
+   logic rst_ni;
 
-      // core signals
-      input ctrl_fsm_t  ctrl_fsm_o_i,
-      input             data_bus_req_i,
-      input             data_bus_gnt_i
-
-   );
+   // core signals
+   ctrl_fsm_t  ctrl_fsm_o_i;
+   logic       data_bus_req_i;
+   logic       data_bus_gnt_i;
 
    //results for modport
    logic req_after_exception_o;
@@ -362,30 +359,40 @@ interface uvmt_cv32e40s_support_logic_if
       input #1step
 
       ctrl_fsm_o_i,
-      data_bus_req_i,
+      data_bus_req_i;
 
-      req_after_exception_o;
+      output #0 req_after_exception_o;
 
    endclocking : mon_cb
 
-   modport write (
-      input clk_i,
+   modport master (
+     input  clk_i,
             rst_ni,
 
             ctrl_fsm_o_i,
             data_bus_req_i,
             data_bus_gnt_i,
 
-      output req_after_exception_o
-
+     output req_after_exception_o
    );
 
-   modport read (
-      input clk_i,
+   modport slave (
+     input  clk_i,
             rst_ni,
 
-            req_after_exception_o
+            req_after_exception_o,
+     output ctrl_fsm_o_i,
+            data_bus_req_i
    );
+
+   modport monitor (
+     input  clk_i,
+            rst_ni,
+            req_after_exception_o,
+            ctrl_fsm_o_i,
+            data_bus_req_i
+   );
+
 
 
 endinterface : uvmt_cv32e40s_support_logic_if

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_zc_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_zc_assert.sv
@@ -21,7 +21,7 @@ module uvmt_cv32e40s_zc_assert
   import cv32e40s_pkg::*;
   (
       uvma_rvfi_instr_if rvfi,
-      uvmt_cv32e40s_support_logic_if.read support_if
+      uvmt_cv32e40s_support_logic_if.monitor support_if
 
   );
 

--- a/cv32e40s/tests/cfg/clic_default.yaml
+++ b/cv32e40s/tests/cfg/clic_default.yaml
@@ -1,0 +1,16 @@
+name: clic_default
+description: Default clic configuration for CV32E40S simulations
+compile_flags:
+    +define+ZBA_ZBB_ZBC_ZBS
+    +define+SMCLIC_EN
+ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
+cflags: >
+plusargs: >
+    +enable_clic
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
+cv_sw_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00

--- a/cv32e40s/tests/uvmt/compliance-tests/uvmt_cv32e40s_firmware_test.sv
+++ b/cv32e40s/tests/uvmt/compliance-tests/uvmt_cv32e40s_firmware_test.sv
@@ -79,6 +79,11 @@ class uvmt_cv32e40s_firmware_test_c extends uvmt_cv32e40s_base_test_c;
     */
    extern virtual task irq_noise();
 
+   /**
+    *  Start the clic interrupt sequencer to apply random clic interrupts during test
+    */
+   extern virtual task clic_noise();
+
 endclass : uvmt_cv32e40s_firmware_test_c
 
 
@@ -116,6 +121,7 @@ task uvmt_cv32e40s_firmware_test_c::run_phase(uvm_phase phase);
 
    if ($test$plusargs("gen_irq_noise")) begin
     fork
+      clic_noise();
       irq_noise();
     join_none
    end
@@ -200,4 +206,17 @@ task uvmt_cv32e40s_firmware_test_c::irq_noise();
   end
 endtask : irq_noise
 
+task uvmt_cv32e40s_firmware_test_c::clic_noise();
+  `uvm_info("TEST", "Starting CLIC Noise thread in UVM test", UVM_NONE);
+  while (1) begin
+    uvme_cv32e40s_clic_noise_c clic_noise_vseq;
+
+    clic_noise_vseq = uvme_cv32e40s_clic_noise_c::type_id::create("clic_noise_vseqr");
+
+    assert(clic_noise_vseq.randomize() with { });
+    clic_noise_vseq.start(vsequencer);
+    break;
+  end
+
+endtask : clic_noise
 `endif // __UVMT_CV32E40S_FIRMWARE_TEST_SV__

--- a/lib/uvm_agents/uvma_clic/cov/uvma_clic_cov_model.sv
+++ b/lib/uvm_agents/uvma_clic/cov/uvma_clic_cov_model.sv
@@ -1,0 +1,177 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_COV_MODEL_SV__
+`define __UVMA_CLIC_COV_MODEL_SV__
+
+
+/**
+ * Component encapsulating Interrupt functional coverage model.
+ */
+class uvma_clic_cov_model_c extends uvm_component;
+
+   // Objects
+   uvma_clic_cfg_c       cfg;
+   uvma_clic_cntxt_c     cntxt;
+   uvma_clic_mon_trn_c   mon_trn;
+   uvma_clic_seq_item_c  seq_item;
+
+   // TLM
+   uvm_tlm_analysis_fifo#(uvma_clic_mon_trn_c )  mon_trn_fifo;
+   uvm_tlm_analysis_fifo#(uvma_clic_seq_item_c)  seq_item_fifo;
+
+
+   `uvm_component_utils_begin(uvma_clic_cov_model_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_cov_model", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null.
+    * 2. Builds fifos.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Forks all sampling loops
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * TODO Describe sample_cfg
+    */
+   extern virtual function void sample_cfg();
+
+   /**
+    * TODO Describe sample_cntxt
+    */
+   extern virtual function void sample_cntxt();
+
+   /**
+    * TODO Describe sample_mon_trn
+    */
+   extern virtual function void sample_mon_trn();
+
+   /**
+    * TODO Describe sample_seq_item
+    */
+   extern virtual function void sample_seq_item();
+
+endclass : uvma_clic_cov_model_c
+
+
+`pragma protect begin
+
+
+function uvma_clic_cov_model_c::new(string name="uvma_clic_cov_model", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_clic_cov_model_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_clic_cfg_c)::get(this, "", "cfg", cfg));
+   if (cfg == null) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvma_clic_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (cntxt == null) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+   mon_trn_fifo  = new("mon_trn_fifo" , this);
+   seq_item_fifo = new("seq_item_fifo", this);
+
+endfunction : build_phase
+
+
+task uvma_clic_cov_model_c::run_phase(uvm_phase phase);
+   super.run_phase(phase);
+
+   if (cfg.enabled && cfg.cov_model_enabled) begin
+      fork
+         // Configuration
+         forever begin
+            cntxt.sample_cfg_e.wait_trigger();
+            sample_cfg();
+         end
+
+         // Context
+         forever begin
+            cntxt.sample_cntxt_e.wait_trigger();
+            sample_cntxt();
+         end
+
+         // Monitor transactions
+         forever begin
+            mon_trn_fifo.get(mon_trn);
+            sample_mon_trn();
+         end
+
+         // Sequence items
+         forever begin
+            seq_item_fifo.get(seq_item);
+            sample_seq_item();
+         end
+      join_none
+   end
+
+endtask : run_phase
+
+
+function void uvma_clic_cov_model_c::sample_cfg();
+
+   // TODO Implement uvma_clic_cov_model_c::sample_cfg();
+
+endfunction : sample_cfg
+
+
+function void uvma_clic_cov_model_c::sample_cntxt();
+
+   // TODO Implement uvma_clic_cov_model_c::sample_cntxt();
+
+endfunction : sample_cntxt
+
+
+function void uvma_clic_cov_model_c::sample_mon_trn();
+
+   // TODO Implement uvma_clic_cov_model_c::sample_mon_trn();
+
+endfunction : sample_mon_trn
+
+
+function void uvma_clic_cov_model_c::sample_seq_item();
+
+   // TODO Implement uvma_clic_cov_model_c::sample_seq_item();
+
+endfunction : sample_seq_item
+
+
+`pragma protect end
+
+
+`endif // __UVMA_CLIC_COV_MODEL_SV__

--- a/lib/uvm_agents/uvma_clic/cov/uvma_clic_cov_model.sv
+++ b/lib/uvm_agents/uvma_clic/cov/uvma_clic_cov_model.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_base_seq.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_base_seq.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_base_seq.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_base_seq.sv
@@ -1,0 +1,55 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_BASE_SEQ_SV__
+`define __UVMA_CLIC_BASE_SEQ_SV__
+
+
+/**
+ * Abstract object from which all other Interrupt agent sequences must extend.
+ * Subclasses must be run on Interrupt sequencer (uvma_clic_sqr_c) instance.
+ */
+class uvma_clic_base_seq_c extends uvm_sequence#(
+   .REQ(uvma_clic_seq_item_c),
+   .RSP(uvma_clic_seq_item_c)
+);
+
+   `uvm_object_utils(uvma_clic_base_seq_c)
+   `uvm_declare_p_sequencer(uvma_clic_sqr_c)
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_base_seq");
+
+endclass : uvma_clic_base_seq_c
+
+
+`pragma protect begin
+
+
+function uvma_clic_base_seq_c::new(string name="uvma_clic_base_seq");
+
+   super.new(name);
+
+endfunction : new
+
+
+`pragma protect end
+
+
+`endif // __UVMA_CLIC_BASE_SEQ_SV__

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item.sv
@@ -1,0 +1,116 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_SEQ_ITEM_SV__
+`define __UVMA_CLIC_SEQ_ITEM_SV__
+
+
+/**
+ * Object created by Interrupt agent sequences extending uvma_clic_seq_base_c.
+ */
+class uvma_clic_seq_item_c extends uvml_trn_seq_item_c;
+
+   rand uvma_clic_seq_item_action_enum   action;
+   rand int unsigned                     index;
+   rand bit [8:0]                        level;
+   rand bit [1:0]                        privilege_mode;
+   rand bit                              sel_hardware_vectoring;
+
+   rand int unsigned                     skew; // Skew (in cycles) before applying individual interrupt actions per interrupt
+   rand int unsigned                     repeat_count; // Number of times to apply action to interrupt
+
+   rand int unsigned                     no_skew_wgt;
+   rand int unsigned                     skew_wgt;
+
+
+   // TODO FIXME update actually used signals
+   `uvm_object_utils_begin(uvma_clic_seq_item_c)
+      `uvm_field_enum(uvma_clic_seq_item_action_enum, action, UVM_DEFAULT)
+      `uvm_field_int(index, UVM_DEFAULT)
+      `uvm_field_int(level, UVM_DEFAULT)
+      `uvm_field_int(privilege_mode, UVM_DEFAULT)
+      `uvm_field_int(sel_hardware_vectoring, UVM_DEFAULT)
+      `uvm_field_int(skew, UVM_DEFAULT)
+      `uvm_field_int(no_skew_wgt, UVM_DEFAULT)
+      `uvm_field_int(skew_wgt, UVM_DEFAULT)
+      `uvm_field_int(repeat_count, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+  //constraint irq_index_c {
+  //  irq_index inside {[0:4095]};
+  //}
+
+  // FIXME TODO move to core specific cfg
+  constraint irq_privilege_mode_c {
+    privilege_mode == 2'b11;
+  }
+  constraint irq_privilege_level_c {
+    level inside {[0:255]};
+  }
+  constraint irq_index_c {
+    index inside {[0:1023]};
+  }
+
+   constraint valid_repeat_count_c {
+      repeat_count != 0;
+   }
+
+   constraint default_repeat_count_c {
+      soft repeat_count == 1;
+   }
+
+   constraint valid_skew_wgt {
+      no_skew_wgt + skew_wgt != 0;
+      skew_wgt == 1;
+      no_skew_wgt == 0;
+   }
+
+   constraint default_skew_wgt_c {
+      no_skew_wgt inside {[0:5]};
+      skew_wgt inside {[0:3]};
+   }
+
+   constraint skew_wgt_order_c {
+         solve skew_wgt before skew;
+         solve no_skew_wgt before skew;
+   }
+
+   constraint default_skew_c {
+         skew dist { 0      :/ no_skew_wgt,
+                     [1:32] :/ skew_wgt};
+   }
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_seq_item");
+
+endclass : uvma_clic_seq_item_c
+
+`pragma protect begin
+
+
+function uvma_clic_seq_item_c::new(string name="uvma_clic_seq_item");
+
+   super.new(name);
+
+endfunction : new
+
+
+`pragma protect end
+
+
+`endif // __UVMA_CLIC_SEQ_ITEM_SV__

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item_logger.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item_logger.sv
@@ -1,0 +1,112 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_SEQ_ITEM_LOGGER_SV__
+`define __UVMA_CLIC_SEQ_ITEM_LOGGER_SV__
+
+
+/**
+ * Component writing Interrupt sequence items interrupt data to disk as plain text.
+ */
+class uvma_clic_seq_item_logger_c extends uvml_logs_seq_item_logger_c#(
+   .T_TRN  (uvma_clic_seq_item_c),
+   .T_CFG  (uvma_clic_cfg_c     ),
+   .T_CNTXT(uvma_clic_cntxt_c   )
+);
+
+   `uvm_component_utils(uvma_clic_seq_item_logger_c)
+
+
+   /**
+    * Default constructor.
+    */
+   function new(string name="uvma_clic_seq_item_logger", uvm_component parent=null);
+
+      super.new(name, parent);
+
+   endfunction : new
+
+   /**
+    * Writes contents of t to disk.
+    */
+   virtual function void write(uvma_clic_seq_item_c t);
+
+      // TODO Implement uvma_clic_seq_item_logger_c::write()
+      // Ex: fwrite($sformatf(" %t | %08h | %02b | %04d | %02h |", $realtime(), t.a, t.b, t.c, t.d));
+
+   endfunction : write
+
+   /**
+    * Writes log header to disk.
+    */
+   virtual function void print_header();
+
+      // TODO Implement uvma_clic_seq_item_logger_c::print_header()
+      // Ex: fwrite("----------------------------------------------");
+      //     fwrite(" TIME | FIELD A | FIELD B | FIELD C | FIELD D ");
+      //     fwrite("----------------------------------------------");
+
+   endfunction : print_header
+
+endclass : uvma_clic_seq_item_logger_c
+
+
+/**
+ * Component writing INTERRUPT monitor transactions interrupt data to disk as JavaScript Object Notation (JSON).
+ */
+class uvma_clic_seq_item_logger_json_c extends uvma_clic_seq_item_logger_c;
+
+   `uvm_component_utils(uvma_clic_seq_item_logger_json_c)
+
+
+   /**
+    * Set file extension to '.json'.
+    */
+   function new(string name="uvma_clic_seq_item_logger_json", uvm_component parent=null);
+
+      super.new(name, parent);
+      fextension = "json";
+
+   endfunction : new
+
+   /**
+    * Writes contents of t to disk.
+    */
+   virtual function void write(uvma_clic_seq_item_c t);
+
+      // TODO Implement uvma_clic_seq_item_logger_json_c::write()
+      // Ex: fwrite({"{",
+      //       $sformatf("\"time\":\"%0t\",", $realtime()),
+      //       $sformatf("\"a\":%h,"        , t.a        ),
+      //       $sformatf("\"b\":%b,"        , t.b        ),
+      //       $sformatf("\"c\":%d,"        , t.c        ),
+      //       $sformatf("\"d\":%h,"        , t.c        ),
+      //     "},"});
+
+   endfunction : write
+
+   /**
+    * Empty function.
+    */
+   virtual function void print_header();
+
+      // Do nothing: JSON files do not use headers.
+
+   endfunction : print_header
+
+endclass : uvma_clic_seq_item_logger_json_c
+
+`endif // __UVMA_CLIC_SEQ_ITEM_LOGGER_SV__

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item_logger.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_item_logger.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_lib.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_lib.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_lib.sv
+++ b/lib/uvm_agents/uvma_clic/seq/uvma_clic_seq_lib.sv
@@ -1,0 +1,53 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_SEQ_LIB_SV__
+`define __UVMA_CLIC_SEQ_LIB_SV__
+
+
+/**
+ * Object holding sequence library for Interrupt agent.
+ */
+class uvma_clic_seq_lib_c extends uvm_sequence_library#(
+   .REQ(uvma_clic_seq_item_c),
+   .RSP(uvma_clic_seq_item_c)
+);
+
+   `uvm_object_utils          (uvma_clic_seq_lib_c)
+   `uvm_sequence_library_utils(uvma_clic_seq_lib_c)
+
+
+   /**
+    * Initializes sequence library
+    */
+   extern function new(string name="uvma_clic_seq_lib");
+
+endclass : uvma_clic_seq_lib_c
+
+
+function uvma_clic_seq_lib_c::new(string name="uvma_clic_seq_lib");
+
+   super.new(name);
+   init_sequence_library();
+
+   // TODO Add sequences to uvma_clic_seq_lib_c
+   //      Ex: add_sequence(uvma_clic_abc_seq_c::get_type());
+
+endfunction : new
+
+
+`endif // __UVMA_CLIC_SEQ_LIB_SV__
+

--- a/lib/uvm_agents/uvma_clic/uvma_clic_agent.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_agent.sv
@@ -1,7 +1,7 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_agent.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_agent.sv
@@ -1,0 +1,234 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_CLIC_AGENT_SV__
+`define __UVMA_CLIC_AGENT_SV__
+
+/**
+ * Top-level component that encapsulates, builds and connects all others.
+ * Capable of driving/monitoring Clock & Reset interface.
+ */
+class uvma_clic_agent_c extends uvm_agent;
+
+   // Objects
+   uvma_clic_cfg_c    cfg;
+   uvma_clic_cntxt_c  cntxt;
+
+   // Components
+   uvma_clic_drv_c              driver;
+   uvma_clic_mon_c              monitor;
+   uvma_clic_sqr_c              sequencer;
+   uvma_clic_cov_model_c        cov_model;
+   uvma_clic_seq_item_logger_c  seq_item_logger;
+   uvma_clic_mon_trn_logger_c   mon_trn_logger;
+
+   // TLM
+   uvm_analysis_port#(uvma_clic_seq_item_c)  drv_ap;
+   uvm_analysis_port#(uvma_clic_mon_trn_c )  mon_ap;
+
+
+   `uvm_component_utils_begin(uvma_clic_agent_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_agent", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null
+    * 2. Builds all components
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * 1. Links agent's analysis ports to sub-components'
+    * 2. Connects coverage models and loggers
+    */
+   extern virtual function void connect_phase(uvm_phase phase);
+
+   /**
+    * Uses uvm_config_db to retrieve cfg and hand out to sub-components.
+    */
+   extern function void get_and_set_cfg();
+
+   /**
+    * Uses uvm_config_db to retrieve cntxt and hand out to sub-components.
+    */
+   extern function void get_and_set_cntxt();
+
+   /**
+    * Uses uvm_config_db to retrieve the Virtual Interface (vif) associated with this
+    * agent.
+    */
+   extern function void retrieve_vif();
+
+   /**
+    * Creates sub-components.
+    */
+   extern function void create_components();
+
+   /**
+    * Connects sequencer and driver's TLM port(s).
+    */
+   extern function void connect_sequencer_and_driver();
+
+   /**
+    * Connects agent's TLM ports to driver's and monitor's.
+    */
+   extern function void connect_analysis_ports();
+
+   /**
+    * Connects coverage model to monitor and driver's analysis ports.
+    */
+   extern function void connect_cov_model();
+
+   /**
+    * Connects transaction loggers to monitor and driver's analysis ports.
+    */
+   extern function void connect_trn_loggers();
+
+endclass : uvma_clic_agent_c
+
+
+function uvma_clic_agent_c::new(string name="uvma_clic_agent", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_clic_agent_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   get_and_set_cfg  ();
+   get_and_set_cntxt();
+   retrieve_vif     ();
+   create_components();
+
+endfunction : build_phase
+
+
+function void uvma_clic_agent_c::connect_phase(uvm_phase phase);
+
+   super.connect_phase(phase);
+
+   connect_sequencer_and_driver();
+   connect_analysis_ports();
+
+   if (cfg.cov_model_enabled) begin
+      connect_cov_model();
+   end
+   if (cfg.trn_log_enabled) begin
+      connect_trn_loggers();
+   end
+
+endfunction: connect_phase
+
+
+function void uvma_clic_agent_c::get_and_set_cfg();
+
+   void'(uvm_config_db#(uvma_clic_cfg_c)::get(this, "", "cfg", cfg));
+   if (cfg == null) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+   else begin
+      `uvm_info("CFG", $sformatf("Found configuration handle:\n%s", cfg.sprint()), UVM_DEBUG)
+      uvm_config_db#(uvma_clic_cfg_c)::set(this, "*", "cfg", cfg);
+   end
+
+endfunction : get_and_set_cfg
+
+
+function void uvma_clic_agent_c::get_and_set_cntxt();
+
+   void'(uvm_config_db#(uvma_clic_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (cntxt == null) begin
+      `uvm_info("CNTXT", "Context handle is null; creating.", UVM_DEBUG)
+      cntxt = uvma_clic_cntxt_c::type_id::create("cntxt");
+   end
+   uvm_config_db#(uvma_clic_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+endfunction : get_and_set_cntxt
+
+
+function void uvma_clic_agent_c::retrieve_vif();
+
+   if (!uvm_config_db#(virtual uvma_clic_if)::get(this, "", "vif", cntxt.vif)) begin
+      `uvm_fatal("VIF", $sformatf("Could not find vif handle of type %s in uvm_config_db", $typename(cntxt.vif)))
+   end
+   else begin
+      `uvm_info("VIF", $sformatf("Found vif handle of type %s in uvm_config_db", $typename(cntxt.vif)), UVM_DEBUG)
+   end
+
+endfunction : retrieve_vif
+
+
+function void uvma_clic_agent_c::create_components();
+
+   monitor         = uvma_clic_mon_c            ::type_id::create("monitor"        , this);
+   cov_model       = uvma_clic_cov_model_c      ::type_id::create("cov_model"      , this);
+   mon_trn_logger  = uvma_clic_mon_trn_logger_c ::type_id::create("mon_trn_logger" , this);
+
+   if (cfg.is_active == UVM_ACTIVE) begin
+      sequencer       = uvma_clic_sqr_c            ::type_id::create("sequencer"      , this);
+      driver          = uvma_clic_drv_c            ::type_id::create("driver"         , this);
+      seq_item_logger = uvma_clic_seq_item_logger_c::type_id::create("seq_item_logger", this);
+   end
+
+endfunction : create_components
+
+
+function void uvma_clic_agent_c::connect_sequencer_and_driver();
+
+   //sequencer.set_arbitration(cfg.sqr_arb_mode);
+   driver.seq_item_port.connect(sequencer.seq_item_export);
+
+endfunction : connect_sequencer_and_driver
+
+
+function void uvma_clic_agent_c::connect_analysis_ports();
+
+   drv_ap = driver .ap;
+   mon_ap = monitor.ap;
+
+endfunction : connect_analysis_ports
+
+
+function void uvma_clic_agent_c::connect_cov_model();
+
+   mon_ap.connect(cov_model.mon_trn_fifo.analysis_export);
+   drv_ap.connect(cov_model.seq_item_fifo.analysis_export);
+
+endfunction : connect_cov_model
+
+
+function void uvma_clic_agent_c::connect_trn_loggers();
+
+   mon_ap.connect(mon_trn_logger .analysis_export);
+   drv_ap.connect(seq_item_logger.analysis_export);
+
+endfunction : connect_trn_loggers
+
+
+`endif // __UVMA_CLIC_AGENT_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_cfg.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_cfg.sv
@@ -1,0 +1,81 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_CLIC_CFG_SV__
+`define __UVMA_CLIC_CFG_SV__
+
+
+/**
+ * Object encapsulating all parameters for creating, connecting and running all
+ * Clock & Reset agent (uvma_clic_agent_c) components.
+ */
+class uvma_clic_cfg_c extends uvm_object;
+
+   // Common options
+   rand bit                      enabled;
+   rand uvm_active_passive_enum  is_active;
+   rand bit                      is_mmode_irq_only;
+
+   rand bit                      cov_model_enabled;
+   rand bit                      trn_log_enabled;
+
+   // Implementation options
+   rand bit[31:0]                valid_irq_mask;   ///< State variable: the valid clics for the core under test
+   rand bit[31:0]                enabled_irq_mask; ///< The mask of clics that can be driven
+
+   `uvm_object_utils_begin(uvma_clic_cfg_c)
+      `uvm_field_int (                         enabled           , UVM_DEFAULT)
+      `uvm_field_enum(uvm_active_passive_enum, is_active         , UVM_DEFAULT)
+      `uvm_field_int (                         is_mmode_irq_only , UVM_DEFAULT)
+      `uvm_field_int (                         cov_model_enabled , UVM_DEFAULT)
+      `uvm_field_int (                         trn_log_enabled   , UVM_DEFAULT)
+
+      `uvm_field_int (                         enabled_irq_mask  , UVM_DEFAULT)
+   `uvm_object_utils_end
+
+
+   constraint defaults_cons {
+      soft enabled           == 1;
+      soft is_active         == UVM_PASSIVE;
+      soft is_mmode_irq_only == 0;
+      soft cov_model_enabled == 0;
+      soft trn_log_enabled   == 1;
+
+      soft enabled_irq_mask         == 32'hffff_ffff;
+   }
+
+   constraint valid_irq {
+      // Should always have at least one valid clic enabled
+      (enabled_irq_mask & valid_irq_mask) != 0;
+   }
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_cfg");
+
+endclass : uvma_clic_cfg_c
+
+function uvma_clic_cfg_c::new(string name="uvma_clic_cfg");
+
+   super.new(name);
+
+endfunction : new
+
+`endif // __UVMA_CLIC_CFG_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_cntxt.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_cntxt.sv
@@ -1,0 +1,75 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_CNTXT_SV__
+`define __UVMA_CLIC_CNTXT_SV__
+
+
+/**
+ * Object encapsulating all state variables for all Interrupt agent
+ * (uvma_clic_agent_c) components.
+ */
+class uvma_clic_cntxt_c extends uvm_object;
+
+   // Handle to agent interface
+   virtual uvma_clic_if  vif;
+
+   // Events
+   uvm_event  sample_cfg_e;
+   uvm_event  sample_cntxt_e;
+
+   `uvm_object_utils_begin(uvma_clic_cntxt_c)
+      `uvm_field_event(sample_cfg_e  , UVM_DEFAULT)
+      `uvm_field_event(sample_cntxt_e, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   /**
+    * Builds events.
+    */
+   extern function new(string name="uvma_clic_cntxt");
+
+   /**
+    * TODO Describe uvma_clic_cntxt_c::reset()
+    */
+   extern function void reset();
+
+endclass : uvma_clic_cntxt_c
+
+
+`pragma protect begin
+
+
+function uvma_clic_cntxt_c::new(string name="uvma_clic_cntxt");
+
+   super.new(name);
+
+   sample_cfg_e   = new("sample_cfg_e"  );
+   sample_cntxt_e = new("sample_cntxt_e");
+
+endfunction : new
+
+function void uvma_clic_cntxt_c::reset();
+
+   // TODO Implement uvma_clic_cntxt_c::reset()
+
+endfunction : reset
+
+
+`pragma protect end
+
+
+`endif // __UVMA_CLIC_CNTXT_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_cntxt.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_cntxt.sv
@@ -1,6 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_constants.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_constants.sv
@@ -1,13 +1,13 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_constants.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_constants.sv
@@ -1,0 +1,25 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_CONSTANTS_SV__
+`define __UVMA_CLIC_CONSTANTS_SV__
+
+
+
+
+
+`endif // __UVMA_CLIC_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
@@ -223,9 +223,9 @@ task uvma_clic_drv_c::irq_ack_clear();
 
          irq_id  = cntxt.vif.mon_cb.clic_irq_id_drv;
 
-         `uvm_info("IRQDRV", $sformatf("irq_ack_clear: ack for IRQ: %0d", irq_id), UVM_LOW);
+         `uvm_info("IRQDRV", $sformatf("irq_ack_clear: ack for IRQ: %0d", irq_id), UVM_DEBUG);
          if (assert_until_ack_sem[irq_id].try_get(1)) begin
-            `uvm_info("IRQDRV", $sformatf("irq_ack_clear: Clearing IRQ: %0d", irq_id), UVM_LOW);
+            `uvm_info("IRQDRV", $sformatf("irq_ack_clear: Clearing IRQ: %0d", irq_id), UVM_DEBUG);
             cntxt.vif.drv_cb.clic_irq_drv       <= 1'b0;
             cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
             cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;

--- a/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
@@ -1,7 +1,7 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,7 +215,7 @@ endtask : deassert_irq
 task uvma_clic_drv_c::irq_ack_clear();
    while(1) begin
       @(cntxt.vif.mon_cb);
-      if (cntxt.vif.mon_cb.irq_ack) begin
+      if (cntxt.vif.mon_cb.irq_ack && cfg.enabled) begin
          // Try to get the semaphore for the irq_id,
          // If we can't get it, then this irq is managed by assert_irq_until_ack and we will ignore this ack
          // Otherwise deassert the interrupt
@@ -223,9 +223,9 @@ task uvma_clic_drv_c::irq_ack_clear();
 
          irq_id  = cntxt.vif.mon_cb.clic_irq_id_drv;
 
-         `uvm_info("IRQDRV", $sformatf("irq_ack_clear: ack for IRQ: %0d", irq_id), UVM_DEBUG);
+         `uvm_info("IRQDRV", $sformatf("irq_ack_clear: ack for IRQ: %0d", irq_id), UVM_LOW);
          if (assert_until_ack_sem[irq_id].try_get(1)) begin
-            `uvm_info("IRQDRV", $sformatf("irq_ack_clear: Clearing IRQ: %0d", irq_id), UVM_DEBUG);
+            `uvm_info("IRQDRV", $sformatf("irq_ack_clear: Clearing IRQ: %0d", irq_id), UVM_LOW);
             cntxt.vif.drv_cb.clic_irq_drv       <= 1'b0;
             cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
             cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;

--- a/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_drv.sv
@@ -1,0 +1,240 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+`ifndef __UVMA_CLIC_DRV_SV__
+`define __UVMA_CLIC_DRV_SV__
+
+/**
+ * Component driving a Clock & Reset virtual interface (uvma_clic_if).
+ */
+class uvma_clic_drv_c extends uvm_driver#(
+   .REQ(uvma_clic_seq_item_c),
+   .RSP(uvma_clic_seq_item_c)
+);
+
+   // Objects
+   uvma_clic_cfg_c    cfg;
+   uvma_clic_cntxt_c  cntxt;
+
+   semaphore               assert_until_ack_sem[4096];
+
+   // TLM
+   uvm_analysis_port#(uvma_clic_seq_item_c)  ap;
+
+   `uvm_component_utils_begin(uvma_clic_drv_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_drv", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null.
+    * 2. Builds ap.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Obtains the reqs from the sequence item port and calls drv_req()
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Thread that clears acknowledged interrupts that were randomly asserted
+    */
+   extern task irq_ack_clear();
+
+   /**
+    * Drives the virtual interface's (cntxt.vif) signals using req's contents.
+    */
+   extern task drv_req(uvma_clic_seq_item_c req);
+
+   /**
+    * Forked thread to handle interrupts
+    */
+   extern task assert_irq_until_ack(uvma_clic_seq_item_c req);
+
+   /**
+    * Assert an interrupt signal
+    */
+   extern task assert_irq(uvma_clic_seq_item_c req);
+
+   /**
+    * Deassert an interrupt signal
+    */
+   extern task deassert_irq(uvma_clic_seq_item_c req);
+
+endclass : uvma_clic_drv_c
+
+function uvma_clic_drv_c::new(string name="uvma_clic_drv", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_clic_drv_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_clic_cfg_c)::get(this, "", "cfg", cfg));
+   if (cfg == null) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+   uvm_config_db#(uvma_clic_cfg_c)::set(this, "*", "cfg", cfg);
+
+   void'(uvm_config_db#(uvma_clic_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (cntxt == null) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+   uvm_config_db#(uvma_clic_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+   ap = new("ap", this);
+
+   foreach (assert_until_ack_sem[i]) begin
+      assert_until_ack_sem[i] = new(1);
+   end
+endfunction : build_phase
+
+
+task uvma_clic_drv_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+   // Enable the driver in the interface
+   cntxt.vif.is_active = cfg.enabled;
+   cntxt.vif.is_mmode_irq_only = cfg.is_mmode_irq_only;
+
+   // Fork thread to deassert randomly asserted clics when acknowledged
+   fork
+      irq_ack_clear();
+   join_none
+
+   forever begin
+      seq_item_port.get_next_item(req);
+      `uvml_hrtbt()
+      drv_req(req);
+      ap.write(req);
+      seq_item_port.item_done();
+   end
+
+endtask : run_phase
+
+task uvma_clic_drv_c::drv_req(uvma_clic_seq_item_c req);
+   `uvm_info("CLICDRV", $sformatf("Driving:\n%s", req.sprint()), UVM_HIGH);
+   case (req.action)
+      UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT_UNTIL_ACK: begin
+         assert_irq_until_ack(req);
+      end
+      UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT: begin
+         assert_irq(req);
+      end
+      UVMA_CLIC_SEQ_ITEM_ACTION_DEASSERT: begin
+         deassert_irq(req);
+      end
+   endcase
+
+endtask : drv_req
+
+task uvma_clic_drv_c::assert_irq_until_ack(uvma_clic_seq_item_c req);
+   // If a thread is already running on this irq, then exit
+   if (!assert_until_ack_sem[req.index].try_get(1))
+      return;
+
+   repeat (req.skew) @(cntxt.vif.drv_cb);
+
+   for (int loop = 0; loop < req.repeat_count; loop++) begin
+      repeat (req.skew) @(cntxt.vif.drv_cb);
+      cntxt.vif.drv_cb.clic_irq_drv       <= 1'b1;
+      cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
+      cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;
+      cntxt.vif.drv_cb.clic_irq_priv_drv  <= req.privilege_mode;
+      cntxt.vif.drv_cb.clic_irq_level_drv <= req.level;
+
+      while (1) begin
+         @(cntxt.vif.mon_cb);
+         if (cntxt.vif.mon_cb.irq_ack) begin
+            break;
+         end
+      end
+   end
+
+   `uvm_info("CLICDRV", $sformatf("assert_irq_until_ack: Deasserting irq: %0d", req.index), UVM_DEBUG);
+   cntxt.vif.drv_cb.clic_irq_drv       <= 1'b0;
+   cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
+   cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;
+   cntxt.vif.drv_cb.clic_irq_priv_drv  <= req.privilege_mode;
+   cntxt.vif.drv_cb.clic_irq_level_drv <= req.level;
+   assert_until_ack_sem[req.index].put(1);
+endtask : assert_irq_until_ack
+
+task uvma_clic_drv_c::assert_irq(uvma_clic_seq_item_c req);
+   if (assert_until_ack_sem[req.index].try_get(1)) begin
+      repeat (req.skew) @(cntxt.vif.drv_cb);
+      cntxt.vif.drv_cb.clic_irq_drv       <= 1'b1;
+      cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
+      cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;
+      cntxt.vif.drv_cb.clic_irq_priv_drv  <= req.privilege_mode;
+      cntxt.vif.drv_cb.clic_irq_level_drv <= req.level;
+      assert_until_ack_sem[req.index].put(1);
+      return;
+   end
+endtask : assert_irq
+
+task uvma_clic_drv_c::deassert_irq(uvma_clic_seq_item_c req);
+   if (assert_until_ack_sem[req.index].try_get(1)) begin
+      repeat (req.skew) @(cntxt.vif.drv_cb);
+      cntxt.vif.drv_cb.clic_irq_drv       <= 1'b0;
+      cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
+      cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;
+      cntxt.vif.drv_cb.clic_irq_priv_drv  <= req.privilege_mode;
+      cntxt.vif.drv_cb.clic_irq_level_drv <= req.level;
+      assert_until_ack_sem[req.index].put(1);
+      return;
+   end
+endtask : deassert_irq
+
+task uvma_clic_drv_c::irq_ack_clear();
+   while(1) begin
+      @(cntxt.vif.mon_cb);
+      if (cntxt.vif.mon_cb.irq_ack) begin
+         // Try to get the semaphore for the irq_id,
+         // If we can't get it, then this irq is managed by assert_irq_until_ack and we will ignore this ack
+         // Otherwise deassert the interrupt
+         int unsigned irq_id;
+
+         irq_id  = cntxt.vif.mon_cb.clic_irq_id_drv;
+
+         `uvm_info("IRQDRV", $sformatf("irq_ack_clear: ack for IRQ: %0d", irq_id), UVM_DEBUG);
+         if (assert_until_ack_sem[irq_id].try_get(1)) begin
+            `uvm_info("IRQDRV", $sformatf("irq_ack_clear: Clearing IRQ: %0d", irq_id), UVM_DEBUG);
+            cntxt.vif.drv_cb.clic_irq_drv       <= 1'b0;
+            cntxt.vif.drv_cb.clic_irq_id_drv    <= req.index;
+            cntxt.vif.drv_cb.clic_irq_shv_drv   <= req.sel_hardware_vectoring;
+            cntxt.vif.drv_cb.clic_irq_priv_drv  <= req.privilege_mode;
+            cntxt.vif.drv_cb.clic_irq_level_drv <= req.level;
+            assert_until_ack_sem[irq_id].put(1);
+         end
+      end
+   end
+endtask
+
+`endif // __UVMA_CLIC_DRV_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
@@ -1,0 +1,124 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_IF_SV__
+`define __UVMA_CLIC_IF_SV__
+
+
+/**
+ * Encapsulates all signals and clocking of Interrupt interface. Used by
+ * monitor and driver.
+ */
+interface uvma_clic_if#(SMCLIC_ID_WIDTH = 5)
+   (
+   );
+
+    // ---------------------------------------------------------------------------
+    // Interface wires
+    // ---------------------------------------------------------------------------
+    wire        clk;
+    wire        reset_n;
+
+    wire                        clic_irq;
+    wire [SMCLIC_ID_WIDTH-1:0]  clic_irq_id;
+    wire [7:0]                  clic_irq_level;
+    wire [1:0]                  clic_irq_priv;
+    wire                        clic_irq_shv;
+    wire                        irq_ack;
+    wire [31:0]                 irq;
+    wire [4:0]                  irq_id;
+
+    // // Used to time true clic entry with tracer instruction retirement
+    wire        deferint;
+    wire        ovp_cpu_state_stepi;
+
+    // -------------------------------------------------------------------
+    // Testbench control
+    // ---------------------------------------------------------------------------
+    // -------------------------------------------------------------------
+    bit         is_active;  // Set to active drive the clic lines
+    bit         is_mmode_irq_only;
+    bit [31:0]  irq_drv;    // TB clic driver
+
+    bit                       clic_irq_drv;
+    bit [SMCLIC_ID_WIDTH-1:0] clic_irq_id_drv;
+    bit [1:0]                 clic_irq_priv_drv;
+    bit [7:0]                 clic_irq_level_drv;
+    bit                       clic_irq_shv_drv;
+
+    bit [1:0]                 clic_irq_priv_masked;
+    // -------------------------------------------------------------------
+    // Begin module code
+    // -------------------------------------------------------------------
+
+    // Mux in driver to irq lines
+    //always_comb begin
+    //  clic_irq = is_active ? clic_irq_drv : 1'b0;
+    //end
+    assign clic_irq       = is_active ? clic_irq_drv          : 1'b0;
+    assign clic_irq_id    = is_active ? clic_irq_id_drv       : 1'b0;
+    assign clic_irq_level = is_active ? clic_irq_level_drv    : 1'b0;
+    assign clic_irq_priv  = is_active ? clic_irq_priv_masked  : 1'b0;
+    assign clic_irq_shv   = is_active ? clic_irq_shv_drv      : 1'b0;
+
+    assign clic_irq_priv_masked = is_mmode_irq_only ? 2'b11 : clic_irq_priv_drv;
+
+    initial begin
+        is_active = 1'b0;
+        clic_irq_drv = '0;
+    end
+
+    /**
+        * Used by target DUT.
+    */
+    clocking dut_cb @(posedge clk or reset_n);
+    endclocking : dut_cb
+
+    /**
+       * Used by uvma_clic_drv_c.
+    */
+    clocking drv_cb @(posedge clk or reset_n);
+        input #1step irq_ack;
+        output       irq_drv,
+                     clic_irq_drv,
+                     clic_irq_id_drv,
+                     clic_irq_level_drv,
+                     clic_irq_priv_drv,
+                     clic_irq_shv_drv;
+    endclocking : drv_cb
+
+    /**
+        * Used by uvma_clic_mon_c.
+    */
+    clocking mon_cb @(posedge clk or reset_n);
+        input #1step irq_ack,
+                     irq_drv,
+                     clic_irq_drv,
+                     clic_irq_id_drv,
+                     clic_irq_level_drv,
+                     clic_irq_priv_drv,
+                     clic_irq_shv_drv;
+    endclocking : mon_cb
+
+    modport dut_mp    (clocking dut_cb);
+    modport active_mp (clocking drv_cb);
+    modport passive_mp(clocking mon_cb);
+
+endinterface : uvma_clic_if
+
+
+`endif // __UVMA_CLIC_IF_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
@@ -23,9 +23,7 @@
  * Encapsulates all signals and clocking of Interrupt interface. Used by
  * monitor and driver.
  */
-interface uvma_clic_if#(SMCLIC_ID_WIDTH = 5)
-   (
-   );
+interface uvma_clic_if#(SMCLIC_ID_WIDTH = 5)();
 
     // ---------------------------------------------------------------------------
     // Interface wires
@@ -77,10 +75,12 @@ interface uvma_clic_if#(SMCLIC_ID_WIDTH = 5)
 
     assign clic_irq_priv_masked = is_mmode_irq_only ? 2'b11 : clic_irq_priv_drv;
 
+    `ifndef FORMAL // suppress warning, initial is not supported in formal
     initial begin
         is_active = 1'b0;
         clic_irq_drv = '0;
     end
+    `endif
 
     /**
         * Used by target DUT.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
@@ -1,6 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_macros.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_macros.sv
@@ -1,13 +1,13 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_macros.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_macros.sv
@@ -1,0 +1,25 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_MACROS_SV__
+`define __UVMA_CLIC_MACROS_SV__
+
+
+
+
+
+`endif // __UVMA_CLIC_MACROS_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon.sv
@@ -1,0 +1,160 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_CLIC_MON_SV__
+`define __UVMA_CLIC_MON_SV__
+
+
+/**
+ * Component sampling transactions from a Clock & Reset virtual interface
+ * (uvma_clic_if).
+ */
+class uvma_clic_mon_c extends uvm_monitor;
+
+   // Objects
+   uvma_clic_cfg_c    cfg;
+   uvma_clic_cntxt_c  cntxt;
+
+   // TLM
+   // This analysis port will fire when the irq_ack_o is seen (core acknowledges the clic)
+   uvm_analysis_port#(uvma_clic_mon_trn_c)  ap;
+
+   // This analysis port will fire when the first instruction in the ISR is retired (i.e. the MTVEC location)
+   uvm_analysis_port#(uvma_clic_mon_trn_c)  ap_iss;
+
+   `uvm_component_utils_begin(uvma_clic_mon_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_mon", uvm_component parent=null);
+
+   /**
+    * 1. Ensures cfg & cntxt handles are not null.
+    * 2. Builds ap.
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+   /**
+    * Oversees monitoring via monitor_clk() and monitor_reset() tasks in parallel
+    * forks.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Publish a monitor transactin when clic is taken.
+    */
+   extern virtual task monitor_irq();
+
+   /**
+    * Publish a monitor transaction when clic is taken (delayed until the first instruction of the ISR is retired)
+    */
+   extern virtual task monitor_irq_iss();
+
+endclass : uvma_clic_mon_c
+
+function uvma_clic_mon_c::new(string name="uvma_clic_mon", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_clic_mon_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_clic_cfg_c)::get(this, "", "cfg", cfg));
+   if (cfg == null) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvma_clic_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (cntxt == null) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+   ap     = new("ap", this);
+   ap_iss = new("ap_iss", this);
+
+endfunction : build_phase
+
+task uvma_clic_mon_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+
+   if (cfg.enabled) begin
+      while (1) begin
+         wait (cntxt.vif.reset_n === 1'b0);
+         wait (cntxt.vif.reset_n === 1'b1);
+
+         fork begin
+            // To maintain random thread stability launch iss thread always, but it will exit immediately if no iss configured
+            fork
+               monitor_irq();
+               monitor_irq_iss();
+            join_none
+
+            wait (cntxt.vif.reset_n === 1'b0);
+
+            disable fork;
+         end
+         join
+      end
+   end
+endtask : run_phase
+
+task uvma_clic_mon_c::monitor_irq();
+   while(1) begin
+      @(cntxt.vif.mon_cb);
+
+      if (cntxt.vif.mon_cb.irq_ack) begin
+         uvma_clic_mon_trn_c mon_trn = uvma_clic_mon_trn_c::type_id::create("mon_irq_trn");
+         mon_trn.action = UVMA_CLIC_MON_ACTION_IRQ;
+         mon_trn.id = cntxt.vif.mon_cb.clic_irq_id_drv;
+         ap.write(mon_trn);
+      end
+   end
+endtask : monitor_irq
+
+task uvma_clic_mon_c::monitor_irq_iss();
+   if ($test$plusargs("USE_ISS")) begin
+      while(1) begin
+         @(cntxt.vif.mon_cb);
+
+         if (cntxt.vif.mon_cb.irq_ack) begin
+            uvma_clic_mon_trn_c mon_trn = uvma_clic_mon_trn_c::type_id::create("mon_irq_trn");
+            mon_trn.action = UVMA_CLIC_MON_ACTION_IRQ;
+            mon_trn.id = cntxt.vif.mon_cb.clic_irq_id_drv;
+
+            // Wait for the ISS to enter
+            wait (cntxt.vif.deferint == 1'b0);
+            wait (cntxt.vif.ovp_cpu_state_stepi == 1'b1);
+
+            ap_iss.write(mon_trn);
+         end
+      end
+   end
+endtask : monitor_irq_iss
+
+
+`endif // __UVMA_CLIC_MON_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon.sv
@@ -1,7 +1,7 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn.sv
@@ -1,6 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn.sv
@@ -1,0 +1,57 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_MON_TRN_SV__
+`define __UVMA_CLIC_MON_TRN_SV__
+
+
+/**
+ * Object rebuilt from the Interrupt monitor Analog of uvma_clic_seq_item_c.
+ */
+class uvma_clic_mon_trn_c extends uvml_trn_mon_trn_c;
+
+   uvma_clic_mon_action_enum action;
+
+   int unsigned  id;
+
+   `uvm_object_utils_begin(uvma_clic_mon_trn_c)
+      `uvm_field_enum(uvma_clic_mon_action_enum, action, UVM_DEFAULT)
+      `uvm_field_int(id, UVM_DEFAULT)
+   `uvm_object_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_mon_trn");
+
+endclass : uvma_clic_mon_trn_c
+
+
+`pragma protect begin
+
+
+function uvma_clic_mon_trn_c::new(string name="uvma_clic_mon_trn");
+
+   super.new(name);
+
+endfunction : new
+
+
+`pragma protect end
+
+
+`endif // __UVMA_CLIC_MON_TRN_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn_logger.sv
@@ -1,6 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_mon_trn_logger.sv
@@ -1,0 +1,114 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_MON_TRN_LOGGER_SV__
+`define __UVMA_CLIC_MON_TRN_LOGGER_SV__
+
+
+/**
+ * Component writing Interrupt monitor transactions clic data to disk as plain text.
+ */
+class uvma_clic_mon_trn_logger_c extends uvml_logs_mon_trn_logger_c#(
+   .T_TRN  (uvma_clic_mon_trn_c),
+   .T_CFG  (uvma_clic_cfg_c    ),
+   .T_CNTXT(uvma_clic_cntxt_c  )
+);
+
+   `uvm_component_utils(uvma_clic_mon_trn_logger_c)
+
+
+   /**
+    * Default constructor.
+    */
+   function new(string name="uvma_clic_mon_trn_logger", uvm_component parent=null);
+
+      super.new(name, parent);
+
+   endfunction : new
+
+   /**
+    * Writes contents of t to disk
+    */
+   virtual function void write(uvma_clic_mon_trn_c t);
+
+      // TODO Implement uvma_clic_mon_trn_logger_c::write()
+      // Ex: fwrite($sformatf(" %t | %08h | %02b | %04d | %02h |", $realtime(), t.a, t.b, t.c, t.d));
+
+   endfunction : write
+
+   /**
+    * Writes log header to disk
+    */
+   virtual function void print_header();
+
+      // TODO Implement uvma_clic_mon_trn_logger_c::print_header()
+      // Ex: fwrite("----------------------------------------------");
+      //     fwrite(" TIME | FIELD A | FIELD B | FIELD C | FIELD D ");
+      //     fwrite("----------------------------------------------");
+
+   endfunction : print_header
+
+endclass : uvma_clic_mon_trn_logger_c
+
+
+/**
+ * Component writing CLIC monitor transactions clic data to disk as JavaScript Object Notation (JSON).
+ */
+class uvma_clic_mon_trn_logger_json_c extends uvma_clic_mon_trn_logger_c;
+
+   `uvm_component_utils(uvma_clic_mon_trn_logger_json_c)
+
+
+   /**
+    * Set file extension to '.json'.
+    */
+   function new(string name="uvma_clic_mon_trn_logger_json", uvm_component parent=null);
+
+      super.new(name, parent);
+      fextension = "json";
+
+   endfunction : new
+
+   /**
+    * Writes contents of t to disk.
+    */
+   virtual function void write(uvma_clic_mon_trn_c t);
+
+      // TODO Implement uvma_clic_mon_trn_logger_json_c::write()
+      // Ex: fwrite({"{",
+      //       $sformatf("\"time\":\"%0t\",", $realtime()),
+      //       $sformatf("\"a\":%h,"        , t.a        ),
+      //       $sformatf("\"b\":%b,"        , t.b        ),
+      //       $sformatf("\"c\":%d,"        , t.c        ),
+      //       $sformatf("\"d\":%h,"        , t.c        ),
+      //     "},"});
+
+   endfunction : write
+
+   /**
+    * Empty function.
+    */
+   virtual function void print_header();
+
+      // Do nothing: JSON files do not use headers.
+
+   endfunction : print_header
+
+endclass : uvma_clic_mon_trn_logger_json_c
+
+
+`endif // __UVMA_CLIC_MON_TRN_LOGGER_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_pkg.flist
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_pkg.flist
@@ -1,7 +1,7 @@
 // 
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 // 
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_pkg.flist
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_pkg.flist
@@ -1,0 +1,26 @@
+// 
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+
+// Directories
++incdir+${DV_UVMA_CLIC_PATH}
++incdir+${DV_UVMA_CLIC_PATH}/cov
++incdir+${DV_UVMA_CLIC_PATH}/seq
+
+// Files
+${DV_UVMA_CLIC_PATH}/uvma_clic_pkg.sv

--- a/lib/uvm_agents/uvma_clic/uvma_clic_pkg.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_pkg.sv
@@ -1,0 +1,71 @@
+// 
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+
+`ifndef __UVMA_CLIC_PKG_SV__
+`define __UVMA_CLIC_PKG_SV__
+
+
+// Pre-processor macros
+`include "uvm_macros.svh"
+`include "uvml_hrtbt_macros.sv"
+`include "uvma_clic_macros.sv"
+
+// Interface(s) / Module(s) / Checker(s)
+`include "uvma_clic_if.sv"
+
+/**
+ * Encapsulates all the types needed for an UVM agent capable of driving and/or
+ * monitoring Clock & Reset.
+ */
+package uvma_clic_pkg;
+
+   import uvm_pkg       ::*;
+   import uvml_hrtbt_pkg::*;
+   import uvml_trn_pkg  ::*;
+   import uvml_logs_pkg ::*;
+
+   // Constants / Structs / Enums
+   `include "uvma_clic_constants.sv"
+   `include "uvma_clic_tdefs.sv"
+   
+   // Objects
+   `include "uvma_clic_cfg.sv"
+   `include "uvma_clic_cntxt.sv"
+   
+   // High-level transactions
+   `include "uvma_clic_mon_trn.sv"
+   `include "uvma_clic_mon_trn_logger.sv"
+   `include "uvma_clic_seq_item.sv"
+   `include "uvma_clic_seq_item_logger.sv"
+   
+   // Agent components
+   `include "uvma_clic_cov_model.sv"
+   `include "uvma_clic_drv.sv"
+   `include "uvma_clic_mon.sv"
+   `include "uvma_clic_sqr.sv"
+   `include "uvma_clic_agent.sv"
+   
+   // Sequences
+   `include "uvma_clic_base_seq.sv"
+   `include "uvma_clic_seq_lib.sv"
+   
+endpackage : uvma_clic_pkg
+
+
+`endif // __UVMA_CLIC_PKG_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_pkg.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_pkg.sv
@@ -1,20 +1,20 @@
-// 
+//
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
-// 
+// Copyright 2022 Silicon Labs, Inc.
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 
 
 `ifndef __UVMA_CLIC_PKG_SV__
@@ -43,28 +43,28 @@ package uvma_clic_pkg;
    // Constants / Structs / Enums
    `include "uvma_clic_constants.sv"
    `include "uvma_clic_tdefs.sv"
-   
+
    // Objects
    `include "uvma_clic_cfg.sv"
    `include "uvma_clic_cntxt.sv"
-   
+
    // High-level transactions
    `include "uvma_clic_mon_trn.sv"
    `include "uvma_clic_mon_trn_logger.sv"
    `include "uvma_clic_seq_item.sv"
    `include "uvma_clic_seq_item_logger.sv"
-   
+
    // Agent components
    `include "uvma_clic_cov_model.sv"
    `include "uvma_clic_drv.sv"
    `include "uvma_clic_mon.sv"
    `include "uvma_clic_sqr.sv"
    `include "uvma_clic_agent.sv"
-   
+
    // Sequences
    `include "uvma_clic_base_seq.sv"
    `include "uvma_clic_seq_lib.sv"
-   
+
 endpackage : uvma_clic_pkg
 
 

--- a/lib/uvm_agents/uvma_clic/uvma_clic_sqr.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_sqr.sv
@@ -1,7 +1,7 @@
 //
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
+// Copyright 2022 Silicon Labs, Inc.
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_sqr.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_sqr.sv
@@ -1,0 +1,81 @@
+//
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_CLIC_SQR_SV__
+`define __UVMA_CLIC_SQR_SV__
+
+
+/**
+ * Component running Clock & Reset sequences extending uvma_clic_seq_base_c.
+ * Provides sequence items for uvma_clic_drv_c.
+ */
+class uvma_clic_sqr_c extends uvm_sequencer#(
+   .REQ(uvma_clic_seq_item_c),
+   .RSP(uvma_clic_seq_item_c)
+);
+
+   // Objects
+   uvma_clic_cfg_c    cfg;
+   uvma_clic_cntxt_c  cntxt;
+
+
+   `uvm_component_utils_begin(uvma_clic_sqr_c)
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+      `uvm_field_object(cntxt, UVM_DEFAULT)
+   `uvm_component_utils_end
+
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_clic_sqr", uvm_component parent=null);
+
+   /**
+    * Ensures cfg & cntxt handles are not null
+    */
+   extern virtual function void build_phase(uvm_phase phase);
+
+endclass : uvma_clic_sqr_c
+
+
+function uvma_clic_sqr_c::new(string name="uvma_clic_sqr", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_clic_sqr_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_clic_cfg_c)::get(this, "", "cfg", cfg));
+   if (cfg == null) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   void'(uvm_config_db#(uvma_clic_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (cntxt == null) begin
+      `uvm_fatal("CNTXT", "Context handle is null")
+   end
+
+endfunction : build_phase
+
+
+`endif // __UVMA_CLIC_SQR_SV__

--- a/lib/uvm_agents/uvma_clic/uvma_clic_tdefs.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_tdefs.sv
@@ -1,13 +1,13 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
-// Copyright 2020 Silicon Labs, Inc.
-// 
+// Copyright 2022 Silicon Labs, Inc.
+//
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://solderpad.org/licenses/
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/uvm_agents/uvma_clic/uvma_clic_tdefs.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_tdefs.sv
@@ -1,0 +1,31 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Datum Technology Corporation
+// Copyright 2020 Silicon Labs, Inc.
+// 
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://solderpad.org/licenses/
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CLIC_TDEFS_SV__
+`define __UVMA_CLIC_TDEFS_SV__
+
+typedef enum {
+   UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT_UNTIL_ACK,
+   UVMA_CLIC_SEQ_ITEM_ACTION_ASSERT,
+   UVMA_CLIC_SEQ_ITEM_ACTION_DEASSERT
+} uvma_clic_seq_item_action_enum;
+
+typedef enum {
+   UVMA_CLIC_MON_ACTION_IRQ
+} uvma_clic_mon_action_enum;
+
+`endif // __UVMA_CLIC_TDEFS_SV__

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
@@ -120,7 +120,7 @@ task uvma_interrupt_drv_c::run_phase(uvm_phase phase);
    super.run_phase(phase);
 
    // Enable the driver in the interface
-   cntxt.vif.is_active = 1;
+   cntxt.vif.is_active = cfg.enabled;
 
    // Fork thread to deassert randomly asserted interrupts when acknowledged
    fork

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
@@ -219,7 +219,7 @@ endtask : deassert_irq
 task uvma_interrupt_drv_c::irq_ack_clear();
    while(1) begin
       @(cntxt.vif.mon_cb);
-      if (cntxt.vif.mon_cb.irq_ack) begin
+      if (cntxt.vif.mon_cb.irq_ack && cfg.enabled) begin
          // Try to get the semaphore for the irq_id,
          // If we can't get it, then this irq is managed by assert_irq_until_ack and we will ignore this ack
          // Otherwise deassert the interrupt

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cfg.sv
@@ -39,6 +39,8 @@ class uvma_obi_memory_cfg_c extends uvm_object;
 
    string                        mon_logger_name = "OBI";
 
+   rand bit clic_interrupts_enabled;
+   rand bit basic_interrupts_enabled;
    // Protocol parameters
    rand uvma_obi_memory_version_enum    version;
    rand bit                             ignore_rready;
@@ -101,6 +103,9 @@ class uvma_obi_memory_cfg_c extends uvm_object;
       `uvm_field_int (                         stall_disable            , UVM_DEFAULT)
       `uvm_field_int (                         rvalid_singles_stall     , UVM_DEFAULT)
 
+      `uvm_field_int (                       clic_interrupts_enabled     , UVM_DEFAULT)
+      `uvm_field_int (                       basic_interrupts_enabled    , UVM_DEFAULT)
+
       `uvm_field_enum(uvma_obi_memory_version_enum, version, UVM_DEFAULT)
       `uvm_field_int (                        auser_width  , UVM_DEFAULT | UVM_DEC)
       `uvm_field_int (                        wuser_width  , UVM_DEFAULT | UVM_DEC)
@@ -147,6 +152,8 @@ class uvma_obi_memory_cfg_c extends uvm_object;
       soft cov_model_enabled    == 0;
       soft trn_log_enabled      == 1;
 
+      soft clic_interrupts_enabled        == 0;
+      soft basic_interrupts_enabled       == 1;
       soft version                        == UVMA_OBI_MEMORY_VERSION_1P1;
       /*soft*/ ignore_rready              == 1;
       soft auser_width                    == uvma_obi_memory_default_auser_width;

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_mon.sv
@@ -38,7 +38,7 @@ class uvma_rvfi_instr_mon_c#(int ILEN=DEFAULT_ILEN,
 
    // State of monitor
    bit                last_dcsr_nmip = 0;
-   bit [uvma_rvfi_csr_seq_item_c::XLEN-1:0] dcsr_ret_data;
+   bit [XLEN-1:0] dcsr_ret_data;
 
    string log_tag = "RVFIMONLOG";
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
@@ -33,12 +33,12 @@ typedef struct packed {
 } rvfi_intr_t;
 
 typedef struct packed {
-   logic [1:0]  cause_type;
-   logic [2:0]  debug_cause;
-   logic [5:0]  exception_cause;
-   logic        debug;
-   logic        exception;
-   logic        trap;
+  logic [1:0]  cause_type;
+  logic [2:0]  debug_cause;
+  logic [5:0]  exception_cause;
+  logic        debug;
+  logic        exception;
+  logic        trap;
 } rvfi_trap_t;
 
 function string get_mode_str(uvma_rvfi_mode mode);

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -111,6 +111,7 @@ export DV_UVMA_RVVI_PATH        = $(CORE_V_VERIF)/lib/uvm_agents/uvma_rvvi
 export DV_UVMA_RVVI_OVPSIM_PATH = $(CORE_V_VERIF)/lib/uvm_agents/uvma_rvvi_ovpsim
 export DV_UVMA_CLKNRST_PATH     = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clknrst
 export DV_UVMA_INTERRUPT_PATH   = $(CORE_V_VERIF)/lib/uvm_agents/uvma_interrupt
+export DV_UVMA_CLIC_PATH        = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clic
 export DV_UVMA_DEBUG_PATH       = $(CORE_V_VERIF)/lib/uvm_agents/uvma_debug
 export DV_UVMA_PMA_PATH         = $(CORE_V_VERIF)/lib/uvm_agents/uvma_pma
 export DV_UVMA_OBI_MEMORY_PATH  = $(CORE_V_VERIF)/lib/uvm_agents/uvma_obi_memory


### PR DESCRIPTION
Signed-off-by: Henrik Fegran <Henrik.Fegran@silabs.com>

Includes: 
- clic assertions (some minor work and bugfixes remains - some are pending rtl fixes for completion)
- uvm clic interrupt agent
- infrastructure updates to support clic agent in sim

Lacks:
- ISS setup for CLIC (lack of documentation for old interface, awaiting ImperasDV update)
- Full core_v_dv support (notably interrupt handler code and constraints for edge case instructions (e.g. mscratchcs* accesses not defined for anything but CSRRW)
