### PR TITLE
Clean up handling of ISA variants when disassembling RTL sim output.

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -25,9 +25,6 @@ FLIST_TB   := $(CVA6_TB_DIR)/Flist.cva6_tb
 target     ?= cv64a6_imafdc_sv39
 FLIST_CORE := $(CVA6_REPO_DIR)/core/Flist.$(target)
 
-# Convert target name to a valid ISA name for DASM.
-target_isa ?= $(shell echo $(target) | cut -d_ -f1,2 | sed -e 's/^cv\(32\|64\)/rv\1/')
-
 TRACE_FAST      ?=
 TRACE_COMPACT   ?=
 VERDI           ?=
@@ -110,13 +107,13 @@ spike:
 vcs-testharness:
 	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
 	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
-	$(tool_path)/spike-dasm --isa=$(target_isa) < ./trace_rvfi_hart_00.dasm > $(log)
+	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 veri-testharness:
 	make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
 	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts)
-	$(tool_path)/spike-dasm --isa=$(target_isa) < ./trace_rvfi_hart_00.dasm > $(log)
+	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	# If present, move default trace files to per-test directory.
 	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.$(target).fst
 	[ ! -f verilator.vcd ] || mv verilator.vcd `dirname $(log)`/`basename $(log) .log`.$(target).vcd
@@ -219,7 +216,7 @@ vcs_uvm_run:
 vcs-uvm:
 	make vcs_uvm_comp
 	make vcs_uvm_run
-	$(tool_path)/spike-dasm --isa=$(target_isa) < ./trace_rvfi_hart_00.dasm > $(log)
+	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 	[ -z "`ls *.$(SIMV_TRACE_EXTN)`" ] || \
           for i in `ls *.$(SIMV_TRACE_EXTN)` ; do mv $$i `dirname $(log)`/`basename $(log) .log`.$(target).$$i ; done || true

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -25,7 +25,7 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   cmd: >
-    make veri-testharness target=<target> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
+    make veri-testharness target=<target> variant=<variant> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 ###############################################################################
 # Synopsys VCS specific commands, variables
@@ -35,18 +35,18 @@
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   cmd: >
-    make vcs-testharness target=<target> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
+    make vcs-testharness target=<target> variant=<variant> elf=<elf> path_var=<path_var> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 - iss: vcs-gate
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   cmd: >
-    make vcs-uvm target=<target>_gate cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
+    make vcs-uvm target=<target>_gate cov=${cov} variant=<variant> elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
 
 - iss: vcs-uvm
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
   cmd: >
-    make vcs-uvm target=<target> cov=${cov} elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>
+    make vcs-uvm target=<target> cov=${cov} variant=<variant> elf=<elf> tool_path=<tool_path> isscomp_opts=<isscomp_opts> issrun_opts=<issrun_opts> isspostrun_opts=<isspostrun_opts> log=<log>


### PR DESCRIPTION
This PR streamlines the handling of ISA variants when post-processing RTL simulationt output.  In particular, it should now seamlessly handle HW configurations with non-standard names (broken since commit c13b99ac).

## Root cause

In order to correctly disassemble the instruction trace, the RISC-V disassembler `dasm` needs to know the exact ISA variant used during the simulation (the same encodings can have distinct interpretations depending on `XLEN`.)  However, the guessing approach implemented in commit c13b99ac did not handle arbitrary target configuration names such as those used for `HW config` tests.

## Root fix

Use the same information passing mechanism as for `spike` simulations: the ISA variant is available in DV parameter `<variant>` and its value should be passed to the simulation Makefile upon invoking `make` for all RTL simulation targets.

## Change log

* cva6/sim/Makefile (target_isa): Remove. (vcs-testharness): Use `$(variant)` instead of `$(target_isa)`.
  (veri-testharness): Ditto. (vcs-uvm): Ditto.
* cva6/sim/cva6.yaml (veri-testharness): Provide ISA variant to simulation wrapper.
  (vcs-testharness): Ditto.
  (vcs-gate): Ditto.
  (vcs-uvm): Ditto.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>