### PR TITLE
CVA6 testlist_riscv-compliance-*.yaml: enable DIV and REM tests

### DIFF
--- a/cva6/tests/testlist_riscv-compliance-cv32a60x.yaml
+++ b/cva6/tests/testlist_riscv-compliance-cv32a60x.yaml
@@ -135,7 +135,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
 
 - test: rv32im-DIV
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
@@ -153,7 +153,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
 
 - test: rv32im-REM
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S

--- a/cva6/tests/testlist_riscv-compliance-cv32a6_imac_sv0.yaml
+++ b/cva6/tests/testlist_riscv-compliance-cv32a6_imac_sv0.yaml
@@ -135,7 +135,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
 
 - test: rv32im-DIV
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
@@ -153,7 +153,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
 
 - test: rv32im-REM
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S

--- a/cva6/tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml
+++ b/cva6/tests/testlist_riscv-compliance-cv64a6_imafdc_sv39.yaml
@@ -135,7 +135,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
 
 - test: rv32im-DIV
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
@@ -153,7 +153,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
 
 - test: rv32im-REM
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S

--- a/cva6/tests/testlist_riscv-compliance-rv32ima.yaml
+++ b/cva6/tests/testlist_riscv-compliance-rv32ima.yaml
@@ -135,7 +135,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MUL.S
 
 - test: rv32im-DIV
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/DIV.S
@@ -153,7 +153,7 @@
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/MULHU.S
 
 - test: rv32im-REM
-  iterations: 0 # see https://github.com/openhwgroup/cva6/issues/421
+  iterations: 1
   path_var: TESTS_PATH
   gcc_opts: "-static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-compliance/riscv-test-env/ -I<path_var>/riscv-compliance/riscv-test-env/p/ -I<path_var>/riscv-compliance/riscv-target/spike/"
   asm_tests: <path_var>/riscv-compliance/riscv-test-suite/rv32im/src/REM.S


### PR DESCRIPTION
as https://github.com/openhwgroup/cva6/issues/421 is fixed