### PR TITLE
Test termination: Streamline the definitions of termination sequences.

### DIFF
--- a/cva6/regress/install-riscv-arch-test.sh
+++ b/cva6/regress/install-riscv-arch-test.sh
@@ -7,6 +7,12 @@
 #
 # Original Author: Jean-Roch COULON - Thales
 
+# riscv-arch-tests uses definition of RVMODEL_HALT provided by Spike.
+. cva6/regress/install-spike.sh
+if [ ! -d $SPIKE_ROOT/riscv-isa-sim/arch_test_target ]; then
+  echo "*** Variable SPIKE_ROOT must point to a source-based installation of Spike."
+fi
+
 if ! [ -n "$ARCH_TEST_REPO" ]; then
   ARCH_TEST_REPO=https://github.com/riscv-non-isa/riscv-arch-test
   ARCH_TEST_BRANCH=main
@@ -16,10 +22,13 @@ echo $ARCH_TEST_REPO
 echo $ARCH_TEST_BRANCH
 echo $ARCH_TEST_HASH
 
+
 mkdir -p cva6/tests
 if ! [ -d cva6/tests/riscv-arch-test ]; then
   git clone $ARCH_TEST_REPO -b $ARCH_TEST_BRANCH cva6/tests/riscv-arch-test
   cd cva6/tests/riscv-arch-test; git checkout $ARCH_TEST_HASH;
+  # Copy Spike definitions to the corresponding riscv-target subdirectory.
+  cp -rpa $SPIKE_ROOT/riscv-isa-sim/arch_test_target/spike riscv-target
   cd -
 fi
 

--- a/cva6/regress/riscv-compliance.patch
+++ b/cva6/regress/riscv-compliance.patch
@@ -1,3 +1,34 @@
+diff --git a/riscv-test-env/p/riscv_test.h b/riscv-test-env/p/riscv_test.h
+index eaa6758..887408a 100644
+--- a/riscv-test-env/p/riscv_test.h
++++ b/riscv-test-env/p/riscv_test.h
+@@ -162,7 +162,7 @@ handle_exception:                                                       \
+   1:    ori TESTNUM, TESTNUM, 1337;                                     \
+   write_tohost:                                                         \
+         sw TESTNUM, tohost, t5;                                         \
+-        j write_tohost;                                                 \
++  2:    j 2b;                                                           \
+ reset_vector:                                                           \
+         RISCV_MULTICORE_DISABLE;                                        \
+         INIT_SPTBR;                                                     \
+@@ -215,7 +215,7 @@ end_testcode:                                                           \
+         RVTEST_SYNC;                                                    \
+         li TESTNUM, 1;                                                  \
+         SWSIG (0, TESTNUM);                                             \
+-        ecall
++        j write_tohost;
+ 
+ #define TESTNUM gp
+ #define RVTEST_FAIL                                                     \
+@@ -224,7 +224,7 @@ end_testcode:                                                           \
+         sll TESTNUM, TESTNUM, 1;                                        \
+         or TESTNUM, TESTNUM, 1;                                         \
+         SWSIG (0, TESTNUM);                                             \
+-        ecall
++        j write_tohost;
+ 
+ //-----------------------------------------------------------------------
+ // Data Section Macro
 diff --git a/riscv-test-env/v/vm.c b/riscv-test-env/v/vm.c
 index 6ab7fd1..fc01b94 100644
 --- a/riscv-test-env/v/vm.c

--- a/cva6/regress/riscv-tests-env.patch
+++ b/cva6/regress/riscv-tests-env.patch
@@ -1,21 +1,25 @@
 diff --git a/p/riscv_test.h b/p/riscv_test.h
-index 88ca6c1..d345eb5 100644
+index 88ca6c1..61c53ca 100644
 --- a/p/riscv_test.h
 +++ b/p/riscv_test.h
-@@ -238,7 +238,8 @@ reset_vector:                                                           \
+@@ -236,9 +236,8 @@ reset_vector:                                                           \
+ #define RVTEST_PASS                                                     \
+         fence;                                                          \
          li TESTNUM, 1;                                                  \
-         li a7, 93;                                                      \
-         li a0, 0;                                                       \
+-        li a7, 93;                                                      \
+-        li a0, 0;                                                       \
 -        ecall
 +        sw TESTNUM, tohost, t5;                                         \
 +42:     j 42b
  
  #define TESTNUM gp
  #define RVTEST_FAIL                                                     \
-@@ -248,7 +249,8 @@ reset_vector:                                                           \
+@@ -246,9 +245,8 @@ reset_vector:                                                           \
+ 1:      beqz TESTNUM, 1b;                                               \
+         sll TESTNUM, TESTNUM, 1;                                        \
          or TESTNUM, TESTNUM, 1;                                         \
-         li a7, 93;                                                      \
-         addi a0, TESTNUM, 0;                                            \
+-        li a7, 93;                                                      \
+-        addi a0, TESTNUM, 0;                                            \
 -        ecall
 +        sw TESTNUM, tohost, t5;                                         \
 +42:     j 42b

--- a/cva6/regress/smoke-tests.sh
+++ b/cva6/regress/smoke-tests.sh
@@ -38,6 +38,8 @@ make clean_all
 python3 cva6.py --testlist=../tests/testlist_riscv-compliance-cv32a60x.yaml --test rv32i-I-ADD-01 --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_riscv-tests-cv32a60x-p.yaml --test rv32ui-p-add --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS
 python3 cva6.py --testlist=../tests/testlist_riscv-arch-test-cv32a60x.yaml --test rv32im-cadd-01 --iss_yaml cva6.yaml --target cv32a60x --iss=$DV_SIMULATORS $DV_OPTS  --linker=../tests/riscv-isa-sim/arch_test_target/spike/link.ld
+python3 cva6.py --target cv32a60x --iss=$DV_SIMULATORS --iss_yaml=cva6.yaml --c_tests ../tests/custom/hello_world/hello_world.c\
+  --gcc_opts "-g ../tests/custom/common/syscalls.c ../tests/custom/common/crt.S -lgcc -I../tests/custom/env -I../tests/custom/common -T ../tests/custom/common/test.ld"
 make -C ../../core-v-cores/cva6 clean
 make clean_all
 

--- a/cva6/tests/custom/common/crt.S
+++ b/cva6/tests/custom/common/crt.S
@@ -134,6 +134,7 @@ _start:
   add tp, tp, a2
 
   j _init
+  .size    _start, . - _start
 
   .align 2
 trap_entry:
@@ -215,6 +216,42 @@ trap_entry:
 
   addi sp, sp, 272
   mret
+
+  // Default definition of handle_trap: Exit with code 0x7ffffff0.
+  .weak   handle_trap
+  .type	handle_trap, @function
+handle_trap:
+        li  a0, -32
+	j   _exit
+  .size handle_trap, . - handle_trap
+
+  // Default, overrideable definition of _init:
+  // Call 'main' and jump to '_exit' which never returns.
+  .weak   _init
+  .type   _init, @function
+_init:
+  jal     main
+  j       _exit
+  .size   _init, . - _init
+
+  // Default, overrideable definition of 'exit':
+  // Jump to '_exit' low-level termination function.
+  .weak   exit
+  .type   exit, @function
+exit:
+  j       _exit
+  .size   exit, . - exit
+
+  // Minimal low-level exit function.
+  .global  _exit
+_exit:
+  sll  a0, a0, 1      # Set up exit code: shift a0 left by 1
+  add  a0, a0, 1      # and set bit 0.
+  sw   a0, tohost, t5 # Store bits [31:0] of a0 into variable tohost
+  nop                 # Leave one cycle of slack before entering endless loop
+1:
+  j        1b;        # Wait indefinitely (until the env terminates the simulation)
+  .size    _exit, . - _exit
 
 .section ".tohost","aw",@progbits
 .align 6

--- a/cva6/tests/testlist_riscv-arch-test-cv32a60x.yaml
+++ b/cva6/tests/testlist_riscv-arch-test-cv32a60x.yaml
@@ -33,440 +33,440 @@
 - test: rv32im-cadd-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cadd-01.S
   
 - test: rv32im-caddi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi-01.S
   
 - test: rv32im-caddi16sp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi16sp-01.S
   
 - test: rv32im-caddi4spn-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/caddi4spn-01.S
 
 - test: rv32im-cand-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cand-01.S
   
 - test: rv32im-candi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/candi-01.S
   
 - test: rv32im-cbeqz-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbeqz-01.S
   
 - test: rv32im-cbnez-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cbnez-01.S
 
 - test: rv32im-cebreak-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cebreak-01.S
 
 - test: rv32im-cj-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cj-01.S
   
 - test: rv32im-cjal-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjal-01.S
  
 - test: rv32im-cjalr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjalr-01.S
   
 - test: rv32im-cjr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cjr-01.S
 
 - test: rv32im-cli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cli-01.S
 
 - test: rv32im-clui-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clui-01.S
 
 - test: rv32im-clw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clw-01.S
 
 - test: rv32im-clwsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/clwsp-01.S
 
 - test: rv32im-cmv-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cmv-01.S
 
 - test: rv32im-cnop-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cnop-01.S
 
 - test: rv32im-cor-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cor-01.S
 
 - test: rv32im-cslli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cslli-01.S
 
 - test: rv32im-csrai-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csrai-01.S
 
 - test: rv32im-csrli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csrli-01.S
 
 - test: rv32im-csub-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csub-01.S
 
 - test: rv32im-csw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/csw-01.S
 
 - test: rv32im-cswsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cswsp-01.S
 
 - test: rv32im-cxor-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/C/src/cxor-01.S
   
   # I  
 - test: rv32im-add-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/add-01.S
 
 - test: rv32im-addi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/addi-01.S
 
 - test: rv32im-and-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/and-01.S
 
 - test: rv32im-andi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/andi-01.S
 
 - test: rv32im-auipc-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/auipc-01.S
 
 - test: rv32im-beq-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/beq-01.S
 
 - test: rv32im-bge-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bge-01.S
 
 - test: rv32im-bgeu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bgeu-01.S
 
 - test: rv32im-blt-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/blt-01.S
 
 - test: rv32im-bltu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bltu-01.S
 
 - test: rv32im-bne-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/bne-01.S
 
 - test: rv32im-fence-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/fence-01.S
  
 - test: rv32im-jal-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jal-01.S
  
 - test: rv32im-jalr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/jalr-01.S
  
 - test: rv32im-lb-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lb-align-01.S
  
 - test: rv32im-lbu-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lbu-align-01.S
  
 - test: rv32im-lh-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lh-align-01.S
 
 - test: rv32im-lhu-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lhu-align-01.S
 
 - test: rv32im-lui-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lui-01.S
 
 - test: rv32im-lw-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/lw-align-01.S
 
 - test: rv32im-or-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/or-01.S
 
 - test: rv32im-ori-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/ori-01.S
  
 - test: rv32im-sb-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sb-align-01.S
  
 - test: rv32im-sh-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sh-align-01.S
  
 - test: rv32im-sll-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sll-01.S
  
 - test: rv32im-slli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slli-01.S
  
 - test: rv32im-slt-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slt-01.S
  
 - test: rv32im-slti-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/slti-01.S
  
 - test: rv32im-sltiu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltiu-01.S
  
 - test: rv32im-sltu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sltu-01.S
  
 - test: rv32im-sra-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sra-01.S
  
 - test: rv32im-srai-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srai-01.S
  
 - test: rv32im-srl-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srl-01.S
  
 - test: rv32im-srli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/srli-01.S
  
 - test: rv32im-sub-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sub-01.S
  
 - test: rv32im-sw-align-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/sw-align-01.S
  
 - test: rv32im-xor-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xor-01.S
  
 - test: rv32im-xori-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/I/src/xori-01.S
  
   # M
 - test: rv32im-div-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/div-01.S
  
 - test: rv32im-divu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/divu-01.S
  
 - test: rv32im-mul-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mul-01.S
  
 - test: rv32im-mulh-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulh-01.S
 
 - test: rv32im-mulhsu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhsu-01.S
  
 - test: rv32im-mulhu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/mulhu-01.S
   
 - test: rv32im-rem-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/rem-01.S
    
 - test: rv32im-remu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=32 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv32i_m/M/src/remu-01.S
 

--- a/cva6/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
+++ b/cva6/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml
@@ -36,741 +36,741 @@
 - test: rv64i_m-add-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/add-01.S
 
 - test: rv64i_m-addi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/addi-01.S
 
 - test: rv64i_m-addiw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/addiw-01.S
 
 - test: rv64i_m-addw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/addw-01.S
 
 - test: rv64i_m-and-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/and-01.S
 
 - test: rv64i_m-andi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/andi-01.S
 
 - test: rv64i_m-auipc-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/auipc-01.S
 
 - test: rv64i_m-beq-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/beq-01.S
 
 - test: rv64i_m-bge-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/bge-01.S
 
 - test: rv64i_m-bgeu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/bgeu-01.S
 
 - test: rv64i_m-blt-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/blt-01.S
 
 - test: rv64i_m-bltu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/bltu-01.S
 
 - test: rv64i_m-bne-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/bne-01.S
 
 - test: rv64i_m-fence-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/fence-01.S
 
 - test: rv64i_m-jal-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/jal-01.S
 
 - test: rv64i_m-jalr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/jalr-01.S
 
 - test: rv64i_m-lb-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lb-align-01.S
 
 - test: rv64i_m-lbu-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lbu-align-01.S
 
 - test: rv64i_m-ld-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/ld-align-01.S
 
 - test: rv64i_m-lh-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lh-align-01.S
 
 - test: rv64i_m-lhu-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lhu-align-01.S
 
 - test: rv64i_m-lui
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lui-01.S
 
 - test: rv64i_m-lw-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lw-align-01.S
 
 - test: rv64i_m-lb-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/lb-align-01.S
 
 - test: rv64i_m-or
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/or-01.S
 
 - test: rv64i_m-ori
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/ori-01.S
 
 - test: rv64i_m-sb-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sb-align-01.S
 
 - test: rv64i_m-sd-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sd-align-01.S
 
 - test: rv64i_m-sh-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sh-align-01.S
 
 - test: rv64i_m-sw-align01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sw-align-01.S
 
 - test: rv64i_m-sll
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sll-01.S
 
 - test: rv64i_m-slli
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/slli-01.S
 
 - test: rv64i_m-slliw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/slliw-01.S
 
 - test: rv64i_m-sllw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sllw-01.S
 
 - test: rv64i_m-slt
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/slt-01.S
 
 - test: rv64i_m-slti
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/slti-01.S
 
 - test: rv64i_m-sltiu
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sltiu-01.S
 
 - test: rv64i_m-sltu
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sltu-01.S
 
 - test: rv64i_m-sra
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sra-01.S
 
 - test: rv64i_m-srai
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/srai-01.S
 
 - test: rv64i_m-sraiw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sraiw-01.S
 
 - test: rv64i_m-sraw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sraw-01.S
 
 - test: rv64i_m-srl
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/srl-01.S
 
 - test: rv64i_m-srli
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/srli-01.S
 
 - test: rv64i_m-srliw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/srliw-01.S
 
 - test: rv64i_m-srlw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/srlw-01.S
 
 - test: rv64i_m-sub
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/sub-01.S
 
 - test: rv64i_m-subw
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/subw-01.S
 
 - test: rv64i_m-xor
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/xor-01.S
 
 - test: rv64i_m-xori
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/I/src/xori-01.S
 
   #M
 - test: rv64i_m-div-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/div-01.S
 
 - test: rv64i_m-divu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/divu-01.S
 
 - test: rv64i_m-divuw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/divuw-01.S
 
 - test: rv64i_m-divw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/divw-01.S
 
 - test: rv64i_m-mul-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mul-01.S
 
 - test: rv64i_m-mulh-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulh-01.S
 
 - test: rv64i_m-mulhsu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulhsu-01.S
 
 - test: rv64i_m-mulhu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulhu-01.S
 
 - test: rv64i_m-mulw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/mulw-01.S
 
 - test: rv64i_m-rem-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/rem-01.S
 
 - test: rv64i_m-remu-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/remu-01.S
 
 - test: rv64i_m-remuw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/remuw-01.S
 
 - test: rv64i_m-remw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/M/src/remw-01.S
 
   #C
 - test: rv64i_m-cadd-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cadd-01.S
 
 - test: rv64i_m-caddi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/caddi-01.S
 
 - test: rv64i_m-caddi16sp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/caddi16sp-01.S
 
 - test: rv64i_m-caddi4spn-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/caddi4spn-01.S
 
 - test: rv64i_m-caddiw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/caddiw-01.S
 
 - test: rv64i_m-caddw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/caddw-01.S
 
 - test: rv64i_m-cand-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cand-01.S
 
 - test: rv64i_m-candi-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/candi-01.S
 
 - test: rv64i_m-cbeqz-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cbeqz-01.S
 
 - test: rv64i_m-cbnez-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cbnez-01.S
 
 - test: rv64i_m-cebreak-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cebreak-01.S
 
 - test: rv64i_m-cj-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cj-01.S
 
 - test: rv64i_m-cjalr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cjalr-01.S
 
 - test: rv64i_m-cjr-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cjr-01.S
 
 - test: rv64i_m-cld-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cld-01.S
 
 - test: rv64i_m-cldsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cldsp-01.S
 
 - test: rv64i_m-cli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cli-01.S
 
 - test: rv64i_m-clui-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/clui-01.S
 
 - test: rv64i_m-clw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/clw-01.S
 
 - test: rv64i_m-clwsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/clwsp-01.S
 
 - test: rv64i_m-cmv-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cmv-01.S
 
 - test: rv64i_m-cnop-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cnop-01.S
 
 - test: rv64i_m-cor-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cor-01.S
 
 - test: rv64i_m-csd-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csd-01.S
 
 - test: rv64i_m-csdsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csdsp-01.S
 
 - test: rv64i_m-cslli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cslli-01.S
 
 - test: rv64i_m-csrai-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csrai-01.S
 
 - test: rv64i_m-csrli-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csrli-01.S
 
 - test: rv64i_m-csub-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csub-01.S
 
 - test: rv64i_m-csubw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csubw-01.S
 
 - test: rv64i_m-csw-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/csw-01.S
 
 - test: rv64i_m-cswsp-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cswsp-01.S
 
 - test: rv64i_m-cxor-01
   iterations: 1
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/C/src/cxor-01.S
 
 #D
 - test: rv64i_m-fcvt.d.l_b25-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.d.l_b25-01.S
 
 - test: rv64i_m-fcvt.d.l_b26-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.d.l_b26-01.S
 
 - test: rv64i_m-fcvt.d.lu_b25-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.d.lu_b25-01.S
 
 - test: rv64i_m-fcvt.d.lu_b26-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.d.lu_b26-01.S
 
 - test: rv64i_m-fcvt.l.d_b1-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b1-01.S
 
 - test: rv64i_m-fcvt.l.d_b22-01.S
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b22-01.S
 
 - test: rv64i_m-fcvt.l.d_b23-01.S
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b23-01.S
 
 - test: rv64i_m-fcvt.l.d_b24-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b24-01.S
 
 - test: rv64i_m-fcvt.l.d_b27-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b27-01.S
 
 - test: rv64i_m-fcvt.l.d_b28-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b28-01.S
   
 - test: rv64i_m-fcvt.l.d_b29-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.l.d_b29-01.S
 
 - test: rv64i_m-fcvt.lu.d_b1-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b1-01.S
 
 - test: rv64i_m-fcvt.lu.d_b22-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b22-01.S
 
 - test: rv64i_m-fcvt.lu.d_b23-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b23-01.S
 
 - test: rv64i_m-fcvt.lu.d_b24-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b24-01.S
   
 - test: rv64i_m-fcvt.lu.d_b27-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b27-01.S
 
 - test: rv64i_m-fcvt.lu.d_b28-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b28-01.S
 
 - test: rv64i_m-fcvt.lu.d_b29-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fcvt.lu.d_b29-01.S
 
 - test: rv64i_m-fmv.d.x_b25-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.d.x_b25-01.S
 
 - test: rv64i_m-fmv.d.x_b26-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.d.x_b26-01.S
 
 - test: rv64i_m-fmv.x.d_b1-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b1-01.S
 
 - test: rv64i_m-fmv.x.d_b22-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b22-01.S
 
 - test: rv64i_m-fmv.x.d_b23-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b23-01.S
 
 - test: rv64i_m-fmv.x.d_b24-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b24-01.S
 
 - test: rv64i_m-fmv.x.d_b27-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b27-01.S
 
 - test: rv64i_m-fmv.x.d_b28-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b28-01.S
 
 - test: rv64i_m-fmv.x.d_b29-01
   iterations: 0
   path_var: TESTS_PATH
-  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-isa-sim/arch_test_target/spike/"
+  gcc_opts: "-DXLEN=64  -DFLEN=64 -DTEST_CASE_1=True -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -I<path_var>/riscv-arch-test/riscv-test-suite/env/ -I<path_var>/riscv-arch-test/riscv-target/spike/"
   asm_tests: <path_var>/riscv-arch-test/riscv-test-suite/rv64i_m/D/src/fmv.x.d_b29-01.S
 


### PR DESCRIPTION
This PR aims at streamlining the handling of termination sequences so that they systematically use the RISC-V HTIF convention of writing an odd value into variable `tohost`.

The termination sequence cannot reliably stop on a `wfi` instruction because in CVA6 its behavior depends on the current privilege level and even the presence of alarms.  Therefore, the write of the termination value into `tohost` is followed by a jump-to-self loop.  As a consequence, the testbench is resposible for detecting the writes into `tohost` and for eventually stopping the simulation when the bit 0 of `tohost` was set.

This PR addresses the code generation side of test termination.  It does so by modifying the patches (`riscv-tests`, `riscv-compliance`), the installation scripts (`riscv-isa-sim`), and by adding minimal, overrideable  startup/termination functions to the custom BSP.

Files changed/added:

* cva6/regress/install-riscv-arch-test.sh: Complain if Spike is not installed alongside its source code.  Copy Spike target definitions to corresponding riscv-arch-test target directory.
* cva6/regress/riscv-compoliance.patch: Update to use write-into-tohost termination.
* cva6/regress/riscv-tests-env.patch: Do not set up ECALL arguments.
* cva6/regress/smoke-tests.sh: Add cv32a60x version of hello_world to check sanity of 32b custom BSP support.
* cva6/tests/custom/common/crt.S (handle_trap): Add default overrideable definition. (_init): Likewise. (exit): Likewise. (_exit): New.
* cva6/tests/testlist_riscv-arch-test-cv32a60x.yaml: Use target definitions copied from Spike tree upon arch-test installation.
* cva6/tests/testlist_riscv-arch-test-cv64a6_imafdc_sv39.yaml: Likewise.(_exit): New.