### PR TITLE
Update installation flow of test infrastructure.

### DIFF
--- a/cva6/regress/install-riscv-arch-test.sh
+++ b/cva6/regress/install-riscv-arch-test.sh
@@ -18,9 +18,9 @@ if ! [ -n "$ARCH_TEST_REPO" ]; then
   ARCH_TEST_BRANCH=main
   ARCH_TEST_HASH=ad04e119a5d846a1c11159786ad3382cf5ad3649
 fi
-echo $ARCH_TEST_REPO
-echo $ARCH_TEST_BRANCH
-echo $ARCH_TEST_HASH
+echo "Repo:  " $ARCH_TEST_REPO
+echo "Branch:" $ARCH_TEST_BRANCH
+echo "Hash:  " $ARCH_TEST_HASH
 
 
 mkdir -p cva6/tests

--- a/cva6/regress/install-riscv-compliance.sh
+++ b/cva6/regress/install-riscv-compliance.sh
@@ -8,21 +8,22 @@
 # Original Author: Jean-Roch COULON - Thales
 
 if ! [ -n "$COMPLIANCE_REPO" ]; then
-  COMPLIANCE_REPO="https://github.com/riscv/riscv-compliance.git"
+  COMPLIANCE_REPO="https://github.com/riscv-non-isa/riscv-arch-test.git"
   COMPLIANCE_BRANCH="main"
   COMPLIANCE_HASH="220e78542da4510e40eac31e31fdd4e77cdae437"
   COMPLIANCE_PATCH="../../../cva6/regress/riscv-compliance.patch"
 fi
-echo $COMPLIANCE_REPO
-echo $COMPLIANCE_BRANCH
-echo $COMPLIANCE_HASH
-echo $COMPLIANCE_PATCH
+echo "Repo:  " $COMPLIANCE_REPO
+echo "Branch:" $COMPLIANCE_BRANCH
+echo "Hash:  " $COMPLIANCE_HASH
+echo "Patch: " $COMPLIANCE_PATCH
 
 mkdir -p cva6/tests
 if ! [ -d cva6/tests/riscv-compliance ]; then
   git clone $COMPLIANCE_REPO -b $COMPLIANCE_BRANCH cva6/tests/riscv-compliance
   cd cva6/tests/riscv-compliance; git checkout $COMPLIANCE_HASH;
   if [ -f "$COMPLIANCE_PATCH" ]; then
+    echo "Applying patch $COMPLIANCE_PATCH in $PWD..."
     git apply $COMPLIANCE_PATCH
   fi
   cd -

--- a/cva6/regress/install-riscv-dv.sh
+++ b/cva6/regress/install-riscv-dv.sh
@@ -26,10 +26,10 @@ if ! [ -n "$DV_REPO" ]; then
   export DV_HASH=96c1ee6f371f2754c45b4831fcab95f6671689d9
   export DV_PATCH=
 fi
-echo $DV_REPO
-echo $DV_BRANCH
-echo $DV_HASH
-echo $DV_PATCH
+echo "Repo:  " $DV_REPO
+echo "Branch:" $DV_BRANCH
+echo "Hash:  " $DV_HASH
+echo "Patch: " $DV_PATCH
 
 mkdir -p cva6/sim
 if ! [ -d cva6/sim/dv ]; then

--- a/cva6/regress/install-riscv-tests.sh
+++ b/cva6/regress/install-riscv-tests.sh
@@ -12,9 +12,9 @@ if ! [ -n "$TESTS_REPO" ]; then
   TESTS_BRANCH="master"
   TESTS_HASH="f92842f91644092960ac7946a61ec2895e543cec"
 fi
-echo $TESTS_REPO
-echo $TESTS_BRANCH
-echo $TESTS_HASH
+echo "Repo:  " $TESTS_REPO
+echo "Branch:" $TESTS_BRANCH
+echo "Hash:  " $TESTS_HASH
 
 mkdir -p cva6/tests
 if ! [ -d cva6/tests/riscv-tests ]; then


### PR DESCRIPTION
Update repository URL of the `riscv-compliance` suite and improve messages describing the actual configuration used to instantiate individual test suites.

* cva6/regress/install-riscv-arch-test.sh: Improve installation messages.
* cva6/regress/install-riscv-compliance.sh: Update repo URL.  Improve installation messages.
* cva6/regress/install-riscv-dv.sh: Improve installation messages.
* cva6/regress/install-riscv-tests.sh: Likewise.