### PR TITLE
[VPTOOL] Improve Markdown output.  Regenerate CV32A6 frontend verif plan and improve usability

### DIFF
--- a/cva6/docs/VerifPlans/FRONTEND/runme.sh
+++ b/cva6/docs/VerifPlans/FRONTEND/runme.sh
@@ -7,9 +7,8 @@
 #############################################################################
 #!/bin/sh
 
-# Root of the example directories.  VPTOOL is located in '../vptool' relative
-# to the location of 'vptool-example.sh'.
-ROOTDIR=`readlink -f $(dirname $0)`
+# Location of project-specific directories
+ROOTDIR=`readlink -f $(dirname "${BASH_SOURCE[0]}")`
 
 # Set up platform location.  It can be anywhere but should contain
 # a valid `vp_config.py` file in `vptool` directory.
@@ -19,7 +18,11 @@ export PLATFORM_TOP_DIR="$ROOTDIR"
 # Set a meaningful name for the example project.
 export PROJECT_NAME="FRONTEND"
 
-export PYTHONPATH=`pwd`
+# Set Python path to make vpconfig.py reachable.
+export PYTHONPATH="$ROOTDIR:$PYTHONPATH"
 
 # Run VPTOOL overriding the default theme from Yaml config with 'winxpblue'.
+# FIXME: Introduce a suitably named shell variable that points to the root
+# directory of the tool set (TOOL_TOP etc.)
+# FORNOW use a hardcoded relative path.
 python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py -t winxpblue

--- a/cva6/docs/VerifPlans/source/dvplan_FRONTEND.md
+++ b/cva6/docs/VerifPlans/source/dvplan_FRONTEND.md
@@ -9,10 +9,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Branch Predict
 * **Feature Description:** If instruction is a JALR and BTB (Branch Target Buffer) returns a valid address, next PC is predicted by BTB. Else JALR is not considered as a control flow instruction, which will generate a mispredict.
 * **Verification goals:** Execute test with JALR instructions. Functional cov: JALR is executed and BTB output is not valid.
-* **Pass/Fail Criteria:** 3
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P001_I002
 * **Comments:** 
 
@@ -23,10 +23,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Branch Predict
 * **Feature Description:** If instruction is a branch and BTH (Branch History table) returns a valid address, next PC is predicted by BHT. Else branch is not considered as an control flow instruction, which will generate a mispredict when branch is taken.
 * **Verification goals:** Execute test with BRANCH instructions. Functional cov: a BRANCH is executed, BTB output is not valid and the branch is taken.
-* **Pass/Fail Criteria:** 3
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P002_I002
 * **Comments:** 
 
@@ -37,10 +37,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Branch Predict
 * **Feature Description:** If instruction is a RET and RAS (Return Address Stack) returns a valid address and RET has already been consummed by instruction queue. Else RET is considered as a control flow instruction but next PC is not predicted. A mispredict wil be generated.
 * **Verification goals:** Execute test with RET instructions. Functional cov: RET is executed and RAS output is not valid.
-* **Pass/Fail Criteria:** 3
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P003_I002
 * **Comments:** 
 
@@ -51,10 +51,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Return from env call
 * **Feature Description:** When CSR asks a return from an environment call, the PC is assigned to the successive PC to the one stored in the CSR [m-s]epc register.
 * **Verification goals:** Set two different addresses for mepc and sepc in CSR registers. Use a arc_test returning from machine env call. Check by assertion that when machine return occurs the mepc address is fetched. Functional cov: execute a machine return.
-* **Pass/Fail Criteria:** 4
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Assertion
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P004_I000
 * **Comments:** 
 
@@ -65,10 +65,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Exception
 * **Feature Description:** If an exception (or interrupt, which is in the context of RISC-V systems quite similar) is triggered by the COMMIT, the next PC Gen is assigned to the CSR trap vector base address. The trap vector base address can be different depending on whether the exception traps to S-Mode or M-Mode (user mode exceptions are currently not supported)
 * **Verification goals:** Set two different addresses for machine and supervisor handlers in CSR registers. Use a test which executes in machine mode and generates a machine exception by UVM. Check by assertion that when machine exception occurs the machine address is fetched. Functional cov: exception occurs in machine mode.
-* **Pass/Fail Criteria:** 4
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Assertion
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P005_I000
 * **Comments:** 
 
@@ -79,10 +79,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage/Pipeline flush
 * **Feature Description:** FRONTEND starts fetching from the next instruction again in order to take the up-dated information into account
 * **Verification goals:** [no need to verify this point]
-* **Pass/Fail Criteria:** -1
-* **Test Type:** -1
-* **Coverage Method:** -1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P006_I000
 * **Comments:** 
 
@@ -97,10 +97,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage
 * **Feature Description:** The next PC can originate from the following sources (listed in order of precedence)
 * **Verification goals:** Use arc_test executing return from env call and generate Exceptions by UVM during reset, Branch predict, default, mispredict, replay and return from env call. Functional cov: monitor the 6 events
-* **Pass/Fail Criteria:** 3
-* **Test Type:** 0
-* **Coverage Method:** 1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Check RM
+* **Test Type:** RISC-V Arch-test
+* **Coverage Method:** Functional Coverage
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P009_I000
 * **Comments:** 
 
@@ -109,10 +109,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/PC generation stage
 * **Feature Description:** The next PC can originate from the following sources (listed in order of precedence)
 * **Verification goals:** [other cases to be elaborated]
-* **Pass/Fail Criteria:** -1
-* **Test Type:** -1
-* **Coverage Method:** -1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP003_P009_I002
 * **Comments:** 
 
@@ -133,6 +133,18 @@
 ### 002_table update sub-feature
 
 ### 003_saturation sub-feature
+
+#### 000 item
+
+* **Requirement location:** FRONTEND sub-system/Architecture and Modules/BHT
+* **Feature Description:** The Branch History table is a two-bit saturation counter that takes the virtual address of the current fetched instruction by the CACHE. It states whether the current branch request should be taken or not. The two bit counter is updated by the successive execution of the current instructions as shown in the following figure.
+* **Verification goals:** Execute a serie of taken and not taken branch to check the saturation mechanism
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32E40P, CV32E40S, CV32E40X, CV32A6-step1, CV32A6-step2, CV64A6-step3
+* **Link to Coverage:** VP_IP005_P003_I000
+* **Comments:** 
 
 ### 004_Table depth sub-feature
 
@@ -163,10 +175,10 @@
 * **Requirement location:** FRONTEND sub-system/Architecture and Modules/Instr_queue
 * **Feature Description:** The instruction queue contains max 4 instructions.
 * **Verification goals:** Confirm that the best configuration for instruction queue entry number is 4 by monitoring the Coremark performance and silicon footprint
-* **Pass/Fail Criteria:** 11
-* **Test Type:** 10
-* **Coverage Method:** 10
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** Other
+* **Test Type:** Other
+* **Coverage Method:** N/A
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP008_P000_I000
 * **Comments:** 
 
@@ -187,10 +199,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/Fetch stage
 * **Feature Description:** Memory and MMU (MMU is not enabled in CV32A6-step1) can feedback potential exceptions generated by the memory fetch request. They can be bus errors, invalid accesses or instruction page faults.
 * **Verification goals:** Generate a bus error exception by UVM or by test (to be decided) and check that the exception address is fetched. Functional cov: a bus error exception occurs.
-* **Pass/Fail Criteria:** -1
-* **Test Type:** -1
-* **Coverage Method:** -1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP010_P002_I000
 * **Comments:** 
 
@@ -199,10 +211,10 @@
 * **Requirement location:** FRONTEND sub-system/functionality/Fetch stage
 * **Feature Description:** Memory and MMU (MMU is not enabled in CV32A6-step1) can feedback potential exceptions generated by the memory fetch request. They can be bus errors, invalid accesses or instruction page faults.
 * **Verification goals:** Generate an invalid access exception by UVM or by test (to be decided) and check that the exception address is fetched. Functional cov: an invalid access exception occurs.
-* **Pass/Fail Criteria:** -1
-* **Test Type:** -1
-* **Coverage Method:** -1
-* **Applicable Cores:** 8
+* **Pass/Fail Criteria:** NDY (Not Defined Yet)
+* **Test Type:** NDY (Not Defined Yet)
+* **Coverage Method:** NDY (Not Defined Yet)
+* **Applicable Cores:** CV32A6-step1
 * **Link to Coverage:** VP_IP010_P002_I002
 * **Comments:** 
 

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -1727,18 +1727,30 @@ class MyMain:
                         list(self.ip_list.items()), key=lambda key: key[1].ip_num
                     )
                     # Create DVPLAN in Markdown format
-                    md_dir = os.path.join(os.path.dirname(vp_config.SAVED_DB_LOCATION), '..', 'source')
+                    md_dir = os.path.join(
+                        os.path.dirname(vp_config.SAVED_DB_LOCATION), "..", "source"
+                    )
                     if os.path.isfile(md_dir):
-                        print("*** MD destination '%s' is not a directory, cannot generate markdown output!" % md_dir)
+                        print(
+                            "*** MD destination '%s' is not a directory, cannot generate markdown output!"
+                            % md_dir
+                        )
                     else:
                         if not os.path.exists(md_dir):
                             try:
                                 os.makedirs(md_dir)
                             except Exception as e:
-                                print("*** Cannot create markdown output directory '%s', output will be sent to database directory" % md_dir)
+                                print(
+                                    "*** Cannot create markdown output directory '%s', output will be sent to database directory"
+                                    % md_dir
+                                )
                                 md_dir = os.path.dirname(vp_config.SAVED_DB_LOCATION)
-                        with open(os.path.join(md_dir, "dvplan_") + vp_config.PROJECT_NAME + ".md", "w"
-                         ) as md_file:
+                        with open(
+                            os.path.join(md_dir, "dvplan_")
+                            + vp_config.PROJECT_NAME
+                            + ".md",
+                            "w",
+                        ) as md_file:
                             md_file.write("# %s module\n\n" % (vp_config.PROJECT_NAME))
                             for ip_elt in pickle_ip_list:
                                 md_file.write(str(ip_elt[1]))

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -1745,8 +1745,8 @@ class MyMain:
                                 for rfu1_elt in ip_elt[1].rfu_list:
                                     md_file.write(str(rfu1_elt[1]))
                                     for rfu2_elt in rfu1_elt[1].rfu_list:
-                                        # FORNOW Generate only when cores = cv32a6-step1
-                                        if rfu2_elt[1].cores == 8:
+                                        # FORNOW Generate only when 'cores' include cv32a6-step1
+                                        if rfu2_elt[1].cores & 8 != 0:
                                             md_file.write(str(rfu2_elt[1]))
                     if self.split_save:
                         save_dir = os.path.dirname(vp_config.SAVED_DB_LOCATION)

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -1727,18 +1727,27 @@ class MyMain:
                         list(self.ip_list.items()), key=lambda key: key[1].ip_num
                     )
                     # Create DVPLAN in Markdown format
-                    with open(
-                        "../source/dvplan_" + vp_config.PROJECT_NAME + ".md", "w"
-                    ) as md_file:
-                        md_file.write("# %s module\n\n" % (vp_config.PROJECT_NAME))
-                        for ip_elt in pickle_ip_list:
-                            md_file.write(str(ip_elt[1]))
-                            for rfu1_elt in ip_elt[1].rfu_list:
-                                md_file.write(str(rfu1_elt[1]))
-                                for rfu2_elt in rfu1_elt[1].rfu_list:
-                                    # Generate only when cores = cv32a6-step1
-                                    if rfu2_elt[1].cores == 8:
-                                        md_file.write(str(rfu2_elt[1]))
+                    md_dir = os.path.join(os.path.dirname(vp_config.SAVED_DB_LOCATION), '..', 'source')
+                    if os.path.isfile(md_dir):
+                        print("*** MD destination '%s' is not a directory, cannot generate markdown output!" % md_dir)
+                    else:
+                        if not os.path.exists(md_dir):
+                            try:
+                                os.makedirs(md_dir)
+                            except Exception as e:
+                                print("*** Cannot create markdown output directory '%s', output will be sent to database directory" % md_dir)
+                                md_dir = os.path.dirname(vp_config.SAVED_DB_LOCATION)
+                        with open(os.path.join(md_dir, "dvplan_") + vp_config.PROJECT_NAME + ".md", "w"
+                         ) as md_file:
+                            md_file.write("# %s module\n\n" % (vp_config.PROJECT_NAME))
+                            for ip_elt in pickle_ip_list:
+                                md_file.write(str(ip_elt[1]))
+                                for rfu1_elt in ip_elt[1].rfu_list:
+                                    md_file.write(str(rfu1_elt[1]))
+                                    for rfu2_elt in rfu1_elt[1].rfu_list:
+                                        # FORNOW Generate only when cores = cv32a6-step1
+                                        if rfu2_elt[1].cores == 8:
+                                            md_file.write(str(rfu2_elt[1]))
                     if self.split_save:
                         save_dir = os.path.dirname(vp_config.SAVED_DB_LOCATION)
                         saved_ip_str = ""

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -1757,7 +1757,8 @@ class MyMain:
                                 for rfu1_elt in ip_elt[1].rfu_list:
                                     md_file.write(str(rfu1_elt[1]))
                                     for rfu2_elt in rfu1_elt[1].rfu_list:
-                                        # FORNOW Generate only when 'cores' include cv32a6-step1
+                                        # FORNOW Generate only when 'cores' include CV32A6-step1
+                                        # (see sibling file 'vptool.yml').
                                         if rfu2_elt[1].cores & 8 != 0:
                                             md_file.write(str(rfu2_elt[1]))
                     if self.split_save:

--- a/tools/vptool/vptool/vp_pack.py
+++ b/tools/vptool/vptool/vp_pack.py
@@ -72,16 +72,40 @@ class Item:
         self.rfu_dict = {}  # used as lock. will be updated with class update
         self.rfu_dict["lock_status"] = 0
 
+    def attrval2str(self, attr):
+        if attr == 'cores' and 'cores' in vp_config.yaml_config:
+            # 'cores' are at toplevel of the Yaml config and the attr value is a bitmap.
+            # Select entries corresponding to each bit that is set
+            # and return a comma-separated list of associated names.
+            matches = [ x['label'] for x in vp_config.yaml_config[attr]['values'] if x['value'] & getattr(self, attr) != 0]
+            if len(matches) == 0:
+                return 'None applicable'
+            else:
+                return ', '.join(matches)
+        elif 'values' in vp_config.yaml_config['gui'][attr]:
+            # This attribute takes predefined values.
+            # A single value is allowed.
+            if getattr(self, attr) == vp_config.yaml_config['gui'][attr]['default']['value']:
+                return 'NDY (Not Defined Yet)'
+            else:
+                matches = [ x['label'] for x in vp_config.yaml_config['gui'][attr]['values'] if x['value'] == getattr(self, attr)]
+                if len(matches) == 0:
+                    return '<UNKNOWN>'
+                else:
+                    return matches[0]
+        else:
+            return "N/A (unsupported field '%s')" % attr
+
     def __str__(self):
         return0 = ""
         return0 += format("#### %s item\n\n" % self.name)
         return0 += format("* **Requirement location:** %s\n" % self.purpose)
         return0 += format("* **Feature Description:** %s\n" % self.description)
         return0 += format("* **Verification goals:** %s\n" % self.verif_goals)
-        return0 += format("* **Pass/Fail Criteria:** %s\n" % self.pfc)
-        return0 += format("* **Test Type:** %s\n" % self.test_type)
-        return0 += format("* **Coverage Method:** %s\n" % self.cov_method)
-        return0 += format("* **Applicable Cores:** %s\n" % self.cores)
+        return0 += format("* **Pass/Fail Criteria:** %s\n" % self.attrval2str('pfc'))
+        return0 += format("* **Test Type:** %s\n" % self.attrval2str('test_type'))
+        return0 += format("* **Coverage Method:** %s\n" % self.attrval2str('cov_method'))
+        return0 += format("* **Applicable Cores:** %s\n" % self.attrval2str('cores'))
         return0 += format("* **Link to Coverage:** %s\n" % self.tag)
         return0 += format("* **Comments:** %s\n\n" % self.comments)
         return return0

--- a/tools/vptool/vptool/vp_pack.py
+++ b/tools/vptool/vptool/vp_pack.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 # Load the configuration associated with the current platform
 if "PLATFORM_TOP_DIR" in os.environ:
-    lib_path = os.path.abspath(os.path.join(os.environ["PLATFORM_TOP_DIR"], 'vptool'))
+    lib_path = os.path.abspath(os.path.join(os.environ["PLATFORM_TOP_DIR"], "vptool"))
     sys.path.append(lib_path)
     try:
         import vp_config
@@ -73,24 +73,35 @@ class Item:
         self.rfu_dict["lock_status"] = 0
 
     def attrval2str(self, attr):
-        if attr == 'cores' and 'cores' in vp_config.yaml_config:
+        if attr == "cores" and "cores" in vp_config.yaml_config:
             # 'cores' are at toplevel of the Yaml config and the attr value is a bitmap.
             # Select entries corresponding to each bit that is set
             # and return a comma-separated list of associated names.
-            matches = [ x['label'] for x in vp_config.yaml_config[attr]['values'] if x['value'] & getattr(self, attr) != 0]
+            matches = [
+                x["label"]
+                for x in vp_config.yaml_config[attr]["values"]
+                if x["value"] & getattr(self, attr) != 0
+            ]
             if len(matches) == 0:
-                return 'None applicable'
+                return "None applicable"
             else:
-                return ', '.join(matches)
-        elif 'values' in vp_config.yaml_config['gui'][attr]:
+                return ", ".join(matches)
+        elif "values" in vp_config.yaml_config["gui"][attr]:
             # This attribute takes predefined values.
             # A single value is allowed.
-            if getattr(self, attr) == vp_config.yaml_config['gui'][attr]['default']['value']:
-                return 'NDY (Not Defined Yet)'
+            if (
+                getattr(self, attr)
+                == vp_config.yaml_config["gui"][attr]["default"]["value"]
+            ):
+                return "NDY (Not Defined Yet)"
             else:
-                matches = [ x['label'] for x in vp_config.yaml_config['gui'][attr]['values'] if x['value'] == getattr(self, attr)]
+                matches = [
+                    x["label"]
+                    for x in vp_config.yaml_config["gui"][attr]["values"]
+                    if x["value"] == getattr(self, attr)
+                ]
                 if len(matches) == 0:
-                    return '<UNKNOWN>'
+                    return "<UNKNOWN>"
                 else:
                     return matches[0]
         else:
@@ -102,10 +113,12 @@ class Item:
         return0 += format("* **Requirement location:** %s\n" % self.purpose)
         return0 += format("* **Feature Description:** %s\n" % self.description)
         return0 += format("* **Verification goals:** %s\n" % self.verif_goals)
-        return0 += format("* **Pass/Fail Criteria:** %s\n" % self.attrval2str('pfc'))
-        return0 += format("* **Test Type:** %s\n" % self.attrval2str('test_type'))
-        return0 += format("* **Coverage Method:** %s\n" % self.attrval2str('cov_method'))
-        return0 += format("* **Applicable Cores:** %s\n" % self.attrval2str('cores'))
+        return0 += format("* **Pass/Fail Criteria:** %s\n" % self.attrval2str("pfc"))
+        return0 += format("* **Test Type:** %s\n" % self.attrval2str("test_type"))
+        return0 += format(
+            "* **Coverage Method:** %s\n" % self.attrval2str("cov_method")
+        )
+        return0 += format("* **Applicable Cores:** %s\n" % self.attrval2str("cores"))
         return0 += format("* **Link to Coverage:** %s\n" % self.tag)
         return0 += format("* **Comments:** %s\n\n" % self.comments)
         return return0


### PR DESCRIPTION
# Purpose

Improve usability of VPTOOL, for now on CVA6 verification plans:

* [generic] Print all elements of a verification item in human-readable form, including the lists of applicable cores;
* [generic] Improve the selection and handling of markdown output directory;
* [CV32A6] Generate MD output for all items applicable to CV32A6-stage1, including those applicable to other cores;
* [CV32A6] Improve robustness of `FRONTEND` verification plan editing script;
* [CV32A6] Regenerate FRONTEND verif plan using updated VPTOOL.

# Change log

* cva6/docs/VerfiPlans/source/dvplan_FRONTEND.md: Regenerate.
* tools/vptool/vptool/vp_pack.py (Item.attrval2str): New.
   (Item.\_\_str__): Convert enumerated and bitmapped fields to associated plain text strings using labels from Yaml file.
* tools/vptool/vptool/vp.py (MyMain.save_db): Send MD output to directory `source`, sibling of the database directory.  Skip generation of MD output altogether if `<database_dir>/../source` designates a plain file.  If `source` does not exist and cannot be created, send MD output to `<database_dir>`.  Update comments.  Generate item description in MD format if the list of applicable cores *includes* CVA6-stage1.
* cva6/docs/VerifPlans/FRONTEND/runme.sh (ROOTDIR): Use path from bash arg list.  Update comment.
   (PYTHONPATH): Use correct directory and keep previous paths if any.
   (vptool invocation): Update comment.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>
