### PR TITLE
install-riscv-dv: Use RISCV_PREFIX

### DIFF
--- a/cva6/regress/install-riscv-dv.sh
+++ b/cva6/regress/install-riscv-dv.sh
@@ -10,10 +10,10 @@
 # riscv-dv env variables
 export RISCV_TOOLCHAIN=$RISCV
 if ! [ -n "$RISCV_GCC" ]; then
-  export RISCV_GCC="$RISCV_TOOLCHAIN/bin/riscv-none-elf-gcc"
+  export RISCV_GCC="${RISCV_PREFIX}gcc"
 fi
 if ! [ -n "$RISCV_OBJCOPY" ]; then
-  export RISCV_OBJCOPY="$RISCV_TOOLCHAIN/bin/riscv-none-elf-objcopy"
+  export RISCV_OBJCOPY="${RISCV_PREFIX}objcopy"
 fi
 export SPIKE_PATH=$SPIKE_ROOT/bin
 export RTL_PATH=$ROOT_PROJECT/core-v-cores/cva6


### PR DESCRIPTION
Use the existing `RISCV_PREFIX` env variable to set up the gnu tool commands. Useful for installations that use the original RISC-V toolchain where the tools have different prefixes (e.g. `riscv64-unknown-elf-`)
