### PR TITLE
Add new mechanism of the end of test for generated tests

### DIFF
--- a/cva6/env/corev-dv/cva6_asm_program_gen.sv
+++ b/cva6/env/corev-dv/cva6_asm_program_gen.sv
@@ -25,7 +25,7 @@
 //-----------------------------------------------------------------------------------------
 // CVA6 assembly program generator - extension of the RISC-V assembly program generator.
 //
-// Overrides gen_program_header()
+// Overrides gen_program_header() and gen_test_done()
 //-----------------------------------------------------------------------------------------
 
 class cva6_asm_program_gen_c extends riscv_asm_program_gen;
@@ -39,6 +39,7 @@ class cva6_asm_program_gen_c extends riscv_asm_program_gen;
    virtual function void gen_program_header();
       string str[$];
       instr_stream.push_back(".include \"user_define.include\"");
+      instr_stream.push_back(".include \"user_define.h\"");
       instr_stream.push_back(".globl _start");
       instr_stream.push_back(".section .text");
       if (cfg.disable_compressed_instr) begin
@@ -53,6 +54,15 @@ class cva6_asm_program_gen_c extends riscv_asm_program_gen;
       for (int hart = 0; hart < cfg.num_of_harts; hart++) begin
          instr_stream.push_back($sformatf("%0d: j h%0d_start", hart, hart));
       end
+   endfunction
+
+
+   virtual function void gen_test_done();
+      string str = format_string("test_done:", LABEL_STR_LEN);
+      instr_stream.push_back(str);
+      instr_stream.push_back({indent, "li gp, 1"});
+      instr_stream.push_back({indent, "sw gp, tohost, t5"});
+      instr_stream.push_back({indent, "wfi"});
    endfunction
 
 endclass : cva6_asm_program_gen_c


### PR DESCRIPTION
Hello, I add in the [cva6_asm_program_gen.sv](https://github.com/openhwgroup/core-v-verif/blob/cva6/dev/cva6/env/corev-dv/cva6_asm_program_gen.sv) file, the gen_test_done function to implement the new end of test mechanism, so to use it you should add in the cmd line : **--sim_opts="+uvm_set_inst_override=riscv_asm_program_gen,cva6_asm_program_gen_c,'uvm_test_top.asm_gen'"** to override the original RISCV-DV class with the new one.