### PR TITLE
Fix directed tests compilation

### DIFF
--- a/cv32e40s/bsp/vectors.S
+++ b/cv32e40s/bsp/vectors.S
@@ -15,6 +15,7 @@
 */
 
 .section .vectors, "ax"
+.option push
 .option norvc
 .global vector_table
 
@@ -51,4 +52,4 @@ vector_table:
 	j m_fast13_irq_handler
 	j m_fast14_irq_handler
 	j m_fast15_irq_handler
-
+.option pop

--- a/cv32e40s/tests/programs/custom/hpmcounter_basic_nostall_test/hpmcounter_basic_nostall_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_basic_nostall_test/hpmcounter_basic_nostall_test.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 
   volatile unsigned int mcycle_count;
 
-  __asm__ volatile(".option rvc");
+  __asm__ volatile(".option rvc");  // TODO:ERROR:silabs-robin  Why? Should be in Yaml cfg.
 
   //////////////////////////////////////////////////////////////
   // Cycle count

--- a/cv32e40s/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_basic_test/hpmcounter_basic_test.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 
   volatile unsigned int mcycle_count;
 
-  __asm__ volatile(".option rvc");
+  __asm__ volatile(".option rvc");  // TODO:ERROR:silabs-robin  Why? Should be in Yaml cfg.
 
   //////////////////////////////////////////////////////////////
   // Cycle count

--- a/cv32e40s/tests/programs/custom/hpmcounter_hazard_test/hpmcounter_hazard_test.c
+++ b/cv32e40s/tests/programs/custom/hpmcounter_hazard_test/hpmcounter_hazard_test.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 
   volatile unsigned int minstret;
 
-  __asm__ volatile(".option rvc");
+  __asm__ volatile(".option rvc");  // TODO:ERROR:silabs-robin  Why? Should be in Yaml cfg.
 
   //////////////////////////////////////////////////////////////
   // Count load use hazards

--- a/cv32e40s/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.S
+++ b/cv32e40s/tests/programs/custom/interrupt_bootstrap/interrupt_bootstrap.S
@@ -61,6 +61,7 @@ _fini:
 .section .vectors.alt, "ax"
 
 .global alt_vector_table
+.option push
 .option norvc
 .align 8
 
@@ -99,3 +100,4 @@ alt_vector_table:
 	j m_fast14_irq_handler
 	j m_fast15_irq_handler
 
+.option pop

--- a/cv32e40s/tests/programs/custom/interrupt_test/interrupt_test.c
+++ b/cv32e40s/tests/programs/custom/interrupt_test/interrupt_test.c
@@ -165,6 +165,7 @@ __attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void)  {
 
     asm (
         ".global alt_vector_table\n"
+        ".option push\n"
         ".option norvc\n"
         ".align 8\n"
         "alt_vector_table:\n"
@@ -200,23 +201,28 @@ __attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void)  {
 	    "j m_fast13_irq_handler\n"
 	    "j m_fast14_irq_handler\n"
 	    "j m_fast15_irq_handler\n"
+        ".option pop\n"
     );
 
     asm (
         ".global alt_direct_vector_table\n"
+        ".option push\n"
         ".option norvc\n"
         ".align 8\n"
         "alt_direct_vector_table:\n"
 	    "j u_sw_direct_irq_handler\n"
+        ".option pop\n"
     );
 
     asm (
         ".global alt_direct_ecall_table\n"
+        ".option push\n"
         ".option norvc\n"
         ".align 8\n"
         "alt_direct_ecall_table:\n"
         "wfi\n"
 	    "j u_sw_irq_handler\n"
+        ".option pop\n"
     );
 
 int main(int argc, char *argv[]) {

--- a/cv32e40s/tests/programs/custom/riscv_arithmetic_basic_test_0/riscv_arithmetic_basic_test_0.S
+++ b/cv32e40s/tests/programs/custom/riscv_arithmetic_basic_test_0/riscv_arithmetic_basic_test_0.S
@@ -11963,6 +11963,7 @@ mmode_intr_vector_15:
 
 .align 7
 mtvec_handler:
+                  .option push;
                   .option norvc;
                   j mmode_exception_handler
                   j mmode_intr_vector_1
@@ -11980,7 +11981,7 @@ mtvec_handler:
                   j mmode_intr_vector_13
                   j mmode_intr_vector_14
                   j mmode_intr_vector_15
-                  .option rvc;
+                  .option pop;
 
 mmode_exception_handler:
                   csrrw x12, 0x340, x12

--- a/cv32e40s/tests/programs/custom/riscv_arithmetic_basic_test_1/riscv_arithmetic_basic_test_1.S
+++ b/cv32e40s/tests/programs/custom/riscv_arithmetic_basic_test_1/riscv_arithmetic_basic_test_1.S
@@ -12009,6 +12009,7 @@ mmode_intr_vector_15:
 
 .align 7
 mtvec_handler:
+                  .option push;
                   .option norvc;
                   j mmode_exception_handler
                   j mmode_intr_vector_1
@@ -12026,7 +12027,7 @@ mtvec_handler:
                   j mmode_intr_vector_13
                   j mmode_intr_vector_14
                   j mmode_intr_vector_15
-                  .option rvc;
+                  .option pop;
 
 mmode_exception_handler:
                   csrrw x15, 0x340, x15

--- a/cv32e40s/tests/uvmt/test-programs/vectors.S
+++ b/cv32e40s/tests/uvmt/test-programs/vectors.S
@@ -15,6 +15,7 @@
 */
 
 .section .vectors, "ax"
+.option push
 .option norvc
 vector_table:
 	j sw_irq_handler
@@ -57,6 +58,9 @@ new vector table (which is at mtvec) */
 /*	j __no_irq_handler */
 /*	j __no_irq_handler */
 /*	j __no_irq_handler */
+
+.option pop
+
 
 .section .text.vecs
 /* exception handling */


### PR DESCRIPTION
`_zcb_zcmp` was previously added to most Yaml cfgs, and that conflicts with our usage of `.option rvc` and `.option norvc`.
This PR fixes that for directed tests.

Problem: Can't test it properly because some of the tests are already failing for other reasons.
Marked as "draft" because I cannot test it properly.

Test status:
ci_check: 1 additional directed test is passing, arith basic  (tho random tests still have issues)
formal: (Should not be relevant)