### PR TITLE
cv_regress script to generate regressions for Siemens verification manager tool

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -155,7 +155,7 @@ def read_file(args, file):
         # Determine if a test is valid, skip for compliance tests
         # Since it is not possible to determine apriori if a compliance test is valid
         if not 'compliance' in test.cmd:
-            check_valid_test(args.project, test.name)
+            check_valid_test(args.project, test.testname)
 
         # Determine if a test is indexed for setting test iterations
         if args.num:
@@ -200,6 +200,7 @@ parser.add_argument('--make', help='Substitute for make command (to use short-cu
 parser.add_argument('--makearg', action='append', help='Arguments to supply to each make command, can be specified multiple times')
 parser.add_argument('--sh', help='Select bash shell script output', action='store_true')
 parser.add_argument('--vsif', help='Select Vmanager VSIF output', action='store_true')
+parser.add_argument('--rmdb', help='Select Vrun RMDB output', action='store_true')
 parser.add_argument('--toolchain', help='Select toolchain to build with', choices=VALID_TOOLCHAINS, default=DEFAULT_TOOLCHAIN)
 args = parser.parse_args()
 
@@ -220,6 +221,8 @@ if not args.outfile:
         args.outfile = args.outfile + '.sh'
     elif args.vsif:
         args.outfile = args.outfile + '.vsif'
+    elif args.rmdb:
+        args.outfile = args.outfile + '.rmdb'
 
 regressions = []
 unique_builds = OrderedDict()
@@ -294,4 +297,27 @@ if args.vsif:
     logger.info('Rendering template: regress_sve.j2 into: {}'.format(sve))
     out_fh = open(sve, 'w')
     out_fh.write(template.render(env=os.environ))
+    out_fh.close()
+
+
+if args.rmdb:
+    # Generate a Vrun-compatible rmdb file (--rmdb)
+    template = env.get_template('regress_rmdb.j2')
+    if not args.cov:
+        logger.warning('Coverage option is not set, regression with Questa Vrun will not be able to detect any failing test')
+    logger.info('Rendering template: regress_rmdb.j2 into: {}'.format(args.outfile))
+    out_fh = open(args.outfile, 'w')
+    out_fh.write(template.render(session=os.path.splitext(os.path.basename(args.outfile))[0],
+                                 results_path=get_results_path(args.project),
+                                 project=args.project,
+                                 parallel=args.parallel,
+                                 regressions=regressions,
+                                 results=args.results,
+                                 makeargs=' '.join(args.makearg) if args.makearg else '',
+                                 lsf=args.lsf,
+                                 toolchain=args.toolchain,
+                                 simulator=args.simulator,
+                                 filter_dir=get_filter_dir(),
+                                 unique_builds=unique_builds,
+                                 coverage=args.cov))
     out_fh.close()

--- a/bin/lib/cv_regression.py
+++ b/bin/lib/cv_regression.py
@@ -85,6 +85,9 @@ class Test:
         # Absolutize a directory if exists
         self.abs_dir = os.path.abspath(os.path.join(get_proj_root(), self.dir))
 
+        if not hasattr(self, 'testname'):
+            self.testname = self.name
+
         # Log equals the test name if does not exist
         if not hasattr(self, 'log'):
             self.log = self.name

--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -1,0 +1,94 @@
+{% import 'regress_macros.j2' as regress_macros -%}
+
+
+<?xml version="1.0" ?>
+<rmdb>
+
+    <runnable name="{{project}}" type="group" sequential="yes">
+        <parameters>
+            <parameter name="results_sim_path">{{results_path}}/{{simulator}}_results</parameter>
+        </parameters>
+        <members>
+{% for r in regressions %}
+            <member>{{r.name}}</member>
+{% endfor %}
+{% if coverage != false %}
+            <member>cov_report</member>
+{% endif %}
+        </members>
+    </runnable>
+
+
+{% for r in regressions %}
+    <runnable name="{{r.name}}" type="group">
+        <members>
+{% for build in r.get_builds() %}
+            <member>config_{{build.cfg}}</member>
+{% endfor %}
+        </members>
+        <preScript launch="exec">
+{% for b in r.get_builds_with_no_tests() %}
+            <command> cd {{b.abs_dir}} &amp;&amp; {{b.cmd}} CV_CORE={{project}} CFG={{b.cfg}} CV_SIM_PREFIX= {{toolchain|upper}}=1 SIMULATOR={{b.simulator}} COV={{regress_macros.yesorno(b.cov)}} {{regress_macros.cv_results(results)}} {{makeargs}} </command>
+{% endfor %}
+        </preScript>
+    </runnable>
+
+
+{% for build in r.get_builds() %}
+        <runnable name="config_{{build.cfg}}" type="group">
+            <members>
+{% for t in r.get_tests_of_build(build.name) %}
+                <member>{{t.name}}</member>
+{% endfor %}
+            </members>
+            <preScript launch="exec">
+                <command> cd {{build.abs_dir}} &amp;&amp; {{build.cmd}} CV_CORE={{project}} CFG={{build.cfg}} CV_SIM_PREFIX= {{toolchain|upper}}=1 SIMULATOR={{build.simulator}} COV={{regress_macros.yesorno(build.cov)}} {{regress_macros.cv_results(results)}} {{makeargs}} </command>
+            </preScript>
+        </runnable>
+
+{% for t in r.get_tests_of_build(build.name) %}
+            <runnable name="{{t.name}}" type="task" repeat="{{t.num}}">
+                <parameters>
+                    <parameter name="ucdbfile" >{{t.abs_dir}}/vsim_results/{{build.cfg}}/{{t.testname}}/(%ITERATION%)/{{t.testname}}.ucdb</parameter>
+                </parameters>
+{% if lsf != None %}
+                <method name="grid" gridtype="lsf" action="execScript">
+                    <command> {{lsf}} -P {{project}} -J (%RUNNABLE%) (%WRAPPER%) </command>
+                </method>
+{% endif %}
+                <execScript launch="exec" usestderr="no">
+                    <command> cd {{t.abs_dir}} &amp;&amp; {{t.cmd}} COMP=0 CV_SIM_PREFIX= CV_CORE={{project}} {{toolchain|upper}}=1 CFG={{build.cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=(%ITERATION%) GEN_START_INDEX=(%ITERATION%) SEED=random {{regress_macros.cv_results(results)}} {{makeargs}} {{t.makearg}}</command>
+                </execScript>
+            </runnable>
+{% endfor %}
+
+
+{% endfor %}
+
+{% endfor %}
+
+    <!-- =========== Reporting =========== -->
+    <runnable name="cov_report" type="group">
+        <parameters>
+            <parameter name="merged_file">(%results_sim_path%)/merged/merged.ucdb</parameter>
+            <!-- <parameter name="tplan_file">(%results_sim_path%)/merged.ucdb</parameter> -->
+        </parameters>
+        <preScript launch="exec">
+            <command> cd {{results_path}} &amp;&amp; make cov_merge </command>
+        </preScript>
+        <members>
+            <member>cov_html_report</member>
+        </members>
+        <postScript>
+
+        </postScript>
+    </runnable>
+
+        <runnable name="cov_html_report" type="task">
+            <execScript>
+                <command> if {[file exists (%merged_file%)]} {vcover report -annotate -testdetails -details -html (%merged_file%) -output [file join {{results_path}} cov_html_summary]} </command>
+                <!-- <command> if {[file exists (%merged_file%)]} {vcover report -plansection=/. -html (%mergefile%) -output [file join (%results_sim_path%) cov_html_summary_testplan]} </command> -->
+            </execScript>
+        </runnable>
+
+</rmdb>

--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -1,3 +1,6 @@
+// Copyright 2023 Dolphin Design
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
 {% import 'regress_macros.j2' as regress_macros -%}
 
 

--- a/cv32e40p/sim/tools/vsim/cov.tcl
+++ b/cv32e40p/sim/tools/vsim/cov.tcl
@@ -1,1 +1,1 @@
-coverage save -onexit -testname ${TEST} ${TEST}.ucdb
+coverage save -onexit -testname ${TEST}__${TEST_CONFIG}__${TEST_SEED} ${TEST}.ucdb

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -702,5 +702,3 @@ firmware-unit-test-clean:
 		$(FIRMWARE_OBJS) $(FIRMWARE_UNIT_TEST_OBJS)
 
 #endend
-
-

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -32,7 +32,7 @@ VCOVER                  = vcover
 
 # Paths
 VWORK     				= work
-VSIM_COV_MERGE_DIR      = $(SIM_CFG_RESULTS)/$(CFG)/merged
+VSIM_COV_MERGE_DIR      = $(SIM_RESULTS)/merged
 UVM_HOME               ?= $(abspath $(shell which $(VLIB))/../../verilog_src/uvm-1.2/src)
 DPI_INCLUDE            ?= $(abspath $(shell which $(VLIB))/../../include)
 USES_DPI = 1
@@ -183,7 +183,7 @@ endif
 ifeq ($(call IS_YES,$(COV)),YES)
 VOPT_FLAGS  += $(VOPT_COV)
 VSIM_FLAGS  += $(VSIM_COV)
-VSIM_FLAGS  += -do 'set TEST ${VSIM_TEST}; source $(VSIM_SCRIPT_DIR)/cov.tcl'
+VSIM_FLAGS  += -do 'set TEST ${VSIM_TEST}; set TEST_CONFIG $(CFG); set TEST_SEED $(RNDSEED); source $(VSIM_SCRIPT_DIR)/cov.tcl'
 endif
 
 ################################################################################
@@ -219,8 +219,8 @@ endif
 COV_FLAGS =
 COV_REPORT = cov_report
 COV_MERGE_TARGET =
-COV_MERGE_FIND = find $(SIM_CFG_RESULTS) -type f -name "*.ucdb" | grep -v merged.ucdb
-COV_MERGE_FLAGS=merge -64 -out merged.ucdb -inputs ucdb.list
+COV_MERGE_FIND = find $(SIM_RESULTS) -type f -name "*.ucdb" | grep -v merged.ucdb
+COV_MERGE_FLAGS=merge -testassociated -verbose -64 -out merged.ucdb -inputs ucdb.list
 
 ifeq ($(call IS_YES,$(MERGE)),YES)
 COV_DIR=$(VSIM_COV_MERGE_DIR)


### PR DESCRIPTION
Added the needed templates to allow the generation of a RMDB File. 

Due to limitations of Questa Vrun, make sure to generate the rmdb file with coverage enabled, as the regression tool is not able to easily detect a failing make command as a test fail. It needs indeed to have access to an .ucdb file with the test status recorded inside. 

Also, Siemens tools expects one unique "testname" when merging ucdb, so tests that are executed with multiple configurations and seeds provoked an issue when merging. I was forced to update some coverage commands and script to solve this. 

I also updated one small thing to cv_regress script, to allow the same test to be executed in multiple configurations inside the same regression. That will be useful for handling all F/Zfinx tests that will be practically the same inside one unique regression. 