### PR TITLE
started the process of updating debug assertion set to latest spec

### DIFF
--- a/cv32e40s/fv/dummy_pkg.sv
+++ b/cv32e40s/fv/dummy_pkg.sv
@@ -19,7 +19,20 @@
 // SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 
-`define  RVFI_CSR_BIND(csr_name)
+//`define  RVFI_CSR_BIND(csr_name)
+
+// Create bind for RVFI CSR interface
+`define RVFI_CSR_BIND(csr_name) \
+  bind cv32e40s_wrapper \
+    uvma_rvfi_csr_if#(uvme_cv32e40s_pkg::XLEN) rvfi_csr_``csr_name``_if_0_i(.clk(clk_i), \
+                                                                            .reset_n(rst_ni), \
+                                                                            .rvfi_csr_rmask(rvfi_i.rvfi_csr_``csr_name``_rmask), \
+                                                                            .rvfi_csr_wmask(rvfi_i.rvfi_csr_``csr_name``_wmask), \
+                                                                            .rvfi_csr_rdata(rvfi_i.rvfi_csr_``csr_name``_rdata), \
+                                                                            .rvfi_csr_wdata(rvfi_i.rvfi_csr_``csr_name``_wdata) \
+    );
+
+
 `define  RVFI_CSR_IDX_BIND(csr_name,csr_suffix,idx)
 `define  RVFI_CSR_UVM_CONFIG_DB_SET(csr_name)
 

--- a/cv32e40s/fv/dummy_pkg.sv
+++ b/cv32e40s/fv/dummy_pkg.sv
@@ -19,8 +19,6 @@
 // SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 
-//`define  RVFI_CSR_BIND(csr_name)
-
 // Create bind for RVFI CSR interface
 `define RVFI_CSR_BIND(csr_name) \
   bind cv32e40s_wrapper \

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -37,8 +37,9 @@ module uvmt_cv32e40s_debug_assert
   localparam CEBREAK_INSTR_OPCODE = 32'h 0000_9002;
   localparam DRET_INSTR_OPCODE    = 32'h 7B20_0073;
   localparam int MSTATUS_TW_POS = 21;
-  localparam int DCSR_NMIP_POS = 3;
   localparam int DCSR_STEP_POS = 2;
+  localparam int DCSR_NMIP_POS = 3;
+  localparam int DCSR_STEPIE_POS = 11;
 
   // ---------------------------------------------------------------------------
   // Local variables
@@ -592,18 +593,18 @@ module uvmt_cv32e40s_debug_assert
 
     // step vs nmi
     // check that single stepping disables nmi
-    property p_step_irq_dis;
-        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS])
+    property p_stepie_irq_dis;
+        rvfi.is_dret && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         |=>
         rvfi.rvfi_valid[->1]
         ##0 !(rvfi.rvfi_intr.intr && rvfi.rvfi_intr.interrupt);
     endproperty
 
-    a_step_irq_dis : assert property(p_step_irq_dis)
-        else `uvm_error(info_tag, "Single stepping should ignore all interrupts");
+    a_stepie_irq_dis : assert property(p_stepie_irq_dis)
+        else `uvm_error(info_tag, "Single stepping should ignore all interrupts if stepie is set");
 
-    cov_step_nmi : cover property (
-        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) && (csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS])
+    cov_step_stepie_nmi : cover property (
+        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) && (!csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]) && (csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS])
     );
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -17,8 +17,14 @@
 
 module uvmt_cv32e40s_debug_assert
   import uvm_pkg::*;
+  import uvma_rvfi_pkg::*;
   import cv32e40s_pkg::*;
   (
+      uvma_rvfi_instr_if rvfi,
+      uvma_rvfi_csr_if csr_dcsr,
+      uvma_rvfi_csr_if csr_dpc,
+      uvma_rvfi_csr_if csr_mepc,
+      uvma_rvfi_csr_if csr_mstatus,
       uvmt_cv32e40s_debug_cov_assert_if cov_assert_if
   );
 
@@ -30,6 +36,9 @@ module uvmt_cv32e40s_debug_assert
   localparam EBREAK_INSTR_OPCODE  = 32'h 0010_0073;
   localparam CEBREAK_INSTR_OPCODE = 32'h 0000_9002;
   localparam DRET_INSTR_OPCODE    = 32'h 7B20_0073;
+  localparam int MSTATUS_TW_POS = 21;
+  localparam int DCSR_NMIP_POS = 3;
+  localparam int DCSR_STEP_POS = 2;
 
   // ---------------------------------------------------------------------------
   // Local variables
@@ -85,7 +94,7 @@ module uvmt_cv32e40s_debug_assert
   assign mtvec_addr = {cov_assert_if.mtvec[31:2], 2'b00};
 
   assign is_rvfi_nmi_handler =
-    cov_assert_if.rvfi_valid && (cov_assert_if.rvfi_intr.cause & 11'h 400);
+    rvfi.rvfi_valid && (rvfi.rvfi_intr.cause & 11'h 400);
     // Note: 0x400 currently uniquely identifies NMIs, though this may (but is not expected to) change.
 
     // ---------------------------------------
@@ -130,8 +139,8 @@ module uvmt_cv32e40s_debug_assert
     a_debug_mode_pc_dpc: assert property(
         $rose(first_debug_ins)
         |->
-        cov_assert_if.depc_q == pc_at_dbg_req
-        ) else `uvm_error(info_tag, $sformatf("Debug mode entered with wrong dpc. dpc==%08x", cov_assert_if.depc_q));
+        cov_assert_if.dpc_q == pc_at_dbg_req
+        ) else `uvm_error(info_tag, $sformatf("Debug mode entered with wrong dpc. dpc==%08x", cov_assert_if.dpc_q));
 
     a_debug_mode_pc_dmode: assert property(
         $rose(first_debug_ins)
@@ -235,13 +244,13 @@ module uvmt_cv32e40s_debug_assert
         |->
         s_conse_next_retire
         ##0 cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] === cv32e40s_pkg::DBG_CAUSE_TRIGGER)
-            && (cov_assert_if.depc_q == tdata2_at_entry) && (cov_assert_if.wb_stage_pc == halt_addr_at_entry);
+            && (cov_assert_if.dpc_q == tdata2_at_entry) && (cov_assert_if.wb_stage_pc == halt_addr_at_entry);
     endproperty
 
     a_trigger_match: assert property(p_trigger_match)
         else `uvm_error(info_tag,
-            $sformatf("Debug mode not correctly entered after trigger match depc=%08x, tdata2=%08x",
-                cov_assert_if.depc_q, tdata2_at_entry));
+            $sformatf("Debug mode not correctly entered after trigger match dpc=%08x, tdata2=%08x",
+                cov_assert_if.dpc_q, tdata2_at_entry));
 
     // Address match without trigger enabled should NOT result in debug mode
 
@@ -305,7 +314,7 @@ module uvmt_cv32e40s_debug_assert
     // Debug request while sleeping makes core wake up and enter debug mode with cause=haltreq
 
     property p_sleep_debug_req;
-        cov_assert_if.in_wfi && cov_assert_if.debug_req_i
+        (cov_assert_if.ctrl_fsm_cs == SLEEP) && cov_assert_if.debug_req_i
         |=>
         !cov_assert_if.core_sleep_o
         ##0 s_conse_next_retire
@@ -339,7 +348,7 @@ module uvmt_cv32e40s_debug_assert
     property p_single_step_exception;
         !cov_assert_if.debug_mode_q && cov_assert_if.dcsr_q[2]
         && cov_assert_if.illegal_insn_i && cov_assert_if.wb_valid && !is_trigger_match
-        |-> ##[1:20] cov_assert_if.debug_mode_q && (cov_assert_if.depc_q == mtvec_addr);
+        |-> ##[1:20] cov_assert_if.debug_mode_q && (cov_assert_if.dpc_q == mtvec_addr);
     endproperty
 
     a_single_step_exception : assert property(p_single_step_exception)
@@ -351,12 +360,12 @@ module uvmt_cv32e40s_debug_assert
         !cov_assert_if.debug_mode_q && cov_assert_if.dcsr_q[2]
         && cov_assert_if.addr_match && cov_assert_if.wb_valid && cov_assert_if.tdata1[2]
         |-> ##[1:20] cov_assert_if.debug_mode_q && (cov_assert_if.dcsr_q[8:6] == cv32e40s_pkg::DBG_CAUSE_TRIGGER)
-        && (cov_assert_if.depc_q == pc_at_dbg_req);
+        && (cov_assert_if.dpc_q == pc_at_dbg_req);
     endproperty
 
     a_single_step_trigger : assert property (p_single_step_trigger)
         else `uvm_error(info_tag,
-        $sformatf("Single step and trigger error: depc = %08x, cause = %d",cov_assert_if.depc_q, cov_assert_if.dcsr_q[8:6]));
+        $sformatf("Single step and trigger error: dpc = %08x, cause = %d",cov_assert_if.dpc_q, cov_assert_if.dcsr_q[8:6]));
 
 
     // Single step WFI must not result in sleeping
@@ -401,13 +410,13 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dmode_dret_pc;
         int dpc;
-        (cov_assert_if.rvfi_valid && cov_assert_if.rvfi_dbg_mode && cov_assert_if.rvfi_insn == DRET_INSTR_OPCODE,
-         dpc = cov_assert_if.rvfi_csr_dpc_rdata)
+        (rvfi.rvfi_valid && rvfi.rvfi_dbg_mode && rvfi.rvfi_insn == DRET_INSTR_OPCODE,
+         dpc = csr_dpc.rvfi_csr_rdata)
         ##1
-        cov_assert_if.rvfi_valid[->1]
-        ##0 (!cov_assert_if.rvfi_intr && !cov_assert_if.rvfi_dbg_mode)
+        rvfi.rvfi_valid[->1]
+        ##0 (!rvfi.rvfi_intr && !rvfi.rvfi_dbg_mode)
         |->
-        cov_assert_if.rvfi_pc_rdata == dpc;
+        rvfi.rvfi_pc_rdata == dpc;
     endproperty
 
     a_dmode_dret_pc : assert property(p_dmode_dret_pc)
@@ -418,13 +427,13 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dmode_dret_pc_int;
         int dpc;
-        (cov_assert_if.rvfi_valid && cov_assert_if.rvfi_dbg_mode && cov_assert_if.rvfi_insn == DRET_INSTR_OPCODE,
-         dpc = cov_assert_if.rvfi_csr_dpc_rdata)
+        (rvfi.rvfi_valid && rvfi.rvfi_dbg_mode && rvfi.rvfi_insn == DRET_INSTR_OPCODE,
+         dpc = csr_dpc.rvfi_csr_rdata)
         ##1
-        cov_assert_if.rvfi_valid[->1]
-        ##0 (cov_assert_if.rvfi_intr && !cov_assert_if.rvfi_dbg_mode && !is_rvfi_nmi_handler)
+        rvfi.rvfi_valid[->1]
+        ##0 (rvfi.rvfi_intr && !rvfi.rvfi_dbg_mode && !is_rvfi_nmi_handler)
         |->
-        cov_assert_if.rvfi_csr_mepc_rdata == dpc;
+        csr_mepc.rvfi_csr_rdata == dpc;
     endproperty
 
     a_dmode_dret_pc_int : assert property(p_dmode_dret_pc_int)
@@ -435,12 +444,12 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dmode_dret_pc_nmi_eq;
         int dpc;
-        (cov_assert_if.rvfi_valid && cov_assert_if.rvfi_dbg_mode && cov_assert_if.rvfi_insn == DRET_INSTR_OPCODE,
-         dpc = cov_assert_if.rvfi_csr_dpc_rdata)
+        (rvfi.rvfi_valid && rvfi.rvfi_dbg_mode && rvfi.rvfi_insn == DRET_INSTR_OPCODE,
+         dpc = csr_dpc.rvfi_csr_rdata)
         ##1
-        cov_assert_if.rvfi_valid[->1]
-        ##0 (!cov_assert_if.rvfi_dbg_mode && is_rvfi_nmi_handler)
-        ##0 (cov_assert_if.rvfi_csr_mepc_rdata == dpc);
+        rvfi.rvfi_valid[->1]
+        ##0 (!rvfi.rvfi_dbg_mode && is_rvfi_nmi_handler)
+        ##0 (csr_mepc.rvfi_csr_rdata == dpc);
     endproperty
 
     cov_dmode_dret_pc_nmi_eq : cover property(p_dmode_dret_pc_nmi_eq);
@@ -450,12 +459,12 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dmode_dret_pc_nmi_neq;
         int dpc;
-        (cov_assert_if.rvfi_valid && cov_assert_if.rvfi_dbg_mode && cov_assert_if.rvfi_insn == DRET_INSTR_OPCODE,
-         dpc = cov_assert_if.rvfi_csr_dpc_rdata)
+        (rvfi.rvfi_valid && rvfi.rvfi_dbg_mode && rvfi.rvfi_insn == DRET_INSTR_OPCODE,
+         dpc = csr_dpc.rvfi_csr_rdata)
         ##1
-        cov_assert_if.rvfi_valid[->1]
-        ##0 (!cov_assert_if.rvfi_dbg_mode && is_rvfi_nmi_handler)
-        ##0 (cov_assert_if.rvfi_csr_mepc_rdata != dpc);
+        rvfi.rvfi_valid[->1]
+        ##0 (!rvfi.rvfi_dbg_mode && is_rvfi_nmi_handler)
+        ##0 (csr_mepc.rvfi_csr_rdata != dpc);
     endproperty
 
     cov_dmode_dret_pc_nmi_neq : cover property(p_dmode_dret_pc_nmi_neq);
@@ -548,7 +557,7 @@ module uvmt_cv32e40s_debug_assert
         (cov_assert_if.ctrl_fsm_cs == cv32e40s_pkg::RESET) && cov_assert_if.debug_req_i
         |->
         s_conse_next_retire
-        ##0 cov_assert_if.debug_mode_q && (cov_assert_if.depc_q == boot_addr_at_entry);
+        ##0 cov_assert_if.debug_mode_q && (cov_assert_if.dpc_q == boot_addr_at_entry);
     endproperty
 
     a_debug_at_reset : assert property(p_debug_at_reset)
@@ -581,6 +590,22 @@ module uvmt_cv32e40s_debug_assert
       && (cov_assert_if.debug_halted  == 1)
       );
 
+    // step vs nmi
+    // check that single stepping disables nmi
+    property p_step_irq_dis;
+        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS])
+        |=>
+        rvfi.rvfi_valid[->1]
+        ##0 !(rvfi.rvfi_intr.intr && rvfi.rvfi_intr.interrupt);
+    endproperty
+
+    a_step_irq_dis : assert property(p_step_irq_dis)
+        else `uvm_error(info_tag, "Single stepping should ignore all interrupts");
+
+    cov_step_nmi : cover property (
+        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) && (csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS])
+    );
+
 
     // Check that we cover the case where a debug_req_i
     // comes while flushing due to an illegal insn, causing
@@ -595,12 +620,12 @@ module uvmt_cv32e40s_debug_assert
 
     sequence s_illegal_insn_debug_req_conse;  // Consequent
         s_conse_next_retire
-        ##0 cov_assert_if.debug_mode_q && (cov_assert_if.depc_q == mtvec_addr);
+        ##0 cov_assert_if.debug_mode_q && (cov_assert_if.dpc_q == mtvec_addr);
     endsequence
 
     // Need to confirm that the assertion can be reached for non-trivial cases
     cov_illegal_insn_debug_req_nonzero : cover property(
-        s_illegal_insn_debug_req_ante |-> s_illegal_insn_debug_req_conse ##0 (cov_assert_if.depc_q != 0));
+        s_illegal_insn_debug_req_ante |-> s_illegal_insn_debug_req_conse ##0 (cov_assert_if.dpc_q != 0));
 
     a_illegal_insn_debug_req : assert property(s_illegal_insn_debug_req_ante |-> s_illegal_insn_debug_req_conse)
         else `uvm_error(info_tag, "Debug mode not entered correctly while handling illegal instruction!");
@@ -619,13 +644,13 @@ module uvmt_cv32e40s_debug_assert
             if (cov_assert_if.ctrl_fsm_cs == cv32e40s_pkg::BOOT_SET) begin
                 pc_at_dbg_req <= {cov_assert_if.boot_addr_i[31:2], 2'b00};
             end
-            if (cov_assert_if.rvfi_valid) begin
-                pc_at_dbg_req <= cov_assert_if.rvfi_pc_wdata;
+            if (rvfi.rvfi_valid) begin
+                pc_at_dbg_req <= rvfi.rvfi_pc_wdata;
                 if ((debug_cause_pri == 2) && !started_decoding_in_debug) begin  // trigger
-                    pc_at_dbg_req <= cov_assert_if.rvfi_pc_rdata;
+                    pc_at_dbg_req <= rvfi.rvfi_pc_rdata;
                 end
                 if ((debug_cause_pri == 1) && !started_decoding_in_debug) begin  // ebreak
-                    pc_at_dbg_req <= cov_assert_if.rvfi_pc_rdata;
+                    pc_at_dbg_req <= rvfi.rvfi_pc_rdata;
                 end
             end
             if (cov_assert_if.addr_match && !cov_assert_if.tdata1[18] && cov_assert_if.wb_valid) begin  // trigger
@@ -656,21 +681,6 @@ module uvmt_cv32e40s_debug_assert
        end
     end
 
-
-  // Keep track of wfi state
-
-  always @(posedge cov_assert_if.clk_i or negedge cov_assert_if.rst_ni) begin
-    if (!cov_assert_if.rst_ni) begin
-      cov_assert_if.in_wfi <= 1'b0;
-    end else begin
-      // Enter wfi if we have a valid instruction, and conditions allow it (e.g. no single-step etc)
-      if (cov_assert_if.is_wfi && cov_assert_if.wb_valid
-          && !cov_assert_if.pending_debug && !cov_assert_if.debug_mode_q && !cov_assert_if.dcsr_q[2])
-        cov_assert_if.in_wfi <= 1'b1;
-      if (cov_assert_if.pending_enabled_irq || cov_assert_if.debug_req_i)
-        cov_assert_if.in_wfi <= 1'b0;
-    end
-  end
 
 
   // Capture dm_halt_addr_i value
@@ -709,11 +719,12 @@ module uvmt_cv32e40s_debug_assert
   end
 
     assign cov_assert_if.addr_match   = (cov_assert_if.wb_stage_pc == cov_assert_if.tdata2);
-    assign cov_assert_if.dpc_will_hit = (cov_assert_if.depc_n == cov_assert_if.tdata2);
+    assign cov_assert_if.dpc_will_hit = (cov_assert_if.dpc_n == cov_assert_if.tdata2);
     assign cov_assert_if.pending_enabled_irq = |(cov_assert_if.irq_i & cov_assert_if.mie_q);
     assign cov_assert_if.is_wfi =
         cov_assert_if.wb_valid
         && ((cov_assert_if.wb_stage_instr_rdata_i & WFI_INSTR_MASK) == WFI_INSTR_OPCODE)
+        && ((rvfi.rvfi_mode == UVMA_RVFI_M_MODE) || (csr_mstatus.rvfi_csr_rdata[MSTATUS_TW_POS] == 1)) //not legal if in user mode with tw == 0
         && !cov_assert_if.wb_err
         && (cov_assert_if.wb_mpu_status == MPU_OK);
     assign cov_assert_if.is_dret =

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -604,7 +604,10 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "Single stepping should ignore all interrupts if stepie is set");
 
     cov_step_stepie_nmi : cover property (
-        rvfi.is_dret && (csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) && (!csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]) && (csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS])
+        rvfi.is_dret
+        && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]
+        && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
+        && csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS]
     );
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -974,8 +974,8 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
 
       .mie_q                  (core_i.cs_registers_i.mie_q),
       .dcsr_q                 (core_i.cs_registers_i.dcsr_q),
-      .depc_q                 (core_i.cs_registers_i.dpc_q),
-      .depc_n                 (core_i.cs_registers_i.dpc_n),
+      .dpc_q                 (core_i.cs_registers_i.dpc_q),
+      .dpc_n                 (core_i.cs_registers_i.dpc_n),
       .mcause_q               (core_i.cs_registers_i.mcause_q),
       .mtvec                  (core_i.cs_registers_i.mtvec_q),
       .mepc_q                 (core_i.cs_registers_i.mepc_q),
@@ -1007,22 +1007,7 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
       .pc_set                 (core_i.ctrl_fsm.pc_set),
       .boot_addr_i            (core_i.boot_addr_i),
 
-      .rvfi_valid             (rvfi_i.rvfi_valid),
-      .rvfi_insn              (rvfi_i.rvfi_insn),
-      .rvfi_intr              (rvfi_i.rvfi_intr),
-      .rvfi_dbg               (rvfi_i.rvfi_dbg),
-      .rvfi_dbg_mode          (rvfi_i.rvfi_dbg_mode),
-      .rvfi_pc_wdata          (rvfi_i.rvfi_pc_wdata),
-      .rvfi_pc_rdata          (rvfi_i.rvfi_pc_rdata),
-      .rvfi_csr_dpc_rdata     (rvfi_i.rvfi_csr_dpc_rdata),
-      .rvfi_csr_mepc_wdata    (rvfi_i.rvfi_csr_mepc_wdata),
-      .rvfi_csr_mepc_wmask    (rvfi_i.rvfi_csr_mepc_wmask),
-      .rvfi_csr_mepc_rdata    (rvfi_i.rvfi_csr_mepc_rdata),
-
-
-
       .is_wfi                 (),
-      .in_wfi                 (),
       .dpc_will_hit           (),
       .addr_match             (),
       .is_ebreak              (),
@@ -1093,7 +1078,12 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
                                                                       .support_if(support_logic_if)
                                                                       );
 
-    bind cv32e40s_wrapper uvmt_cv32e40s_debug_assert u_debug_assert(.cov_assert_if(debug_cov_assert_if));
+    bind cv32e40s_wrapper uvmt_cv32e40s_debug_assert u_debug_assert(.rvfi(rvfi_instr_if_0_i),
+                                                                    .csr_dcsr(rvfi_csr_dcsr_if_0_i),
+                                                                    .csr_dpc(rvfi_csr_dpc_if_0_i),
+                                                                    .csr_mepc(rvfi_csr_mepc_if_0_i),
+                                                                    .csr_mstatus(rvfi_csr_mstatus_if_0_i),
+                                                                    .cov_assert_if(debug_cov_assert_if));
 
     bind cv32e40s_wrapper uvmt_cv32e40s_zc_assert u_zc_assert(.rvfi(rvfi_instr_if_0_i),
                                                               .support_if(support_logic_if)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -293,18 +293,6 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     input  [31:0] boot_addr_i,
     input         fetch_enable_i,
 
-    input              rvfi_valid,
-    input  [31:0]      rvfi_insn,
-    input  rvfi_intr_t rvfi_intr,
-    input  [2:0]       rvfi_dbg,
-    input              rvfi_dbg_mode,
-    input  [31:0]      rvfi_pc_wdata,
-    input  [31:0]      rvfi_pc_rdata,
-    input  [31:0]      rvfi_csr_dpc_rdata,
-    input  [31:0]      rvfi_csr_mepc_rdata,
-    input  [31:0]      rvfi_csr_mepc_wdata,
-    input  [31:0]      rvfi_csr_mepc_wmask,
-
     // Debug signals
     input         debug_req_i, // From controller
     input         debug_req_q, // From controller
@@ -317,8 +305,8 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     input         nmi_allowed, // From controller
     input         debug_mode_q, // From controller
     input  [31:0] dcsr_q, // From controller
-    input  [31:0] depc_q, // From cs regs  //TODO:ropeders rename "dpc_q"
-    input  [31:0] depc_n,
+    input  [31:0] dpc_q, // From cs regs
+    input  [31:0] dpc_n,
     input  [31:0] dm_halt_addr_i,
     input  [31:0] dm_exception_addr_i,
 
@@ -346,7 +334,6 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     input  csr_we_int,
 
     output logic is_wfi,
-    output logic in_wfi,
     output logic dpc_will_hit,
     output logic addr_match,
     output logic is_ebreak,
@@ -375,13 +362,11 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     sys_en_i,
     sys_ecall_insn_i,
     boot_addr_i,
-    rvfi_pc_wdata,
-    rvfi_pc_rdata,
     debug_req_i,
     debug_mode_q,
     dcsr_q,
-    depc_q,
-    depc_n,
+    dpc_q,
+    dpc_n,
     dm_halt_addr_i,
     dm_exception_addr_i,
     mcause_q,
@@ -401,7 +386,6 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     csr_op,
     csr_addr,
     is_wfi,
-    in_wfi,
     dpc_will_hit,
     addr_match,
     is_ebreak,

--- a/cv32e40s/tests/programs/custom/debug_test/debug_test.c
+++ b/cv32e40s/tests/programs/custom/debug_test/debug_test.c
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
     printf("------------------------\n");
     printf(" Test2.2: check access to Trigger registers\n");
     // Writes are ignored
-    temp = 0xFFFFFFFF;
+    temp = 0xFFFFFFFF;    //TODO:MT should these be writes?
     __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
     __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
     __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
@@ -285,7 +285,7 @@ int main(int argc, char *argv[])
     };
     if(mstatus_cmp.bits != mstatus.bits) {printf("ERROR: init mstatus mismatch exp=%x val=%x\n",
                                            mstatus_cmp.bits, mstatus.bits); TEST_FAILED;}
-
+    //TODO:MT are these switched up?
     printf("------------------------\n");
     printf(" Test3.1: check hart ebreak executes ebreak handler but does not execute debugger code\n");
     glb_expect_ebreak_handler = 1;
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
       .fields.value            = 1,
       .fields.pulse_mode       = 1, //PULSE Mode
       .fields.rand_pulse_width = 0,
-      .fields.pulse_width      = 5,// FIXME: BUG: one clock pulse cause core to lock up
+      .fields.pulse_width      = 5,// TODO:MT determine pulse width with non-sticky debug_req
       .fields.rand_start_delay = 0,
       .fields.start_delay      = 200
     };

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -74,6 +74,18 @@ interface uvma_rvfi_instr_if
   );
 
   // -------------------------------------------------------------------
+  // Local param
+  // -------------------------------------------------------------------
+  localparam INSTR_MASK_FULL        = 32'h FFFF_FFFF;
+  localparam DRET_INSTR_OPCODE      = 32'h 7B20_0073;
+  localparam MRET_INSTR_OPCODE      = 32'h 3020_0073;
+  localparam URET_INSTR_OPCODE      = 32'h 0020_0073;
+  localparam WFI_INSTR_OPCODE       = 32'h 1050_0073;
+  localparam WFE_INSTR_OPCODE       = 32'h 8C00_0073;
+  localparam EBREAK_INSTR_OPCODE    = 32'h 0010_0073;
+  localparam ECALL_INSTR_OPCODE     = 32'h 0000_0073;
+
+  // -------------------------------------------------------------------
   // Local variables
   // -------------------------------------------------------------------
   bit [CYCLE_CNT_WL-1:0] cycle_cnt = 0;
@@ -148,7 +160,7 @@ interface uvma_rvfi_instr_if
                               bit [ DEFAULT_XLEN-1:0] ref_mask
                               );
 
-  return ((rvfi_insn & ref_mask) == ref_instr);
+  return rvfi_valid && ((rvfi_insn & ref_mask) == ref_instr);
 
   endfunction : match_instr
 
@@ -219,6 +231,37 @@ function bit [1:0] check_mem_act(  int txn);
   return {read,write};
 
 endfunction : check_mem_act
+
+
+// Short functions for recognising special functions
+
+function logic is_dret();
+  return match_instr(DRET_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_dret
+
+function logic is_mret();
+  return match_instr(MRET_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_mret
+
+function logic is_uret();
+  return match_instr(URET_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_uret
+
+function logic is_wfi();
+  return match_instr(WFI_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_wfi
+
+function logic is_wfe();
+  return match_instr(WFE_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_wfe
+
+function logic is_ebreak();
+  return match_instr(EBREAK_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_ebreak
+
+function logic is_ecall();
+  return match_instr(ECALL_INSTR_OPCODE, INSTR_MASK_FULL);
+endfunction : is_ecall
 
 endinterface : uvma_rvfi_instr_if
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -77,13 +77,13 @@ interface uvma_rvfi_instr_if
   // Local param
   // -------------------------------------------------------------------
   localparam INSTR_MASK_FULL        = 32'h FFFF_FFFF;
-  localparam DRET_INSTR_OPCODE      = 32'h 7B20_0073;
-  localparam MRET_INSTR_OPCODE      = 32'h 3020_0073;
-  localparam URET_INSTR_OPCODE      = 32'h 0020_0073;
-  localparam WFI_INSTR_OPCODE       = 32'h 1050_0073;
-  localparam WFE_INSTR_OPCODE       = 32'h 8C00_0073;
-  localparam EBREAK_INSTR_OPCODE    = 32'h 0010_0073;
-  localparam ECALL_INSTR_OPCODE     = 32'h 0000_0073;
+  localparam INSTR_OPCODE_DRET      = 32'h 7B20_0073;
+  localparam INSTR_OPCODE_MRET      = 32'h 3020_0073;
+  localparam INSTR_OPCODE_URET      = 32'h 0020_0073;
+  localparam INSTR_OPCODE_WFI       = 32'h 1050_0073;
+  localparam INSTR_OPCODE_WFE       = 32'h 8C00_0073;
+  localparam INSTR_OPCODE_EBREAK    = 32'h 0010_0073;
+  localparam INSTR_OPCODE_ECALL     = 32'h 0000_0073;
 
   // -------------------------------------------------------------------
   // Local variables
@@ -236,31 +236,31 @@ endfunction : check_mem_act
 // Short functions for recognising special functions
 
 function logic is_dret();
-  return match_instr(DRET_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_DRET, INSTR_MASK_FULL);
 endfunction : is_dret
 
 function logic is_mret();
-  return match_instr(MRET_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_MRET, INSTR_MASK_FULL);
 endfunction : is_mret
 
 function logic is_uret();
-  return match_instr(URET_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_URET, INSTR_MASK_FULL);
 endfunction : is_uret
 
 function logic is_wfi();
-  return match_instr(WFI_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_WFI, INSTR_MASK_FULL);
 endfunction : is_wfi
 
 function logic is_wfe();
-  return match_instr(WFE_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_WFE, INSTR_MASK_FULL);
 endfunction : is_wfe
 
 function logic is_ebreak();
-  return match_instr(EBREAK_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_EBREAK, INSTR_MASK_FULL);
 endfunction : is_ebreak
 
 function logic is_ecall();
-  return match_instr(ECALL_INSTR_OPCODE, INSTR_MASK_FULL);
+  return match_instr(INSTR_OPCODE_ECALL, INSTR_MASK_FULL);
 endfunction : is_ecall
 
 endinterface : uvma_rvfi_instr_if


### PR DESCRIPTION
Signed-off-by: Marton Teilgard <mateilga@silabs.com>

This work is by no means finished, but I suggest we merge this now for the following two reasons:
~~1. an assert added in this PR is required to reproduce cv32e40x issue [709](https://github.com/openhwgroup/cv32e40x/issues/709)~~ (bug was in the assert, not RTL)
2. New functions in rvfi_instr_if could be useful for other contributors to the 40s/dev

edit: A new bug has been found by asserts added to this PR: [cv32e40x 711](https://github.com/openhwgroup/cv32e40x/issues/711)