### PR TITLE
Isacov - Link to "decoder.h" in Readme

### DIFF
--- a/lib/dpi_dasm/README.md
+++ b/lib/dpi_dasm/README.md
@@ -1,14 +1,20 @@
-`dpi_dasm` is a library for disassembling/decoding instruction binaries.<br>
+`dpi_dasm` is a library for disassembling/decoding instruction binaries.
 
-It uses some of the source files from [spike](https://github.com/riscv/riscv-isa-sim)
-in order to obtain instruction fields and instruction name.
-Via a DPI interface, these C/C++ functions are exposed as SystemVerilog functions.
-This library is compiled into an `.so` file before being included in simulation.<br>
-A 64-bit Linux shared library is included in core-v-verif/lib/dpi_dsam/lib/Linux64/libdpi.dasm.so that should
-link with all SystemVerilog simulators.<br>
+It uses some of the source files from
+[spike](https://github.com/riscv/riscv-isa-sim) in order to obtain instruction
+fields and instruction name
+(see [decode.h](https://github.com/riscv-software-src/riscv-isa-sim/blob/master/riscv/decode.h) ).
+Via a DPI interface, these C/C++ functions are exposed as SystemVerilog
+functions.
+This library is compiled into an `.so` file before being included in simulation.
+A 64-bit Linux shared library is included in
+`core-v-verif/lib/dpi_dsam/lib/Linux64/libdpi.dasm.so` that should
+link with all SystemVerilog simulators.
 
-If the shared library needs to be rebuilt, a make target `dpi_dasm` is provided in the common Makefiles.
-It will overwrite the shared library location above.  Note that a simulator should be provided to locate
-DPI header files (any simulator should suffice).
+If the shared library needs to be rebuilt, a make target `dpi_dasm` is provided
+in the common Makefiles.
+It will overwrite the shared library location above.
+Note that a simulator should be provided to locate DPI header files (any
+simulator should suffice).
 
 `% make dpi_dasm SIMULATOR=xrun`


### PR DESCRIPTION
> > Maybe we could link to https://github.com/riscv-software-src/riscv-isa-sim/blob/master/riscv/decode.h in the lib/dpi_dasm/ readme?
> 
> Good idea! Can you take care of that in a separate PR @silabs-robin?

https://github.com/openhwgroup/core-v-verif/issues/1582#issuecomment-1416380145