### PR TITLE
Added split array aliases for the rvfi gpr- and mem-masks

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -165,7 +165,16 @@ module uvmt_cv32e40s_tb;
                                                                    .rvfi_mem_rdata(rvfi_i.rvfi_mem_rdata[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN*0    +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN]),
                                                                    .rvfi_mem_rmask(rvfi_i.rvfi_mem_rmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8]),
                                                                    .rvfi_mem_wdata(rvfi_i.rvfi_mem_wdata[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN*0    +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN]),
-                                                                   .rvfi_mem_wmask(rvfi_i.rvfi_mem_wmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8])
+                                                                   .rvfi_mem_wmask(rvfi_i.rvfi_mem_wmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8]),
+                                                                   .visualized_gpr_rdata(),
+                                                                   .visualized_gpr_rmask(),
+                                                                   .visualized_gpr_wdata(),
+                                                                   .visualized_gpr_wmask(),
+                                                                   .visualized_mem_addr(),
+                                                                   .visualized_mem_rdata(),
+                                                                   .visualized_mem_rmask(),
+                                                                   .visualized_mem_wdata(),
+                                                                   .visualized_mem_wmask()
                                                                    );
 
   // RVFI CSR binds

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -69,7 +69,18 @@ interface uvma_rvfi_instr_if
     input logic [(NMEM*XLEN)-1:0]    rvfi_mem_rdata,
     input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_rmask,
     input logic [(NMEM*XLEN)-1:0]    rvfi_mem_wdata,
-    input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_wmask
+    input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_wmask,
+
+    output logic [(32)-1:0][XLEN-1:0]       visualized_gpr_rdata,
+    output logic [(32)-1:0]                 visualized_gpr_rmask,
+    output logic [(32)-1:0][XLEN-1:0]       visualized_gpr_wdata,
+    output logic [(32)-1:0]                 visualized_gpr_wmask,
+
+    output logic [NMEM-1:0][XLEN-1:0]       visualized_mem_addr,
+    output logic [NMEM-1:0][XLEN-1:0]       visualized_mem_rdata,
+    output logic [NMEM-1:0][(XLEN/8)-1:0]   visualized_mem_rmask,
+    output logic [NMEM-1:0][XLEN-1:0]       visualized_mem_wdata,
+    output logic [NMEM-1:0][(XLEN/8)-1:0]   visualized_mem_wmask
 
   );
 
@@ -108,6 +119,7 @@ interface uvma_rvfi_instr_if
 
 
 
+
   // -------------------------------------------------------------------
   // Local variables
   // -------------------------------------------------------------------
@@ -116,6 +128,21 @@ interface uvma_rvfi_instr_if
   // -------------------------------------------------------------------
   // Begin module code
   // -------------------------------------------------------------------
+
+  // these signals are added to make it easier to use the signal arrays,
+  // and to inspect them in the waveforms
+  // gpr masks are redundant, but added for ease of use
+  assign {>>{visualized_gpr_rdata}} = rvfi_gpr_rdata;
+  assign visualized_gpr_rmask       = rvfi_gpr_rmask;
+  assign {>>{visualized_gpr_wdata}} = rvfi_gpr_wdata;
+  assign visualized_gpr_wmask       = rvfi_gpr_wmask;
+
+
+  assign {>>{visualized_mem_addr}}  = rvfi_mem_addr;
+  assign {>>{visualized_mem_rdata}} = rvfi_mem_rdata;
+  assign {>>{visualized_mem_rmask}} = rvfi_mem_rmask;
+  assign {>>{visualized_mem_wdata}} = rvfi_mem_wdata;
+  assign {>>{visualized_mem_wmask}} = rvfi_mem_wmask;
 
   always @(posedge clk) begin
     cycle_cnt <= cycle_cnt + 1;


### PR DESCRIPTION
These new signals from the rvfi_instr_if are split up and ordered versions of the `rvfi_gpr_*`- and `rvfi_mem_*` arrays, to help with verification. They are easier to deal with in waveform viewers, and function as better visualized alternatives to the helper functions available.