### PR TITLE
OBI Asserts - Make Formal-Friendly

### DIFF
--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
@@ -185,7 +185,7 @@ module uvma_obi_memory_assert
     `uvm_error(info_tag, "be was zero during an address cycle")
 
   // R-7 All ones must be contiguous in writes
-  reg[3:0] contiguous_be[] = {
+  reg [9:0] [3:0] contiguous_be = '{
     4'b0001,
     4'b0011,
     4'b0111,

--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
@@ -184,8 +184,10 @@ module uvma_obi_memory_assert
   else
     `uvm_error(info_tag, "be was zero during an address cycle")
 
+
   // R-7 All ones must be contiguous in writes
-  reg [9:0] [3:0] contiguous_be = '{
+
+  localparam logic [9:0] [3:0] CONTIGUOUS_BE = '{
     4'b0001,
     4'b0011,
     4'b0111,
@@ -197,16 +199,27 @@ module uvma_obi_memory_assert
     4'b1100,
     4'b1000
   };
-  bit be_inside_contiguous_be;
+
+  bit  be_inside_contiguous_be;
+
   always_comb begin
-    be_inside_contiguous_be = be inside {contiguous_be};
+    be_inside_contiguous_be = 0;
+
+    foreach (CONTIGUOUS_BE[i]) begin
+      if (be == CONTIGUOUS_BE[i]) begin
+        be_inside_contiguous_be = 1;
+      end
+    end
   end
+
   property p_be_contiguous;
-    req ##0 we |-> be_inside_contiguous_be;
+    req && we |-> be_inside_contiguous_be;
   endproperty : p_be_contiguous
-  a_be_contiguous : assert property(p_be_contiguous)
-  else
-    `uvm_error(info_tag, $sformatf("be of 0x%0x was not contiguous", $sampled(be)));
+
+  a_be_contiguous : assert property(
+    p_be_contiguous
+  ) else `uvm_error(info_tag, $sformatf("be of 0x%0x was not contiguous", $sampled(be)));
+
 
   // R-8 Data address LSBs must be consistent with byte enables on writes
   function bit [1:0] get_addr_lsb(bit[3:0] be);


### PR DESCRIPTION
This PR swaps out a dynamic array in the obi memory asserts with a packed array and rewrites the accompanying logic, so that these asserts can be used in formal.

Note: This is in "lib/" so it will affect other cores.
Note: The asserts are already bound in the tb but were not used in fv.

Passes ci_check (except for known debug test).
Runs in formal, and the assert in question passes.