### PR TITLE
Simplify installation of CVA6 environment.

### DIFF
--- a/cva6/docs/VerifPlans/source/conf.py
+++ b/cva6/docs/VerifPlans/source/conf.py
@@ -154,7 +154,7 @@ latex_elements = {
 
     # Additional stuff for the LaTeX preamble.
     #
-    # 'preamble': '',
+    'preamble': r'\DeclareUnicodeCharacter{2260}{$\neq$}',
 
     # Latex figure (float) alignment
     #

--- a/cva6/docs/VerifPlans/source/conf.py
+++ b/cva6/docs/VerifPlans/source/conf.py
@@ -33,7 +33,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
-
+import sphinx_rtd_theme
 
 # -- Project information -----------------------------------------------------
 
@@ -62,6 +62,7 @@ extensions = [
     'recommonmark',
     'sphinxcontrib.inkscapeconverter',
     'sphinx_github_changelog',
+    'sphinx_rtd_theme',
 #    'sphinxcontrib.wavedrom',
 ]
 #wavedrom_html_jsinline = False
@@ -110,7 +111,10 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {'style_nav_header_background': '#DDDDDD'}
+html_theme_options = {
+    'style_nav_header_background': '#DDDDDD',
+    'collapse_navigation': False,
+}
 html_logo = '../images/openhw-landscape.svg'
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -30,13 +30,13 @@ export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
 export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
 
 # number of parallel jobs to use for make commands and simulation
-export NUM_JOBS=24
+export NUM_JOBS=3
 
 # install the required tools for cva6
 if ! [ -n "$CVA6_REPO" ]; then
   CVA6_REPO="https://github.com/openhwgroup/cva6.git"
   CVA6_BRANCH="master"
-  CVA6_HASH="75807530f26ba9a0ca501e9d3a6575ec375ed7ab"
+  CVA6_HASH="32abc1ccda15877936e7e383e0013a3da0a2b33c"
   CVA6_PATCH=
 fi
 echo $CVA6_REPO
@@ -58,3 +58,6 @@ if ! [ -n "$SPIKE_ROOT" ]; then
   export SPIKE_ROOT=$TOP/spike/
 fi
 cva6/regress/install-spike.sh
+
+# Install/update VPTOOL dependencies.
+cva6/regress/install-vptool-deps.sh

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -17,6 +17,9 @@ if ! [ -n "$RISCV" ]; then
   return
 fi
 
+# Install/update VPTOOL dependencies.
+cva6/regress/install-vptool-deps.sh
+
 # install Verilator
 if ! [ -n "$VERILATOR_ROOT" ]; then
   export VERILATOR_ROOT=$TOP/verilator-4.110/
@@ -58,6 +61,3 @@ if ! [ -n "$SPIKE_ROOT" ]; then
   export SPIKE_ROOT=$TOP/spike/
 fi
 cva6/regress/install-spike.sh
-
-# Install/update VPTOOL dependencies.
-cva6/regress/install-vptool-deps.sh

--- a/cva6/regress/install-verilator.sh
+++ b/cva6/regress/install-verilator.sh
@@ -23,7 +23,8 @@ if [ ! -f "$VERILATOR_ROOT/bin/verilator" ]; then
     rm -f v4.*.tar.gz
     cd verilator-4.110
     mkdir -p $VERILATOR_ROOT
-    # copy scripts
+    # Do not build debug version of verilator (UGLY HACK!)
+    sed -i -e '198d' Makefile.in
     autoconf && ./configure --prefix="$VERILATOR_ROOT" && make -j${NUM_JOBS}
     cp -r * $VERILATOR_ROOT/
     make test

--- a/cva6/regress/install-vptool-deps.sh
+++ b/cva6/regress/install-vptool-deps.sh
@@ -1,0 +1,11 @@
+# Copyright 2023 Thales Silicon Security
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
+
+pip3 install --upgrade pyyaml ttkthemes pillow
+

--- a/cva6/regress/install-vptool-deps.sh
+++ b/cva6/regress/install-vptool-deps.sh
@@ -8,4 +8,9 @@
 # Original Author: Zbigniew CHAMSKI (zbigniew.chamski@thalesgroup.fr)
 
 pip3 install --upgrade pyyaml ttkthemes pillow
+pip3 install --upgrade commonmark recommonmark
+pip3 install --upgrade sphinxcontrib_applehelp sphinxcontrib_devhelp \
+     sphinxcontrib_htmlhelp sphinxcontrib_jsmath sphinxcontrib_qthelp \
+     sphinxcontrib_serializinghtml sphinxcontrib_svg2pdfconverter \
+     sphinx_rtd_theme sphinx_github_changelog
 


### PR DESCRIPTION
Bootcamp: Update CVA6 baseline, reduce jobs, install VPTOOL deps.
    
* cva6/regress/install-cva6.sh (NUM_JOBS): Reduce from 24 to 3.
   (CVA6_HASH): Update to 32abc1cc.
   Invoke installer of VPTOOL deps.
* cva6/regress/install-vptool-deps.sh: New.

VerifPlan rendering: Gracefully handle not-equal Unicode char in LaTeX.
    
* cva6/docs/VerifPlans/source/conf.py: Translate U+2260 into \neq in LaTeX preamble.

 [VerifPlan rendering] Enable collapsable nagivation menu in HTML5 output.
    
* cva6/docs/VerifPlans/source/conf.py: Explicitly import sphinx_rtd_theme.
      Disable 'collapse_navigation' option.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>