### PR TITLE
Add unified tracking of simulator elaboration and simulation performance

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -19,6 +19,9 @@ endif
 
 .DEFAULT_GOAL := help
 
+# Timing command
+TIME_CMD = time -f "real %E user %U sys %S"
+
 FLIST_TB   := $(CVA6_TB_DIR)/Flist.cva6_tb
 # target takes one of the following cva6 hardware configuration:
 # cv64a6_imafdc_sv39, cv32a6_imac_sv0, cv32a6_imac_sv32, cv32a6_imafc_sv32
@@ -108,14 +111,14 @@ spike:
 # testharness specific commands, variables
 ###############################################################################
 vcs-testharness:
-	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
-	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
+	$(TIME_CMD) make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	$(TIME_CMD) $(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
 	$(tool_path)/spike-dasm --isa=$(target_isa) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 veri-testharness:
-	make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
-	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts)
+	$(TIME_CMD) make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	$(TIME_CMD) $(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts)
 	$(tool_path)/spike-dasm --isa=$(target_isa) < ./trace_rvfi_hart_00.dasm > $(log)
 	# If present, move default trace files to per-test directory.
 	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.$(target).fst
@@ -197,7 +200,7 @@ dpi_build:
 vcs_uvm_comp: dpi_build
 	@echo "[VCS] Building Model"
 	mkdir -p $(VCS_WORK_DIR)
-	cd $(VCS_WORK_DIR) && vcs $(ALL_UVM_FLAGS) \
+	cd $(VCS_WORK_DIR) && $(TIME_CMD) vcs $(ALL_UVM_FLAGS) \
 	  -f $(FLIST_CORE) -f $(FLIST_TB) \
 	  -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
 	  $(cov-comp-opt) $(isscomp_opts)\
@@ -206,7 +209,7 @@ vcs_uvm_comp: dpi_build
 vcs_uvm_run:
 	$(if $(TRACE_FAST), unset VERDI_HOME ;) \
 	cd $(VCS_WORK_DIR)/ && \
-	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
+	$(TIME_CMD) $(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
 	++$(elf) \
 	+PRELOAD=$(elf) \
 	-sv_lib $(dpi-library)/ariane_dpi \


### PR DESCRIPTION
Add a means of tracking the performance of simulators used in verification, both in terms of model elaboration/compilation time, and of simulation time proper.  The collected performance data are added to the simulator log file, typically `cva6/sim/out_<date>/<simtarget>_sim/*.log.iss`.

# Changelog

* cva6/sim/Makefile (TIME_CMD): New.
  (vcs-testharness): Add timing command defined as $(TIME_CMD).
  (veri-testharness): Ditto.
  (vcs_uvm_comp): Ditto.
  (vcs_vm_run): Ditto.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>