### PR TITLE
This no longer exists, now present in a package

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -22,11 +22,6 @@
 `ifndef __UVMT_CV32E40S_TB_SV__
 `define __UVMT_CV32E40S_TB_SV__
 
-// Import the Imperas-DV RVVI API
-`ifndef FORMAL
-  `include "rvvi/rvvi-api.svh"
-`endif
-
 /**
  * Module encapsulating the CV32E40S DUT wrapper, and associated SV interfaces.
  * Also provide UVM environment entry and exit points.


### PR DESCRIPTION
@silabs-hfegran @MikeOpenHWGroup 
This include should no longer exist.
This has been converted to a package file intended to be imported, rather than an include file