### PR TITLE
[WIP - do not merge] Preview of unified Spike-like termination infrastructure

### DIFF
--- a/cva6/regress/install-spike.sh
+++ b/cva6/regress/install-spike.sh
@@ -26,6 +26,7 @@ if [ ! -f "$SPIKE_ROOT/bin/spike"  ]; then
     git apply $PATCH_DIR/spike/patches/spike-shared-fesvr-lib.patch
     git apply $PATCH_DIR/spike/patches/spike-cvxif-extension.patch
     git apply $PATCH_DIR/spike/patches/spike-dlopen-diagnostics.patch
+    git apply $PATCH_DIR/spike/patches/rtl-termination-hooks.patch
     # Recursively copy Spike files related to CVXIF extension into current
     # directory.
     cp -rpa $PATCH_DIR/spike/cvxif-ext-files/* .

--- a/cva6/regress/spike/patches/rtl-termination-hooks.patch
+++ b/cva6/regress/spike/patches/rtl-termination-hooks.patch
@@ -1,0 +1,14 @@
+diff --git a/fesvr/htif.h b/fesvr/htif.h
+index 3cee25f7..1a94d3c2 100644
+--- a/fesvr/htif.h
++++ b/fesvr/htif.h
+@@ -26,6 +26,9 @@ class htif_t : public chunked_memif_t
+   int run();
+   bool done();
+   int exit_code();
++  void set_exitcode(int code) { exitcode = code; }
++  unsigned long int get_tohost_addr(void) { return (unsigned long int) tohost_addr; }
++  void set_tohost_addr(unsigned long int addr) { tohost_addr = (addr_t) addr; }
+ 
+   virtual memif_t& memif() { return mem; }
+ 

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -106,13 +106,15 @@ spike:
 ###############################################################################
 vcs-testharness:
 	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
-	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
+	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi \
+	  +tohost_addr=$(shell $$RISCV/bin/riscv-none-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
+	  +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 veri-testharness:
 	make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
-	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts)
+	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts) +PRELOAD=$(elf)
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)
 	# If present, move default trace files to per-test directory.
 	[ ! -f verilator.fst ] || mv verilator.fst `dirname $(log)`/`basename $(log) .log`.$(target).fst
@@ -206,6 +208,7 @@ vcs_uvm_run:
 	$(VCS_WORK_DIR)/simv ${ALL_SIMV_UVM_FLAGS} \
 	++$(elf) \
 	+PRELOAD=$(elf) \
+	+tohost_addr=$(shell $$RISCV/bin/riscv-none-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	-sv_lib $(dpi-library)/ariane_dpi \
 	$(cov-run-opt) $(issrun_opts) && \
 	mv $(VCS_WORK_DIR)/trace_rvfi_hart_00.dasm $(CORE_V_VERIF)/cva6/sim/ && \

--- a/cva6/tests/custom/common/syscalls.c
+++ b/cva6/tests/custom/common/syscalls.c
@@ -42,7 +42,7 @@ static uintptr_t syscall(uintptr_t which, uintptr_t arg0, uintptr_t arg1, uintpt
   // - the environment acknowledges the env request by writing 0 into tohost.
   // - the completion of the request is signalled by the environment through
   //   a write of a non-zero value into fromhost.
-  tohost = (((uint64_t) magic_mem) << 16) >> 16;    // clear the DEV and CMD bytes, clip payload.
+  tohost = (((uint64_t) ((unsigned long int) magic_mem)) << 16) >> 16;    // clear the DEV and CMD bytes, clip payload.
   while (fromhost == 0)
     ;
   fromhost = 0;

--- a/cva6/tests/custom/common/syscalls.c
+++ b/cva6/tests/custom/common/syscalls.c
@@ -15,16 +15,34 @@
 extern volatile uint64_t tohost;
 extern volatile uint64_t fromhost;
 
-static uintptr_t syscall(uintptr_t which, uint64_t arg0, uint64_t arg1, uint64_t arg2)
+// tohost is 64 bits wide, irrespective of XLEN.  The structure expected in Spike is:
+// - tohost[63:56] == device (syscall: 0)
+// - tohost[55:48] == command (syscall: 0)
+// - tohost[47:0]  == payload (syscall: address of magic_mem)
+//
+// magic_mem for a syscall contains the following elements (XLEN bits each)
+// - syscall index (93 dec for syscall_exit, cf. Spike values in
+//   riscv-isa-sim/fesvr/syscall.cc:140 and ff.)
+// - syscall args in the declaration order of the given syscall
+
+static uintptr_t syscall(uintptr_t which, uintptr_t arg0, uintptr_t arg1, uintptr_t arg2)
 {
-  volatile uint64_t magic_mem[8] __attribute__((aligned(64)));
+  // Arguments in magic_mem have XLEN bits each.
+  volatile uintptr_t magic_mem[8] __attribute__((aligned(64)));
   magic_mem[0] = which;
   magic_mem[1] = arg0;
   magic_mem[2] = arg1;
   magic_mem[3] = arg2;
   __sync_synchronize();
 
-  tohost = (uintptr_t)magic_mem;
+  // A WRITE_MEM transaction writing non-zero value to TOHOST triggers
+  // the environment (Spike or RTL harness).
+  // - here tohost is guaranteed non-NULL because magic_mem is a valid RISC-V
+  //   pointer.
+  // - the environment acknowledges the env request by writing 0 into tohost.
+  // - the completion of the request is signalled by the environment through
+  //   a write of a non-zero value into fromhost.
+  tohost = (((uint64_t) magic_mem) << 16) >> 16;    // clear the DEV and CMD bytes, clip payload.
   while (fromhost == 0)
     ;
   fromhost = 0;
@@ -55,8 +73,12 @@ void setStats(int enable)
 
 void __attribute__((noreturn)) tohost_exit(uintptr_t code)
 {
-  tohost = (code << 1) | 1;
-  __asm__("ecall\t");
+  // Simply write PASS/FAIL result into 'tohost'.
+  // Left shift 'code' by 1 and set bit 0 to 1, but leave the 16 uppermost bits clear
+  // so that the syscall is properly recognized even if 'code' value is very large.
+  tohost = ((((uint64_t) code) << 17) >> 16) | 1;
+
+  // Don't care about the value returned by host...
   while (1);
 }
 


### PR DESCRIPTION
This PR implements the HTIF-style "write-to-`tohost`" termination protocol for tests and supplies simulation sessions with sufficient information to let the RVFI tracer of CVA6 retrieve the actual address of `tohost` for an orderly termination.

The changes come in four sets:

1. Align 'tohost' addr passing in VCS and Verilator.
  * cva6/sim/Makefile (vcs-testharness): Pass `tohost` address as plus-arg.
    (veri-testharness): Pass ELF file name in `PRELOAD` plus-arg.
    (vcs_uvm_run): Pass `tohost` address as plus-arg.
1. Fix typing issue in custom syscall code.
  * cva6/tests/custom/common/syscalls.c (syscall): Widen value of `magic_mem`after converting it to native unsigned int type.
1. Update custom BSP code to better match HTIF conventions: Signal termination by writing non-zero value into `tohost`, fix sizes of variables.
  * cva6/tests/custom/common/syscalls.c (syscall): Document syscall-related `tohost` and `magic_mem` conventions.  Make `magic_mem` elements XLEN bits wide.  Clear the upper 16 bits of value to be stored into `tohost`.
    (tohost_exit): Write "test result" value (left-shifted by 1 and OR-ed with 0x1) into `tohost` instead of executing an `ECALL` instruction.
1. Add Spike patch with hooks for managing test termination from RTL.
  * cva6/regress/install-spike.sh: Install RTL termination hooks patch.
  * cva6/regress/spike/patches/rtl-termination-hooks.patch: New.
    
Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>
