### PR TITLE
Fix include path to tool-specific DPI libs

### DIFF
--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -105,6 +105,10 @@ ifneq ($(CCOV), 0)
 	DSIM_RUN_FLAGS    += -code-cov block -code-cov-scope-specs $(DSIM_CODE_COV_SCOPE)
 endif
 
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
+DPI_INCLUDE        ?= $(shell dirname $(shell which dsim))/../include
+
 no_rule:
 	@echo 'makefile: SIMULATOR is set to $(SIMULATOR), but no rule/target specified.'
 	@echo 'try "make SIMULATOR=dsim sanity" (or just "make sanity" if shell ENV variable SIMULATOR is already set).'

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -156,6 +156,10 @@ VCS_RUN_FLAGS        += $(VCS_RUN_WAVES_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_COV_FLAGS)
 VCS_RUN_FLAGS        += $(USER_RUN_FLAGS)
 
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
+DPI_INCLUDE          ?= $(shell dirname $(shell which vcs))/../lib
+
 ###############################################################################
 # Targets
 

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -34,8 +34,11 @@ VCOVER                  = vcover
 VWORK     				= work
 VSIM_COV_MERGE_DIR      = $(SIM_CFG_RESULTS)/$(CFG)/merged
 UVM_HOME               ?= $(abspath $(shell which $(VLIB))/../../verilog_src/uvm-1.2/src)
-DPI_INCLUDE            ?= $(abspath $(shell which $(VLIB))/../../include)
 USES_DPI = 1
+
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
+DPI_INCLUDE            ?= $(abspath $(shell which $(VLIB))/../../include)
 
 # Default flags
 VSIM_USER_FLAGS         ?=

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -69,6 +69,9 @@ XRUN_RUN_BASE_FLAGS += -sv_lib $(DPI_DASM_LIB)
 XRUN_RUN_BASE_FLAGS += -sv_lib $(abspath $(SVLIB_LIB))
 
 XRUN_UVM_VERBOSITY ?= UVM_MEDIUM
+
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
 DPI_INCLUDE        ?= $(shell dirname $(shell which xrun))/../include
 
 # Necessary libraries for the PMA generator class


### PR DESCRIPTION
This pull-request is a fix for an issue reported #1656.

The Makefile target `dpi_dasm` requires a path to the simulator tool-specific DPI libraries.  This is both tool (xrun, vcs, etc.) and installation dependent, so it needs to be placed in `mk/uvmt/<simulator>.mk`.  These simulator tool-specific Makefiles are required to set variable `DPI_INCLUDE`.  It was not set properly VCS.

This PR sets `DPI_INCLUDE` for VCS and DSIM and adds a comment to XRUN and VSIM simulator makefiles.