### PR TITLE
Core Params - Add missing & Add external config

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 3b356d64d5ce24e5f3d13e1256e26efb6259ca34
+CV_CORE_HASH   ?= df6c2cd793b4443a39deca7837a63c760c15d0f7
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_constants.sv
@@ -18,77 +18,160 @@
 `ifndef __UVMT_CV32E40S_CONSTANTS_SV__
 `define __UVMT_CV32E40S_CONSTANTS_SV__
 
-   // TODO: Expand as needed
-   `ifdef DBG_NUM_TRIG_0
-      parameter CORE_PARAM_NUM_TRIGGERS = 0;
-   `elsif DBG_NUM_TRIG_1
-      parameter CORE_PARAM_NUM_TRIGGERS = 1;
-   `else
-      parameter CORE_PARAM_NUM_TRIGGERS = 1;
+
+   `ifdef PARAM_SET_0
+      `include  "cvverif_40s_params.svh"
    `endif
 
-   `ifdef SMCLIC_EN
+
+   // Debug
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif DBG_NUM_TRIG_0
+      parameter CORE_PARAM_DBG_NUM_TRIGGERS = 0;
+   `elsif DBG_NUM_TRIG_1
+      parameter CORE_PARAM_DBG_NUM_TRIGGERS = 1;
+   `else
+      parameter CORE_PARAM_DBG_NUM_TRIGGERS = 1;
+   `endif
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter logic [31:0] CORE_PARAM_DM_REGION_START = 32'hF0000000;
+      parameter logic [31:0] CORE_PARAM_DM_REGION_END   = 32'hF0003FFF;
+   `endif
+
+
+   // CLIC
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif SMCLIC_EN
       parameter int CORE_PARAM_SMCLIC = 1;
    `else
       parameter int CORE_PARAM_SMCLIC = 0;
    `endif
-   // Add various clic configurations
+   parameter logic SMCLIC = CORE_PARAM_SMCLIC;
 
-   `ifdef ZBA_ZBB_ZBS
-      parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBS;
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter int  CORE_PARAM_SMCLIC_INTTHRESHBITS = 8;
+      parameter int  CORE_PARAM_SMCLIC_ID_WIDTH = 5;
+   `endif
+
+
+   // B-ext
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif ZBA_ZBB_ZBS
+      parameter cv32e40s_pkg::b_ext_e CORE_PARAM_B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBS;
    `elsif ZBA_ZBB_ZBC_ZBS
-      parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBC_ZBS;
+      parameter cv32e40s_pkg::b_ext_e CORE_PARAM_B_EXT = cv32e40s_pkg::ZBA_ZBB_ZBC_ZBS;
    `else
-      parameter cv32e40s_pkg::b_ext_e B_EXT = cv32e40s_pkg::B_NONE;
+      parameter cv32e40s_pkg::b_ext_e CORE_PARAM_B_EXT = cv32e40s_pkg::B_NONE;
    `endif
 
-   `ifdef SMCLIC_EN
-         parameter logic SMCLIC = 1'b1;
+
+   // M-ext
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
    `else
-         parameter logic SMCLIC = 1'b0;
+      parameter cv32e40s_pkg::m_ext_e CORE_PARAM_M_EXT = cv32e40s_pkg::M;
    `endif
 
-   `ifdef RV32E
-     parameter cv32e40s_pkg::rv32_e RV32 = cv32e40s_pkg::RV32E;
-     parameter CORE_PARAM_REGFILE_NUM_WORDS = 16;
+
+   // I-base & E-base
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif RV32E
+      parameter cv32e40s_pkg::rv32_e CORE_PARAM_RV32              = cv32e40s_pkg::RV32E;
+      parameter                      CORE_PARAM_REGFILE_NUM_WORDS = 16;
    `else
-     parameter cv32e40s_pkg::rv32_e RV32 = cv32e40s_pkg::RV32I;
-     parameter CORE_PARAM_REGFILE_NUM_WORDS = 32;
+      parameter cv32e40s_pkg::rv32_e CORE_PARAM_RV32              = cv32e40s_pkg::RV32I;
+      parameter                      CORE_PARAM_REGFILE_NUM_WORDS = 32;
    `endif
 
-   `ifdef PMP_ENABLE_2
-     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 2;
+
+   // Xsecure
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR0_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
+      parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
+      parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
+   `endif
+
+
+   // PMP
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif PMP_ENABLE_2
+      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 2;
    `elsif PMP_ENABLE_64
-     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
    `elsif PMP_G0R0
-     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
    `elsif PMP_G0R16
-     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 16;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 16;
    `elsif PMP_G1R5
-     parameter int CORE_PARAM_PMP_GRANULARITY = 1;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 5;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 1;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 5;
    `elsif PMP_G2R6
-     parameter int CORE_PARAM_PMP_GRANULARITY = 2;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 6;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 2;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 6;
    `elsif PMP_G3R3
-     parameter int CORE_PARAM_PMP_GRANULARITY = 3;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 3;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 3;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 3;
    `elsif PMP_G27R64
-     parameter int CORE_PARAM_PMP_GRANULARITY = 27;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 27;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 64;
    `else
-     parameter int CORE_PARAM_PMP_GRANULARITY = 0;
-     parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
+      parameter int CORE_PARAM_PMP_GRANULARITY = 0;
+      parameter int CORE_PARAM_PMP_NUM_REGIONS = 0;
+   `endif
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter cv32e40s_pkg::mseccfg_t CORE_PARAM_PMP_MSECCFG_RV = cv32e40s_pkg::MSECCFG_DEFAULT;
+   `endif
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter cv32e40s_pkg::pmpncfg_t  CORE_PARAM_PMP_PMPNCFG_RV [CORE_PARAM_PMP_NUM_REGIONS-1:0] = '{
+         default: cv32e40s_pkg::PMPNCFG_DEFAULT
+      };
+   `endif
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `else
+      parameter logic [31:0] CORE_PARAM_PMP_PMPADDR_RV[CORE_PARAM_PMP_NUM_REGIONS-1:0] = '{
+         default: 32'h 0
+      };
    `endif
 
 
-   `ifdef PMA_CUSTOM_CFG
+   // PMA
+
+   `ifdef PARAM_SET_0
+      // Sat from the include file
+   `elsif PMA_CUSTOM_CFG
       const string pma_cfg_name = "pma_custom_cfg";
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 3;
+      parameter int unsigned  CORE_PARAM_PMA_NUM_REGIONS = 3;
       parameter cv32e40s_pkg::pma_cfg_t CORE_PARAM_PMA_CFG[CORE_PARAM_PMA_NUM_REGIONS-1:0] = '{
          // Overlap "shadow" of main code (.text), for testing overlap priority
          cv32e40s_pkg::pma_cfg_t'{
@@ -142,7 +225,6 @@
       parameter cv32e40s_pkg::pma_cfg_t CORE_PARAM_PMA_CFG[0:CORE_PARAM_PMA_NUM_REGIONS-1] = '{
         '{word_addr_low : 32'h0000_0000>>2, word_addr_high : 32'h7FFF_FFFF>>2, main : 1'b1, bufferable : 1'b1, cacheable : 1'b1, integrity : 1'b0}
       };
-
    `elsif PMA_TEST_CFG_2
       const string pma_cfg_name = "pma_test_cfg_2";
       parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 7;
@@ -230,7 +312,7 @@
         };
    `else
       const string pma_cfg_name = "pma_noregion";
-      parameter int unsigned               CORE_PARAM_PMA_NUM_REGIONS = 0;
+      parameter int unsigned            CORE_PARAM_PMA_NUM_REGIONS = 0;
       parameter cv32e40s_pkg::pma_cfg_t CORE_PARAM_PMA_CFG[-1:0] = '{default:cv32e40s_pkg::PMA_R_DEFAULT};
    `endif
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -41,20 +41,33 @@
  */
 module uvmt_cv32e40s_dut_wrap
   import cv32e40s_pkg::*;
-#(// DUT (riscv_core) parameters.
-    parameter cv32e40s_pkg::b_ext_e B_EXT  = cv32e40s_pkg::B_NONE,
-    parameter int          PMA_NUM_REGIONS =  0,
-    parameter pma_cfg_t    PMA_CFG[PMA_NUM_REGIONS-1 : 0] = '{default:PMA_R_DEFAULT},
-    parameter int          PMP_NUM_REGIONS = 0,
-    parameter int          PMP_GRANULARITY = 0,
-    parameter logic        SMCLIC = 0,
-    parameter int          SMCLIC_ID_WIDTH = 5,
-    parameter int          DBG_NUM_TRIGGERS = 1,
+#(
+    // DUT (riscv_core) parameters.
+    parameter logic [31:0]           DM_REGION_START                     = 32'hF0000000,
+    parameter logic [31:0]           DM_REGION_END                       = 32'hF0003FFF,
+    parameter lfsr_cfg_t             LFSR0_CFG                           = LFSR_CFG_DEFAULT,
+    parameter lfsr_cfg_t             LFSR1_CFG                           = LFSR_CFG_DEFAULT,
+    parameter lfsr_cfg_t             LFSR2_CFG                           = LFSR_CFG_DEFAULT,
+    parameter m_ext_e                M_EXT                               = M,
+    parameter mseccfg_t              PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
+    parameter cv32e40s_pkg::b_ext_e  B_EXT                               = cv32e40s_pkg::B_NONE,
+    parameter int                    PMA_NUM_REGIONS                     =  0,
+    parameter pma_cfg_t              PMA_CFG[PMA_NUM_REGIONS-1 : 0]      = '{default:PMA_R_DEFAULT},
+    parameter int                    PMP_NUM_REGIONS                     = 0,
+    parameter pmpncfg_t              PMP_PMPNCFG_RV[PMP_NUM_REGIONS-1:0] = '{default:PMPNCFG_DEFAULT},
+    parameter logic [31:0]           PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
+    parameter int                    PMP_GRANULARITY                     = 0,
+    parameter logic                  SMCLIC                              = 0,
+    parameter int                    SMCLIC_ID_WIDTH                     = 5,
+    parameter int                    SMCLIC_INTTHRESHBITS                = 8,
+    parameter int                    DBG_NUM_TRIGGERS                    = 1,
+    parameter rv32_e                 RV32                                = RV32I,
+
     // Remaining parameters are used by TB components only
-              INSTR_ADDR_WIDTH    =  32,
-              INSTR_RDATA_WIDTH   =  32,
-              RAM_ADDR_WIDTH      =  20
-   )
+    parameter INSTR_ADDR_WIDTH    =  32,
+    parameter INSTR_RDATA_WIDTH   =  32,
+    parameter RAM_ADDR_WIDTH      =  20
+  )
   (
     uvma_clknrst_if              clknrst_if,
     uvma_interrupt_if            interrupt_if,
@@ -149,13 +162,25 @@ module uvmt_cv32e40s_dut_wrap
     // --------------------------------------------
     // instantiate the core
     cv32e40s_wrapper #(
-                      .B_EXT            (B_EXT),
-                      .PMA_NUM_REGIONS  (PMA_NUM_REGIONS),
-                      .PMA_CFG          (PMA_CFG),
-                      .PMP_GRANULARITY  (PMP_GRANULARITY),
-                      .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
-                      .SMCLIC           (SMCLIC),
-                      .DBG_NUM_TRIGGERS (DBG_NUM_TRIGGERS)
+                      .B_EXT                (B_EXT),
+                      .DBG_NUM_TRIGGERS     (DBG_NUM_TRIGGERS),
+                      .DM_REGION_END        (DM_REGION_END),
+                      .DM_REGION_START      (DM_REGION_START),
+                      .LFSR0_CFG            (LFSR0_CFG),
+                      .LFSR1_CFG            (LFSR1_CFG),
+                      .LFSR2_CFG            (LFSR2_CFG),
+                      .M_EXT                (M_EXT),
+                      .PMA_CFG              (PMA_CFG),
+                      .PMA_NUM_REGIONS      (PMA_NUM_REGIONS),
+                      .PMP_GRANULARITY      (PMP_GRANULARITY),
+                      .PMP_MSECCFG_RV       (PMP_MSECCFG_RV),
+                      .PMP_NUM_REGIONS      (PMP_NUM_REGIONS),
+                      .PMP_PMPADDR_RV       (PMP_PMPADDR_RV),
+                      .PMP_PMPNCFG_RV       (PMP_PMPNCFG_RV),
+                      .RV32                 (RV32),
+                      .SMCLIC               (SMCLIC),
+                      .SMCLIC_ID_WIDTH      (SMCLIC_ID_WIDTH),
+                      .SMCLIC_INTTHRESHBITS (SMCLIC_INTTHRESHBITS)
                       )
     cv32e40s_wrapper_i
         (


### PR DESCRIPTION
This PR adds missing parameters to `_constants.sv` and `dut_wrap`, as well as facilitating for defining these parameters in an external file not checked into this repo.

ci_check passes as much as it does for cv32e40s/dev.
Formal is still runnable.