### PR TITLE
fixes to debug_assert for simulation

### DIFF
--- a/cv32e40s/env/uvme/cov/uvme_debug_covg.sv
+++ b/cv32e40s/env/uvme/cov/uvme_debug_covg.sv
@@ -205,8 +205,8 @@ class uvme_debug_covg extends uvm_component;
     // Cover that we get a debug_req while in wfi
     covergroup cg_wfi_debug_req;
         `per_instance_fcov
-        inwfi : coverpoint cntxt.debug_cov_vif.mon_cb.in_wfi {
-                bins hit  = {1};
+        inwfi : coverpoint cntxt.debug_cov_vif.mon_cb.ctrl_fsm_cs {
+                bins hit  = {SLEEP};
         }
         dreq: coverpoint cntxt.debug_cov_vif.mon_cb.debug_req_i {
             bins hit = {1};

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -594,7 +594,7 @@ module uvmt_cv32e40s_debug_assert
     // step vs nmi
     // check that single stepping disables nmi
     property p_stepie_irq_dis;
-        rvfi.is_dret && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
+        rvfi.is_dret() && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         |=>
         rvfi.rvfi_valid[->1]
         ##0 !(rvfi.rvfi_intr.intr && rvfi.rvfi_intr.interrupt);
@@ -604,7 +604,7 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "Single stepping should ignore all interrupts if stepie is set");
 
     cov_step_stepie_nmi : cover property (
-        rvfi.is_dret
+        rvfi.is_dret()
         && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]
         && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         && csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS]
@@ -615,7 +615,7 @@ module uvmt_cv32e40s_debug_assert
     // if the next instruction after a single step dret is in debug mode,
     // a trap entry has to be the cause.
     property p_step_trap_handler_entry;
-        (rvfi.is_dret &&
+        (rvfi.is_dret() &&
         csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] &&
         csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS])
         ##1 rvfi.rvfi_valid[->1]
@@ -628,7 +628,7 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "single stepping remained in debug mode illegally");
 
     property p_step_no_trap;
-        rvfi.is_dret && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
+        rvfi.is_dret() && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         ##1 rvfi.rvfi_valid[->1]
         ##0 !rvfi.rvfi_dbg_mode
         |->


### PR DESCRIPTION
PR #1515 had syntax errors that wasn't picked up in formal, but crashes sim. This PR fixes that.