### PR TITLE
fix vcs.mk and imperas_CV32.sv problem

### DIFF
--- a/vendor_lib/imperas/imperas_DV_COREV/sv/imperas_CV32.sv
+++ b/vendor_lib/imperas/imperas_DV_COREV/sv/imperas_CV32.sv
@@ -752,7 +752,9 @@ module CPU #(
     
 `ifndef UVM
     final begin
-        svimp_exit();
+        if (!$test$plusargs("DISABLE_OVPSIM")) begin
+            svimp_exit();
+        end
     end
 `endif
  


### PR DESCRIPTION
In the vcs.mk file,

> 1. Delete some duplicate options in the VCS compilation option, VCS_UVM_ARGS variables appear twice

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeL53-L55

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeR182-R185

> 2. +UVM_VERBOSITY= $ (VCS_UVM_VERBOSITY) option is not the compilation option of VCS, but the option of ./simv.

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeL50-R51

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeL222-L230

> 3. Added the FSDB waveform file generation option, which can be directly defined in the vcs compilation option to use FSDB=YES to directly generate the fsdb waveform file for use by verdi

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeR93-R97

> 4. Fixed VCS compilation errors and increased RVFI definition

https://github.com/openhwgroup/core-v-verif/issues/1573#issuecomment-1385558302

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-14ee28fc032c3c15e468d11a3547d65122b2c76198bfd629f3e38055633275eeL139-L140


> 5.https://github.com/openhwgroup/core-v-verif/issues/1573#issuecomment-1384355873

https://github.com/openhwgroup/core-v-verif/compare/cv32e40p/dev...guojiazhuxi:core-v-verif:ultichip_guojiazhuxi_20230207?diff=unified#diff-5dca4d9c9f84dece541a0528769504ac5c20cbff3b5a85624bb96e50cd59a789R753-R759



@MikeOpenHWGroup This is some of the problems that I found with VCS simulation CV32E40P during this time. Please see if it can, thank you!