### PR TITLE
Questa Formal - "Design Checks" Fix

### DIFF
--- a/cv32e40s/fv/qverify.tcl
+++ b/cv32e40s/fv/qverify.tcl
@@ -20,16 +20,17 @@
 proc cvfv_rerun {} {
   onerror  {exit 1}
 
-  # TODO:silabs-robin  Bring up the formal view before executing the rest
-
   puts "cvfv: compiling verilog"
   vlog  -mfcu  -f fv.flist
 
+  puts "cvfv: setting cutpoints"
+  netlist cutpoint {uvmt_cv32e40s_tb.clknrst_if.reset_n} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.debug_if.debug_req} -module uvmt_cv32e40s_tb
+
   puts "cvfv: initializing clock/reset"
-  netlist clock "clknrst_if.clk"
-  netlist reset "clknrst_if.reset_n" -active_low -async
+  netlist clock {uvmt_cv32e40s_tb.clknrst_if.clk} -module uvmt_cv32e40s_tb
+  netlist reset {uvmt_cv32e40s_tb.clknrst_if.reset_n} -active_low -module uvmt_cv32e40s_tb
   formal init -inferred
-  formal init {clknrst_if.reset_n = 1; ##1 clknrst_if.reset_n = 0; ##2}
 
   puts "cvfv: compiling formal model"
   formal  compile  -d uvmt_cv32e40s_tb  -work work

--- a/cv32e40s/fv/qverify.tcl
+++ b/cv32e40s/fv/qverify.tcl
@@ -20,22 +20,51 @@
 proc cvfv_rerun {} {
   onerror  {exit 1}
 
-  puts "cvfv: compiling verilog"
+  puts  "cvfv: compiling verilog"
   vlog  -mfcu  -f fv.flist
 
-  puts "cvfv: setting cutpoints"
+  puts  "cvfv: cutpointing general 'control points'"
   netlist cutpoint {uvmt_cv32e40s_tb.clknrst_if.reset_n} -module uvmt_cv32e40s_tb
   netlist cutpoint {uvmt_cv32e40s_tb.debug_if.debug_req} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.interrupt_if.irq} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.boot_addr} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.mtvec_addr} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.dm_halt_addr} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.dm_exception_addr} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.mhartid} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.core_cntrl_if.mimpid_patch} -module uvmt_cv32e40s_tb
+  #cutpoints needed to subdue "Design Checks" errors that lead to bonkers CEXes
 
-  puts "cvfv: initializing clock/reset"
+  puts  "cvfv: cutpointing obi 'control points'"
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.err} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.gntpar} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.gnt} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.rchk} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.rdata} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.rvalidpar} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_instr_if_i.rvalid} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.err} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.gntpar} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.gnt} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.rchk} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.rdata} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.rvalidpar} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.obi_data_if_i.rvalid} -module uvmt_cv32e40s_tb
+  netlist cutpoint {uvmt_cv32e40s_tb.fencei_if_i.flush_ack} -module uvmt_cv32e40s_tb
+
+  puts  "cvfv: setting constants"
+  netlist constant {uvmt_cv32e40s_tb.core_cntrl_if.scan_cg_en} {0} -module uvmt_cv32e40s_tb
+  netlist constant {uvmt_cv32e40s_tb.core_cntrl_if.fetch_en} {1} -module uvmt_cv32e40s_tb
+
+  puts  "cvfv: initializing clock/reset"
   netlist clock {uvmt_cv32e40s_tb.clknrst_if.clk} -module uvmt_cv32e40s_tb
   netlist reset {uvmt_cv32e40s_tb.clknrst_if.reset_n} -active_low -module uvmt_cv32e40s_tb
   formal init -inferred
 
-  puts "cvfv: compiling formal model"
+  puts  "cvfv: compiling formal model"
   formal  compile  -d uvmt_cv32e40s_tb  -work work
 
-  puts "cvfv: see the visualizer log for compilation warnings"
+  puts  "cvfv: see the visualizer log for compilation warnings"
 }
 
 cvfv_rerun


### PR DESCRIPTION
This PR adds a few constraints to the Questa Formal setup. (Rationale below.)

I think I figured out why the counter-examples looked so nonsensical.
At first I thought it was a problem with the reset initialization sequence, but it was only partially that...

"Free nets" seems to be treated differently in Jasper and Questa. Jasper goes "it's a free net, it can do whatever, and Questa goes "this is not a valid control point, whoops there goes gravity".
Free nets needs to be turned into valid "control points", and one can do that by explicitly setting a cutpoint.
Before this change you could get e.g. rvfi_valid on cycle 0 and all kinds of weird behavior that seems to completely ignore what is written in the rtl.