### PR TITLE
Updated ci_check script to take yaml cfgs into account

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -71,8 +71,14 @@
       {
         "name":     "uvmt_cv32e40s",
         "image":    "gcr.io/openhwgroup-metrics-project/openhwgroup-toolchain:20220328.14.0-dtc.66",
-        "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
-        "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
+        "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim CFG=default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim CFG=default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
+      },
+      {
+        "name":     "uvmt_cv32e40s_clic",
+        "image":    "gcr.io/openhwgroup-metrics-project/openhwgroup-toolchain:20220328.14.0-dtc.66",
+        "cmd":      "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=clic_default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim CFG=clic_default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e40s/sim/uvmt; make corev-dv CV_CORE=cv32e40s SIMULATOR=dsim CFG=clic_default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40s SIMULATOR=dsim CFG=clic_default DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
       },
       {
         "name":     "uvmt_cv32e40s_num_mhpmcounter_29",
@@ -307,7 +313,7 @@
       "verbose":     "true",
       "tests": {
         "resultsDir": "/mux-flow/build/results",
-        "builds":    ["uvmt_cv32e40s", "uvmt_cv32e40s_pma_1", "uvmt_cv32e40s_pma_2" ],
+        "builds":    ["uvmt_cv32e40s", "uvmt_cv32e40s_clic", "uvmt_cv32e40s_pma_1", "uvmt_cv32e40s_pma_2" ],
         "listCmd":   "/mux-flow/build/repo/bin/cv_regress --core=cv32e40s --file=cv32e40s_ci_check --metrics --outfile=/mux-flow/build/repo/cv32e40s_ci_check.json",
         "listFile":  "/mux-flow/build/repo/cv32e40s_ci_check.json"
       }

--- a/bin/ci_check
+++ b/bin/ci_check
@@ -298,7 +298,7 @@ if (uvm):
                    if (debug):
                        print (json.dumps(list_dict, indent=2, sort_keys=True))
             for key in list_dict:
-                if (key['name'] != 'uvmt_{}'.format(args.core.lower())):
+                if ('uvmt_{}'.format(args.core.lower()) not in key['name'] ):
                     continue
                 build_cmd_list = (key['cmd']).split()
                 build_cmd = ' '.join(build_cmd_list[0:-1])
@@ -340,61 +340,71 @@ if (uvm):
                     print('Cannot parse listCmd: {}'.format(item['tests']['listCmd']))
                     exit(1)
                 lists_dict = load_regress_yaml(m.group(1))['tests']
+                cfg_dict = load_regress_yaml(m.group(1))['builds']
 
                 if (debug):
                     pprint.pprint(lists_dict)
 
                 num_tests = 0
                 for key in lists_dict.values():
-                    run_cmd = key['cmd']
-
-                    if run_cmd == '':
-                        print ('ERROR: cannot find run command in .metrics.json')
-                        exit(1)
-
                     try:
-                        if key['num'] > 1:
-                            num = key['num']
-                    except KeyError:
-                        num = 1
+                        if (type(key['builds']) is not list):
+                            key['builds'] = [key['builds']]
+                    except:
+                        key['builds'] = ['default']
+                    for build in key['builds']:
+                        cfg = (load_regress_yaml(m.group(1))['builds'][build]['cfg'])
+                        run_cmd = key['cmd']
 
-                    # The iss command-line switch takes precedence,
-                    # Otherwise use what is in the regression yaml if defined
-                    # Otherwise set to 1
-                    if args.iss != None:
-                        iss = int(args.iss)
-                    else:
+                        if run_cmd == '':
+                            print ('ERROR: cannot find run command in .metrics.json')
+                            exit(1)
+
                         try:
-                            iss = key['iss']
+                            if key['num'] > 1:
+                                num = key['num']
                         except KeyError:
-                            iss = 1
+                            num = 1
 
-                    for n in range(num):
-                        # Add directory
-                        full_run_cmd = 'cd {}; {}'.format(key['dir'], run_cmd)
-                        # Add SIMULATOR
-                        full_run_cmd += ' SIMULATOR={}'.format(svtool)
-                        # Add indices
-                        full_run_cmd += ' GEN_START_INDEX={} RUN_INDEX={}'.format(n, n)
-                        # Add ISS
-                        full_run_cmd += ' USE_ISS={}'.format('YES' if iss else 'NO')
-
-                        # Only DSIM can run corev-dv (riscv-dv) at present
-                        if ( svtool == 'dsim' or svtool == 'xrun' or svtool == 'vsim' or svtool == 'riviera' or svtool == 'vcs'):
-                            num_tests+=1
-                            if (prcmd or debug):
-                                print(full_run_cmd)
-                            else:
-                                os.system(full_run_cmd)
-                                os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
+                        # The iss command-line switch takes precedence,
+                        # Otherwise use what is in the regression yaml if defined
+                        # Otherwise set to 1
+                        if args.iss != None:
+                            iss = int(args.iss)
                         else:
-                            num_tests+=1
-                            if not ( re.search('corev_', full_run_cmd) ):
+                            try:
+                                iss = key['iss']
+                            except KeyError:
+                                iss = 1
+
+                        for n in range(num):
+                            # Add directory
+                            full_run_cmd = 'cd {}; {}'.format(key['dir'], run_cmd)
+                            # Add cfg
+                            if (cfg is not None):
+                                full_run_cmd += ' CFG={}'.format(cfg)
+                            # Add SIMULATOR
+                            full_run_cmd += ' SIMULATOR={}'.format(svtool)
+                            # Add indices
+                            full_run_cmd += ' GEN_START_INDEX={} RUN_INDEX={}'.format(n, n)
+                            # Add ISS
+                            full_run_cmd += ' USE_ISS={}'.format('YES' if iss else 'NO')
+
+                            if ( svtool == 'dsim' or svtool == 'xrun' or svtool == 'vsim' or svtool == 'riviera' or svtool == 'vcs'):
+                                num_tests+=1
                                 if (prcmd or debug):
                                     print(full_run_cmd)
                                 else:
                                     os.system(full_run_cmd)
                                     os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
+                            else:
+                                num_tests+=1
+                                if not ( re.search('corev_', full_run_cmd) ):
+                                    if (prcmd or debug):
+                                        print(full_run_cmd)
+                                    else:
+                                        os.system(full_run_cmd)
+                                        os.chdir(topdir)      # cmd in .metrics.json assumes all cmds start from here
 
 else:  # if(uvm):
     print ('Not running UVM CI regression')

--- a/cv32e40s/regress/cv32e40s_ci_check.yaml
+++ b/cv32e40s/regress/cv32e40s_ci_check.yaml
@@ -5,18 +5,22 @@ description: Commit sanity for the cv32e40s
 builds:
   clone_riscv-dv:
     cmd: make clone_riscv-dv
+    cfg: default
     dir: cv32e40s/sim/uvmt
 
   clone_svlib:
     cmd: make clone_svlib
+    cfg: default
     dir: cv32e40s/sim/uvmt
 
   clone_cv_core_rtl:
     cmd: make clone_cv_core_rtl
+    cfg: default
     dir: cv32e40s/sim/uvmt
 
   uvmt_cv32e40s:
     cmd: make comp_corev-dv comp
+    cfg: default
     dir: cv32e40s/sim/uvmt
 
   uvmt_cv32e40s_clic:
@@ -36,45 +40,46 @@ builds:
 
 tests:
   hello-world:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     description: UVM Hello World Test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hello-world
 
   clic:
-    build: uvmt_cv32e40s_clic
+    builds: uvmt_cv32e40s_clic
     description: CLIC interrupt test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=clic
 
   corev_rand_interrupt:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     description: Interrupt random test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
     num: 2
 
   illegal:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal
 
   debug_test2:
-    builds:
+    builds: 
       - uvmt_cv32e40s
       - uvmt_cv32e40s_clic
+    description: Debug directed test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test2
     makearg: USER_RUN_FLAGS=+rand_stall_obi_disable
 
   csr_instructions:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     description: CSR Instruction Test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   riscv_arithmetic_basic_test_0:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     description: Static riscv-dv arithmetic test 0
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_0
@@ -100,7 +105,7 @@ tests:
     num: 1
 
   corev_rand_jump_stress_test:
-    build: uvmt_cv32e40s
+    builds: uvmt_cv32e40s
     description: Generated corev-dv jump stress test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_jump_stress_test

--- a/cv32e40s/regress/cv32e40s_ci_check.yaml
+++ b/cv32e40s/regress/cv32e40s_ci_check.yaml
@@ -40,72 +40,64 @@ builds:
 
 tests:
   hello-world:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     description: UVM Hello World Test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hello-world
 
   clic:
-    builds: uvmt_cv32e40s_clic
+    builds: [ uvmt_cv32e40s_clic ]
     description: CLIC interrupt test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=clic
 
   corev_rand_interrupt:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     description: Interrupt random test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
     num: 2
 
   illegal:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal
 
   debug_test2:
-    builds: 
-      - uvmt_cv32e40s
-      - uvmt_cv32e40s_clic
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic ]
     description: Debug directed test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test2
     makearg: USER_RUN_FLAGS=+rand_stall_obi_disable
 
   csr_instructions:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     description: CSR Instruction Test
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   riscv_arithmetic_basic_test_0:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     description: Static riscv-dv arithmetic test 0
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_0
 
   corev_rand_arithmetic_base_test:
-    builds:
-      - uvmt_cv32e40s
-      - uvmt_cv32e40s_pma_1
-      - uvmt_cv32e40s_pma_2
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2 ]
     description: Generated corev-dv random arithmetic test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_arithmetic_base_test
     num: 1
 
   corev_rand_instr_test:
-    builds:
-      - uvmt_cv32e40s
-      - uvmt_cv32e40s_pma_1
-      - uvmt_cv32e40s_pma_2
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2 ]
     description: Generated corev-dv random instruction test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_test
     num: 1
 
   corev_rand_jump_stress_test:
-    builds: uvmt_cv32e40s
+    builds: [ uvmt_cv32e40s ]
     description: Generated corev-dv jump stress test
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_jump_stress_test


### PR DESCRIPTION
ci_check only ran with the default configuration, and did not take yaml-specified builds into account. 
This should be working properly with this commit

- Caveat/TODO: This commit will build all the configurations specified in the metrics yaml, some of which will fail. Scripts should be updated to only build the necessary ones. The failing non-related builds have no functional impact on ci_check results. 