### PR TITLE
Re-use Core control Agent

### DIFF
--- a/cva6/env/uvme/uvma_cva6_core_cntrl_agent.sv
+++ b/cva6/env/uvme/uvma_cva6_core_cntrl_agent.sv
@@ -1,0 +1,114 @@
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Datum Technology Corporation
+// Copyright 2023 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+`ifndef __UVMA_CVA6_CORE_CNTRL_AGENT_SV__
+`define __UVMA_CVA6_CORE_CNTRL_AGENT_SV__
+
+/**
+ * Core control agent defined for the CVA6
+ */
+class uvma_cva6_core_cntrl_agent_c extends uvma_core_cntrl_agent_c;
+
+
+   string log_tag = "CVA6CORECTRLAGT";
+
+   `uvm_component_utils_begin(uvma_cva6_core_cntrl_agent_c)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_cva6_core_cntrl_agent", uvm_component parent=null);
+
+   /**
+    * Uses uvm_config_db to retrieve cntxt and hand out to sub-components.
+    */
+   extern virtual function void get_and_set_cntxt();
+
+   /**
+    * Uses uvm_config_db to retrieve the Virtual Interface (vif) associated with this
+    * agent.
+    */
+   extern virtual function void retrieve_vif();
+
+   /**
+    * Spawn active sequnces
+    */
+   extern virtual task run_phase(uvm_phase phase);
+
+   /**
+    * Spawn fetch enable control sequence
+    */
+   extern virtual task start_fetch_toggle_seq();
+
+endclass : uvma_cva6_core_cntrl_agent_c
+
+function uvma_cva6_core_cntrl_agent_c::new(string name="uvma_cva6_core_cntrl_agent", uvm_component parent=null);
+
+   super.new(name, parent);
+
+   set_inst_override_by_type("driver", uvma_core_cntrl_drv_c::get_type(), uvma_cva6_core_cntrl_drv_c::get_type());
+
+endfunction : new
+
+function void uvma_cva6_core_cntrl_agent_c::retrieve_vif();
+
+   uvma_cva6_core_cntrl_cntxt_c cva6_cntxt;
+
+   $cast(cva6_cntxt, cntxt);
+
+   // Core control interface
+   if (!uvm_config_db#(virtual uvme_cva6_core_cntrl_if)::get(this, "", $sformatf("core_cntrl_vif"), cva6_cntxt.core_cntrl_vif)) begin
+      `uvm_fatal("VIF", $sformatf("Could not find vif handle of type %s in uvm_config_db",
+                                    $typename(cva6_cntxt.core_cntrl_vif)))
+   end
+   else begin
+      `uvm_info("VIF", $sformatf("Found vif handle of type %s in uvm_config_db",
+                                 $typename(cva6_cntxt.core_cntrl_vif)), UVM_DEBUG)
+   end
+endfunction : retrieve_vif
+
+function void uvma_cva6_core_cntrl_agent_c::get_and_set_cntxt();
+
+   void'(uvm_config_db#(uvma_core_cntrl_cntxt_c)::get(this, "", "cntxt", cntxt));
+   if (!cntxt) begin
+      `uvm_info(log_tag, "Context handle is null; creating", UVM_LOW);
+      cntxt = uvma_cva6_core_cntrl_cntxt_c::type_id::create("cntxt");
+   end
+
+   uvm_config_db#(uvma_core_cntrl_cntxt_c)::set(this, "*", "cntxt", cntxt);
+
+endfunction : get_and_set_cntxt
+
+task uvma_cva6_core_cntrl_agent_c::run_phase(uvm_phase phase);
+
+   if (cfg.is_active) begin
+      fork
+         start_fetch_toggle_seq();
+      join_none
+   end
+
+endtask : run_phase
+
+task uvma_cva6_core_cntrl_agent_c::start_fetch_toggle_seq();
+
+      `uvm_error(log_tag, "fetch toggle not supported in CVA6");
+
+endtask : start_fetch_toggle_seq
+
+`endif // __UVMA_CVA6_CORE_CNTRL_AGENT_SV__

--- a/cva6/env/uvme/uvma_cva6_core_cntrl_cntxt.sv
+++ b/cva6/env/uvme/uvma_cva6_core_cntrl_cntxt.sv
@@ -1,0 +1,51 @@
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Datum Technology Corporation
+// Copyright 2023 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+`ifndef __UVMA_CVA6_CORE_CNTRL_CNTXT_SV__
+`define __UVMA_CVA6_CORE_CNTRL_CNTXT_SV__
+
+
+/**
+ * Object encapsulating all state variables for all Rvvi agent
+ * (uvma_core_cntrl_agent_c) components.
+ */
+ class uvma_cva6_core_cntrl_cntxt_c extends uvma_core_cntrl_cntxt_c;
+
+   virtual uvme_cva6_core_cntrl_if core_cntrl_vif;
+
+   `uvm_object_utils_begin(uvma_cva6_core_cntrl_cntxt_c)
+   `uvm_object_utils_end
+
+   /**
+    * Builds events.
+    */
+   extern function new(string name="uvma_cva6_core_cntrl_cntxt");
+
+endclass : uvma_cva6_core_cntrl_cntxt_c
+
+`pragma protect begin
+
+function uvma_cva6_core_cntrl_cntxt_c::new(string name="uvma_cva6_core_cntrl_cntxt");
+
+   super.new(name);
+
+endfunction : new
+
+`pragma protect end
+
+
+`endif // __UVMA_CVA6_CORE_CNTRL_CNTXT_SV__

--- a/cva6/env/uvme/uvma_cva6_core_cntrl_drv.sv
+++ b/cva6/env/uvme/uvma_cva6_core_cntrl_drv.sv
@@ -1,0 +1,62 @@
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Datum Technology Corporation
+// Copyright 2023 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+`ifndef __UVMA_CVA6_CORE_CNTRL_DRV_SV__
+`define __UVMA_CVA6_CORE_CNTRL_DRV_SV__
+
+/**
+ * Component driving bootstrap pins and other misecllaneous I/O for cva6 core
+ */
+class uvma_cva6_core_cntrl_drv_c extends uvma_core_cntrl_drv_c;
+
+   `uvm_component_utils_begin(uvma_cva6_core_cntrl_drv_c)
+   `uvm_component_utils_end
+
+   /**
+    * Default constructor.
+    */
+   extern function new(string name="uvma_cva6_core_cntrl_drv", uvm_component parent=null);
+
+   extern task drive_bootstrap();
+
+endclass : uvma_cva6_core_cntrl_drv_c
+
+function uvma_cva6_core_cntrl_drv_c::new(string name="uvma_cva6_core_cntrl_drv", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+task uvma_cva6_core_cntrl_drv_c::drive_bootstrap();
+
+   uvma_cva6_core_cntrl_cntxt_c cva6_cntxt;
+
+   $cast(cva6_cntxt, cntxt);
+
+   cva6_cntxt.core_cntrl_vif.boot_addr         = cfg.boot_addr;
+   cva6_cntxt.core_cntrl_vif.nmi_addr          = cfg.nmi_addr;
+   cva6_cntxt.core_cntrl_vif.mtvec_addr        = cfg.mtvec_addr;
+   cva6_cntxt.core_cntrl_vif.dm_halt_addr      = cfg.dm_halt_addr;
+   cva6_cntxt.core_cntrl_vif.dm_exception_addr = cfg.dm_exception_addr;
+   cva6_cntxt.core_cntrl_vif.mhartid           = cfg.mhartid;
+   cva6_cntxt.core_cntrl_vif.mimpid            = cfg.mimpid;
+   cva6_cntxt.core_cntrl_vif.fetch_en          = 1'b0;
+   cva6_cntxt.core_cntrl_vif.scan_cg_en        = 1'b0;
+
+endtask : drive_bootstrap
+
+`endif // __UVMA_CVA6_CORE_CNTRL_DRV_SV__

--- a/cva6/env/uvme/uvme_cva6_cntxt.sv
+++ b/cva6/env/uvme/uvme_cva6_cntxt.sv
@@ -31,6 +31,7 @@ class uvme_cva6_cntxt_c extends uvm_object;
    uvma_clknrst_cntxt_c    clknrst_cntxt;
    uvma_cvxif_cntxt_c      cvxif_cntxt;
    uvma_axi_cntxt_c        axi_cntxt;
+   uvma_cva6_core_cntrl_cntxt_c  core_cntrl_cntxt;
 
 // Memory modelling
    rand uvml_mem_c                   mem;
@@ -43,6 +44,7 @@ class uvme_cva6_cntxt_c extends uvm_object;
    `uvm_object_utils_begin(uvme_cva6_cntxt_c)
       `uvm_field_object(clknrst_cntxt,   UVM_DEFAULT)
       `uvm_field_object(axi_cntxt,     UVM_DEFAULT)
+      `uvm_field_object(core_cntrl_cntxt,   UVM_DEFAULT)
       `uvm_field_event(sample_cfg_e  , UVM_DEFAULT)
       `uvm_field_event(sample_cntxt_e, UVM_DEFAULT)
       `uvm_field_object(mem, UVM_DEFAULT)
@@ -65,6 +67,7 @@ function uvme_cva6_cntxt_c::new(string name="uvme_cva6_cntxt");
    super.new(name);
 
    clknrst_cntxt   = uvma_clknrst_cntxt_c::type_id::create("clknrst_cntxt");
+   core_cntrl_cntxt   = uvma_cva6_core_cntrl_cntxt_c::type_id::create("core_cntrl_cntxt");
    axi_cntxt       = uvma_axi_cntxt_c::type_id::create("axi_cntxt");
    mem = uvml_mem_c::type_id::create("mem");
 

--- a/cva6/env/uvme/uvme_cva6_constants.sv
+++ b/cva6/env/uvme/uvme_cva6_constants.sv
@@ -24,5 +24,7 @@
 parameter uvme_cva6_sys_default_clk_period   =  1_500; // 10ns
 parameter uvme_cva6_debug_default_clk_period = 10_000; // 10ns
 
+parameter XLEN = 32;
+parameter ILEN = 32;
 
 `endif // __UVME_CVA6_CONSTANTS_SV__

--- a/cva6/env/uvme/uvme_cva6_core_cntrl_if.sv
+++ b/cva6/env/uvme/uvme_cva6_core_cntrl_if.sv
@@ -1,0 +1,31 @@
+/**
+ * Quasi-static core control signals.
+ */
+interface uvme_cva6_core_cntrl_if
+    import uvm_pkg::*;
+    import uvme_cva6_pkg::*;
+    ();
+
+    logic        clk;
+    logic        fetch_en;
+
+    logic        scan_cg_en;
+    logic [XLEN-1:0] boot_addr;
+    logic [XLEN-1:0] mtvec_addr;
+    logic [XLEN-1:0] dm_halt_addr;
+    logic [XLEN-1:0] dm_exception_addr;
+    logic [XLEN-1:0] nmi_addr;
+    logic [XLEN-1:0] mhartid;
+    logic [XLEN-1:0] mimpid;
+
+    logic [XLEN-1:0] num_mhpmcounters;
+    //~ pma_region_t pma_cfg[];
+
+    // Testcase asserts this to load memory (not really a core control signal)
+    logic        load_instr_mem;
+
+  clocking drv_cb @(posedge clk);
+    output fetch_en;
+  endclocking : drv_cb
+
+endinterface : uvme_cva6_core_cntrl_if

--- a/cva6/env/uvme/uvme_cva6_env.sv
+++ b/cva6/env/uvme/uvme_cva6_env.sv
@@ -42,7 +42,7 @@ class uvme_cva6_env_c extends uvm_env;
    uvma_clknrst_agent_c   clknrst_agent;
    uvma_cvxif_agent_c     cvxif_agent;
    uvma_axi_agent_c       axi_agent;
-
+   uvma_cva6_core_cntrl_agent_c core_cntrl_agent;
 
 
    `uvm_component_utils_begin(uvme_cva6_env_c)
@@ -205,6 +205,8 @@ function void uvme_cva6_env_c::assign_cfg();
 
    uvm_config_db#(uvma_axi_cfg_c)::set(this, "*axi_agent", "cfg", cfg.axi_cfg);
 
+   uvm_config_db#(uvma_core_cntrl_cfg_c)::set(this, "core_cntrl_agent", "cfg", cfg);
+
 endfunction: assign_cfg
 
 
@@ -222,6 +224,7 @@ function void uvme_cva6_env_c::create_agents();
    clknrst_agent = uvma_clknrst_agent_c::type_id::create("clknrst_agent", this);
    cvxif_agent   = uvma_cvxif_agent_c::type_id::create("cvxif_agent", this);
    axi_agent     = uvma_axi_agent_c::type_id::create("axi_agent", this);
+   core_cntrl_agent = uvma_cva6_core_cntrl_agent_c::type_id::create("core_cntrl_agent", this);
 
 endfunction: create_agents
 

--- a/cva6/env/uvme/uvme_cva6_pkg.sv
+++ b/cva6/env/uvme/uvme_cva6_pkg.sv
@@ -45,12 +45,14 @@ package uvme_cva6_pkg;
    import uvma_cvxif_pkg::*;
    import uvma_axi_pkg::*;
    import uvml_mem_pkg  ::*;
+   import uvma_core_cntrl_pkg::*;
 
    // Constants / Structs / Enums
    `include "uvme_cva6_constants.sv"
    `include "uvme_cva6_tdefs.sv"
 
    // Objects
+   `include "uvma_cva6_core_cntrl_cntxt.sv"
    `include "uvme_cva6_cfg.sv"
    `include "uvme_cva6_cntxt.sv"
 
@@ -58,6 +60,8 @@ package uvme_cva6_pkg;
    `include "uvme_cva6_prd.sv"
 
    // Environment components
+   `include "uvma_cva6_core_cntrl_drv.sv"
+   `include "uvma_cva6_core_cntrl_agent.sv"
    `include "uvme_cva6_sb.sv"
    `include "uvme_cva6_vsqr.sv"
    `include "uvme_cvxif_covg.sv"
@@ -70,9 +74,8 @@ package uvme_cva6_pkg;
 //   `include "uvme_cva6_interrupt_noise_vseq.sv"
    `include "uvme_cva6_vseq_lib.sv"
 
-
-
 endpackage : uvme_cva6_pkg
 
+`include "uvme_cva6_core_cntrl_if.sv"
 
 `endif // __UVME_CVA6_PKG_SV__

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -137,6 +137,7 @@ export CV_CORE_UC             = CVA6
 export DV_UVMT_PATH           = $(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt
 export DV_UVME_PATH           = $(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme
 export DV_UVML_HRTBT_PATH     = $(CORE_V_VERIF)/lib/uvm_libs/uvml_hrtbt
+export DV_UVMA_CORE_CNTRL_PATH = $(CORE_V_VERIF)/lib/uvm_agents/uvma_core_cntrl
 export DV_UVMA_ISACOV_PATH    = $(CORE_V_VERIF)/lib/uvm_agents/uvma_isacov
 export DV_UVMA_CLKNRST_PATH   = $(CORE_V_VERIF)/lib/uvm_agents/uvma_clknrst
 export DV_UVMA_CVXIF_PATH     = $(CORE_V_VERIF)/lib/uvm_agents/uvma_cvxif

--- a/cva6/tb/uvmt/cva6_tb_wrapper.sv
+++ b/cva6/tb/uvmt/cva6_tb_wrapper.sv
@@ -34,7 +34,9 @@ import "DPI-C" function read_elf(input string filename);
 import "DPI-C" function byte get_section(output longint address, output longint len);
 import "DPI-C" context function void read_section(input longint address, inout byte buffer[]);
 
-module cva6_tb_wrapper #(
+module cva6_tb_wrapper
+ import uvmt_cva6_pkg::*;
+#(
   parameter int unsigned AXI_USER_WIDTH    = 1,
   parameter int unsigned AXI_USER_EN       = 0,
   parameter int unsigned AXI_ADDRESS_WIDTH = 64,
@@ -43,6 +45,7 @@ module cva6_tb_wrapper #(
 ) (
   input  logic                         clk_i,
   input  logic                         rst_ni,
+  input  logic [XLEN-1:0]              boot_addr_i,
   output wire                          tb_exit_o,
   output ariane_rvfi_pkg::rvfi_port_t  rvfi_o,
   input  cvxif_pkg::cvxif_resp_t       cvxif_resp,
@@ -64,7 +67,7 @@ module cva6_tb_wrapper #(
   ) i_cva6 (
     .clk_i                ( clk_i                     ),
     .rst_ni               ( rst_ni                    ),
-    .boot_addr_i          ( 64'h0000_0000_8000_0000   ), //ariane_soc::ROMBase
+    .boot_addr_i          ( boot_addr_i               ),//Driving the boot_addr value from the core control agent
     .hart_id_i            ( 64'h0000_0000_0000_0000   ),
     .irq_i                ( 2'b00 /*irqs*/            ),
     .ipi_i                ( 1'b0  /*ipi*/             ),

--- a/cva6/tb/uvmt/uvmt_cva6.flist
+++ b/cva6/tb/uvmt/uvmt_cva6.flist
@@ -25,6 +25,7 @@
 -f ${DV_UVMA_CLKNRST_PATH}/uvma_clknrst_pkg.flist
 -f ${DV_UVMA_CVXIF_PATH}/src/uvma_cvxif_pkg.flist
 -f ${DV_UVMA_AXI_PATH}/src/uvma_axi_pkg.flist
+-f ${DV_UVMA_CORE_CNTRL_PATH}/uvma_core_cntrl_pkg.flist
 
 // Environments
 -f ${CVA6_UVME_PATH}/uvme_cva6_pkg.flist

--- a/cva6/tb/uvmt/uvmt_cva6_constants.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_constants.sv
@@ -19,5 +19,6 @@
 `ifndef __UVMT_CVA6_CONSTANTS_SV__
 `define __UVMT_CVA6_CONSTANTS_SV__
 
+parameter XLEN = 32;
 
 `endif // __UVMT_CVA6_CONSTANTS_SV__

--- a/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -25,6 +25,7 @@ module uvmt_cva6_dut_wrap # ( parameter int unsigned AXI_USER_WIDTH    = 1,
                             uvma_clknrst_if                     clknrst_if,
                             uvma_cvxif_intf                     cvxif_if,
                             uvma_axi_intf                       axi_if,
+                            uvme_cva6_core_cntrl_if             core_cntrl_if,
                             output wire                         tb_exit_o,
                             output ariane_rvfi_pkg::rvfi_port_t rvfi_o
                            );
@@ -41,6 +42,7 @@ module uvmt_cva6_dut_wrap # ( parameter int unsigned AXI_USER_WIDTH    = 1,
     cva6_tb_wrapper_i        (
          .clk_i                  ( clknrst_if.clk                 ),
          .rst_ni                 ( clknrst_if.reset_n             ),
+         .boot_addr_i            ( core_cntrl_if.boot_addr        ),
          .cvxif_resp             ( cvxif_if.cvxif_resp_o          ),
          .cvxif_req              ( cvxif_if.cvxif_req_i           ),
          .axi_slave              ( axi_if                         ),

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -51,6 +51,7 @@ module uvmt_cva6_tb;
                                          .clk(clknrst_if.clk),
                                          .rst_n(clknrst_if.reset_n)
                                       );
+   uvme_cva6_core_cntrl_if      core_cntrl_if();
 
    //bind assertion module for cvxif interface
    bind uvmt_cva6_dut_wrap
@@ -83,6 +84,7 @@ module uvmt_cva6_tb;
                     .clknrst_if(clknrst_if),
                     .cvxif_if  (cvxif_if),
                     .axi_if    (axi_if),
+                    .core_cntrl_if(core_cntrl_if),
                     .tb_exit_o(),
                     .rvfi_o(rvfi_if.rvfi_o)
                     );
@@ -101,6 +103,7 @@ module uvmt_cva6_tb;
      uvm_config_db#(virtual uvma_cvxif_intf )::set(.cntxt(null), .inst_name("*.env.cvxif_agent"),   .field_name("vif"),       .value(cvxif_if)  );
      uvm_config_db#(virtual uvma_axi_intf   )::set(.cntxt(null), .inst_name("*"),                   .field_name("axi_vif"),    .value(axi_if));
      uvm_config_db#(virtual uvmt_rvfi_if    )::set(.cntxt(null), .inst_name("*"),                   .field_name("rvfi_vif"),  .value(rvfi_if));
+     uvm_config_db#(virtual uvme_cva6_core_cntrl_if)::set(.cntxt(null), .inst_name("*"), .field_name("core_cntrl_vif"),  .value(core_cntrl_if));
 
      // DUT and ENV parameters
      uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("ENV_PARAM_INSTR_ADDR_WIDTH"),  .value(ENV_PARAM_INSTR_ADDR_WIDTH) );
@@ -112,6 +115,8 @@ module uvmt_cva6_tb;
      uvm_top.finish_on_completion  = 1;
      uvm_top.run_test();
    end : test_bench_entry_point
+
+   assign core_cntrl_if.clk = clknrst_if.clk;
 
    /**
     * End-of-test summary printout.


### PR DESCRIPTION
The following PR related to re-use of the existent core control agent.
Things to Know :
The CVA6 has only the **boot_addr** as an input of the signals in the core control agent, so the other signals have no effect.
The **fetch_toogle_seq** as @MikeOpenHWGroup mention was added to verify a requirement of the embedded cores.
We can change the **boot_addr** value from the **uvme_cva6_cfg**.sv file, or add a simulation option +boot_addr = (some value), with that you should give the same value to spike (add a [cva6.py](https://github.com/openhwgroup/core-v-verif/blob/cva6/dev/cva6/sim/cva6.py) option : **--isspostrun_opts**=some value ) and the [linker ](https://github.com/openhwgroup/core-v-verif/blob/cva6/dev/cva6/sim/link.ld) to guaranty that your test run very well, you should know also that there is some limitation in the **boot_addr** values (raise a INSTR_ACCESS_FAULT exception).