### PR TITLE
Remove remains of hpmcounters

### DIFF
--- a/cv32e40s/tb/core/cv32e40s_tb_wrapper.sv
+++ b/cv32e40s/tb/core/cv32e40s_tb_wrapper.sv
@@ -22,9 +22,7 @@ module cv32e40s_tb_wrapper
                 BOOT_ADDR         = 'h80,
                 DM_HALTADDRESS    = 32'h1A11_0800,
                 HART_ID           = 32'h0000_0000,
-                IMP_PATCH_ID      = 4'h0,
-                // Parameters used by DUT
-                NUM_MHPMCOUNTERS  = 1
+                IMP_PATCH_ID      = 4'h0
     )
     (input logic         clk_i,
      input logic         rst_ni,
@@ -72,8 +70,7 @@ module cv32e40s_tb_wrapper
 //          .PULP_XPULP            ( PULP_XPULP            ),
 //          .PULP_CLUSTER          ( PULP_CLUSTER          ),
 //          .FPU                   ( FPU                   ),
-//          .PULP_ZFINX            ( PULP_ZFINX            ),
-//          .NUM_MHPMCOUNTERS      ( NUM_MHPMCOUNTERS      ))
+//          .PULP_ZFINX            ( PULP_ZFINX            ))
 //    core_log_i(
 //          .clk_i              ( cv32e40s_core_i.id_stage_i.clk              ),
 //          .is_decoding_i      ( cv32e40s_core_i.id_stage_i.is_decoding_o    ),
@@ -83,10 +80,7 @@ module cv32e40s_tb_wrapper
 //      );
 
     // instantiate the core
-    cv32e40s_core #(
-                 .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS)
-                )
-    cv32e40s_core_i
+    cv32e40s_core cv32e40s_core_i
         (
          .clk_i                  ( clk_i                 ),
          .rst_ni                 ( rst_ni                ),

--- a/cv32e40s/tb/core/tb_top_verilator.sv
+++ b/cv32e40s/tb/core/tb_top_verilator.sv
@@ -89,8 +89,7 @@ module tb_top_verilator
           .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
           .BOOT_ADDR         (BOOT_ADDR),
           .DM_HALTADDRESS    (32'h1A11_0800),
-          .HART_ID           (32'h0000_0000),
-          .NUM_MHPMCOUNTERS  (1)
+          .HART_ID           (32'h0000_0000)
          )
     cv32e40s_tb_wrapper_i
         (.clk_i          ( clk_i          ),

--- a/cv32e40s/tests/programs/custom/hpmcounter_basic_nostall_test/hpmcounter_basic_nostall_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_basic_nostall_test/hpmcounter_basic_nostall_test.c
@@ -22,6 +22,10 @@
 **
 ** Very basic sanity check for:
 **
+**  - Retired instruction counter
+**  - Cycle counter
+**
+** This test is derived from a test that also checked the hpmcounters on 40x; where it tested:
 **  - Count load use hazards
 **  - Count jump register hazards
 **  - Count memory read transactions
@@ -30,10 +34,8 @@
 **  - Count branches (conditional)
 **  - Count branches taken (conditional)
 **  - Compressed instructions
-**  - Retired instructions
 **
-** Make sure to instantiate cv32e40s_wrapper with the parameter
-** NUM_MHPMCOUNTERS = 1 (or higher)
+** The test is therefore unnecessarily complex for the task
 **
 *******************************************************************************
 */
@@ -58,27 +60,7 @@ int main(int argc, char *argv[])
 {
   int err_cnt = 0;
 
-  enum event_e { EVENT_CYCLES        = 1 << 0,
-                 EVENT_INSTR         = 1 << 1,
-                 EVENT_COMP_INSTR    = 1 << 2,
-                 EVENT_JUMP          = 1 << 3,
-                 EVENT_BRANCH        = 1 << 4,
-                 EVENT_BRANCH_TAKEN  = 1 << 5,
-                 EVENT_INTR_TAKEN    = 1 << 6,
-                 EVENT_DATA_READ     = 1 << 7,
-                 EVENT_DATA_WRITE    = 1 << 8,
-                 EVENT_IF_INVALID    = 1 << 9,
-                 EVENT_ID_INVALID    = 1 << 10,
-                 EVENT_EX_INVALID    = 1 << 11,
-                 EVENT_WB_INVALID    = 1 << 12,
-                 EVENT_ID_LD_STALL   = 1 << 13,
-                 EVENT_ID_JMP_STALL  = 1 << 14,
-                 EVENT_WB_DATA_STALL = 1 << 15 };
-
-  volatile unsigned int event;
-  volatile unsigned int count;
   volatile unsigned int minstret;
-  volatile unsigned int count_while_on;
 
   volatile unsigned int mcycle_count;
 
@@ -89,20 +71,15 @@ int main(int argc, char *argv[])
   printf("\nCycle count");
 
   // Setup events and set csrs to 0
-  event = EVENT_CYCLES;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB00, 0x0");
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
 
   // Readback Counter to verify 0
   __asm__ volatile("csrr %0, 0xB00" : "=r"(mcycle_count));
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
   printf("\nCheck proper zeroization\n");
   err_cnt += chck(minstret, 0);
-  err_cnt += chck(count, 0);
-  err_cnt += chck(count, mcycle_count);
+  err_cnt += chck(mcycle_count, 0);
 
   // Enable counters
   __asm__ volatile("csrwi 0x320, 0x0");
@@ -112,26 +89,20 @@ int main(int argc, char *argv[])
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB00" : "=r"(mcycle_count));
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-  printf("\nCycle count while running = %d", count);
   printf("\nMCYCLE counted cycles = %d\n", mcycle_count);
-  err_cnt += chck(count, mcycle_count);
-  err_cnt += chck(count, 6);
+  err_cnt += chck(mcycle_count, 6);
 
   //////////////////////////////////////////////////////////////
   // IF_INVALID
   printf("\nIF_INVALID");
 
-  event = EVENT_IF_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("addi t1, x0, 0\n\t\
@@ -141,22 +112,16 @@ int main(int argc, char *argv[])
                     nop" \
                     : : : "t0", "t1");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4 + (2*5));
-  printf("\nUnderutilized cycles on ID-stage due to IF stage = %d\n", count);
-  err_cnt += chck(count, 4);
 
   //////////////////////////////////////////////////////////////
   // ID_INVALID - LD_STALL
   printf("\nID_INVALID");
-  event = EVENT_ID_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("lw x4, 0(sp)\n\t\
@@ -165,22 +130,16 @@ int main(int argc, char *argv[])
                     addi x7, x0, 1" \
                     : : : "x4", "x5", "x6", "x7");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-  printf("\nUnderutilized cycles on EX-stage due to ID stage = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // ID_INVALID - JR STALL
   printf("\nID_INVALID");
-  event = EVENT_ID_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("auipc x4, 0\n\t\
@@ -188,23 +147,17 @@ int main(int argc, char *argv[])
                     nop" \
                     : : : "x4");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-  printf("\nUnderutilized cycles on EX-stage due to ID stage = %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // EX_INVALID
   printf("\nEX_INVALID");
-  event = EVENT_EX_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
 
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("lw x0, 0(x0)");
@@ -228,23 +181,17 @@ int main(int argc, char *argv[])
   __asm__ volatile("rem x0, x31, x30");                           // 32 cycles
   __asm__ volatile("lw x0, 0(sp)");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 21);
-  printf("\nUnderutilized cycles on WB-stage due to EX stage = %d\n", count);
-  err_cnt += chck(count, 104);
 
   //////////////////////////////////////////////////////////////
   // WB_INVALID Write port underutilization
 
   printf("\nWrite port underutilization");
-  event = EVENT_WB_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
   __asm__ volatile("li x31, 1\n\t\
@@ -254,23 +201,17 @@ int main(int argc, char *argv[])
                     sw x29, 0(sp)" \
                     : : : "x28", "x29", "x30", "x31");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 6);
-  printf("\nWrite port underutilization cycles: %d\n", count);
-  err_cnt += chck(count, 34);
 
   //////////////////////////////////////////////////////////////
   // WB_DATA_STALL Write port underutilization due to data_rvalid_i (0)
   printf("\nWrite port underutilization due to data_rvalid_i");
-  event = EVENT_WB_DATA_STALL;
 
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
   // Do not count stall cycles (WB_INVALID) due to multicycle instructions
@@ -290,35 +231,24 @@ int main(int argc, char *argv[])
                     div x0, x31, x30" \
                     : : : "x28", "x29", "x30", "x31");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 14);
-  printf("\nWrite port underutilization cycles: %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // Retired instruction count (0) - Immediate minstret read
   printf("\nRetired instruction count (0)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("csrr t0, minstret\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
-  __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
-
-  printf("\nminstret count while running = %d\n", count_while_on);
-  err_cnt += chck(count_while_on, 0);
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
@@ -327,10 +257,7 @@ int main(int argc, char *argv[])
   // Retired instruction count (1) - minstret read-after-write
   printf("\nRetired instruction count (1)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("csrwi minstret, 0xA\n\t\
                     csrr t0, minstret\n\t\
@@ -338,13 +265,8 @@ int main(int argc, char *argv[])
                     addi t2, x0, 0\n\t\
                     nop" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
-  __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    //
-
-  printf("\nminstret count while running = %d\n", count_while_on);
-  err_cnt += chck(count_while_on, 0xA);
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 0xF);
@@ -353,10 +275,7 @@ int main(int argc, char *argv[])
   // Retired instruction count (2)
   printf("\nRetired instruction count (2)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("sw x0, 0(sp)\n\t\
                     addi t0, x0, 5\n\t\
@@ -376,9 +295,8 @@ int main(int argc, char *argv[])
                     nop\n\t\
                     nop" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5 + 6*5 + 4 + 1);
@@ -387,110 +305,74 @@ int main(int argc, char *argv[])
   // Count load use hazards
   printf("\nCount load use hazards");
 
-  event = EVENT_ID_LD_STALL;                                    // Trigger on load use hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x4, 0(sp)\n\t\
                     addi x5, x4, 1\n\t\
                     lw x6, 0(sp)\n\t\
                     addi x7, x0, 1" \
                     : : : "x4", "x5", "x6", "x7");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load use hazards count = %d\n", count);
-  err_cnt += chck(count, 1);                                 // Hazard count is 1 in the absence of interface stalls
 
   //////////////////////////////////////////////////////////////
   // Count jump register hazards
   printf("\nCount Jump register hazards");
 
-  event = EVENT_ID_JMP_STALL;                                   // Trigger on jump register hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("auipc x4, 0x0\n\t\
                     addi x4, x4, 10\n\t\
                     jalr x0, x4, 0x0" \
                     : : : "x4");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Jump register hazards count = %d\n", count);
-  err_cnt += chck(count, 1);                                 // Hazard count is 1 in the absence of interface stalls
 
   //////////////////////////////////////////////////////////////
   // Count memory read transactions - Read while enabled
   printf("\nCount memory read transactions (0)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)\n\t\
                     csrr t0, mhpmcounter3\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
-  __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load count while running = %d\n", count_while_on);
-  err_cnt += chck(count_while_on, 1);
-
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 1);
 
   //////////////////////////////////////////////////////////////
   // Count memory read transactions - Write after load event
   printf("\nCount memory read transactions (1)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)\n\t\
                     csrwi mhpmcounter3, 0xA\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
-  __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 0xA);
 
   //////////////////////////////////////////////////////////////
   // Count memory read transactions
   printf("\nCount memory read transactions (2)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)");                             // count++
   __asm__ volatile("mulh x0, x0, x0");
@@ -498,69 +380,48 @@ int main(int argc, char *argv[])
   __asm__ volatile("nop");                                      // do not count nop in instret
   __asm__ volatile("jump_target_memread:");
   __asm__ volatile("lw x0, 0(sp)");                             // count++
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count memory write transactions
   printf("\nCount memory write transactions");
 
-  event = EVENT_DATA_WRITE;                                     // Trigger on stores
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("sw x0, 0(sp)");                             // count++
   __asm__ volatile("mulh x0, x0, x0");
   __asm__ volatile("sw x0, 0(sp)");                             // count++
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Store count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count jumps
   printf("\nCount jumps");
 
-  event = EVENT_JUMP;                                           // Trigger on jumps
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("j jump_target_0");                          // count++
   __asm__ volatile("jump_target_0:");
   __asm__ volatile("j jump_target_1");                          // count++
   __asm__ volatile("jump_target_1:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 3);
-
-  printf("Jump count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count branches (conditional)
   printf("\nCount branches (conditional)");
 
-  event = EVENT_BRANCH;                                         // Trigger on on taken branches
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("beq x0, x0, branch_target_0");              // count++
   __asm__ volatile("branch_target_0:");
@@ -568,24 +429,17 @@ int main(int argc, char *argv[])
   __asm__ volatile("branch_target_1:");
   __asm__ volatile("beq x0, x0, branch_target_2");              // count++
   __asm__ volatile("branch_target_2:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Branch count = %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // Count branches taken (conditional)
   printf("\nCount branches taken (conditional)");
 
-  event = EVENT_BRANCH_TAKEN;                                   // Trigger on on taken branches
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("beq x0, x0, branch_target_3");              // count++
   __asm__ volatile("branch_target_3:");
@@ -593,38 +447,27 @@ int main(int argc, char *argv[])
   __asm__ volatile("branch_target_4:");
   __asm__ volatile("beq x0, x0, branch_target_5");              // count++
   __asm__ volatile("branch_target_5:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Branch taken count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Compressed instructions
   printf("\nCompressed instructions");
 
-  event = EVENT_COMP_INSTR;                                     // Trigger on compressed instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("c.addi x15, 1\n\t\
                     c.nop\n\t\
                     c.addi x15, 1" \
                     : : : "x15");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Compressed count = %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // Check for errors

--- a/cv32e40s/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
@@ -22,6 +22,10 @@
 **
 ** Very basic sanity check for:
 **
+**  - Retired Instruction Counter
+**  - Cycle counter
+**
+** This test is derived from a test that also checked the hpmcounters on 40x; where it tested:
 **  - Count load use hazards
 **  - Count jump register hazards
 **  - Count memory read transactions
@@ -30,10 +34,8 @@
 **  - Count branches (conditional)
 **  - Count branches taken (conditional)
 **  - Compressed instructions
-**  - Retired instructions
 **
-** Make sure to instantiate cv32e40s_wrapper with the parameter
-** NUM_MHPMCOUNTERS = 1 (or higher)
+** The test is therefore unnecessarily complex for the task
 **
 *******************************************************************************
 */
@@ -56,17 +58,6 @@ static int chck(unsigned int is, unsigned int should)
   return err;
 }
 
-static int chck_le(unsigned int is, unsigned int should)
-{
-  int err;
-  err = is <= should ? 0 : 1;
-  if (err)
-    printf("fail\n");
-  else
-    printf("pass\n");
-  return err;
-}
-
 static int chck_with_pos_margin(unsigned int is, unsigned int should, unsigned int margin)
 {
   int err;
@@ -82,25 +73,6 @@ int main(int argc, char *argv[])
 {
   int err_cnt = 0;
 
-  enum event_e { EVENT_CYCLES        = 1 << 0,
-                 EVENT_INSTR         = 1 << 1,
-                 EVENT_COMP_INSTR    = 1 << 2,
-                 EVENT_JUMP          = 1 << 3,
-                 EVENT_BRANCH        = 1 << 4,
-                 EVENT_BRANCH_TAKEN  = 1 << 5,
-                 EVENT_INTR_TAKEN    = 1 << 6,
-                 EVENT_DATA_READ     = 1 << 7,
-                 EVENT_DATA_WRITE    = 1 << 8,
-                 EVENT_IF_INVALID    = 1 << 9,
-                 EVENT_ID_INVALID    = 1 << 10,
-                 EVENT_EX_INVALID    = 1 << 11,
-                 EVENT_WB_INVALID    = 1 << 12,
-                 EVENT_ID_LD_STALL   = 1 << 13,
-                 EVENT_ID_JMP_STALL  = 1 << 14,
-                 EVENT_WB_DATA_STALL = 1 << 15 };
-
-  volatile unsigned int event;
-  volatile unsigned int count;
   volatile unsigned int minstret;
   volatile unsigned int count_while_on;
 
@@ -113,20 +85,14 @@ int main(int argc, char *argv[])
   printf("\nCycle count");
 
   // Setup events and set csrs to 0
-  event = EVENT_CYCLES;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB00, 0x0");
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
 
   // Readback Counter to verify 0
   __asm__ volatile("csrr %0, 0xB00" : "=r"(mcycle_count));
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
   printf("\nCheck proper zeroization\n");
   err_cnt += chck(minstret, 0);
-  err_cnt += chck(count, 0);
-  err_cnt += chck(count, mcycle_count);
 
   // Enable counters
   __asm__ volatile("csrwi 0x320, 0x0");
@@ -136,26 +102,20 @@ int main(int argc, char *argv[])
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB00" : "=r"(mcycle_count));
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-  printf("\nCycle count while running = %d", count);
   printf("\nMCYCLE counted cycles = %d\n", mcycle_count);
-  err_cnt += chck(count, mcycle_count);
-  err_cnt += chck_with_pos_margin(count, 6, 4*MAX_STALL_CYCLES);
+  err_cnt += chck_with_pos_margin(mcycle_count, 6, 4*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // IF_INVALID
   printf("\nIF_INVALID");
 
-  event = EVENT_IF_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("addi t1, x0, 0\n\t\
@@ -165,26 +125,18 @@ int main(int argc, char *argv[])
                     nop" \
                     : : : "t0", "t1");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4+(2*5));
-  printf("\nUnderutilized cycles on ID-stage due to IF stage = %d\n", count);
 
-  err_cnt += chck_with_pos_margin(count, 4, (4 /*non looped*/ +
-                                             5 /*looped addi*/ +
-                                             4*2 /*taken branches, potenially misaligned*/ +
-                                             2 /*non-taken, potentially misaligned*/)*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // ID_INVALID - LD_STALL
   printf("\nID_INVALID");
-  event = EVENT_ID_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
+
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("lw x4, 0(sp)\n\t\
@@ -193,22 +145,16 @@ int main(int argc, char *argv[])
                     addi x7, x0, 1" \
                     : : : "x4", "x5", "x6", "x7");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-  printf("\nUnderutilized cycles on EX-stage due to ID stage = %d\n", count);
-  err_cnt += chck_with_pos_margin(count, 2, 5*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // ID_INVALID - JR STALL
   printf("\nID_INVALID");
-  event = EVENT_ID_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("auipc x4, 0\n\t\
@@ -216,23 +162,17 @@ int main(int argc, char *argv[])
                     nop" \
                     : : : "x4");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-  printf("\nUnderutilized cycles on EX-stage due to ID stage = %d\n", count);
-  err_cnt += chck_with_pos_margin(count, 3, 4*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // EX_INVALID
   printf("\nEX_INVALID");
-  event = EVENT_EX_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));
 
   __asm__ volatile("csrwi 0xB02, 0x0");
-  __asm__ volatile("csrwi 0xB03, 0x0");
   __asm__ volatile("csrwi 0x320, 0x0");
 
   __asm__ volatile("lw x0, 0(x0)");
@@ -256,24 +196,17 @@ int main(int argc, char *argv[])
   __asm__ volatile("rem x0, x31, x30");                           // 32 cycles
   __asm__ volatile("lw x0, 0(sp)");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");
+  __asm__ volatile("csrwi 0x320, 0x5");
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 21);
-  printf("\nUnderutilized cycles on WB-stage due to EX stage = %d\n", count);
-  // -6 due to potential random stalls preventing hazard stalls
-  err_cnt += chck_with_pos_margin(count, 104 - 6, 21*MAX_STALL_CYCLES + 6);
 
   //////////////////////////////////////////////////////////////
   // WB_INVALID Write port underutilization
 
   printf("\nWrite port underutilization");
-  event = EVENT_WB_INVALID;
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
   __asm__ volatile("li x31, 1\n\t\
@@ -283,23 +216,17 @@ int main(int argc, char *argv[])
                     sw x29, 0(sp)" \
                     : : : "x28", "x29", "x30", "x31");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 6);
-  printf("\nWrite port underutilization cycles: %d\n", count);
-  err_cnt += chck_with_pos_margin(count, 34, 6*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // WB_DATA_STALL Write port underutilization due to data_rvalid_i (0)
   printf("\nWrite port underutilization due to data_rvalid_i");
-  event = EVENT_WB_DATA_STALL;
 
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
   __asm__ volatile("li x31, 7\n\t\
@@ -317,32 +244,25 @@ int main(int argc, char *argv[])
                     div x0, x31, x30" \
                     : : : "x28", "x29", "x30", "x31");
 
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 14);
-  printf("\nWrite port underutilization cycles: %d\n", count);
-  err_cnt += chck_with_pos_margin(count, 3, 14*MAX_STALL_CYCLES);
 
   //////////////////////////////////////////////////////////////
   // Retired instruction count (0) - Immediate minstret read
   printf("\nRetired instruction count (0)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
 
   __asm__ volatile("csrr t0, minstret\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
   __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
 
   printf("\nminstret count while running = %d\n", count_while_on);
@@ -355,10 +275,7 @@ int main(int argc, char *argv[])
   // Retired instruction count (1) - minstret read-after-write
   printf("\nRetired instruction count (1)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("csrwi minstret, 0xA\n\t\
                     csrr t0, minstret\n\t\
@@ -366,9 +283,8 @@ int main(int argc, char *argv[])
                     addi t2, x0, 0\n\t\
                     nop" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
   __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    //
 
   printf("\nminstret count while running = %d\n", count_while_on);
@@ -381,10 +297,7 @@ int main(int argc, char *argv[])
   // Retired instruction count (2)
   printf("\nRetired instruction count (2)");
 
-  event = EVENT_INSTR;                                          // Trigger on retired instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("sw x0, 0(sp)\n\t\
                     addi t0, x0, 5\n\t\
@@ -404,9 +317,8 @@ int main(int argc, char *argv[])
                     nop\n\t\
                     nop" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
-  __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
+  __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));         // minstret
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5 + 6*5 + 4 + 1);
@@ -415,110 +327,75 @@ int main(int argc, char *argv[])
   // Count load use hazards
   printf("\nCount load use hazards");
 
-  event = EVENT_ID_LD_STALL;                                    // Trigger on load use hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x4, 0(sp)\n\t\
                     addi x5, x4, 1\n\t\
                     lw x6, 0(sp)\n\t\
                     addi x7, x0, 1" \
                     : : : "x4", "x5", "x6", "x7");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load use hazards count = %d\n", count);
-  err_cnt += chck_le(count, 1);                                 // Hazard count is 0 or 1 (0 if due to instruction interface stalls 'use' did not closely follow the load)
 
   //////////////////////////////////////////////////////////////
   // Count jump register hazards
   printf("\nCount Jump register hazards");
 
-  event = EVENT_ID_JMP_STALL;                                   // Trigger on jump register hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("auipc x4, 0x0\n\t\
                     addi x4, x4, 10\n\t\
                     jalr x0, x4, 0x0" \
                     : : : "x4");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Jump register hazards count = %d\n", count);
-  err_cnt += chck_le(count, 1);                                 // Hazard count is 0 or 1 (0 if due to instruction interface stalls jalr did not closely follow the addi before it)
 
   //////////////////////////////////////////////////////////////
   // Count memory read transactions - Read while enabled
   printf("\nCount memory read transactions (0)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)\n\t\
                     csrr t0, mhpmcounter3\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
-  __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load count while running = %d\n", count_while_on);
-  err_cnt += chck(count_while_on, 1);
-
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 1);
 
   //////////////////////////////////////////////////////////////
   // Count memory read transactions - Write after load event
   printf("\nCount memory read transactions (1)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)\n\t\
                     csrwi mhpmcounter3, 0xA\n\t\
                     addi t1, x0, 0\n\t\
                     addi t2, x0, 0" \
                     : : : "t0", "t1", "t2");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
   __asm__ volatile("addi %0, t0, 0" : "=r"(count_while_on));    // count_while_on
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
 
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 0xA);
-
   //////////////////////////////////////////////////////////////
   // Count memory read transactions
   printf("\nCount memory read transactions (2)");
 
-  event = EVENT_DATA_READ;                                      // Trigger on loads
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x0, 0(sp)");                             // count++
   __asm__ volatile("mulh x0, x0, x0");
@@ -526,69 +403,48 @@ int main(int argc, char *argv[])
   __asm__ volatile("nop");                                      // do not count nop in instret
   __asm__ volatile("jump_target_memread:");
   __asm__ volatile("lw x0, 0(sp)");                             // count++
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count memory write transactions
   printf("\nCount memory write transactions");
 
-  event = EVENT_DATA_WRITE;                                     // Trigger on stores
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("sw x0, 0(sp)");                             // count++
   __asm__ volatile("mulh x0, x0, x0");
   __asm__ volatile("sw x0, 0(sp)");                             // count++
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Store count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count jumps
   printf("\nCount jumps");
 
-  event = EVENT_JUMP;                                           // Trigger on jumps
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("j jump_target_0");                          // count++
   __asm__ volatile("jump_target_0:");
   __asm__ volatile("j jump_target_1");                          // count++
   __asm__ volatile("jump_target_1:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                        // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 3);
-
-  printf("Jump count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Count branches (conditional)
   printf("\nCount branches (conditional)");
 
-  event = EVENT_BRANCH;                                         // Trigger on on taken branches
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("beq x0, x0, branch_target_0");              // count++
   __asm__ volatile("branch_target_0:");
@@ -596,24 +452,17 @@ int main(int argc, char *argv[])
   __asm__ volatile("branch_target_1:");
   __asm__ volatile("beq x0, x0, branch_target_2");              // count++
   __asm__ volatile("branch_target_2:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Branch count = %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // Count branches taken (conditional)
   printf("\nCount branches taken (conditional)");
 
-  event = EVENT_BRANCH_TAKEN;                                   // Trigger on on taken branches
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("beq x0, x0, branch_target_3");              // count++
   __asm__ volatile("branch_target_3:");
@@ -621,38 +470,27 @@ int main(int argc, char *argv[])
   __asm__ volatile("branch_target_4:");
   __asm__ volatile("beq x0, x0, branch_target_5");              // count++
   __asm__ volatile("branch_target_5:");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Branch taken count = %d\n", count);
-  err_cnt += chck(count, 2);
 
   //////////////////////////////////////////////////////////////
   // Compressed instructions
   printf("\nCompressed instructions");
 
-  event = EVENT_COMP_INSTR;                                     // Trigger on compressed instructions
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("c.addi x15, 1\n\t\
                     c.nop\n\t\
                     c.addi x15, 1" \
                     : : : "x15");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Compressed count = %d\n", count);
-  err_cnt += chck(count, 3);
 
   //////////////////////////////////////////////////////////////
   // Check for errors

--- a/cv32e40s/tests/programs/custom/hpmcounter_hazard_test/hpmcounter_hazard_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_hazard_test/hpmcounter_hazard_test.c
@@ -22,11 +22,14 @@
 **
 ** Very basic sanity check for:
 **
+**  - Retired Instruction Counter
+**  - Cycle counter
+**
+** This test is derived from a test that also checked the hpmcounters on 40x; where it tested:
 **  - Count load use hazards
 **  - Count jump register hazards
 **
-** Make sure to instantiate cv32e40s_wrapper with the parameter
-** NUM_MHPMCOUNTERS = 1 (or higher)
+** The test is therefore unnecessarily complex for the task
 **
 ** Make sure to only run this test without wait states on instr_gnt_i/
 ** instr_rvalid_i. The test should tolerate wait states on data_gnt_i/
@@ -51,40 +54,10 @@ static int chck(unsigned int is, unsigned int should)
   return err;
 }
 
-static int chck_le(unsigned int is, unsigned int should)
-{
-  int err;
-  err = is <= should ? 0 : 1;
-  if (err)
-    printf("fail\n");
-  else
-    printf("pass\n");
-  return err;
-}
-
 int main(int argc, char *argv[])
 {
   int err_cnt = 0;
 
-  enum event_e { EVENT_CYCLES        = 1 << 0,
-                 EVENT_INSTR         = 1 << 1,
-                 EVENT_COMP_INSTR    = 1 << 2,
-                 EVENT_JUMP          = 1 << 3,
-                 EVENT_BRANCH        = 1 << 4,
-                 EVENT_BRANCH_TAKEN  = 1 << 5,
-                 EVENT_INTR_TAKEN    = 1 << 6,
-                 EVENT_DATA_READ     = 1 << 7,
-                 EVENT_DATA_WRITE    = 1 << 8,
-                 EVENT_IF_INVALID    = 1 << 9,
-                 EVENT_ID_INVALID    = 1 << 10,
-                 EVENT_EX_INVALID    = 1 << 11,
-                 EVENT_WB_INVALID    = 1 << 12,
-                 EVENT_ID_LD_STALL   = 1 << 13,
-                 EVENT_ID_JMP_STALL  = 1 << 14,
-                 EVENT_WB_DATA_STALL = 1 << 15 };
-
-  volatile unsigned int event;
-  volatile unsigned int count;
   volatile unsigned int minstret;
 
   __asm__ volatile(".option rvc");
@@ -93,48 +66,34 @@ int main(int argc, char *argv[])
   // Count load use hazards
   printf("\nCount load use hazards");
 
-  event = EVENT_ID_LD_STALL;                                    // Trigger on load use hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("lw x4, 0(sp)\n\t\
                     addi x5, x4, 1\n\t\
                     lw x6, 0(sp)\n\t\
                     addi x7, x0, 1" \
                     : : : "x4", "x5", "x6", "x7");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 5);
-
-  printf("Load use hazards count = %d\n", count);
-  err_cnt += chck_le(count, 1);                                    // Interface stalls can cause this to be 0, otherwise 1
 
   //////////////////////////////////////////////////////////////
   // Count jump register hazards
   printf("\nCount Jump register hazards");
 
-  event = EVENT_ID_JMP_STALL;                                   // Trigger on jump register hazards
-  __asm__ volatile("csrw 0x323, %0 " :: "r"(event));            // Set mphmevent3
   __asm__ volatile("csrwi 0xB02, 0x0");                         // minstret = 0
-  __asm__ volatile("csrwi 0xB03, 0x0");                         // mhpmcounter3 = 0
   __asm__ volatile("csrwi 0x320, 0x0");                         // Enable counters
   __asm__ volatile("auipc x4, 0x0\n\t\
                     addi x4, x4, 10\n\t\
                     jalr x28, x4, 0x0" \
                     : : : "x4");
-  __asm__ volatile("csrwi 0x320, 0x1F");                        // Inhibit mcycle, minstret, mhpmcounter3-4
+  __asm__ volatile("csrwi 0x320, 0x5");                         // Inhibit mcycle, minstret
   __asm__ volatile("csrr %0, 0xB02" : "=r"(minstret));          // minstret
-  __asm__ volatile("csrr %0, 0xB03" : "=r"(count));             // mhpmcounter3
 
   printf("\nminstret count = %d\n", minstret);
   err_cnt += chck(minstret, 4);
-
-  printf("Jump register hazards count = %d\n", count);
-  err_cnt += chck_le(count, 1);                                    // Interface stalls can cause this to be 0, otherwise 1
 
   //////////////////////////////////////////////////////////////
   // Check for errors


### PR DESCRIPTION
Removed hpmcounter testing from performance counter tests (currently named hpmcounter_*_test, will rename in separate PR).
Removed NUM_MHPMCOUNTER parameter which does not exist in RTL for 40s.