### PR TITLE
RVFI Assert - Fix CEXes

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
@@ -20,7 +20,9 @@ module uvmt_cv32e40s_rvfi_assert
   import cv32e40s_pkg::*;
   import cv32e40s_rvfi_pkg::*;
   import uvm_pkg::*;
-(
+#(
+  parameter logic  SMCLIC
+)(
   input  clk_i,
   input  rst_ni,
 
@@ -133,12 +135,15 @@ module uvmt_cv32e40s_rvfi_assert
     rvfi_trap.exception_cause
   ) else `uvm_error(info_tag, "rvfi_trap exceptions must have a cause");
 
-  a_interrupts_cause: assert property (
-    rvfi_valid  &&
-    rvfi_intr
-    |->
-    rvfi_intr.cause
-  ) else `uvm_error(info_tag, "rvfi_intr interrupts must have a cause");
+  if (!SMCLIC) begin: gen_clint_cause
+    a_interrupts_cause: assert property (
+      rvfi_valid  &&
+      rvfi_intr
+      |->
+      rvfi_intr.cause
+    ) else `uvm_error(info_tag, "rvfi_intr interrupts must have a cause");
+    // TODO:silabs-robin  Could also assert "cause < 2^clicwidth"
+  end : gen_clint_cause
 
   a_debugs_cause: assert property (
     rvfi_valid  &&

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
@@ -76,12 +76,37 @@ module uvmt_cv32e40s_rvfi_assert
 
   // RVFI debug cause matches dcsr debug cause
 
-  a_dbg_cause: assert property (
+  a_dbg_cause_general: assert property (
     rvfi_valid  &&
     rvfi_dbg    &&
     !was_rvfi_dbg_mode
     |->
     (rvfi_dbg == rvfi_csr_dcsr_rdata[8:6])
+  ) else `uvm_error(info_tag, "'rvfi_dbg' did not match 'dcsr.cause'");
+
+  property  p_dbg_cause_n (n);
+    rvfi_valid          &&
+    rvfi_dbg            &&
+    !was_rvfi_dbg_mode  &&
+    (rvfi_csr_dcsr_rdata[8:6] == n)
+    |->
+    (rvfi_dbg == n);
+  endproperty : p_dbg_cause_n
+
+  a_dbg_cause_ebreak: assert property (
+    p_dbg_cause_n(1)
+  ) else `uvm_error(info_tag, "'rvfi_dbg' did not match 'dcsr.cause'");
+
+  a_dbg_cause_trigger: assert property (
+    p_dbg_cause_n(2)
+  ) else `uvm_error(info_tag, "'rvfi_dbg' did not match 'dcsr.cause'");
+
+  a_dbg_cause_haltreq: assert property (
+    p_dbg_cause_n(3)
+  ) else `uvm_error(info_tag, "'rvfi_dbg' did not match 'dcsr.cause'");
+
+  a_dbg_cause_step: assert property (
+    p_dbg_cause_n(4)
   ) else `uvm_error(info_tag, "'rvfi_dbg' did not match 'dcsr.cause'");
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
@@ -87,13 +87,15 @@ module uvmt_cv32e40s_rvfi_assert
 
   // RVFI exception cause matches "mcause"
 
+  wire logic [10:0]  rvfi_mcause_exccode;
+  assign rvfi_mcause_exccode = (rvfi_csr_mcause_wdata & rvfi_csr_mcause_wmask);
+
   a_exc_cause: assert property (
     rvfi_valid           &&
     rvfi_trap.exception  &&
     !rvfi_dbg_mode
     |->
-    (rvfi_trap.exception_cause
-      == (rvfi_csr_mcause_wdata & rvfi_csr_mcause_wmask))
+    (rvfi_trap.exception_cause == rvfi_mcause_exccode)
   ) else `uvm_error(info_tag, "'exception_cause' must match 'mcause'");
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
@@ -142,7 +142,7 @@ module uvmt_cv32e40s_rvfi_assert
   end : gen_legal_cause_clint
 
   if (SMCLIC) begin: gen_legal_cause_clic
-    localparam logic [31:0]  MAX_CLIC_ID = 2^SMCLIC_ID_WIDTH - 1;
+    localparam logic [31:0]  MAX_CLIC_ID = 2**SMCLIC_ID_WIDTH - 1;
 
     a_irq_cause_clic: assert property (
       rvfi_valid  &&

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -699,7 +699,8 @@ module uvmt_cv32e40s_tb;
 
   bind  dut_wrap.cv32e40s_wrapper_i.rvfi_i
     uvmt_cv32e40s_rvfi_assert #(
-      .SMCLIC (uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC)
+      .SMCLIC          (uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC),
+      .SMCLIC_ID_WIDTH (uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC_ID_WIDTH)
     ) rvfi_assert_i (
       .*
     );

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -698,7 +698,9 @@ module uvmt_cv32e40s_tb;
   // RVFI assertions
 
   bind  dut_wrap.cv32e40s_wrapper_i.rvfi_i
-    uvmt_cv32e40s_rvfi_assert  rvfi_assert_i (
+    uvmt_cv32e40s_rvfi_assert #(
+      .SMCLIC (uvmt_cv32e40s_pkg::CORE_PARAM_SMCLIC)
+    ) rvfi_assert_i (
       .*
     );
 

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -37,25 +37,30 @@ SIMVISION         = $(CV_TOOL_PREFIX) simvision
 INDAGO            = $(CV_TOOL_PREFIX) indago
 IMC               = $(CV_SIM_PREFIX) imc
 
-XRUN_UVMHOME_ARG     ?= CDNS-1.2-ML
+XRUN_UVMHOME_ARG ?= CDNS-1.2-ML
 
 # Flags
-XRUN_COMP_FLAGS  ?= -64bit \
-					-disable_sem2009 \
-					-access +rwc \
-                    -nowarn UEXPSC \
-					-lwdgen \
-                    -sv \
-					-uvm \
-					-uvmhome $(XRUN_UVMHOME_ARG) \
-                    $(TIMESCALE) \
-					$(SV_CMP_FLAGS)
+XRUN_COMP_FLAGS  ?=               \
+    -64bit                        \
+    -disable_sem2009              \
+    -access +rwc                  \
+    -nowarn UEXPSC                \
+    -lwdgen                       \
+    -sv                           \
+    -uvm                          \
+    -uvmhome $(XRUN_UVMHOME_ARG)  \
+    $(TIMESCALE)                  \
+    $(SV_CMP_FLAGS)
 
-XRUN_LDGEN_COMP_FLAGS ?= -64bit -disable_sem2009 -access +rwc \
-												 -nowarn UEXPSC \
-												 -nowarn DLCPTH \
-												 -sv \
-												 $(TIMESCALE) $(SV_CMP_FLAGS)
+XRUN_LDGEN_COMP_FLAGS ?=  \
+    -64bit                \
+    -disable_sem2009      \
+    -access +rwc          \
+    -nowarn UEXPSC        \
+    -nowarn DLCPTH        \
+    -sv                   \
+    $(TIMESCALE)          \
+    $(SV_CMP_FLAGS)
 
 XRUN_RUN_BASE_FLAGS ?= -64bit $(XRUN_GUI) -licqueue +UVM_VERBOSITY=$(XRUN_UVM_VERBOSITY) \
                        $(XRUN_PLUSARGS) -svseed $(RNDSEED)
@@ -244,6 +249,9 @@ XRUN_COMP_FLAGS += -nowarn CGPIDF
 # deselect_coverage -all warnings
 XRUN_COMP_FLAGS += -nowarn CGNSWA
 
+# Value Parameters without default values
+XRUN_COMP_FLAGS += -setenv CADENCE_ENABLE_AVSREQ_44905_PHASE_1=1
+
 # deselect_coverage -all warnings
 XRUN_COMP_COREV_DV_FLAGS += -nowarn BNDWRN
 XRUN_COMP_COREV_DV_FLAGS += $(CFG_COMPILE_FLAGS)
@@ -259,6 +267,7 @@ XRUN_RUN_COV    += -nowarn WCROSS
 
 # Un-named covergroup instances
 XRUN_RUN_COV    += -nowarn CGDEFN
+
 
 ###############################################################################
 # Targets


### PR DESCRIPTION
This PR updates rvfi_assert to keep up with changes to the core and the environment.

Passes ci_check (except you know).
The asserts in question passes in formal.