### PR TITLE
Disable A extension in CV32A60X step1 config.  Adapt CVA6 BSP accordingly.

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -857,7 +857,7 @@ def load_config(args, cwd):
       args.isa  = "rv64gc"
     elif args.target == "cv32a60x":
       args.mabi = "ilp32"
-      args.isa  = "rv32imac" # A is needed to compile custom BSP
+      args.isa  = "rv32imc" # Step1 configuration has no A extension.
     elif args.target == "cv32a6_imac_sv0":
       args.mabi = "ilp32"
       args.isa  = "rv32imac"

--- a/cva6/tests/custom/common/syscalls.c
+++ b/cva6/tests/custom/common/syscalls.c
@@ -22,14 +22,18 @@ static uintptr_t syscall(uintptr_t which, uint64_t arg0, uint64_t arg1, uint64_t
   magic_mem[1] = arg0;
   magic_mem[2] = arg1;
   magic_mem[3] = arg2;
+#ifdef __riscv_atomic // __sync_synchronize requires A extension
   __sync_synchronize();
+#endif
 
   tohost = (uintptr_t)magic_mem;
   while (fromhost == 0)
     ;
   fromhost = 0;
 
+#ifdef __riscv_atomic // __sync_synchronize requires A extension
   __sync_synchronize();
+#endif
   return magic_mem[0];
 }
 

--- a/cva6/tests/custom/common/util.h
+++ b/cva6/tests/custom/common/util.h
@@ -43,6 +43,7 @@ static int verifyDouble(int n, const volatile double* test, const double* verify
 
 static void __attribute__((noinline)) barrier(int ncores)
 {
+#ifdef __riscv_atomic // __sync_* builtins require A extension
   static volatile int sense;
   static volatile int count;
   static __thread int threadsense;
@@ -59,6 +60,7 @@ static void __attribute__((noinline)) barrier(int ncores)
     ;
 
   __sync_synchronize();
+#endif // __riscv_atomic
 }
 
 static uint64_t lfsr(uint64_t x)


### PR DESCRIPTION
Account for the absence of `A` extension in CV32A60X step1 configuration and in BSP code.

* cva/sim/cva6.py (load_config): Disable A extension for cv32a60x config.
* cva6/tests/custom/common/syscalls.c (syscall): Do not use synchronization primitives without A extension.
* cva6/tests/custom/common/util.h (barrier): Disable functionality when no A extension is present.

Signed-off-by: Zbigniew Chamski <zbigniew.chamski@thalesgroup.com>