### PR TITLE
Include Imperas DV Functional Coverage

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
@@ -1,6 +1,6 @@
 //
 // Copyright 2022 OpenHW Group
-// Copyright 2022 Imperas
+// Copyright 2023 Imperas
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -323,9 +323,11 @@ module uvmt_cv32e40s_imperas_dv_wrap
                    .CMP_VR      (0),
                    .CMP_CSR     (1)
                    )
-                   trace2api(rvvi);
+                   idv_trace2api(rvvi);
 
-   trace2log       trace2log(rvvi);
+   trace2log       idv_trace2log(rvvi);
+
+   trace2cov       idv_trace2cov(rvvi);
 
    string info_tag = "ImperasDV_wrap";
 


### PR DESCRIPTION
The addition of trace2cov allows functional coverage using riscvISACOV to be used

Clone the repository github.com/Imperas/ImperasDV-OpenHW and view the file scripts/cv32e40s/README.run.txt for full information on how to enable

No additional System Verilog is included unless it is compiled with +define+INCLUDE_TRACE2COV

Some information is included here 

```
COVERAGE_ENABLE="\
    +define+INCLUDE_TRACE2COV \
    +incdir+${IMPERAS_HOME}/ImpProprietary/source/host/riscvISACOV/source \
    +define+COVER_BASE_RV32I \
    +define+COVER_LEVEL_DV_PR_EXT  \
    +define+COVER_RV32ZCA \
    +define+COVER_RV32ZCMP \
    +define+COVER_RV32ZCMT \
"
# for zc_test
export CV_SW_MARCH=rv32im_zicsr_zifencei_zcmp

make clean test TEST=zc_test \
   USER_COMPILE_FLAGS="${COVERAGE_ENABLE}" \
   USER_RUN_FLAGS="+TRACE2COV_ENABLE=1" \
   USE_ISS=yes \
   COV=yes \
   CV_CORE=${CV_CORE}

# The coverage can be viewed with
make cov TEST=zc_test GUI=1

```
