### PR TITLE
[VPTOOL] Add support for precise requirement locations and requirement/design doc viewing.

### DIFF
--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -688,7 +688,7 @@ class MyTextWidget(ttk.LabelFrame):
             self.text1frame,
             cue_text=vp_config.yaml_config["gui"]["requirement_loc"]["cue_text"],
             state="disabled",
-            height=1,
+            height=2,
             bg=BG_COLOR,
             undo=True,
             wrap="word",

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -577,7 +577,7 @@ class MyTextWidget(ttk.LabelFrame):
         # Use a callaback to update state upon changes to section number field.
         self.section_num_var.trace("w", self.ref_section_num_changed)
 
-        view_btn = ttk.Button(self.text1frame, text="Show design doc", command=self.view_file)
+        view_btn = ttk.Button(self.text1frame, text="View design doc", command=self.view_design_doc)
         view_btn.grid(column=5, row=2, sticky=tk.E)
         self.ref_mode_var = tk.StringVar(self)
         ref_mode_names = ("(consecutive) page #", "section #")
@@ -852,7 +852,7 @@ class MyTextWidget(ttk.LabelFrame):
         if current_item and not self.parent.get_current_item().is_locked():
             self.parent.get_current_item().ref_section = self.section_num_var.get()
 
-    def view_file(self):
+    def view_design_doc(self):
         """
         View the requirement file (Design Doc) at the position specified in Requirement Location frame.
         """
@@ -864,8 +864,13 @@ class MyTextWidget(ttk.LabelFrame):
                 ref_in_doc = f"#nameddest=section.{self.section_num_var.get().rstrip()}"
             else:
                 ref_in_doc = ""
-            command = [ "firefox",
-                "file://" + self.text1.get(0.0, tk.END).rstrip() + ref_in_doc ]
+            # Assume the location is a valid URL or an absolute path.
+            doc_location = self.text1.get(0.0, tk.END).rstrip()
+            # If no scheme (http://, file:// etc.) is given, treat it
+            # as an absolute file path.
+            if doc_location[0] == '/':
+                doc_location = "file://" + doc_location
+            command = [ "firefox", doc_location + ref_in_doc ]
         elif self.viewer_var.get() == "evince":
             # PDF viewer mode: use appropriate cmdline option.
             if self.ref_mode_var.get() == "page":
@@ -874,6 +879,7 @@ class MyTextWidget(ttk.LabelFrame):
                 ref_in_doc = ["-n", f"section.{self.section_num_var.get().rstrip()}"]
             else:
                 ref_in_doc = []
+            # The requirement location should be a valid path to a PDF file.
             command = ["evince"] + ref_in_doc + [self.text1.get(0.0, tk.END).rstrip()]
         print(f"### ==> command = {command}")
         subprocess.Popen(command)

--- a/tools/vptool/vptool/vp_pack.py
+++ b/tools/vptool/vptool/vp_pack.py
@@ -74,6 +74,10 @@ class Item:
         self.verif_goals = ""
         # Location of coverage data
         self.coverage_loc = ""
+        # Use page as the default reference mode for design docs.
+        # This will work with all files (no reliance on named dests).
+        self.ref_mode = "page"
+        self.viewer = "firefox"
         # FIXME: Propagate default value from YAML config.
         self.pfc = -1  # none selected, must choose
         self.test_type = -1  # none selected, must choose

--- a/tools/vptool/vptool/vp_pack.py
+++ b/tools/vptool/vptool/vp_pack.py
@@ -68,7 +68,8 @@ class Item:
         self.tag = tag
         # Description of feature to be tested
         self.description = description
-        # Requirement to be verified
+        # Requirement to be verified (from now on, the design document...)
+        # FIXME: field naming needs a major rework.
         self.purpose = purpose
         # Summary of verification goals
         self.verif_goals = ""
@@ -77,7 +78,9 @@ class Item:
         # Use page as the default reference mode for design docs.
         # This will work with all files (no reliance on named dests).
         self.ref_mode = "page"
-        self.viewer = "firefox"
+        self.ref_page = ""
+        self.ref_section = ""
+        self.ref_viewer = "firefox"
         # FIXME: Propagate default value from YAML config.
         self.pfc = -1  # none selected, must choose
         self.test_type = -1  # none selected, must choose


### PR DESCRIPTION
This PR extends `VPTOOL` with GUI and database format support for:

* Precise *Requirement Location* references (down to section or page number);
* Direct viewing of requirement/design document at the specified location using either an HTML browser (for PDF file URLs) or a PDF viewer (for local files).

This is an initial implementation of the feature: all feedback and comments are welcome and encouraged.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>