### PR TITLE
Track cva6 commit upon install

### DIFF
--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -47,6 +47,7 @@ echo $CVA6_PATCH
 if ! [ -d core-v-cores/cva6 ]; then
   git clone --recursive $CVA6_REPO -b $CVA6_BRANCH core-v-cores/cva6
   cd core-v-cores/cva6; git checkout $CVA6_HASH;
+  echo -n "Using CVA6 commit "; git describe --always HEAD
   if [ -f ../$CVA6_PATCH ]; then
     git apply ../$CVA6_PATCH
   fi


### PR DESCRIPTION
This PR is a help for tracking configuration issues in automated CI.  When installing a CVA6 RTL tree, it prints on console the actual commit extracted from the cva6 repo clone.

Changed files:
* cva6/sim/install-cva6.sh: Print the commit which was checked out upon installing a fresh CVA6 RTL tree.