### PR TITLE
FenceiAssert - Check Handshake vs RVFI

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_fencei_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_fencei_assert.sv
@@ -165,6 +165,14 @@ module uvmt_cv32e40s_fencei_assert
     is_rvfiinstr_fencei
   ) else `uvm_error(info_tag, "A handshake must results in fencei retire");
 
+  // (Just a helper/sanity assert complementing the above)
+  a_req_mustnt_rvfi_fence: assert property (
+    fencei_flush_req_o
+    |=>
+    (rvfi_valid [->1])   ##0
+    !is_rvfiinstr_fence
+  ) else `uvm_error(info_tag, "A handshake must not results in a fence retire");
+
 
   // vplan:Fetching
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_fencei_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_fencei_assert.sv
@@ -163,7 +163,7 @@ module uvmt_cv32e40s_fencei_assert
     |=>
     (rvfi_valid [->1])   ##0
     is_rvfiinstr_fencei
-  ) else `uvm_error(info_tag, "TODO");
+  ) else `uvm_error(info_tag, "A handshake must results in fencei retire");
 
 
   // vplan:Fetching

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -650,6 +650,7 @@ module uvmt_cv32e40s_tb;
       .rvfi_valid         (rvfi_i.rvfi_valid),
       .rvfi_intr          (rvfi_i.rvfi_intr.intr),
       .rvfi_dbg_mode      (rvfi_i.rvfi_dbg_mode),
+      .rvfi_insn          (rvfi_i.rvfi_insn),
 
       .*
     );


### PR DESCRIPTION
This PR adds one assert to the fencei assertion set.

As mentioned by @silabs-oysteink, there is a problem that the RTL treats `fence` as `fencei`.
The original fencei asserts probed some internal signals and did not double check against RVFI!

@silabs-mateilga, @silabs-krdosvik, @MikeOpenHWGroup, I would appreciate a review and merge. (Very little code to review.)