### PR TITLE
CV32E40P requires rv32imc_zicsr

### DIFF
--- a/cv32e40p/bsp/Makefile
+++ b/cv32e40p/bsp/Makefile
@@ -6,7 +6,7 @@ RISCV_AR = $(RISCV_EXE_PREFIX)ar
 SRC = crt0.S handlers.S syscalls.c vectors.S
 OBJ = crt0.o handlers.o syscalls.o vectors.o
 LIBCV-VERIF = libcv-verif.a 
-CFLAGS ?= -Os -g -static -mabi=ilp32 -march=rv32imc -Wall -pedantic
+CFLAGS ?= -Os -g -static -mabi=ilp32 -march=$(RISCV_MARCH) -Wall -pedantic
 
 all: $(LIBCV-VERIF)
 

--- a/cv32e40p/sim/uvmt/Makefile
+++ b/cv32e40p/sim/uvmt/Makefile
@@ -52,5 +52,18 @@ DPI_DASM_SPIKE_REPO  ?= https://github.com/riscv/riscv-isa-sim.git
 CV_SW_TOOLCHAIN      ?= /opt/riscv
 CV_SW_PREFIX         ?= " "
 
+YOUR_GCC_VERSION     := $(shell $(CV_SW_TOOLCHAIN)/bin/$(CV_SW_PREFIX)gcc -dumpversion)
+REQD_GCC_VERSION     := 13.0.0
+
+ifeq ($(REQD_GCC_VERSION), $(YOUR_GCC_VERSION))
+$(warning 'Required GCC version: $(REQD_GCC_VERSION) == your GCC version: $(YOUR_GCC_VERSION)... OK')
+else
+ifeq ($(REQD_GCC_VERSION),$(firstword $(sort $(YOUR_GCC_VERSION) $(REQD_GCC_VERSION))))
+$(warning 'Required GCC version: $(REQD_GCC_VERSION) < your GCC version: $(YOUR_GCC_VERSION)... OK')
+else
+$(error 'ERROR!!! Required GCC version: $(REQD_GCC_VERSION) > your GCC version: $(YOUR_GCC_VERSION)')
+endif
+endif
+
 include ../ExternalRepos.mk
 include $(CORE_V_VERIF)/mk/uvmt/uvmt.mk

--- a/cv32e40p/tests/cfg/default.yaml
+++ b/cv32e40p/tests/cfg/default.yaml
@@ -9,3 +9,4 @@ ovpsim: >
 #    --trace --tracechange --traceshowicount --monitornets
 cflags: >
     -DNO_PULP
+cv_sw_march: rv32imc_zicsr

--- a/cv32e40p/tests/cfg/no_pulp.yaml
+++ b/cv32e40p/tests/cfg/no_pulp.yaml
@@ -8,3 +8,4 @@ ovpsim: >
     --override root/cpu/noinhibit_mask=0xFFFFFFF0
 cflags: >
     -DNO_PULP
+cv_sw_march: rv32imc_zicsr

--- a/cv32e40p/tests/cfg/num_mhpmcounter_29.yaml
+++ b/cv32e40p/tests/cfg/num_mhpmcounter_29.yaml
@@ -8,3 +8,4 @@ ovpsim: >
     --override root/cpu/noinhibit_mask=0000000000
 cflags: >
     -DNO_PULP
+cv_sw_march: rv32imc_zicsr

--- a/cv32e40p/tests/cfg/pulp.yaml
+++ b/cv32e40p/tests/cfg/pulp.yaml
@@ -17,3 +17,4 @@ ovpsim: >
     --override root/cpu/noinhibit_mask=0xFFFFFFF0
 cflags: >
     -DPULP
+cv_sw_march: rv32imc_zicsr


### PR DESCRIPTION
This PR is motivated by #1506.

Here, we are trying to do two things:
1.  Set `rv32imc_zicsr` are the default march for gcc.
2. Put in a simple (?) check in the Makefile to ensure you are using an up-to-date version of the compiler that supports `_zicsr`.

...this is at the limit of my Makefile scripting skills :frowning_face:   Please do not merge yet.