### PR TITLE
setup-ci-example: Fix typo

### DIFF
--- a/.gitlab-ci/setup-ci-example/core-v-verif-cv32.yml
+++ b/.gitlab-ci/setup-ci-example/core-v-verif-cv32.yml
@@ -15,8 +15,8 @@ variables:
   COMPLIANCE_HASH: 220e78542da4510e40eac31e31fdd4e77cdae437
   COMPLIANCE_PATCH: ../../../cva6/riscv-compliance.patch
   TESTS_REPO: https://github.com/riscv/riscv-tests.git
-  TEST_BRANCH: master
-  TEST_HASH: f92842f91644092960ac7946a61ec2895e543cec
+  TESTS_BRANCH: master
+  TESTS_HASH: f92842f91644092960ac7946a61ec2895e543cec
   DV_REPO: https://github.com/google/riscv-dv.git
   DV_BRANCH: master
   NUM_JOBS: 24

--- a/.gitlab-ci/setup-ci-example/core-v-verif-cva6.yml
+++ b/.gitlab-ci/setup-ci-example/core-v-verif-cva6.yml
@@ -16,8 +16,8 @@ variables:
   COMPLIANCE_HASH: 220e78542da4510e40eac31e31fdd4e77cdae437
   COMPLIANCE_PATCH: ../../../cva6/riscv-compliance.patch
   TESTS_REPO: https://github.com/riscv/riscv-tests.git
-  TEST_BRANCH: master
-  TEST_HASH: f92842f91644092960ac7946a61ec2895e543cec
+  TESTS_BRANCH: master
+  TESTS_HASH: f92842f91644092960ac7946a61ec2895e543cec
   DV_REPO: https://github.com/google/riscv-dv.git
   DV_BRANCH: master
   NUM_JOBS: 24


### PR DESCRIPTION
The scripts expect `TESTS_BRANCH` and `TESTS_HASH`:
https://github.com/openhwgroup/core-v-verif/blob/6113f4f179645eb05c4178b6ec25be316a9a1aa8/cva6/regress/install-riscv-tests.sh#L21-L22