### PR TITLE
Pull in latest 40s core rtl

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 6d8e63a3e60ed650e5aa9a0d2e01106deea59df5
+CV_CORE_HASH   ?= dce36a268b5a564d8a4e9fe10bfb996d65e5595a
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -190,7 +190,8 @@ module uvmt_cv32e40s_debug_assert
         && !cov_assert_if.dcsr_q[2]
         && !cov_assert_if.dcsr_q[15]
         ##0 (
-          (!cov_assert_if.pending_debug && !cov_assert_if.irq_ack_o && !cov_assert_if.pending_nmi)
+          (!(cov_assert_if.pending_sync_debug || cov_assert_if.pending_async_debug) &&
+           !cov_assert_if.irq_ack_o && !cov_assert_if.pending_nmi)
           throughout (##1 cov_assert_if.wb_valid [->1])
           )
         |->
@@ -399,7 +400,8 @@ module uvmt_cv32e40s_debug_assert
     // dret in M-mode will cause illegal instruction
     // If pending debug req, illegal insn will not assert until resume
     property p_mmode_dret;
-        !cov_assert_if.debug_mode_q && cov_assert_if.is_dret && !cov_assert_if.pending_debug
+        !cov_assert_if.debug_mode_q && cov_assert_if.is_dret &&
+        !(cov_assert_if.pending_sync_debug || cov_assert_if.pending_async_debug)
         |-> cov_assert_if.illegal_insn_i;
     endproperty
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -976,7 +976,8 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
       .debug_halted           (core_i.debug_halted_o),
 
       .debug_req_q            (core_i.controller_i.controller_fsm_i.debug_req_q),
-      .pending_debug          (core_i.controller_i.controller_fsm_i.pending_debug),
+      .pending_sync_debug     (core_i.controller_i.controller_fsm_i.pending_sync_debug),
+      .pending_async_debug    (core_i.controller_i.controller_fsm_i.pending_async_debug),
       .pending_nmi            (core_i.controller_i.controller_fsm_i.pending_nmi),
       .nmi_allowed            (core_i.controller_i.controller_fsm_i.nmi_allowed),
       .debug_mode_q           (core_i.controller_i.controller_fsm_i.debug_mode_q),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -311,7 +311,8 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     input         debug_running,
     input         debug_halted,
 
-    input         pending_debug, // From controller
+    input         pending_sync_debug, // From controller
+    input         pending_async_debug, // From controller
     input         pending_nmi, // From controller
     input         nmi_allowed, // From controller
     input         debug_mode_q, // From controller
@@ -385,6 +386,7 @@ interface uvmt_cv32e40s_debug_cov_assert_if
     mepc_q,
     tdata1,
     tdata2,
+    pending_sync_debug,
     trigger_match_in_wb,
     sys_fence_insn_i,
     mcountinhibit_q,


### PR DESCRIPTION
Pulled in latest core and split debug_pending signal in sync and async to match the updated rtl.

Signed-off-by: Halfdan Bechmann <halfdan.bechmann@silabs.com>