### PR TITLE
Fix ci_check and hello world

### DIFF
--- a/cv32e40s/tests/cfg/b_ext_abs.yaml
+++ b/cv32e40s/tests/cfg/b_ext_abs.yaml
@@ -6,5 +6,5 @@ ovpsim: >
 #    --showoverrides
 #    --trace --tracechange --traceshowicount --monitornets
 cflags: >
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbs1p00_zicsr_zca_zifencei
 

--- a/cv32e40s/tests/cfg/b_ext_all.yaml
+++ b/cv32e40s/tests/cfg/b_ext_all.yaml
@@ -6,5 +6,5 @@ ovpsim: >
 #    --showoverrides
 #    --trace --tracechange --traceshowicount --monitornets
 cflags: >
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei
 

--- a/cv32e40s/tests/cfg/default.yaml
+++ b/cv32e40s/tests/cfg/default.yaml
@@ -11,4 +11,4 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_1.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_1.yaml
@@ -12,4 +12,4 @@ plusargs:
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_2.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_2.yaml
@@ -10,4 +10,4 @@ plusargs:
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_3.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_3.yaml
@@ -13,4 +13,4 @@ plusargs:
    +enable_zbb_extension=1
    +enable_zbc_extension=1
    +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_4.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_4.yaml
@@ -14,4 +14,4 @@ plusargs:
    +enable_zbb_extension=1
    +enable_zbc_extension=1
    +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_5.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_5.yaml
@@ -13,4 +13,4 @@ plusargs:
    +enable_zbb_extension=1
    +enable_zbc_extension=1
    +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei_zcmp
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei


### PR DESCRIPTION
Hello world and ci_check is broken. This PR fixes it by removing Zc from "march" in the cfg yamls, as that was pushed before the rest of the system has Zc enabled. I will be doing x-s merging and need clean points of comparison. If this is not merged into cv32e40s/dev now, then I will either have to juggle having lots of temporarily not-checked-in files at the same time as I am trying to hold track of the manual copy of untracked files from x to s and it will make the job a lot harder, or I can check it in to the local merging branch and then it will get merged into cv32e40s/dev later but with the disadvantage that it will happen more silently and hello world etc will not work in the meantime.

Passes ci_check, except for "debug_test" which was known to fail before.

@silabs-hfegran @silabs-mateilga 