### PR TITLE
dump memory arrays to fsdb

### DIFF
--- a/cv32e40p/sim/tools/vcs/vcs_wave.tcl
+++ b/cv32e40p/sim/tools/vcs/vcs_wave.tcl
@@ -1,0 +1,5 @@
+global env
+fsdbDumpfile "wave.fsdb"
+fsdbDumpvars 0 
+fsdbDumpMDA 0
+run

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -92,6 +92,7 @@ VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
 else
 ifeq ($(call IS_YES,$(FSDB)),YES)
 VCS_USER_COMPILE_ARGS += -debug_access+all +vcs+fsdbon -kdb
+VCS_RUN_WAVES_FLAGS  ?= -ucli -i $(abspath $(MAKE_PATH)/../tools/vcs/vcs_wave.tcl)
 else
 VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
 endif


### PR DESCRIPTION
@MikeOpenHWGroup Add a vcs compilation function
dump memory arrays to fsdb file. Using it, you can tracer two-dimensional arrays and memory signals in verdi.