### PR TITLE
Csr hardening update 2

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -826,8 +826,8 @@ module uvmt_cv32e40s_tb;
       .core_i_cs_registers_i_mie_q                                                                                      (core_i.cs_registers_i.mie_q),
 
       // Shadow registers
-      .core_cs_registers_mstateen0_csr_gen_hardened_shadow_q (core_i.cs_registers_i.mstateen0_csr_i.gen_hardened.shadow_q),
-      .core_cs_registers_priv_lvl_gen_hardened_shadow_q (core_i.cs_registers_i.priv_lvl_i.gen_hardened.shadow_q),
+      .core_cs_registers_mstateen0_csr_gen_hardened_shadow_q                                                            (core_i.cs_registers_i.mstateen0_csr_i.gen_hardened.shadow_q),
+      .core_cs_registers_priv_lvl_gen_hardened_shadow_q                                                                 (core_i.cs_registers_i.priv_lvl_i.gen_hardened.shadow_q),
       .core_cs_registers_jvt_csr_gen_hardened_shadow_q                                                                  (core_i.cs_registers_i.jvt_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_mstatus_csr_gen_hardened_shadow_q                                                              (core_i.cs_registers_i.mstatus_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q                                                      (core_i.cs_registers_i.xsecure.cpuctrl_csr_i.gen_hardened.shadow_q),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -671,103 +671,49 @@ module uvmt_cv32e40s_tb;
 
   localparam PMP_ADDR_WIDTH = (uvmt_cv32e40s_pkg::CORE_PARAM_PMP_GRANULARITY > 0) ? 33 - uvmt_cv32e40s_pkg::CORE_PARAM_PMP_GRANULARITY : 32;
 
-  logic [PMP_MAX_REGIONS-1:0][7:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q;
-  logic [PMP_MAX_REGIONS-1:0][PMP_ADDR_WIDTH-1:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q;
+  // Shadow:
+  mseccfg_t pmp_mseccfg_q_shadow_q;
+  pmpncfg_t pmpncfg_q_shadow_q[PMP_MAX_REGIONS];
+  logic [PMP_ADDR_WIDTH-1:0] pmp_addr_q_shadow_q[PMP_MAX_REGIONS];
 
-  logic [PMP_MAX_REGIONS-1:0][7:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q;
-  logic [PMP_MAX_REGIONS-1:0][PMP_ADDR_WIDTH-1:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q;
-
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q;
-
-  // SMCLIC
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q;
-
-  logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q;
-
-
-  // BASE
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q;
-
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q;
-  logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q;
-
+  mtvt_t mtvt_q_shadow_q;
+  mtvec_t mtvec_q_shadow_q;
+  mintstatus_t mintstatus_q_shadow_q;
+  logic [31:0] mintthresh_q_shadow_q;
+  logic [31:0] mie_q_hardened_shadow_q;
 
   // PMP register
   generate
     if (uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS > 0) begin
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q     = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.pmp_mseccfg_csr_i.gen_hardened.shadow_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q                 = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.pmp_mseccfg_csr_i.rdata_q);
-
+      assign pmp_mseccfg_q_shadow_q = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.pmp_mseccfg_csr_i.gen_hardened.shadow_q);
     end else begin
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q     = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q                 = '0;
-
+      assign pmp_mseccfg_q_shadow_q = '0;
     end
   endgenerate
 
-generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n++) begin
-    // Shadow:
-    assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.gen_hardened.shadow_q;
-    assign dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.gen_hardened.shadow_q;
-
-    // CSR:
-    assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q[n]  = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.rdata_q;
-    assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.rdata_q;
-
+  generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n++) begin
+    assign pmpncfg_q_shadow_q[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.gen_hardened.shadow_q;
+    assign pmp_addr_q_shadow_q[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.gen_hardened.shadow_q;
   end endgenerate
-
 
   generate
     if (SMCLIC==1) begin
 
-      //Shadow registers - SMILIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q         = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvt_csr_i.gen_hardened.shadow_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q        = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvec_csr_i.gen_hardened.shadow_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q   = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintstatus_csr_i.gen_hardened.shadow_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q   = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintthresh_csr_i.gen_hardened.shadow_q);
+      assign mtvt_q_shadow_q       = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvt_csr_i.gen_hardened.shadow_q);
+      assign mtvec_q_shadow_q      = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvec_csr_i.gen_hardened.shadow_q);
+      assign mintstatus_q_shadow_q = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintstatus_csr_i.gen_hardened.shadow_q);
+      assign mintthresh_q_shadow_q = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintthresh_csr_i.gen_hardened.shadow_q);
 
-      //Shadow registers - BASIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q    = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q      = '0;
-
-      //CSR registers - SMCLIC
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q                      = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvt_csr_i.rdata_q);
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q                     = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mtvec_csr_i.rdata_q);
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q                = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintstatus_csr_i.rdata_q);
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q                = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.smclic_csrs.mintthresh_csr_i.rdata_q);
-
-      //CSR registers - BASIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q    = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q      = '0;
+      assign mie_q_hardened_shadow_q = '0;
 
     end else begin
 
-      //Shadow registers - SMILIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q         = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q        = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q   = '0;
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q   = '0;
+      assign mtvt_q_shadow_q       = '0;
+      assign mtvec_q_shadow_q      = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mtvec_csr_i.gen_hardened.shadow_q);
+      assign mintstatus_q_shadow_q = '0;
+      assign mintthresh_q_shadow_q = '0;
 
-      //Shadow registers - BASIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q    = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mtvec_csr_i.gen_hardened.shadow_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q      = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mie_csr_i.gen_hardened.shadow_q);
-
-      //CSR registers - SMCLIC
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q               = '0;
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q         = '0;
-      assign dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q         = '0;
-
-      //CSR registers - BASIC
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q    = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mtvec_csr_i.rdata_q);
-      assign dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q      = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mie_csr_i.rdata_q);
+      assign mie_q_hardened_shadow_q = (dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.basic_mode_csrs.mie_csr_i.gen_hardened.shadow_q);
 
     end
   endgenerate
@@ -825,7 +771,7 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
 
       .core_xsecure_ctrl_cpuctrl_dataindtiming	                                                                        (core_i.xsecure_ctrl.cpuctrl.dataindtiming),
       .core_xsecure_ctrl_cpuctrl_rnddummy		                                                                            (core_i.xsecure_ctrl.cpuctrl.rnddummy),
-      .core_xsecure_ctrl_cpuctrl_integrity (core_i.xsecure_ctrl.cpuctrl.integrity),
+      .core_xsecure_ctrl_cpuctrl_integrity                                                                              (core_i.xsecure_ctrl.cpuctrl.integrity),
       .core_xsecure_ctrl_cpuctrl_pc_hardening                                                                           (core_i.xsecure_ctrl.cpuctrl.pc_hardening),
       .core_xsecure_ctrl_cpuctrl_rndhint                                                                                (core_i.xsecure_ctrl.cpuctrl.rndhint),
 
@@ -860,48 +806,44 @@ generate for (genvar n = 0; n < uvmt_cv32e40s_pkg::CORE_PARAM_PMP_NUM_REGIONS; n
       .core_i_cs_registers_i_mepc_o                                                                                     (core_i.cs_registers_i.mepc_o),
 
       // Hardend CSR registers
-      .core_i_cs_registers_i_jvt_csr_i_rdata_q                                                                          (core_i.cs_registers_i.jvt_csr_i.rdata_q),
-      .core_i_cs_registers_i_mstatus_csr_i_rdata_q                                                                      (core_i.cs_registers_i.mstatus_csr_i.rdata_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q                                    (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q),
-      .core_i_cs_registers_i_xsecure_cpuctrl_csr_i_rdata_q                                                              (core_i.cs_registers_i.xsecure.cpuctrl_csr_i.rdata_q),
-      .core_i_cs_registers_i_dcsr_csr_i_rdata_q                                                                         (core_i.cs_registers_i.dcsr_csr_i.rdata_q),
-      .core_i_cs_registers_i_mepc_csr_i_rdata_q                                                                         (core_i.cs_registers_i.mepc_csr_i.rdata_q),
-      .core_i_cs_registers_i_mscratch_csr_i_rdata_q                                                                     (core_i.cs_registers_i.mscratch_csr_i.rdata_q),
+      .core_i_cs_registers_i_mstateen0_q                                                                                (core_i.cs_registers_i.mstateen0_q),
+      .core_i_cs_registers_i_priv_lvl_q_int                                                                             (core_i.cs_registers_i.priv_lvl_q_int),
+      .core_i_cs_registers_i_jvt_q                                                                                      (core_i.cs_registers_i.jvt_q),
+      .core_i_cs_registers_i_mstatus_q                                                                                  (core_i.cs_registers_i.mstatus_q),
+      .core_i_cs_registers_i_cpuctrl_q                                                                                  (core_i.cs_registers_i.cpuctrl_q),
+      .core_i_cs_registers_i_dcsr_q                                                                                     (core_i.cs_registers_i.dcsr_q),
+      .core_i_cs_registers_i_mepc_q                                                                                     (core_i.cs_registers_i.mepc_q),
+      .core_i_cs_registers_i_mscratch_q                                                                                 (core_i.cs_registers_i.mscratch_q),
 
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q         (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q),
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q        (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q),
+      .core_i_cs_registers_i_pmp_mseccfg_q                                                                              (core_i.cs_registers_i.pmp_mseccfg_q),
+      .core_i_cs_registers_i_pmpncfg_q                                                                                  (core_i.cs_registers_i.pmpncfg_q),
+      .core_i_cs_registers_i_pmp_addr_q                                                                                 (core_i.cs_registers_i.pmp_addr_q),
 
-      // SMCLIC
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q                                 (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q),
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q                                (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q),
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q                           (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q),
-      .dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q                           (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q),
-
-      // BASE
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q                                    (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q                                      (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q),
+      .core_i_cs_registers_i_mtvt_q                                                                                     (core_i.cs_registers_i.mtvt_q),
+      .core_i_cs_registers_i_mtvec_q                                                                                    (core_i.cs_registers_i.mtvec_q),
+      .core_i_cs_registers_i_mintstatus_q                                                                               (core_i.cs_registers_i.mintstatus_q),
+      .core_i_cs_registers_i_mintthresh_q                                                                               (core_i.cs_registers_i.mintthresh_q),
+      .core_i_cs_registers_i_mie_q                                                                                      (core_i.cs_registers_i.mie_q),
 
       // Shadow registers
+      .core_cs_registers_mstateen0_csr_gen_hardened_shadow_q (core_i.cs_registers_i.mstateen0_csr_i.gen_hardened.shadow_q),
+      .core_cs_registers_priv_lvl_gen_hardened_shadow_q (core_i.cs_registers_i.priv_lvl_i.gen_hardened.shadow_q),
       .core_cs_registers_jvt_csr_gen_hardened_shadow_q                                                                  (core_i.cs_registers_i.jvt_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_mstatus_csr_gen_hardened_shadow_q                                                              (core_i.cs_registers_i.mstatus_csr_i.gen_hardened.shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q                        (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q),
       .core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q                                                      (core_i.cs_registers_i.xsecure.cpuctrl_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_dcsr_csr_gen_hardened_shadow_q                                                                 (core_i.cs_registers_i.dcsr_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_mepc_csr_gen_hardened_shadow_q                                                                 (core_i.cs_registers_i.mepc_csr_i.gen_hardened.shadow_q),
       .core_cs_registers_mscratch_csr_gen_hardened_shadow_q                                                             (core_i.cs_registers_i.mscratch_csr_i.gen_hardened.shadow_q),
 
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q  (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q),
+      .uvmt_cv32e40s_tb_pmp_mseccfg_q_shadow_q                                                                          (uvmt_cv32e40s_tb.pmp_mseccfg_q_shadow_q),
+      .uvmt_cv32e40s_tb_pmpncfg_q_shadow_q                                                                              (uvmt_cv32e40s_tb.pmpncfg_q_shadow_q),
+      .uvmt_cv32e40s_tb_pmp_addr_q_shadow_q                                                                             (uvmt_cv32e40s_tb.pmp_addr_q_shadow_q),
 
-      // SMILIC
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q                           (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q                          (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q                     (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q                     (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q),
-
-      // BASIC
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q                      (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q),
-      .dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q                        (uvmt_cv32e40s_tb.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q),
+      .uvmt_cv32e40s_tb_mtvt_q_shadow_q                                                                                 (uvmt_cv32e40s_tb.mtvt_q_shadow_q),
+      .uvmt_cv32e40s_tb_mtvec_q_shadow_q                                                                                (uvmt_cv32e40s_tb.mtvec_q_shadow_q),
+      .uvmt_cv32e40s_tb_mintstatus_q_shadow_q                                                                           (uvmt_cv32e40s_tb.mintstatus_q_shadow_q),
+      .uvmt_cv32e40s_tb_mintthresh_q_shadow_q                                                                           (uvmt_cv32e40s_tb.mintthresh_q_shadow_q),
+      .uvmt_cv32e40s_tb_mie_q_hardened_shadow_q                                                                         (uvmt_cv32e40s_tb.mie_q_hardened_shadow_q),
 
       // IF stage
       .core_if_stage_if_valid_o                                                                                         (core_i.if_stage_i.if_valid_o),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -197,48 +197,46 @@ interface uvmt_cv32e40s_xsecure_if
     input logic [31:0] core_i_cs_registers_i_mepc_o,
 
     // Hardened CSR registers
-    input logic [31:0] core_i_cs_registers_i_jvt_csr_i_rdata_q,
-    input logic [31:0] core_i_cs_registers_i_mstatus_csr_i_rdata_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q,
-    input logic [31:0] core_i_cs_registers_i_xsecure_cpuctrl_csr_i_rdata_q,
-    input logic [31:0] core_i_cs_registers_i_dcsr_csr_i_rdata_q,
-    input logic [31:0] core_i_cs_registers_i_mepc_csr_i_rdata_q,
-    input logic [31:0] core_i_cs_registers_i_mscratch_csr_i_rdata_q,
+    input logic [31:0] core_i_cs_registers_i_mstateen0_q,
+    input logic [1:0] core_i_cs_registers_i_priv_lvl_q_int,
 
-    input logic [PMP_MAX_REGIONS-1:0][7:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q,
-    input logic [PMP_MAX_REGIONS-1:0][PMP_ADDR_WIDTH-1:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q,
+    input logic [31:0] core_i_cs_registers_i_jvt_q,
+    input logic [31:0] core_i_cs_registers_i_mstatus_q,
+    input logic [31:0] core_i_cs_registers_i_cpuctrl_q,
+    input logic [31:0] core_i_cs_registers_i_dcsr_q,
+    input logic [31:0] core_i_cs_registers_i_mepc_q,
+    input logic [31:0] core_i_cs_registers_i_mscratch_q,
 
-    // SMCLIC
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q,
+    input mseccfg_t core_i_cs_registers_i_pmp_mseccfg_q,
+    input pmpncfg_t core_i_cs_registers_i_pmpncfg_q[PMP_MAX_REGIONS],
+    input logic [PMP_ADDR_WIDTH-1:0] core_i_cs_registers_i_pmp_addr_q[PMP_MAX_REGIONS],
 
-    // BASE
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q,
+    input mtvt_t core_i_cs_registers_i_mtvt_q,
+    input mtvec_t core_i_cs_registers_i_mtvec_q,
+    input mintstatus_t core_i_cs_registers_i_mintstatus_q,
+    input logic [31:0] core_i_cs_registers_i_mintthresh_q,
+    input logic [31:0] core_i_cs_registers_i_mie_q,
 
     // Shadow registers
+    input logic [31:0] core_cs_registers_mstateen0_csr_gen_hardened_shadow_q,
+    input logic [1:0] core_cs_registers_priv_lvl_gen_hardened_shadow_q,
+
     input logic [31:0] core_cs_registers_jvt_csr_gen_hardened_shadow_q,
     input logic [31:0] core_cs_registers_mstatus_csr_gen_hardened_shadow_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q,
     input logic [31:0] core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q,
     input logic [31:0] core_cs_registers_dcsr_csr_gen_hardened_shadow_q,
     input logic [31:0] core_cs_registers_mepc_csr_gen_hardened_shadow_q,
     input logic [31:0] core_cs_registers_mscratch_csr_gen_hardened_shadow_q,
 
-    input logic [PMP_MAX_REGIONS-1:0][7:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q,
-    input logic [PMP_MAX_REGIONS-1:0][PMP_ADDR_WIDTH-1:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q,
+    input mseccfg_t uvmt_cv32e40s_tb_pmp_mseccfg_q_shadow_q,
+    input pmpncfg_t uvmt_cv32e40s_tb_pmpncfg_q_shadow_q[PMP_MAX_REGIONS],
+    input logic [PMP_ADDR_WIDTH-1:0] uvmt_cv32e40s_tb_pmp_addr_q_shadow_q[PMP_MAX_REGIONS],
 
-    // SMILIC
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q,
-
-    // BASIC
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q,
-    input logic [31:0] dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q,
+    input mtvt_t uvmt_cv32e40s_tb_mtvt_q_shadow_q,
+    input mtvec_t uvmt_cv32e40s_tb_mtvec_q_shadow_q,
+    input mintstatus_t uvmt_cv32e40s_tb_mintstatus_q_shadow_q,
+    input logic [31:0] uvmt_cv32e40s_tb_mintthresh_q_shadow_q,
+    input logic [31:0] uvmt_cv32e40s_tb_mie_q_hardened_shadow_q,
 
     // IF stage
     input logic core_if_stage_if_valid_o,

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
@@ -452,95 +452,151 @@ module uvmt_cv32e40s_xsecure_assert
   ////////////////////////////////////////////////////////////////
 
 
-  ////////// SOME CSRS ARE SHADOWED //////////
+  ////////// CSRS ARE SHADOWED //////////
 
-  /****************************************
-  The following 4 assertions make sure the CSRs are shadowed at all times:
-  The shadow registers are the compliments of the CSRs
-  ****************************************/
+  //The following assertions make sure the CSRs are shadowed at all times.
+  //The shadow registers are the complements of the CSRs
 
-  a_xsecure_hardened_CSRs_no_mismatch_static_registers: assert property (
-    //Make sure the following CSRs are shadowed at all times:
+  property p_hardened_csr(csr, shadow);
+    //Make sure the CSR is shadowed at all times, and that the shadow is equal to the complement of the CSR
+    csr == ~shadow;
+  endproperty
 
-    //JVT
-    xsecure_if.core_cs_registers_jvt_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_jvt_csr_i_rdata_q & cv32e40s_pkg::CSR_JVT_MASK)
+  //MSTATEEN0
+  a_xsecure_hardened_csr_mstateen0: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_mstateen0_q,
+      xsecure_if.core_cs_registers_mstateen0_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR MSTATEEN0 is not shadowed.\n");
 
-    //MSTATUS
-    and xsecure_if.core_cs_registers_mstatus_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_mstatus_csr_i_rdata_q & cv32e40s_pkg::CSR_MSTATUS_MASK)
+  //PRIVILEGE LEVEL
+  a_xsecure_hardened_csr_privlvl: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_priv_lvl_q_int,
+      xsecure_if.core_cs_registers_priv_lvl_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The priviliged level is not shadowed.\n");
 
-    //CPUCTRL
-    and xsecure_if.core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_xsecure_cpuctrl_csr_i_rdata_q & cv32e40s_pkg::CSR_CPUCTRL_MASK)
+  //JVT
+  a_xsecure_hardened_csr_jvt: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_jvt_q,
+      xsecure_if.core_cs_registers_jvt_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR JVT is not shadowed.\n");
 
-    //DCSR
-    and xsecure_if.core_cs_registers_dcsr_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_dcsr_csr_i_rdata_q & cv32e40s_pkg::CSR_DCSR_MASK)
+  //MSTATUS
+  a_xsecure_hardened_csr_mstatus: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_mstatus_q,
+      xsecure_if.core_cs_registers_mstatus_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR MSTATUS is not shadowed.\n");
 
-    //MEPC
-    and xsecure_if.core_cs_registers_mepc_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_mepc_csr_i_rdata_q & cv32e40s_pkg::CSR_MEPC_MASK)
+  //CPUCTRL
+  a_xsecure_hardened_csr_cpuctrl: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_cpuctrl_q,
+      xsecure_if.core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR CPUCTRL is not shadowed.\n");
 
-    //MSCRATCH
-    and xsecure_if.core_cs_registers_mscratch_csr_gen_hardened_shadow_q == ~(xsecure_if.core_i_cs_registers_i_mscratch_csr_i_rdata_q & cv32e40s_pkg::CSR_MSCRATCH_MASK)
+  //DCSR
+  a_xsecure_hardened_csr_dcsr: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_dcsr_q,
+      xsecure_if.core_cs_registers_dcsr_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR DCSR is not shadowed.\n");
 
-  ) else `uvm_error(info_tag, "One or several of the CSRs JVT, MSTATUS, CPUCTRL, DCSR, MEPC, MSCRATCH are not shadowed.\n");
+  //MEPC
+  a_xsecure_hardened_csr_mepc: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_mepc_q,
+      xsecure_if.core_cs_registers_mepc_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR MEPC is not shadowed.\n");
+
+  //MSCRATCH (Therby also MSCRATCHCSW and MSCRATCHCSWL)
+  a_xsecure_hardened_csr_mscratch: assert property (
+    p_hardened_csr(
+      xsecure_if.core_i_cs_registers_i_mscratch_q,
+      xsecure_if.core_cs_registers_mscratch_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "The CSR MSCRATCH is not shadowed.\n");
 
   generate
     if(PMP_NUM_REGIONS > 0) begin
-      a_xsecure_hardened_CSRs_no_mismatch_pmp_register: assert property (
-      //Make sure the MSECCFG CSR is shadowed at all times (given that we use PMP regions)
 
       //MSECCFG
-      xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q & cv32e40s_pkg::CSR_MSECCFG_MASK)
-
+      a_xsecure_hardened_csr_mseccfg: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_pmp_mseccfg_q,
+          xsecure_if.uvmt_cv32e40s_tb_pmp_mseccfg_q_shadow_q)
       ) else `uvm_error(info_tag, "The CSR MSECCFG is not shadowed.\n");
 
     end
   endgenerate
 
-  generate for (genvar n = 0; n < PMP_NUM_REGIONS; n++) begin
-
-    a_xsecure_hardened_CSRs_no_mismatch_pmp_region_registers: assert property (
-      //Make sure the existing PMP CSRs are shadowed at all times
+  generate
+    for (genvar n = 0; n < PMP_NUM_REGIONS; n++) begin
 
       //PMPNCFG
-      xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q[n] == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q[n] & cv32e40s_pkg::CSR_PMPNCFG_MASK)
+      a_xsecure_hardened_csr_pmpncfg: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_pmpncfg_q[n],
+          xsecure_if.uvmt_cv32e40s_tb_pmpncfg_q_shadow_q[n])
+      ) else `uvm_error(info_tag, $sformatf("The CSR PMP%0dCFG is not shadowed.\n", n));
 
       //PMPADDR
-      and xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q[n] == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q[n] & cv32e40s_pkg::CSR_PMPADDR_MASK[PMP_ADDR_WIDTH-1:0])
+      a_xsecure_hardened_csr_pmpaddr: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_pmp_addr_q[n],
+          xsecure_if.uvmt_cv32e40s_tb_pmp_addr_q_shadow_q[n])
+      ) else `uvm_error(info_tag, $sformatf("The CSR PMPADDR[%0d] is not shadowed.\n", n));
 
-    ) else `uvm_error(info_tag, $sformatf("One or several of the CSRs PMP%0dCFG or PMPADDR[%0d] are not shadowed.\n", n, n));
-
-  end endgenerate
+    end
+  endgenerate
 
   generate
     if(SMCLIC) begin
-      a_xsecure_hardened_CSRs_no_mismatch_smclic_registers: assert property (
-        //Make sure the smclic CSRs are shadowed at all times if smclic is enabled
 
-        //MTVT
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q & cv32e40s_pkg::CSR_MTVT_MASK)
+      //MTVT
+      a_xsecure_hardened_csr_mtvt: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mtvt_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvt_q_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MTVT is not shadowed.\n");
 
-        //MTVEC
-        and xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q & cv32e40s_pkg::CSR_MTVEC_CLIC_MASK)
+      //MTVEC
+      a_xsecure_hardened_csr_mtvec: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mtvec_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MTVEC is not shadowed.\n");
 
-        //MINTSTATUS
-        and xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q & cv32e40s_pkg::CSR_MINTSTATUS_MASK)
+      //MINTSTATUS
+      a_xsecure_hardened_csr_mintstatus: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mintstatus_q,
+          xsecure_if.uvmt_cv32e40s_tb_mintstatus_q_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MINTSTATUS is not shadowed.\n");
 
-        //MINTTHRESH
-        and xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q & CSR_MINTTHRESH_MASK)
-
-      ) else `uvm_error(info_tag, "One or several of the CSRs MTVT, MTVEC, MINTSTATUS or MINTTHRESH are not shadowed.\n");
+      //MINTTHRESH
+      a_xsecure_hardened_csr_mintthresh: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mintthresh_q,
+          xsecure_if.uvmt_cv32e40s_tb_mintthresh_q_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MINTTHRESH is not shadowed.\n");
 
     end else begin
 
-      a_xsecure_hardened_CSRs_no_mismatch_basic_mode_registers: assert property (
-        //Make sure the CSRs used when smclic is disabled are shadowed at all times
+      //MTVEC
+      a_xsecure_hardened_csr_mtvec: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mtvec_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MTVEC is not shadowed.\n");
 
-        //MTVEC
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q & cv32e40s_pkg::CSR_MTVEC_BASIC_MASK)
-
-        //MIE
-        and xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q == ~(xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q & cv32e40s_pkg::IRQ_MASK)
-
-      ) else `uvm_error(info_tag, "The CSRs MTVEC or MIE are not shadowed.\n");
+      //MIE
+      a_xsecure_hardened_csr_mie: assert property (
+        p_hardened_csr(
+          xsecure_if.core_i_cs_registers_i_mie_q,
+          xsecure_if.uvmt_cv32e40s_tb_mie_q_hardened_shadow_q)
+      ) else `uvm_error(info_tag, "The CSR MIE is not shadowed.\n");
 
     end
   endgenerate
@@ -548,160 +604,160 @@ module uvmt_cv32e40s_xsecure_assert
 
   ////////// SET THE MAJOR ALERT IF A CSR IS NOT SHADOWED //////////
 
-  property p_xsecure_hardned_csr_mismatch_sets_alert_major(csr, shadow, MASK);
-    //Make sure we only set the major alert if we are in the operating mode (use the gated clock)
+  //The following assertions check if mismatches between the CSRs and their corresponding shadow registers result in the major alert being set
+
+  property p_hardened_csr_mismatch_sets_major_aler(csr, shadow);
     @(posedge xsecure_if.core_clk)
 
-    //csr & mask: make sure the bits we are not interested in are set to 0s, which is determined by the mask
-    //(shadow | ~MASK): this operation turns the unmasked bits of the shadow register to 1s (so they will become compliments of the unmasked bits of the CSR (which are all 0s))
-    //~(shadow | ~MASK) != (CSR & MASK): this operation checks if the shadow register (and its unmasked bits) are compliments of the CSR (and its unmasked bits)
-    ~(shadow | ~MASK) != (csr & MASK)
+    //Make sure the shadow is not the complement of the CSR
+    shadow != ~csr
 
-    //Make sure the alert major is set if there is a mismatch of the CSR and shadow register
     |=>
+    //Verify that the major alert is set
     xsecure_if.core_alert_major_o;
-
   endproperty
 
-  /****************************************
-  The following assertions check whether a mismatch between a CSR and its corresponding shadow register results in the major alert being set.
-  ****************************************/
+  //MSTATEEN0
+  a_xsecure_hardened_csr_mismatch_mstateen0: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_mstateen0_q,
+      xsecure_if.core_cs_registers_mstateen0_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR MSTATEEN0 and its shadow does not set the major alert.\n");
 
-  //JVT:
-  a_xsecure_hardened_CSRs_mismatch_jvt: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_jvt_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_jvt_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_JVT_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the JVT CSR and its shadow register does not result in the major alert being set.\n");
+  //PRIVILEGE LEVEL
+  a_xsecure_hardened_csr_mismatch_privlvl: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_priv_lvl_q_int,
+      xsecure_if.core_cs_registers_priv_lvl_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the priviliged level and its shadow does not set the major alert.\n");
 
-  //MSTATUS:
-  a_xsecure_hardened_CSRs_mismatch_mstatus: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_mstatus_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_mstatus_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_MSTATUS_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the MSTATUS CSR and its shadow register does not result in the major alert being set.\n");
+  //JVT
+  a_xsecure_hardened_csr_mismatch_jvt: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_jvt_q,
+      xsecure_if.core_cs_registers_jvt_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR JVT and its shadow does not set the major alert.\n");
 
-  //CPUCTRL:
-  a_xsecure_hardened_CSRs_mismatch_cpuctrl: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_xsecure_cpuctrl_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_CPUCTRL_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the CPUCTRL CSR and its shadow register does not result in the major alert being set.\n");
+  //MSTATUS
+  a_xsecure_hardened_csr_mismatch_mstatus: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_mstatus_q,
+      xsecure_if.core_cs_registers_mstatus_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR MSTATUS and its shadow does not set the major alert.\n");
 
-  //DCSR:
-  a_xsecure_hardened_CSRs_mismatch_dcsr: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_dcsr_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_dcsr_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_DCSR_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the DCSR CSR and its shadow register does not result in the major alert being set.\n");
+  //CPUCTRL
+  a_xsecure_hardened_csr_mismatch_cpuctrl: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_cpuctrl_q,
+      xsecure_if.core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR CPUCTRL and its shadow does not set the major alert.\n");
 
-  //MEPC:
-  a_xsecure_hardened_CSRs_mismatch_mepc: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_mepc_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_mepc_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_MEPC_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the MEPC CSR and its shadow register does not result in the major alert being set.\n");
+  //DCSR
+  a_xsecure_hardened_csr_mismatch_dcsr: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_dcsr_q,
+      xsecure_if.core_cs_registers_dcsr_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR DCSR and its shadow does not set the major alert.\n");
 
-  //MSCRATCH:
-  a_xsecure_hardened_CSRs_mismatch_mscratch: assert property (
-    p_xsecure_hardned_csr_mismatch_sets_alert_major(
-      xsecure_if.core_i_cs_registers_i_mscratch_csr_i_rdata_q,
-      xsecure_if.core_cs_registers_mscratch_csr_gen_hardened_shadow_q,
-      cv32e40s_pkg::CSR_MSCRATCH_MASK)
-  ) else `uvm_error(info_tag_glitch, "A mismatch between the MSCRATCH CSR and its shadow register does not result in the major alert being set.\n");
+  //MEPC
+  a_xsecure_hardened_csr_mismatch_mepc: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_mepc_q,
+      xsecure_if.core_cs_registers_mepc_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR MEPC and its shadow does not set the major alert.\n");
+
+  //MSCRATCH
+  a_xsecure_hardened_csr_mismatch_mscratch: assert property (
+    p_hardened_csr_mismatch_sets_major_aler(
+      xsecure_if.core_i_cs_registers_i_mscratch_q,
+      xsecure_if.core_cs_registers_mscratch_csr_gen_hardened_shadow_q)
+  ) else `uvm_error(info_tag, "A mismatch between the CSR MSCRATCH and its shadow does not set the major alert.\n");
+
+
 
   generate
     if(PMP_NUM_REGIONS > 0) begin
 
-      //MSECCFG:
-      a_xsecure_hardened_CSRs_mismatch_mseccfg: assert property (
-        p_xsecure_hardned_csr_mismatch_sets_alert_major(
-          xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_i_rdata_q,
-          xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_pmp_mseccfg_csr_gen_hardened_shadow_q,
-          cv32e40s_pkg::CSR_MSECCFG_MASK)
-      ) else `uvm_error(info_tag_glitch, "A mismatch between the MSECCFG CSR and its shadow register does not result in the major alert being set.\n");
+      //MSECCFG
+      a_xsecure_hardened_csr_mismatch_mseccfg: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_pmp_mseccfg_q,
+          xsecure_if.uvmt_cv32e40s_tb_pmp_mseccfg_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MSECCFG and its shadow does not set the major alert.\n");
 
     end
   endgenerate
 
+  generate
+    for (genvar n = 0; n < PMP_NUM_REGIONS; n++) begin
 
-  generate for (genvar n = 0; n < PMP_NUM_REGIONS; n++) begin
-    //PMPNCFG:
-    a_xsecure_hardened_CSRs_mismatch_pmpncfg: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_rdata_q[n],
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmpncfg_csr_i_gen_hardened_shadow_q[n],
-        cv32e40s_pkg::CSR_PMPNCFG_MASK)
-    ) else `uvm_error(info_tag_glitch, $sformatf("The mismatch between the PMP%0dCFG CSR and its shadow register does not result in the major alert being set.\n", n));
+      //PMPNCFG
+      a_xsecure_hardened_csr_mismatch_pmpncfg: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_pmpncfg_q[n],
+          xsecure_if.uvmt_cv32e40s_tb_pmpncfg_q_shadow_q[n])
+      ) else `uvm_error(info_tag, $sformatf("A mismatch between the CSR PMP%0dCFG and its shadow does not set the major alert.\n", n));
 
-    //PMPADDR:
-    a_xsecure_hardened_CSRs_mismatch_pmpaddr: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_i_rdata_q[n],
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_csr_pmp_gen_pmp_csr_n_pmp_region_pmp_addr_csr_gen_hardened_shadow_q[n],
-        cv32e40s_pkg::CSR_PMPADDR_MASK[PMP_ADDR_WIDTH-1:0])
-    ) else `uvm_error(info_tag_glitch, $sformatf("The mismatch between the PMPADDR[%0d] CSR and its shadow register does not result in the major alert being set.\n", n));
+      //PMPADDR
+      a_xsecure_hardened_csr_mismatch_pmpaddr: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_pmp_addr_q[n],
+          xsecure_if.uvmt_cv32e40s_tb_pmp_addr_q_shadow_q[n])
+      ) else `uvm_error(info_tag, $sformatf("A mismatch between the CSR PMPADDR[%0d] and its shadow does not set the major alert.\n", n));
 
-  end endgenerate
+    end
+  endgenerate
 
+  generate
+    if(SMCLIC) begin
 
-  if(SMCLIC) begin
-    //MTVT:
-    a_xsecure_hardened_CSRs_mismatch_mtvt: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvt_csr_i_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvt_csr_gen_hardened_shadow_q,
-        cv32e40s_pkg::CSR_MTVT_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MTVT CSR and its shadow register does not result in the major alert being set.\n");
+      //MTVT
+      a_xsecure_hardened_csr_mismatch_mtvt: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mtvt_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvt_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVT and its shadow does not set the major alert.\n");
 
-    //MTVEC:
-    a_xsecure_hardened_CSRs_mismatch_mtvec: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mtvec_csr_i_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mtvec_csr_gen_hardened_shadow_q,
-        cv32e40s_pkg::CSR_MTVEC_CLIC_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MTVEC CSR and its shadow register does not result in the major alert being set.\n");
+      //MTVEC
+      a_xsecure_hardened_csr_mismatch_mtvec: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mtvec_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
 
-    //MINTSTATUS:
-    a_xsecure_hardened_CSRs_mismatch_mintstatus: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintstatus_csr_i_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintstatus_csr_gen_hardened_shadow_q,
-        cv32e40s_pkg::CSR_MINTSTATUS_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MINTSTATUS CSR and its shadow register does not result in the major alert being set.\n");
+      //MINTSTATUS
+      a_xsecure_hardened_csr_mismatch_mintstatus: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mintstatus_q,
+          xsecure_if.uvmt_cv32e40s_tb_mintstatus_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MINTSTATUS and its shadow does not set the major alert.\n");
 
-    //MINTTHRESH:
-    a_xsecure_hardened_CSRs_mismatch_mintthresh: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_i_core_i_cs_registers_i_smclic_csrs_mintthresh_csr_i_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_smclic_csrs_mintthresh_csr_gen_hardened_shadow_q,
-        CSR_MINTTHRESH_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MINTTHRESH CSR and its shadow register does not result in the major alert being set.\n");
+      //MINTTHRESH
+      a_xsecure_hardened_csr_mismatch_mintthresh: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mintthresh_q,
+          xsecure_if.uvmt_cv32e40s_tb_mintthresh_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MINTTHRESH and its shadow does not set the major alert.\n");
 
-  end else begin
+    end else begin
 
-    //MTVEC:
-    a_xsecure_hardened_CSRs_mismatch_mtvec: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mtvec_csr_gen_hardened_shadow_q,
-        cv32e40s_pkg::CSR_MTVEC_BASIC_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MTVEC CSR and its shadow register does not result in the major alert being set.\n");
+      //MTVEC
+      a_xsecure_hardened_csr_mismatch_mtvec: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mtvec_q,
+          xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
 
-    //MIE:
-    a_xsecure_hardened_CSRs_mismatch_mie: assert property (
-      p_xsecure_hardned_csr_mismatch_sets_alert_major(
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_rdata_q,
-        xsecure_if.dut_wrap_cv32e40s_wrapper_core_cs_registers_basic_mode_csrs_mie_csr_gen_hardened_shadow_q,
-        cv32e40s_pkg::IRQ_MASK)
-    ) else `uvm_error(info_tag_glitch, "A mismatch between the MIE CSR and its shadow register does not result in the major alert being set.\n");
+      //MIE
+      a_xsecure_hardened_csr_mismatch_mie: assert property (
+        p_hardened_csr_mismatch_sets_major_aler(
+          xsecure_if.core_i_cs_registers_i_mie_q,
+          xsecure_if.uvmt_cv32e40s_tb_mie_q_hardened_shadow_q)
+      ) else `uvm_error(info_tag, "A mismatch between the CSR MIE and its shadow does not set the major alert.\n");
 
-  end
+    end
+  endgenerate
+
 
   /////////////////////////////////////////////////////////////////////
   ///////////////////////// REGISTER FILE ECC /////////////////////////
@@ -936,7 +992,7 @@ module uvmt_cv32e40s_xsecure_assert
   ) else `uvm_error(info_tag, "Interface integrity checking is not enabled when exiting reset.\n");
 
 
-  ////////// INTERFACE INTEGRITY PARITY BITS ARE COMPLIMENT BITS AT ALL TIMES GIVEN THERE IS NO GLITCH //////////
+  ////////// INTERFACE INTEGRITY PARITY BITS ARE COMPLEMENT BITS AT ALL TIMES GIVEN THERE IS NO GLITCH //////////
 
   property p_parity_signal_is_invers_of_signal(signal, parity_signal);
     @(posedge clk_i)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
@@ -1,4 +1,20 @@
-//TODO: make header
+// Copyright 2022 OpenHW Group
+// Copyright 2022 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+
 
 module uvmt_cv32e40s_xsecure_assert
   import uvm_pkg::*;

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert.sv
@@ -50,13 +50,13 @@ module uvmt_cv32e40s_xsecure_assert
   localparam FREQ_SETTING_64_MIN = 4'b1000;
   localparam FREQ_SETTING_64_MAX = 4'b1111;
   localparam FREQ_SETTING_32_MIN = 4'b0100;
-  localparam FREQ_SETTING_32_MAX = FREQ_SETTING_64_MIN -1;
+  localparam logic [3:0] FREQ_SETTING_32_MAX = FREQ_SETTING_64_MIN -1;
   localparam FREQ_SETTING_16_MIN = 4'b0010;
-  localparam FREQ_SETTING_16_MAX = FREQ_SETTING_32_MIN -1;
+  localparam logic [3:0] FREQ_SETTING_16_MAX = FREQ_SETTING_32_MIN -1;
   localparam FREQ_SETTING_8_MIN = 4'b0001;
-  localparam FREQ_SETTING_8_MAX = FREQ_SETTING_16_MIN -1;
+  localparam logic [3:0] FREQ_SETTING_8_MAX = FREQ_SETTING_16_MIN -1;
   localparam FREQ_SETTING_4_MIN = 4'b0000;
-  localparam FREQ_SETTING_4_MAX = FREQ_SETTING_8_MIN -1;
+  localparam logic [3:0] FREQ_SETTING_4_MAX = FREQ_SETTING_8_MIN -1;
 
 
   localparam BRANCH_STATE = 4'b0101;
@@ -97,6 +97,7 @@ module uvmt_cv32e40s_xsecure_assert
 
   logic [4:0] if_id_pipe_instr_rs1;
   logic [4:0] if_id_pipe_instr_rs2;
+  logic [4:0] if_id_pipe_instr_rd;
   logic [6:0] if_id_pipe_instr_opcode;
   logic [12:0] if_id_pipe_bltu_incrementation;
 
@@ -104,7 +105,6 @@ module uvmt_cv32e40s_xsecure_assert
   assign if_id_pipe_instr_rs2 = xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[24:20];
   assign if_id_pipe_instr_rd = xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[11:7];
   assign if_id_pipe_instr_opcode = xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[6:0];
-
   assign if_id_pipe_bltu_incrementation = {xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[31],
     xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[7],
     xsecure_if.core_if_id_pipe_instr_bus_resp_rdata[30:25],
@@ -622,56 +622,56 @@ module uvmt_cv32e40s_xsecure_assert
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_mstateen0_q,
       xsecure_if.core_cs_registers_mstateen0_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR MSTATEEN0 and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MSTATEEN0 and its shadow does not set the major alert.\n");
 
   //PRIVILEGE LEVEL
   a_xsecure_hardened_csr_mismatch_privlvl: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_priv_lvl_q_int,
       xsecure_if.core_cs_registers_priv_lvl_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the priviliged level and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the priviliged level and its shadow does not set the major alert.\n");
 
   //JVT
   a_xsecure_hardened_csr_mismatch_jvt: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_jvt_q,
       xsecure_if.core_cs_registers_jvt_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR JVT and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR JVT and its shadow does not set the major alert.\n");
 
   //MSTATUS
   a_xsecure_hardened_csr_mismatch_mstatus: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_mstatus_q,
       xsecure_if.core_cs_registers_mstatus_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR MSTATUS and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MSTATUS and its shadow does not set the major alert.\n");
 
   //CPUCTRL
   a_xsecure_hardened_csr_mismatch_cpuctrl: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_cpuctrl_q,
       xsecure_if.core_cs_registers_xsecure_cpuctrl_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR CPUCTRL and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR CPUCTRL and its shadow does not set the major alert.\n");
 
   //DCSR
   a_xsecure_hardened_csr_mismatch_dcsr: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_dcsr_q,
       xsecure_if.core_cs_registers_dcsr_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR DCSR and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR DCSR and its shadow does not set the major alert.\n");
 
   //MEPC
   a_xsecure_hardened_csr_mismatch_mepc: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_mepc_q,
       xsecure_if.core_cs_registers_mepc_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR MEPC and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MEPC and its shadow does not set the major alert.\n");
 
   //MSCRATCH
   a_xsecure_hardened_csr_mismatch_mscratch: assert property (
     p_hardened_csr_mismatch_sets_major_aler(
       xsecure_if.core_i_cs_registers_i_mscratch_q,
       xsecure_if.core_cs_registers_mscratch_csr_gen_hardened_shadow_q)
-  ) else `uvm_error(info_tag, "A mismatch between the CSR MSCRATCH and its shadow does not set the major alert.\n");
+  ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MSCRATCH and its shadow does not set the major alert.\n");
 
 
 
@@ -683,7 +683,7 @@ module uvmt_cv32e40s_xsecure_assert
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_pmp_mseccfg_q,
           xsecure_if.uvmt_cv32e40s_tb_pmp_mseccfg_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MSECCFG and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MSECCFG and its shadow does not set the major alert.\n");
 
     end
   endgenerate
@@ -696,14 +696,14 @@ module uvmt_cv32e40s_xsecure_assert
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_pmpncfg_q[n],
           xsecure_if.uvmt_cv32e40s_tb_pmpncfg_q_shadow_q[n])
-      ) else `uvm_error(info_tag, $sformatf("A mismatch between the CSR PMP%0dCFG and its shadow does not set the major alert.\n", n));
+      ) else `uvm_error(info_tag_glitch, $sformatf("A mismatch between the CSR PMP%0dCFG and its shadow does not set the major alert.\n", n));
 
       //PMPADDR
       a_xsecure_hardened_csr_mismatch_pmpaddr: assert property (
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_pmp_addr_q[n],
           xsecure_if.uvmt_cv32e40s_tb_pmp_addr_q_shadow_q[n])
-      ) else `uvm_error(info_tag, $sformatf("A mismatch between the CSR PMPADDR[%0d] and its shadow does not set the major alert.\n", n));
+      ) else `uvm_error(info_tag_glitch, $sformatf("A mismatch between the CSR PMPADDR[%0d] and its shadow does not set the major alert.\n", n));
 
     end
   endgenerate
@@ -716,28 +716,28 @@ module uvmt_cv32e40s_xsecure_assert
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mtvt_q,
           xsecure_if.uvmt_cv32e40s_tb_mtvt_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVT and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MTVT and its shadow does not set the major alert.\n");
 
       //MTVEC
       a_xsecure_hardened_csr_mismatch_mtvec: assert property (
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mtvec_q,
           xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
 
       //MINTSTATUS
       a_xsecure_hardened_csr_mismatch_mintstatus: assert property (
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mintstatus_q,
           xsecure_if.uvmt_cv32e40s_tb_mintstatus_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MINTSTATUS and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MINTSTATUS and its shadow does not set the major alert.\n");
 
       //MINTTHRESH
       a_xsecure_hardened_csr_mismatch_mintthresh: assert property (
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mintthresh_q,
           xsecure_if.uvmt_cv32e40s_tb_mintthresh_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MINTTHRESH and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MINTTHRESH and its shadow does not set the major alert.\n");
 
     end else begin
 
@@ -746,14 +746,14 @@ module uvmt_cv32e40s_xsecure_assert
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mtvec_q,
           xsecure_if.uvmt_cv32e40s_tb_mtvec_q_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MTVEC and its shadow does not set the major alert.\n");
 
       //MIE
       a_xsecure_hardened_csr_mismatch_mie: assert property (
         p_hardened_csr_mismatch_sets_major_aler(
           xsecure_if.core_i_cs_registers_i_mie_q,
           xsecure_if.uvmt_cv32e40s_tb_mie_q_hardened_shadow_q)
-      ) else `uvm_error(info_tag, "A mismatch between the CSR MIE and its shadow does not set the major alert.\n");
+      ) else `uvm_error(info_tag_glitch, "A mismatch between the CSR MIE and its shadow does not set the major alert.\n");
 
     end
   endgenerate
@@ -2117,7 +2117,6 @@ property p_parity_signal_is_not_invers_of_signal_set_major_alert(signal, parity_
     //Verify that alert major is set
     xsecure_if.core_alert_major_o
   ) else `uvm_error(info_tag_glitch, "The counter underflows but does not set the major alert.\n");
-
 
 
 endmodule : uvmt_cv32e40s_xsecure_assert


### PR DESCRIPTION
The vmanager is down, but test passes hello-world simulation at least.

Changes:
1) Made one assertion for each CSR.
2) Changed signals used to check CSR values
3) Changed logic to check if csr and shadow are complements of eachother.
