### PR TITLE
[VPTOOL] Improve dependency handling

### DIFF
--- a/cva6/docs/VerifPlans/AXI/runme.sh
+++ b/cva6/docs/VerifPlans/AXI/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py $*
+sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*

--- a/cva6/docs/VerifPlans/CVXIF/runme.sh
+++ b/cva6/docs/VerifPlans/CVXIF/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py -t winxpblue
+sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*

--- a/cva6/docs/VerifPlans/FRONTEND/runme.sh
+++ b/cva6/docs/VerifPlans/FRONTEND/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py $*
+sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*

--- a/cva6/docs/VerifPlans/ISA_RV32/runme.sh
+++ b/cva6/docs/VerifPlans/ISA_RV32/runme.sh
@@ -31,4 +31,4 @@ export MARKDOWN_OUTPUT_DIR=`readlink -f "$ROOTDIR/../source"`
 # FIXME: Introduce a suitably named shell variable that points to the root
 # directory of the tool set (TOOL_TOP etc.)
 # FORNOW use a hardcoded relative path.
-python3 $ROOTDIR/../../../../tools/vptool/vptool/vp.py $*
+sh $ROOTDIR/../../../../tools/vptool/vptool.sh $*

--- a/cva6/docs/VerifPlans/install-prerequisites.sh
+++ b/cva6/docs/VerifPlans/install-prerequisites.sh
@@ -9,17 +9,29 @@
 #############################################################################
 # Make sure all necessary components are installed/available.
 #
-# Install Python dependencies.
+# Install Python dependencies. We can extract the full path of the script only
+# when invoked using '$SHELL <script>' syntax.  With "source" and "dot" invocation
+# methods (basename of $0 equal to $SHELL), the script must be run from the
+# directory containing 'requirements.txt'.
+[ $(basename $SHELL) = $0 ] && { \
+  echo "Please run this script from the directory in which it is located,"
+  echo "or use the syntax '"$0 path-to-script"'"
+  return 1
+}
 python3 -m pip install -q -r $(dirname $(readlink -f $0))/requirements.txt
 
 # Check for a LaTeX installation.
 which latex > /dev/null || { \
   echo "*** LaTeX ecosystem missing on you machine!"
   echo "*** Please install a LaTeX distribution if you intend to produce DV plans in PDF and/or ePub formats."
+  return 1
 }
 
 # Check for latexmk which is required for printable output.
 which latexmk > /dev/null || { \
   echo "*** LaTeX wrapper 'latexmk' missing!"
   echo "*** Please install it if you intend to produce DV plans in PDF and/or ePub formats."
+  return 1
 }
+
+echo "All dependencies for human-readable Verification Plan generation are OK."

--- a/cva6/docs/VerifPlans/install-prerequisites.sh
+++ b/cva6/docs/VerifPlans/install-prerequisites.sh
@@ -10,9 +10,7 @@
 # Make sure all necessary components are installed/available.
 #
 # Install Python dependencies.
-for REQT in `cat requirements.txt` ; do
-  python3 -m pip install $REQT
-done
+python3 -m pip install -q -r $(dirname $(readlink -f $0))/requirements.txt
 
 # Check for a LaTeX installation.
 which latex > /dev/null || { \

--- a/tools/vptool/README.md
+++ b/tools/vptool/README.md
@@ -39,7 +39,8 @@ If you encounter a problem with VPTOOL, please open an issue on this repository 
   use `sudo apt-get install python3-tk`.  On RedHat-based systems (RedHat/CentOS/Fedora), use
   `sudo dnf install python3-tkinter` or `sudo yum install python3-tkinter`, as appropriate.
 
-* PyYAML: a YAML I/O library for Python.  Install using `pip3 install --upgrade pyyaml`.
+* Ruamel YAML: a YAML I/O library for Python with round-trip parse/unparse capabilities.
+  Install using `pip3 install --upgrade ruamel.yaml`.
 
 * Pillow: A replacement for the original PIL (Python Image Library).  Install using
   `pip3 install --upgrade pillow`.
@@ -86,7 +87,7 @@ shell script named `vptool-example.sh` which can be invoked from any location.
 
 ### Directory structure
 
-- VPTOOL-readme.txt           this file
+- README.md                   this file
 - vptool                      the code of `VPTOOL`
 - vptool-example              an example of `VPTOOL` configuration with a verification database
   - runme.sh                  a shell script to run `VPTOOL` with the example database

--- a/tools/vptool/vptool.sh
+++ b/tools/vptool/vptool.sh
@@ -1,0 +1,29 @@
+#############################################################################
+# Copyright (C) 2023 Thales DIS France SAS
+#
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0.
+#
+# Original Author: Zbigniew Chamski (zbigniew.chamski@thalesgroup.com)
+#############################################################################
+#!/bin/sh
+
+# Set the canonical path of the current script.
+VPTOOL_DIR=$(dirname $(readlink -f $0))
+
+# Install any missing dependencies.
+# - check if tkinter module is available (its installation requires super-user privileges.)
+#   If not, provide installation hints.
+echo "import tkinter" | python3 || \
+{
+  echo "*** Missing system-wide dependency: Python3 module 'tkinter' not installed."
+  echo "*** Please ask your administrator to install the required package:"
+  echo "***   - Debian, Ubuntu:             'python3-tk'"
+  echo "***   - RedHat EL, CentOS, Fedora:  'python3-tkinter'"
+  exit 1;
+}
+
+# - install Python3 required modules in user space.
+python3 -m pip install -q -r $VPTOOL_DIR/vptool/requirements.txt
+
+# Run VPTOOL with the arguments as supplied by the caller.
+python3 $VPTOOL_DIR/vptool/vp.py $*

--- a/tools/vptool/vptool/requirements.txt
+++ b/tools/vptool/vptool/requirements.txt
@@ -1,0 +1,3 @@
+ruamel.yaml>=0.16
+pillow
+ttkthemes

--- a/tools/vptool/vptool/vp.py
+++ b/tools/vptool/vptool/vp.py
@@ -39,11 +39,6 @@ from PIL import Image, ImageTk
 import shutil
 import hashlib
 
-try:
-    from yaml import CLoader as Loader, CDumper as Dumper
-except ImportError:
-    from yaml import Loader, Dumper
-
 global ip_list  # Dict Containing IPs->Prop->item. Eventually, it contains the whole DB
 global MASTER_LABEL_COLOR, SECONDARY_LABEL_COLOR, TERTIARY_LABEL_COLOR, BG_COLOR, LOCK_COLOR
 global CUSTOM_NUM


### PR DESCRIPTION
This PR improves the process of installing required dependencies for VPTOOL and the downstream publishing flow for DV plans.

The installation dependencies of VPTOOL are now checked using a dedicated `requirements.txt` file and a shell wrapper script.  The per-DV-plan shortcut scripts have been updated accordingly.

The script which checks the dependencies for the downstream publishing flow (Sphinx, latex etc.) can now be invoked from arbitrary locations by using a sub-shell (`sh path-to-dvplans/install-prerequisites.sh`).  The diagnostics are also improved.