### PR TITLE
temporary fixes to integrity-related signals

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,10 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= ed92096c08e6dbebfbf1e4295f7583f365519648
+CV_CORE_HASH   ?= 4a9ff950f56136863eaff7a11baa83b73fcafab9
+#CV_CORE_REPO   ?= https://github.com/silabs-oysteink/cv32e40s
+#CV_CORE_BRANCH ?= silabs-oysteink_obi-data-counter
+#CV_CORE_HASH   ?= a73b6cb889cfd1fee0d8c1bf014135555269533f8
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -16,9 +16,6 @@ export SHELL = /bin/bash
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
 CV_CORE_HASH   ?= 4a9ff950f56136863eaff7a11baa83b73fcafab9
-#CV_CORE_REPO   ?= https://github.com/silabs-oysteink/cv32e40s
-#CV_CORE_BRANCH ?= silabs-oysteink_obi-data-counter
-#CV_CORE_HASH   ?= a73b6cb889cfd1fee0d8c1bf014135555269533f8
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -138,6 +138,41 @@ module uvmt_cv32e40s_dut_wrap
       end
     end
 
+
+//TODO: These are temporary hacks to get the very basics working wit integrity checks
+//      Needs to be reworked in to the obi memory agent
+logic [4:0]  instr_rchk;
+assign instr_rchk = {
+      ^{obi_instr_if_i.err, 1'b0},
+      ^{obi_instr_if_i.rdata[31:24]},
+      ^{obi_instr_if_i.rdata[23:16]},
+      ^{obi_instr_if_i.rdata[15:8]},
+      ^{obi_instr_if_i.rdata[7:0]}
+    };
+
+    logic [4:0]  rchk_lsu;
+assign rchk_lsu = {
+
+      ^{obi_data_if_i.err, 1'b0},
+      ^{obi_data_if_i.rdata[31:24]},
+      ^{obi_data_if_i.rdata[23:16]},
+      ^{obi_data_if_i.rdata[15:8]},
+      ^{obi_data_if_i.rdata[7:0]}
+    };
+
+
+  logic gntpar_int;
+  assign gntpar_int = !obi_instr_if_i.gnt;
+
+  logic rvalidpar_int;
+  assign rvalidpar_int = !obi_instr_if_i.rvalid;
+
+  logic gntpar_lsu;
+  assign gntpar_lsu = !obi_data_if_i.gnt;
+
+  logic rvalidpar_lsu;
+  assign rvalidpar_lsu = !obi_data_if_i.rvalid;
+
     // --------------------------------------------
     // instantiate the core
     cv32e40s_wrapper #(
@@ -162,47 +197,48 @@ module uvmt_cv32e40s_dut_wrap
          .dm_exception_addr_i    ( core_cntrl_if.dm_exception_addr),
 
          .instr_req_o            ( obi_instr_if_i.req             ),
-         .instr_reqpar_o         ( obi_instr_if_i.reqpar          ),
+         .instr_reqpar_o         (      /* todo: connect */       ),
          .instr_gnt_i            ( obi_instr_if_i.gnt             ),
-         .instr_gntpar_i         ( obi_instr_if_i.gntpar          ),
+         .instr_gntpar_i         ( gntpar_int),//!obi_instr_if_i.gnt /* todo: connect */       ),
          .instr_addr_o           ( obi_instr_if_i.addr            ),
-         .instr_achk_o           ( obi_instr_if_i.achk            ),
+         .instr_achk_o           (      /* todo: connect */       ),
          .instr_prot_o           ( obi_instr_if_i.prot            ),
          .instr_dbg_o            ( /* obi_instr_if_i.dbg */       ), // todo: Support OBI 1.3
          .instr_memtype_o        ( obi_instr_if_i.memtype         ),
          .instr_rdata_i          ( obi_instr_if_i.rdata           ),
-         .instr_rchk_i           ( obi_instr_if_i.rchk            ),
+         .instr_rchk_i           ( instr_rchk        ),
          .instr_rvalid_i         ( obi_instr_if_i.rvalid          ),
-         .instr_rvalidpar_i      ( obi_instr_if_i.rvalidpar       ),
+         .instr_rvalidpar_i      ( rvalidpar_int /* todo: connect */       ),
          .instr_err_i            ( obi_instr_if_i.err             ),
 
          .data_req_o             ( obi_data_if_i.req              ),
-         .data_reqpar_o          ( obi_data_if_i.reqpar           ),
+         .data_reqpar_o          (      /* todo: connect */       ),
          .data_gnt_i             ( obi_data_if_i.gnt              ),
-         .data_gntpar_i          ( obi_data_if_i.gntpar           ),
+         .data_gntpar_i          ( gntpar_lsu /* todo: connect */       ),
          .data_rvalid_i          ( obi_data_if_i.rvalid           ),
-         .data_rvalidpar_i       ( obi_data_if_i.rvalidpar        ),
+         .data_rvalidpar_i       ( rvalidpar_lsu /* todo: connect */       ),
          .data_we_o              ( obi_data_if_i.we               ),
          .data_be_o              ( obi_data_if_i.be               ),
          .data_addr_o            ( obi_data_if_i.addr             ),
-         .data_achk_o            ( obi_data_if_i.achk             ),
+         .data_achk_o            (      /* todo: connect */       ),
          .data_wdata_o           ( obi_data_if_i.wdata            ),
          .data_prot_o            ( obi_data_if_i.prot             ),
-         .data_dbg_o             (  /* obi_data_if_i.dbg */       ), // todo: Support OBI 1.3
+         .data_dbg_o             ( /* obi_data_if_i.dbg */        ), // todo: Support OBI 1.3
          .data_memtype_o         ( obi_data_if_i.memtype          ),
          .data_rdata_i           ( obi_data_if_i.rdata            ),
-         .data_rchk_i            ( obi_data_if_i.rchk             ),
+         .data_rchk_i            ( rchk_lsu  /* todo: connect */       ),
          .data_err_i             ( obi_data_if_i.err              ),
 
          .mcycle_o               ( /*todo: connect */             ),
 
          .irq_i                  ( interrupt_if.irq               ),
-
+         .wu_wfe_i               ( 1'b0                           ), // todo: hook up
          .clic_irq_i             ( '0   /*todo: connect */        ),
          .clic_irq_id_i          ( '0   /*todo: connect */        ),
          .clic_irq_level_i       ( '0   /*todo: connect */        ),
          .clic_irq_priv_i        ( '0   /*todo: connect */        ),
          .clic_irq_shv_i         ( '0   /*todo: connect */        ),
+
 
          .fencei_flush_req_o     ( fencei_if_i.flush_req          ),
          .fencei_flush_ack_i     ( fencei_if_i.flush_ack          ),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_interrupt_assert.sv
@@ -92,7 +92,7 @@ module uvmt_cv32e40s_interrupt_assert
   wire [31:0] pending_enabled_irq;
   wire [31:0] pending_enabled_irq_q;
 
-  reg  in_wfi; // Local model of WFI state of core
+  reg  in_wfi_wfe; // Local model of WFI state of core
 
   reg[31:0] irq_q;
 
@@ -346,17 +346,18 @@ module uvmt_cv32e40s_interrupt_assert
     assign is_wfe = wb_stage_instr_valid_i                   &&
                   (wb_stage_instr_rdata_i == WFE_INSTR_DATA) &&
                   !branch_taken_ex                           &&
+                  !((priv_lvl == PRIV_LVL_U) && mstatus_tw)  &&
                   !wb_stage_instr_err_i                      &&
                   (wb_stage_instr_mpu_status == MPU_OK);
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      in_wfi <= 1'b0;
+      in_wfi_wfe <= 1'b0;
     end
     else begin
-      if ((is_wfi || is_wfe) && !in_wfi)
-        in_wfi <= 1'b1;
+      if ((is_wfi || is_wfe) && !in_wfi_wfe) //
+        in_wfi_wfe <= 1'b1;
       else if (|pending_enabled_irq || debug_req_i)
-        in_wfi <= 1'b0;
+        in_wfi_wfe <= 1'b0;
     end
   end
 
@@ -364,10 +365,10 @@ module uvmt_cv32e40s_interrupt_assert
 
   // WFI assertion will assert core_sleep_o (in WFI_TO_CORE_SLEEP_LATENCY cycles after wb, given ideal conditions)
   property p_wfi_assert_core_sleep_o;
-    !in_wfi
-    ##1 (in_wfi && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)[*(WFI_TO_CORE_SLEEP_LATENCY-1)]
+    !in_wfi_wfe
+    ##1 (in_wfi_wfe && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)[*(WFI_TO_CORE_SLEEP_LATENCY-1)]
     ##1 (
-      (in_wfi && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)
+      (in_wfi_wfe && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)
         throughout $past(pipeline_ready_for_wfi)[->1]
       )
     |->
@@ -381,9 +382,9 @@ module uvmt_cv32e40s_interrupt_assert
 
   // WFI assertion will assert core_sleep_o (after required conditions are met)
   property p_wfi_assert_core_sleep_o_cond;
-    !in_wfi
+    !in_wfi_wfe
     ##1 (
-      (in_wfi && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)
+      (in_wfi_wfe && !(|pending_enabled_irq) && !debug_mode_q && !debug_req_i)
       throughout (##1 ($past(pipeline_ready_for_wfi)[->1]) )
       )
     |->
@@ -397,7 +398,7 @@ module uvmt_cv32e40s_interrupt_assert
 
   // core_sleep_o deassertion in wfi should be followed by WFI deassertion
   property p_core_sleep_deassert;
-    $fell(core_sleep_o) ##0 in_wfi |-> ##1 !in_wfi;
+    $fell(core_sleep_o) ##0 in_wfi_wfe |-> ##1 !in_wfi_wfe;
   endproperty
   a_core_sleep_deassert: assert property(p_core_sleep_deassert)
     else
@@ -415,15 +416,15 @@ module uvmt_cv32e40s_interrupt_assert
 
   // Outside of WFI, the core should not sleep
   a_wfi_deny_core_sleep_o: assert property (
-    !in_wfi |-> !core_sleep_o
+    !in_wfi_wfe |-> !core_sleep_o
   ) else
     `uvm_error(info_tag, "Only WFI should trigger core sleep");
 
   // WFI wakeup to next instruction fetch/execution
   property p_wfi_wake_to_instr_fetch;
     disable iff (!rst_ni || !fetch_enable_i || debug_mode_q)
-    core_sleep_o && in_wfi
-    ##1 !in_wfi[->1]
+    core_sleep_o && in_wfi_wfe
+    ##1 !in_wfi_wfe[->1]
     |->
     ##[0:WFI_WAKEUP_LATENCY]
       ($rose(if_stage_instr_req_o)  // IF starts fetching again
@@ -436,7 +437,7 @@ module uvmt_cv32e40s_interrupt_assert
 
   // Cover property, detect sleep deassertion due to asserted and non-asserted interrupts
   property p_wfi_wake_mstatus_mie(irq, mie);
-    $fell(in_wfi) ##0 irq_i[irq] ##0 mie_q[irq] ##0 mstatus_mie == mie;
+    $fell(in_wfi_wfe) ##0 irq_i[irq] ##0 mie_q[irq] ##0 mstatus_mie == mie;
   endproperty
 
   generate for(genvar gv_i = 0; gv_i < 32; gv_i++) begin : gen_wfi_cov

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -436,7 +436,7 @@ module uvmt_cv32e40s_tb;
 
       .ex_stage_instr_valid (ex_stage_i.id_ex_pipe_i.instr_valid),
 
-      .wb_stage_instr_valid_i    (wb_stage_i.instr_valid),
+      .wb_stage_instr_valid_i    (wb_stage_i.ex_wb_pipe_i.instr_valid),
       .wb_stage_instr_rdata_i    (wb_stage_i.ex_wb_pipe_i.instr.bus_resp.rdata),
       .wb_stage_instr_err_i      (wb_stage_i.ex_wb_pipe_i.instr.bus_resp.err),
       .wb_stage_instr_mpu_status (wb_stage_i.ex_wb_pipe_i.instr.mpu_status),
@@ -482,9 +482,9 @@ module uvmt_cv32e40s_tb;
 
   // Xsecure assertion and coverage interface
 
-  bind cv32e40s_wrapper	
+  bind cv32e40s_wrapper
     uvmt_cv32e40s_xsecure_if  xsecure_if (
-   
+
 	    // Core signals: cpuctrl rdata registeret cannot be read by rvfi, we must therefore use core signales instead
       // Gated clock
       .core_clk_gated                                     (core_i.clk),
@@ -507,7 +507,7 @@ module uvmt_cv32e40s_tb;
       .core_cs_registers_mhpmevent_31_to_3                (core_i.cs_registers_i.mhpmevent_q[31:3]),
       .core_cs_registers_mcountinhibit_q_mcycle_inhibit   (core_i.cs_registers_i.mcountinhibit_q[0]),
       .core_cs_registers_mcountinhibit_q_minstret_inhibit (core_i.cs_registers_i.mcountinhibit_q[2]),
-      
+
       .core_cs_registers_csr_en_gated                     (core_i.cs_registers_i.csr_en_gated),
       .core_cs_registers_csr_waddr                        (core_i.cs_registers_i.csr_waddr),
 
@@ -539,11 +539,11 @@ module uvmt_cv32e40s_tb;
       // ID stage
       .core_id_stage_id_valid_o                           (core_i.id_stage_i.id_valid_o),
       .core_id_stage_ex_ready_i                           (core_i.id_stage_i.ex_ready_i),
-      
+
       // ID EX pipe
       .core_id_ex_pipe_instr_meta_dummy                   (core_i.id_ex_pipe.instr_meta.dummy),
       .core_id_ex_pipe_instr_bus_resp_rdata               (core_i.id_ex_pipe.instr.bus_resp.rdata),
-      
+
       // EX WB pipe
       .core_wb_stage_ex_wb_pipe_instr_meta_dummy          (core_i.wb_stage_i.ex_wb_pipe_i.instr_meta.dummy),
 
@@ -551,7 +551,7 @@ module uvmt_cv32e40s_tb;
       .core_wb_stage_wb_valid_o                           (core_i.wb_stage_i.wb_valid_o),
       .*
     );
- 
+
     // Xsecure assertions
 
  bind cv32e40s_wrapper

--- a/cv32e40s/tests/cfg/no_bitmanip.yaml
+++ b/cv32e40s/tests/cfg/no_bitmanip.yaml
@@ -1,2 +1,7 @@
 name: no_bitmanip
 description: Default configuration for CV32E40S simulations
+ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
+cflags: >
+cv_sw_march: rv32im_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/num_mhpmcounter_29.yaml
+++ b/cv32e40s/tests/cfg/num_mhpmcounter_29.yaml
@@ -1,6 +1,9 @@
 name: num_mhpmcounters_29
 description: Configuration for CV32E40S simulations with NUM_MHPMCOUNTER set to 29
-compile_flags: 
+compile_flags:
     +define+SET_NUM_MHPMCOUNTERS=29
 ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
 cflags: >
+cv_sw_march: rv32im_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma.yaml
+++ b/cv32e40s/tests/cfg/pma.yaml
@@ -2,4 +2,8 @@ name: pma
 description: PMA configuration for regions and attributes
 compile_flags:
     +define+PMA_CUSTOM_CFG
-
+ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
+cflags: >
+cv_sw_march: rv32im_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pma_debug.yaml
+++ b/cv32e40s/tests/cfg/pma_debug.yaml
@@ -2,3 +2,8 @@ name: pma
 description: PMA configuration for pma_debug test
 compile_flags:
     +define+PMA_DEBUG_CFG
+ovpsim: >
+    # --showoverrides
+    # --trace --tracechange --traceshowicount --monitornets
+cflags: >
+cv_sw_march: rv32im_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pmp.yaml
+++ b/cv32e40s/tests/cfg/pmp.yaml
@@ -12,4 +12,4 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/cv32e40s/tests/cfg/pmp_g3r3.yaml
+++ b/cv32e40s/tests/cfg/pmp_g3r3.yaml
@@ -13,4 +13,4 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32imc_zba1p00_zbb1p00_zbc1p00_zbs1p00
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zifencei

--- a/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_agent.sv
+++ b/lib/uvm_agents/uvma_rvvi_ovpsim/uvma_rvvi_ovpsim_agent.sv
@@ -142,9 +142,10 @@ function void uvma_rvvi_ovpsim_agent_c::configure_iss();
      $fwrite(fh, $sformatf("--override root/cpu/ecode_mask=0x7ff\n"));
      $fwrite(fh, $sformatf("--override root/cpu/mtvec_mask=0xffffff81\n"));
      $fwrite(fh, $sformatf("--override root/cpu/Zca=1\n"));
-     $fwrite(fh, $sformatf("--override root/cpu/Zcb=1\n"));
-     $fwrite(fh, $sformatf("--override root/cpu/Zcmp=1\n"));
-     $fwrite(fh, $sformatf("--override root/cpu/Zcmt=1\n"));
+     $fwrite(fh, $sformatf("--override root/cpu/Zcb=0\n"));
+     $fwrite(fh, $sformatf("--override root/cpu/Zcmp=0\n"));
+     $fwrite(fh, $sformatf("--override root/cpu/Zcmb=0\n"));
+     $fwrite(fh, $sformatf("--override root/cpu/Zcmt=0\n"));
 
    end
 


### PR DESCRIPTION
Temporary fixes to get the integrity related signals to a non-blocking state. Work on obi_memory_agent and a thorough look at the signal connections in the wrappers required to solve these properly.

Signed-off-by: Marton Teilgard <mateilga@silabs.com>