### PR TITLE
cva6.py : Disable compressed instruction when 'disable_compressed_instr=1'

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -364,7 +364,7 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd, linker):
         cmd += test['gcc_opts']
       if 'gen_opts' in test:
         # Disable compressed instruction
-        if re.search('disable_compressed_instr', test['gen_opts']):
+        if re.search('disable_compressed_instr=1', test['gen_opts']):
           test_isa = re.sub("c",  "", test_isa)
       # If march/mabi is not defined in the test gcc_opts, use the default
       # setting from the command line.


### PR DESCRIPTION
The cva6.py script use the YAML description to generate random tests, the problem here in the compressed instructions, actually these instructions are active by default, so to disable these instructions we should add an option in the YAML description (disable_compressed_instr=1), but in the **cva6.py** disable the compressed instructions when it detect the string **disable_compressed_instr** only, but what if we passed to disable_compressed_instr=0, that's means the C extension still active, so we need to modify the condition to disable compered inst only when **disable_compressed_instr=1**.