### PR TITLE
Core cntrl Agent : Add a constraint related to boot_addr value

### DIFF
--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_cfg.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_cfg.sv
@@ -205,6 +205,10 @@
       }
    }
 
+   constraint boot_addr_cons { //boot addr should be half-word aligned
+      boot_addr % 2 == 0;
+   }
+
    /**
     * Creates sub-configuration objects.
     */


### PR DESCRIPTION
In order to keep the boot_addr values in green, the best way i think to add a constraint the core control agent config file.