### PR TITLE
Enable Zcmt support in core-v-verif tests

### DIFF
--- a/cv32e40s/env/corev-dv/cv32e40s_zcmt_instr_lib.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_zcmt_instr_lib.sv
@@ -145,12 +145,12 @@ function void corev_zcmt_base_stream::generate_jump_table_instr(int entries);
 
   // Insert random end of sequence target instruction (no flow change) as it is
   // unsafe to return to the instruction after the last in sequence
-  instr = riscv_instr::get_rand_instr(.include_category({LOAD, SHIFT, ARITHMETIC, LOGICAL, COMPARE, SYNCH}));
+  instr = riscv_instr::get_rand_instr(.include_category({SHIFT, ARITHMETIC, LOGICAL, COMPARE, SYNCH}));
   `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
-    (category inside {LOAD, SHIFT, ARITHMETIC, LOGICAL, COMPARE, SYNCH});
+    (category inside {SHIFT, ARITHMETIC, LOGICAL, COMPARE, SYNCH});
       // Note: Several of the constraints could be relaxed, but it turns really complicated
-    !(rd inside {cfg.reserved_regs});
-    !((rd == ZERO) && (instr_name inside {ADDI, C_ADDI}));
+    has_rd == 1 -> !(rd inside {cfg.reserved_regs});
+    has_rd == 0 && has_rs1 -> !(rs1 inside {cfg.reserved_regs});
     , "failed to randomize dummy instruction"
   )
   instr.has_label = 1'b1;

--- a/cv32e40s/tests/cfg/clic_default.yaml
+++ b/cv32e40s/tests/cfg/clic_default.yaml
@@ -24,4 +24,4 @@ plusargs: >
     +enable_zbb_extension=1
     +enable_zbc_extension=1
     +enable_zbs_extension=1
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zca_zcb_zcmp_zicsr_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zca_zcb_zcmp_zcmt_zicsr_zifencei

--- a/cv32e40s/tests/cfg/default.yaml
+++ b/cv32e40s/tests/cfg/default.yaml
@@ -190,4 +190,4 @@ plusargs: >
     #+pmp_randomize=0
     #+pmp_num_regions=64
     #+pmp_granularity=0
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_1.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_1.yaml
@@ -184,4 +184,4 @@ ovpsim: >
    #--trace
    #--tracechange
    #--trace --tracechange --traceshowicount --monitornetschange
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_2.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_2.yaml
@@ -180,4 +180,4 @@ ovpsim: >
    --override cpu/mask_pmpcfg13=0x00000000
    --override cpu/mask_pmpcfg14=0x00000000
    --override cpu/mask_pmpcfg15=0x00000000
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_3.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_3.yaml
@@ -183,4 +183,4 @@ ovpsim: >
    --override cpu/mask_pmpcfg13=0x00000000
    --override cpu/mask_pmpcfg14=0x00000000
    --override cpu/mask_pmpcfg15=0x00000000
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_4.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_4.yaml
@@ -184,4 +184,4 @@ ovpsim: >
    --override cpu/mask_pmpcfg13=0x00000000
    --override cpu/mask_pmpcfg14=0x00000000
    --override cpu/mask_pmpcfg15=0x00000000
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/cfg/pma_test_cfg_5.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_5.yaml
@@ -183,4 +183,4 @@ ovpsim: >
    --override cpu/mask_pmpcfg13=0x00000000
    --override cpu/mask_pmpcfg14=0x00000000
    --override cpu/mask_pmpcfg15=0x00000000
-cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zifencei
+cv_sw_march: rv32im_zba1p00_zbb1p00_zbc1p00_zbs1p00_zicsr_zca_zcb_zcmp_zcmt_zifencei

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_data_obi_err/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_data_obi_err/corev-dv.yaml
@@ -16,6 +16,7 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +directed_instr_8=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_9=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
     +randomize_csr=1
     +boot_mode=m
@@ -27,4 +28,3 @@ plusargs: >
     +set_dcsr_ebreak=0
     +enable_debug_single_step=1
     +gen_debug_section=1
-    #+directed_instr_9=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_data_obi_err_debug/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_data_obi_err_debug/corev-dv.yaml
@@ -14,6 +14,7 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +directed_instr_8=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_9=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
     +randomize_csr=1
     +boot_mode=m
@@ -25,5 +26,3 @@ plusargs: >
     +set_dcsr_ebreak=0
     +enable_debug_single_step=0
     +gen_debug_section=1
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_9=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_illegal_instr_test/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_illegal_instr_test/corev-dv.yaml
@@ -13,8 +13,7 @@ plusargs: >
     +directed_instr_5=riscv_mem_region_stress_test,4
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_8=corev_zcmt_base_stream,4
     +illegal_instr_ratio=10
     +hint_instr_ratio=5
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_8=corev_zcmt_base_stream,4
 

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_instr_long_stall/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_instr_long_stall/corev-dv.yaml
@@ -15,6 +15,5 @@ plusargs: >
     +directed_instr_5=riscv_mem_region_stress_test,4
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_8=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_8=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_instr_obi_err/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_instr_obi_err/corev-dv.yaml
@@ -16,6 +16,7 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +directed_instr_8=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_9=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
     +randomize_csr=1
     +boot_mode=m
@@ -27,5 +28,3 @@ plusargs: >
     +set_dcsr_ebreak=0
     +enable_debug_single_step=1
     +gen_debug_section=1
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_9=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_instr_obi_err_debug/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_instr_obi_err_debug/corev-dv.yaml
@@ -14,6 +14,7 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +directed_instr_8=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_9=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
     +randomize_csr=1
     +boot_mode=m
@@ -26,5 +27,3 @@ plusargs: >
     +enable_debug_single_step=1
     +gen_debug_section=1
     +exit_on_debug_exception=1
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_9=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_instr_test/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_instr_test/corev-dv.yaml
@@ -16,6 +16,5 @@ plusargs: >
     +directed_instr_6=riscv_jal_instr,4
     +directed_instr_7=corev_xori_not_instr,1
     +directed_instr_8=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_9=corev_zcmt_base_stream,4
     +hint_instr_ratio=2
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_9=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_interrupt/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_interrupt/corev-dv.yaml
@@ -12,11 +12,10 @@ plusargs: >
     +directed_instr_4=riscv_jal_instr,3
     +directed_instr_5=corev_interrupt_csr_instr_stream,3
     +directed_instr_6=corev_zcmp_pushpop_base_stream,4
+    +directed_instr_7=corev_zcmt_base_stream,4
     +no_fence=0
     +enable_interrupt=1
     +enable_fast_interrupt_handler=1
     +randomize_csr=1
     +boot_mode=m
     +no_csr_instr=1
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_7=corev_zcmt_base_stream,4

--- a/cv32e40s/tests/programs/corev-dv/corev_rand_jump_stress_test/corev-dv.yaml
+++ b/cv32e40s/tests/programs/corev-dv/corev_rand_jump_stress_test/corev-dv.yaml
@@ -11,6 +11,5 @@ plusargs: >
     +num_of_sub_program=5
     +directed_instr_1=riscv_jal_instr,20
     +directed_instr_2=corev_zcmp_pushpop_base_stream,20
-    # TODO enable when zcmt toolchain issues are resolved
-    #+directed_instr_3=corev_zcmt_base_stream,20
+    +directed_instr_3=corev_zcmt_base_stream,20
 


### PR DESCRIPTION
This PR introduces zcmt to riscv-dv randomtesting and enables zcmt compiler flags for all? relevant configurations. 

Note: This _requires_ updated compiler support, tested with: corev-openhw-gcc-centos7-20230310
