### PR TITLE
PMP Assert - Fix CEXes

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmp_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmp_assert.sv
@@ -1,4 +1,24 @@
+// Copyright 2022 Silicon Labs, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
+// not use this file except in compliance with the License, or, at your option,
+// the Apache License version 2.0.
+//
+// You may obtain a copy of the License at
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
 `default_nettype none
+
 
 module uvmt_cv32e40s_pmp_assert
   import uvm_pkg::*;
@@ -15,13 +35,14 @@ module uvmt_cv32e40s_pmp_assert
    input wire            clk,
    input wire            rst_n,
 
-   // Interface to CSRs
+   // CSRs
    input wire pmp_csr_t  csr_pmp_i,
 
-   // Privilege mode
+   // Mode Info
    input wire privlvl_t  priv_lvl_i,
+   input wire            bus_trans_dbg,
 
-   // Access checking
+   // Access Checking
    input wire [33:0]     pmp_req_addr_i,
    input wire pmp_req_e  pmp_req_type_i,
    input wire            pmp_req_err_o,
@@ -51,8 +72,11 @@ module uvmt_cv32e40s_pmp_assert
   match_status_t  match_status;
   uvmt_cv32e40s_pmp_model #(
     .PMP_GRANULARITY  (PMP_GRANULARITY),
-    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+    .DM_REGION_START  (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_START),
+    .DM_REGION_END    (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_END)
   ) model_i (
+    .debug_mode     (bus_trans_dbg),
     .match_status_o (match_status),
     .*
   );

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmp_model.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmp_model.sv
@@ -321,46 +321,47 @@ module uvmt_cv32e40s_pmp_model
           end // PMP_ACC_EXEC
         endcase // case(pmp_req_type_i)
 
-        end else begin // mmwp low
-          case ( priv_lvl_i )
-            PRIV_LVL_M:
-              case ( {pmp_req_type_i, match_status_o.is_locked} )
-                { PMP_ACC_READ,  1'b1 }: match_status_o.val_access_allowed_reason.r_mmode_lr = csr_pmp_i.cfg[match_status_o.val_index].read;
-                { PMP_ACC_READ,  1'b0 }: match_status_o.val_access_allowed_reason.r_mmode_r  = 1'b1;
-                { PMP_ACC_WRITE, 1'b1 }: match_status_o.val_access_allowed_reason.w_mmode_lw = csr_pmp_i.cfg[match_status_o.val_index].write;
-                { PMP_ACC_WRITE, 1'b0 }: match_status_o.val_access_allowed_reason.w_mmode_w  = 1'b1;
-                { PMP_ACC_EXEC,  1'b1 }: match_status_o.val_access_allowed_reason.x_mmode_lx = csr_pmp_i.cfg[match_status_o.val_index].exec;
-                { PMP_ACC_EXEC,  1'b0 }: match_status_o.val_access_allowed_reason.x_mmode_x  = 1'b1;
-              endcase
-            PRIV_LVL_U:
-              case ( pmp_req_type_i )
-                PMP_ACC_READ:  match_status_o.val_access_allowed_reason.r_umode_r = csr_pmp_i.cfg[match_status_o.val_index].read;
-                PMP_ACC_WRITE: match_status_o.val_access_allowed_reason.w_umode_w = csr_pmp_i.cfg[match_status_o.val_index].write;
-                PMP_ACC_EXEC:  match_status_o.val_access_allowed_reason.x_umode_x = csr_pmp_i.cfg[match_status_o.val_index].exec;
-              endcase
-          endcase // case (priv_lvl_i)
+      end else begin // mmwp low
+        case ( priv_lvl_i )
+          PRIV_LVL_M:
+            case ( {pmp_req_type_i, match_status_o.is_locked} )
+              { PMP_ACC_READ,  1'b1 }: match_status_o.val_access_allowed_reason.r_mmode_lr = csr_pmp_i.cfg[match_status_o.val_index].read;
+              { PMP_ACC_READ,  1'b0 }: match_status_o.val_access_allowed_reason.r_mmode_r  = 1'b1;
+              { PMP_ACC_WRITE, 1'b1 }: match_status_o.val_access_allowed_reason.w_mmode_lw = csr_pmp_i.cfg[match_status_o.val_index].write;
+              { PMP_ACC_WRITE, 1'b0 }: match_status_o.val_access_allowed_reason.w_mmode_w  = 1'b1;
+              { PMP_ACC_EXEC,  1'b1 }: match_status_o.val_access_allowed_reason.x_mmode_lx = csr_pmp_i.cfg[match_status_o.val_index].exec;
+              { PMP_ACC_EXEC,  1'b0 }: match_status_o.val_access_allowed_reason.x_mmode_x  = 1'b1;
+            endcase
+          PRIV_LVL_U:
+            case ( pmp_req_type_i )
+              PMP_ACC_READ:  match_status_o.val_access_allowed_reason.r_umode_r = csr_pmp_i.cfg[match_status_o.val_index].read;
+              PMP_ACC_WRITE: match_status_o.val_access_allowed_reason.w_umode_w = csr_pmp_i.cfg[match_status_o.val_index].write;
+              PMP_ACC_EXEC:  match_status_o.val_access_allowed_reason.x_umode_x = csr_pmp_i.cfg[match_status_o.val_index].exec;
+            endcase
+        endcase // case (priv_lvl_i)
 
-        end
-      match_status_o.is_rwx_ok = |match_status_o.val_access_allowed_reason;
-
-      end else begin
-        // ------------------------------------------------------------
-        // NO MATCH REGION
-        // ------------------------------------------------------------
-        // No matching region found, allow only M-access, and only if MMWP bit is not set
-        case ( {pmp_req_type_i, priv_lvl_i} )
-          { PMP_ACC_READ,  PRIV_LVL_M }:
-            match_status_o.val_access_allowed_reason.r_mmode_nomatch_nommwp_r = !csr_pmp_i.mseccfg.mmwp;
-          { PMP_ACC_WRITE, PRIV_LVL_M }:
-            match_status_o.val_access_allowed_reason.w_mmode_nomatch_nommwp_w = !csr_pmp_i.mseccfg.mmwp;
-          { PMP_ACC_EXEC,  PRIV_LVL_M }:
-            match_status_o.val_access_allowed_reason.x_mmode_nomatch_nommwp_x = !csr_pmp_i.mseccfg.mmwp && !csr_pmp_i.mseccfg.mml;
-        endcase
-        match_status_o.is_access_allowed_no_match = |match_status_o.val_access_allowed_reason;
       end
-      // Access is allowed if any one of the above conditions matches
-      match_status_o.is_access_allowed = |match_status_o.val_access_allowed_reason;
+
+      match_status_o.is_rwx_ok = |match_status_o.val_access_allowed_reason;
+    end else begin
+      // ------------------------------------------------------------
+      // NO MATCH REGION
+      // ------------------------------------------------------------
+      // No matching region found, allow only M-access, and only if MMWP bit is not set
+      case ( {pmp_req_type_i, priv_lvl_i} )
+        { PMP_ACC_READ,  PRIV_LVL_M }:
+          match_status_o.val_access_allowed_reason.r_mmode_nomatch_nommwp_r = !csr_pmp_i.mseccfg.mmwp;
+        { PMP_ACC_WRITE, PRIV_LVL_M }:
+          match_status_o.val_access_allowed_reason.w_mmode_nomatch_nommwp_w = !csr_pmp_i.mseccfg.mmwp;
+        { PMP_ACC_EXEC,  PRIV_LVL_M }:
+          match_status_o.val_access_allowed_reason.x_mmode_nomatch_nommwp_x = !csr_pmp_i.mseccfg.mmwp && !csr_pmp_i.mseccfg.mml;
+      endcase
+      match_status_o.is_access_allowed_no_match = |match_status_o.val_access_allowed_reason;
     end
+
+    // Access is allowed if any one of the above conditions matches
+    match_status_o.is_access_allowed = |match_status_o.val_access_allowed_reason;
+  end
 
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmprvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmprvfi_assert.sv
@@ -45,7 +45,10 @@ module uvmt_cv32e40s_pmprvfi_assert
   input wire [31:0]  rvfi_csr_mseccfgh_wdata,
   input wire [31:0]  rvfi_csr_mseccfgh_wmask,
   //(mstatus)
-  input wire [31:0]  rvfi_csr_mstatus_rdata
+  input wire [31:0]  rvfi_csr_mstatus_rdata,
+
+  // Debug
+  input wire  rvfi_dbg_mode
 );
 
 
@@ -187,66 +190,86 @@ module uvmt_cv32e40s_pmprvfi_assert
 
   uvmt_cv32e40s_pmp_model #(
     .PMP_GRANULARITY  (PMP_GRANULARITY),
-    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+    .DM_REGION_START  (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_START),
+    .DM_REGION_END    (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_END)
   ) model_instr_i (
     .clk   (clk_i),
     .rst_n (rst_ni),
 
     .csr_pmp_i      (pmp_csr_rvfi_rdata),
-    .priv_lvl_i     (privlvl_t'(rvfi_mode)),
+    .debug_mode     (rvfi_dbg_mode),
     .pmp_req_addr_i ({2'b 00, rvfi_pc_rdata}),
-    .pmp_req_type_i (PMP_ACC_EXEC),
     .pmp_req_err_o  ('Z),
+    .pmp_req_type_i (PMP_ACC_EXEC),
+    .priv_lvl_i     (privlvl_t'(rvfi_mode)),
 
-    .match_status_o (match_status_instr)
+    .match_status_o (match_status_instr),
+
+    .*
   );
 
   uvmt_cv32e40s_pmp_model #(
     .PMP_GRANULARITY  (PMP_GRANULARITY),
-    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+    .DM_REGION_START  (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_START),
+    .DM_REGION_END    (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_END)
   ) model_data_i (
     .clk   (clk_i),
     .rst_n (rst_ni),
 
     .csr_pmp_i      (pmp_csr_rvfi_rdata),
-    .priv_lvl_i     (privlvl_t'(rvfi_effective_mode)),
+    .debug_mode     (rvfi_dbg_mode),
     .pmp_req_addr_i ({2'b 00, rvfi_mem_addr}),  // TODO:silabs-robin  Multi-op instructions
-    .pmp_req_type_i (rvfi_mem_wmask ? PMP_ACC_WRITE : PMP_ACC_READ),  // TODO:silabs-robin  Not completely accurate...
     .pmp_req_err_o  ('Z),
+    .pmp_req_type_i (rvfi_mem_wmask ? PMP_ACC_WRITE : PMP_ACC_READ),  // TODO:silabs-robin  Not completely accurate...
+    .priv_lvl_i     (privlvl_t'(rvfi_effective_mode)),
 
-    .match_status_o (match_status_data)
+    .match_status_o (match_status_data),
+
+    .*
   );
 
   uvmt_cv32e40s_pmp_model #(
     .PMP_GRANULARITY  (PMP_GRANULARITY),
-    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+    .DM_REGION_START  (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_START),
+    .DM_REGION_END    (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_END)
   ) model_upperinstr_i (
     .clk   (clk_i),
     .rst_n (rst_ni),
 
     .csr_pmp_i      (pmp_csr_rvfi_rdata),
-    .priv_lvl_i     (privlvl_t'(rvfi_mode)),
+    .debug_mode     (rvfi_dbg_mode),
     .pmp_req_addr_i ({2'b 00, rvfi_pc_upperrdata}),
-    .pmp_req_type_i (PMP_ACC_EXEC),
     .pmp_req_err_o  ('Z),
+    .pmp_req_type_i (PMP_ACC_EXEC),
+    .priv_lvl_i     (privlvl_t'(rvfi_mode)),
 
-    .match_status_o (match_status_upperinstr)
+    .match_status_o (match_status_upperinstr),
+
+    .*
   );
 
   uvmt_cv32e40s_pmp_model #(
     .PMP_GRANULARITY  (PMP_GRANULARITY),
-    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS)
+    .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+    .DM_REGION_START  (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_START),
+    .DM_REGION_END    (uvmt_cv32e40s_pkg::CORE_PARAM_DM_REGION_END)
   ) model_upperdata_i (
     .clk   (clk_i),
     .rst_n (rst_ni),
 
     .csr_pmp_i      (pmp_csr_rvfi_rdata),
-    .priv_lvl_i     (privlvl_t'(rvfi_effective_mode)),
+    .debug_mode     (rvfi_dbg_mode),
     .pmp_req_addr_i ({2'b 00, rvfi_mem_upperaddr}),  // TODO:silabs-robin  Multi-op instructions
-    .pmp_req_type_i (rvfi_mem_wmask ? PMP_ACC_WRITE : PMP_ACC_READ),  // TODO:silabs-robin  Not completely accurate...
     .pmp_req_err_o  ('Z),
+    .pmp_req_type_i (rvfi_mem_wmask ? PMP_ACC_WRITE : PMP_ACC_READ),  // TODO:silabs-robin  Not completely accurate...
+    .priv_lvl_i     (privlvl_t'(rvfi_effective_mode)),
 
-    .match_status_o (match_status_upperdata)
+    .match_status_o (match_status_upperdata),
+
+    .*
   );
 
   var [31:0]  clk_cnt;

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1087,10 +1087,10 @@ module uvmt_cv32e40s_tb;
     bind cv32e40s_pmp :
       uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.if_stage_i.mpu_i.pmp.pmp_i
       uvmt_cv32e40s_pmp_assert #(
-        .PMP_GRANULARITY   (PMP_GRANULARITY),
-        .PMP_NUM_REGIONS   (PMP_NUM_REGIONS),
-        .IS_INSTR_SIDE     (1'b1),
-        .MSECCFG_RESET_VAL (cv32e40s_pkg::MSECCFG_DEFAULT)
+        .PMP_GRANULARITY  (PMP_GRANULARITY),
+        .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+        .IS_INSTR_SIDE    (1'b1),
+        .PMP_MSECCFG_RV   (uvmt_cv32e40s_pkg::CORE_PARAM_PMP_MSECCFG_RV)
       )
       u_pmp_assert_if_stage(.rst_n          (clknrst_if.reset_n),
                             .bus_trans_dbg  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.if_stage_i.mpu_i.bus_trans_o.dbg),
@@ -1104,10 +1104,10 @@ module uvmt_cv32e40s_tb;
     bind  cv32e40s_pmp :
       uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.load_store_unit_i.mpu_i.pmp.pmp_i
       uvmt_cv32e40s_pmp_assert#(
-        .PMP_GRANULARITY   (PMP_GRANULARITY),
-        .PMP_NUM_REGIONS   (PMP_NUM_REGIONS),
-        .IS_INSTR_SIDE     (1'b0),
-        .MSECCFG_RESET_VAL (cv32e40s_pkg::MSECCFG_DEFAULT)
+        .PMP_GRANULARITY  (PMP_GRANULARITY),
+        .PMP_NUM_REGIONS  (PMP_NUM_REGIONS),
+        .IS_INSTR_SIDE    (1'b0),
+        .PMP_MSECCFG_RV   (uvmt_cv32e40s_pkg::CORE_PARAM_PMP_MSECCFG_RV)
       )
       u_pmp_assert_lsu(.rst_n          (clknrst_if.reset_n),
                        .bus_trans_dbg  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.load_store_unit_i.mpu_i.bus_trans_o.dbg),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1086,34 +1086,36 @@ module uvmt_cv32e40s_tb;
 
     bind cv32e40s_pmp :
       uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.if_stage_i.mpu_i.pmp.pmp_i
-      uvmt_cv32e40s_pmp_assert#(
-        .PMP_GRANULARITY(PMP_GRANULARITY),
-        .PMP_NUM_REGIONS(PMP_NUM_REGIONS),
-        .IS_INSTR_SIDE(1'b1),
-        .MSECCFG_RESET_VAL(cv32e40s_pkg::MSECCFG_DEFAULT)
+      uvmt_cv32e40s_pmp_assert #(
+        .PMP_GRANULARITY   (PMP_GRANULARITY),
+        .PMP_NUM_REGIONS   (PMP_NUM_REGIONS),
+        .IS_INSTR_SIDE     (1'b1),
+        .MSECCFG_RESET_VAL (cv32e40s_pkg::MSECCFG_DEFAULT)
       )
-      u_pmp_assert_if_stage(.rst_n (clknrst_if.reset_n),
-                            .obi_req (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_req_o),
-                            .obi_addr (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_addr_o),
-                            .obi_gnt (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_gnt_i),
-                            .rvfi_valid (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_valid),
-                            .rvfi_pc_rdata (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_pc_rdata),
+      u_pmp_assert_if_stage(.rst_n          (clknrst_if.reset_n),
+                            .bus_trans_dbg  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.if_stage_i.mpu_i.bus_trans_o.dbg),
+                            .obi_addr       (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_addr_o),
+                            .obi_gnt        (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_gnt_i),
+                            .obi_req        (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.instr_req_o),
+                            .rvfi_pc_rdata  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_pc_rdata),
+                            .rvfi_valid     (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_valid),
                             .*);
 
     bind  cv32e40s_pmp :
       uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.load_store_unit_i.mpu_i.pmp.pmp_i
       uvmt_cv32e40s_pmp_assert#(
-        .PMP_GRANULARITY(PMP_GRANULARITY),
-        .PMP_NUM_REGIONS(PMP_NUM_REGIONS),
-        .IS_INSTR_SIDE(1'b0),
-        .MSECCFG_RESET_VAL(cv32e40s_pkg::MSECCFG_DEFAULT)
+        .PMP_GRANULARITY   (PMP_GRANULARITY),
+        .PMP_NUM_REGIONS   (PMP_NUM_REGIONS),
+        .IS_INSTR_SIDE     (1'b0),
+        .MSECCFG_RESET_VAL (cv32e40s_pkg::MSECCFG_DEFAULT)
       )
-      u_pmp_assert_lsu(.rst_n (clknrst_if.reset_n),
-                       .obi_req (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_req_o),
-                       .obi_addr (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_addr_o),
-                       .obi_gnt (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_gnt_i),
-                       .rvfi_valid (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_valid),
-                       .rvfi_pc_rdata (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_pc_rdata),
+      u_pmp_assert_lsu(.rst_n          (clknrst_if.reset_n),
+                       .bus_trans_dbg  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.load_store_unit_i.mpu_i.bus_trans_o.dbg),
+                       .obi_addr       (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_addr_o),
+                       .obi_gnt        (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_gnt_i),
+                       .obi_req        (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.core_i.data_req_o),
+                       .rvfi_pc_rdata  (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_pc_rdata),
+                       .rvfi_valid     (uvmt_cv32e40s_tb.dut_wrap.cv32e40s_wrapper_i.rvfi_i.rvfi_valid),
                        .*);
 
     bind  dut_wrap.cv32e40s_wrapper_i.rvfi_i

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tdefs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tdefs.sv
@@ -92,13 +92,14 @@ typedef struct packed {
  * PMP matching status
  */
 typedef struct {
-  logic        is_matched;
-  logic        is_locked;
-  logic        is_any_locked;
-  logic        is_rwx_ok;
-  logic        is_access_allowed;
-  logic        is_access_allowed_no_match;
-  access_rsn_t val_access_allowed_reason;
+  logic         is_access_allowed;
+  logic         is_access_allowed_no_match;
+  logic         is_any_locked;
+  logic         is_dm_override;
+  logic         is_locked;
+  logic         is_matched;
+  logic         is_rwx_ok;
+  access_rsn_t  val_access_allowed_reason;
   logic[$clog2(PMP_MAX_REGIONS)-1:0]  val_index;
 } match_status_t;
 


### PR DESCRIPTION
This PR fixes some CEXes in the PMP asserts, mostly related to the new DM_REGION_START/END.

Passes in formal.
Passes ci_check (except debug_test) BUT ONLY AFTER https://github.com/openhwgroup/core-v-verif/pull/1631 IS MERGED.