### PR TITLE
Added signal aliases the rvfi helper functions

### DIFF
--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
@@ -100,7 +100,7 @@ module uvmt_cv32e40s_support_logic
               end else begin
                   first_debug_ins_flag <= 0;
               end
-              if(rvfi.is_dret() && !rvfi.rvfi_trap.trap) begin
+              if(rvfi.is_dret && !rvfi.rvfi_trap.trap) begin
                   ins_was_dret <= 1;
               end
           end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -228,7 +228,7 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dpc_dbg_step_nmi;
         $rose(support_if.first_debug_ins) &&
-        rvfi.is_nmi() &&
+        rvfi.is_nmi &&
         (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_STEP)
         |=>
         dpc_rdata_q == dpc_dbg_step_nmi;
@@ -242,7 +242,7 @@ module uvmt_cv32e40s_debug_assert
         $rose(support_if.first_debug_ins) &&
         rvfi.rvfi_intr.intr &&
         rvfi.rvfi_intr.interrupt &&
-        !rvfi.is_nmi() &&
+        !rvfi.is_nmi &&
         (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_STEP)
         |=>
         dpc_rdata_q == dpc_dbg_step_irq;
@@ -285,7 +285,7 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dpc_dbg_haltreq_nmi;
         $rose(support_if.first_debug_ins) &&
-        rvfi.is_nmi() &&
+        rvfi.is_nmi &&
         (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_HALTREQ)
         |=>
         dpc_rdata_q == dpc_dbg_haltreq_nmi;
@@ -299,7 +299,7 @@ module uvmt_cv32e40s_debug_assert
         $rose(support_if.first_debug_ins) &&
         rvfi.rvfi_intr.intr &&
         rvfi.rvfi_intr.interrupt &&
-        !rvfi.is_nmi() &&
+        !rvfi.is_nmi &&
         (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_HALTREQ)
         |=>
         dpc_rdata_q == dpc_dbg_haltreq_irq;
@@ -340,9 +340,9 @@ module uvmt_cv32e40s_debug_assert
 
     // ebreak / c.ebreak without dcsr.ebreak[prv] results in exception at mtvec
     property p_ebreak_mmode_exception;
-        rvfi.is_ebreak() &&
+        rvfi.is_ebreak &&
         !rvfi.rvfi_dbg_mode &&
-        rvfi.is_mmode() &&
+        rvfi.is_mmode &&
         !csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKM_POS]
         |-> rvfi.rvfi_trap.trap && rvfi.rvfi_trap.exception
             or
@@ -350,9 +350,9 @@ module uvmt_cv32e40s_debug_assert
     endproperty
 
     property p_ebreak_umode_exception;
-        rvfi.is_ebreak() &&
+        rvfi.is_ebreak &&
         !rvfi.rvfi_dbg_mode &&
-        rvfi.is_umode() &&
+        rvfi.is_umode &&
         !csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKU_POS]
         |-> rvfi.rvfi_trap.trap && rvfi.rvfi_trap.exception
             or
@@ -368,7 +368,7 @@ module uvmt_cv32e40s_debug_assert
 
     // ebreak and cebreak during debug mode results in relaunch
     property p_ebreak_during_debug_mode;
-        rvfi.is_ebreak() &&
+        rvfi.is_ebreak &&
         rvfi.rvfi_trap.debug_cause == cv32e40s_pkg::DBG_CAUSE_EBREAK && //The ebreak is actually taken
         rvfi.rvfi_dbg_mode
         ##1 rvfi.rvfi_valid[->1]
@@ -383,10 +383,10 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag,$sformatf("Debug mode not restarted after ebreak"));
 
     cov_cebreak_dbg : cover property(
-        rvfi.is_ebreak_compr() && rvfi.rvfi_dbg_mode
+        rvfi.is_ebreak_compr && rvfi.rvfi_dbg_mode
     );
     cov_ebreak_dbg : cover property(
-        rvfi.is_ebreak_noncompr() && rvfi.rvfi_dbg_mode
+        rvfi.is_ebreak_noncompr && rvfi.rvfi_dbg_mode
     );
 
 
@@ -496,7 +496,7 @@ module uvmt_cv32e40s_debug_assert
         rvfi.rvfi_valid && //valid
         !rvfi.rvfi_dbg_mode && //not in dbg
         csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && // step set
-        !(rvfi.is_dbg_trg() || exception_trigger_hit) && // not trigger
+        !(rvfi.is_dbg_trg || exception_trigger_hit) && // not trigger
         rvfi.rvfi_trap.exception // exception
         ##1 rvfi.rvfi_valid[->1]
         |->
@@ -511,7 +511,7 @@ module uvmt_cv32e40s_debug_assert
 
     // Trigger during single step
     property p_single_step_trigger;
-        (rvfi.is_dbg_trg() || exception_trigger_hit) &&
+        (rvfi.is_dbg_trg || exception_trigger_hit) &&
         !rvfi.rvfi_dbg_mode &&
         csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]
         ##1 rvfi.rvfi_valid[->1]
@@ -554,7 +554,7 @@ module uvmt_cv32e40s_debug_assert
 
 
     property p_mumode_dret;
-        rvfi.is_dret() && !rvfi.rvfi_dbg_mode
+        rvfi.is_dret && !rvfi.rvfi_dbg_mode
         |-> rvfi.rvfi_trap;
     endproperty
 
@@ -566,7 +566,7 @@ module uvmt_cv32e40s_debug_assert
 
     property p_dmode_dret_pc;
         int dpc;
-        (rvfi.is_dret() && rvfi.rvfi_dbg_mode,
+        (rvfi.is_dret && rvfi.rvfi_dbg_mode,
          dpc = csr_dpc.rvfi_csr_rdata)
         ##1
         rvfi.rvfi_valid[->1]
@@ -583,11 +583,11 @@ module uvmt_cv32e40s_debug_assert
     //TODO:MT fails due to irregular behaviour in RVFI. Await 40S bug issue 414 before changing
     property p_dmode_dret_pc_int;
         int dpc;
-        (rvfi.is_dret() && rvfi.rvfi_dbg_mode,
+        (rvfi.is_dret && rvfi.rvfi_dbg_mode,
          dpc = csr_dpc.rvfi_csr_rdata)
         ##1
         rvfi.rvfi_valid[->1]
-        ##0 (rvfi.rvfi_intr && !rvfi.rvfi_dbg_mode && !rvfi.is_nmi())
+        ##0 (rvfi.rvfi_intr && !rvfi.rvfi_dbg_mode && !rvfi.is_nmi)
         |->
         csr_mepc.rvfi_csr_rdata == dpc;
     endproperty
@@ -604,7 +604,7 @@ module uvmt_cv32e40s_debug_assert
          dpc = csr_dpc.rvfi_csr_rdata)
         ##1
         rvfi.rvfi_valid[->1]
-        ##0 (!rvfi.rvfi_dbg_mode && rvfi.is_nmi())
+        ##0 (!rvfi.rvfi_dbg_mode && rvfi.is_nmi)
         ##0 (csr_mepc.rvfi_csr_rdata == dpc);
     endproperty
 
@@ -619,7 +619,7 @@ module uvmt_cv32e40s_debug_assert
          dpc = csr_dpc.rvfi_csr_rdata)
         ##1
         rvfi.rvfi_valid[->1]
-        ##0 (!rvfi.rvfi_dbg_mode && rvfi.is_nmi())
+        ##0 (!rvfi.rvfi_dbg_mode && rvfi.is_nmi)
         ##0 (csr_mepc.rvfi_csr_rdata != dpc);
     endproperty
 
@@ -711,7 +711,7 @@ module uvmt_cv32e40s_debug_assert
     // step vs nmi
     // check that stepie disables nmi
     property p_stepie_irq_dis;
-        rvfi.is_dret() && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
+        rvfi.is_dret && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         ##1 rvfi.rvfi_valid[->1]
         |->
         !(rvfi.rvfi_intr.intr && rvfi.rvfi_intr.interrupt);
@@ -721,7 +721,7 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "Single stepping should ignore all interrupts if stepie is set");
 
     cov_step_stepie_nmi : cover property (
-        rvfi.is_dret()
+        rvfi.is_dret
         && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]
         && !csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         && csr_dcsr.rvfi_csr_rdata[DCSR_NMIP_POS]
@@ -732,7 +732,7 @@ module uvmt_cv32e40s_debug_assert
     // if the next instruction after a single step dret is in debug mode,
     // a trap entry has to be the cause.
     property p_step_trap_handler_entry;
-        (rvfi.is_dret() &&
+        (rvfi.is_dret &&
         csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] &&
         csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS])
         ##1 rvfi.rvfi_valid[->1]
@@ -745,7 +745,7 @@ module uvmt_cv32e40s_debug_assert
         else `uvm_error(info_tag, "single stepping remained in debug mode illegally");
 
     property p_step_no_trap;
-        rvfi.is_dret() && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
+        rvfi.is_dret && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS] && csr_dcsr.rvfi_csr_rdata[DCSR_STEPIE_POS]
         ##1 rvfi.rvfi_valid[->1]
         ##0 !rvfi.rvfi_dbg_mode
         |->
@@ -857,7 +857,7 @@ module uvmt_cv32e40s_debug_assert
             pc_at_dbg_req <= 32'h0;
         end else begin
             //NMI has highest priority for dpc
-            if(rvfi.is_nmi() && rvfi.rvfi_dbg_mode) begin
+            if(rvfi.is_nmi && rvfi.rvfi_dbg_mode) begin
                 if (csr_mtvec.rvfi_csr_rdata[1:0] == 1) begin // vectored CLINT
                     pc_at_dbg_req <= mtvec_addr+'h3C;
                 end else begin //unvectored CLINT
@@ -878,7 +878,7 @@ module uvmt_cv32e40s_debug_assert
             end else if (exception_trigger_hit) begin
                 pc_at_dbg_req <= rvfi.rvfi_pc_wdata;
 
-            end else if ((rvfi.is_ebreak() && ebreak_allowed)|| rvfi.is_dbg_trg()) begin
+            end else if ((rvfi.is_ebreak && ebreak_allowed)|| rvfi.is_dbg_trg) begin
                 pc_at_dbg_req <= rvfi.rvfi_pc_rdata;
 
             end else if (support_if.first_fetch) begin
@@ -895,7 +895,7 @@ module uvmt_cv32e40s_debug_assert
         if(!cov_assert_if.rst_ni) begin
             dpc_dbg_ebreak <= 32'h0;
         end else begin
-            if (rvfi.is_ebreak()) begin
+            if (rvfi.is_ebreak) begin
                 dpc_dbg_ebreak <=  rvfi.rvfi_pc_rdata;
             end
         end
@@ -905,7 +905,7 @@ module uvmt_cv32e40s_debug_assert
         if(!cov_assert_if.rst_ni) begin
             dpc_dbg_trg <= 32'h0;
         end else begin
-            if (rvfi.is_dbg_trg()) begin
+            if (rvfi.is_dbg_trg) begin
                 dpc_dbg_trg <=  rvfi.rvfi_pc_rdata;
             end else if (exception_trigger_hit) begin
                 dpc_dbg_trg <=  rvfi.rvfi_pc_wdata;
@@ -925,7 +925,7 @@ module uvmt_cv32e40s_debug_assert
             dpc_dbg_haltreq_nmi     <= 32'h0;
         end else begin
             //NMI has highest priority for dpc
-            if(rvfi.is_nmi() && rvfi.rvfi_dbg_mode) begin
+            if(rvfi.is_nmi && rvfi.rvfi_dbg_mode) begin
                 if (csr_mtvec.rvfi_csr_rdata[1:0] == 1) begin // vectored CLINT
                     dpc_dbg_step        <= mtvec_addr+'h3C;
                     dpc_dbg_step_nmi    <= mtvec_addr+'h3C;
@@ -1034,13 +1034,13 @@ module uvmt_cv32e40s_debug_assert
         if( !cov_assert_if.rst_ni) begin
             debug_cause_pri <= 3'b000;
         end else begin  //TODO:MT placeholder for new trigger support logic, this only works with 1 trigger.
-            if (rvfi.is_dbg_trg() || exception_trigger_hit) begin
+            if (rvfi.is_dbg_trg || exception_trigger_hit) begin
                 debug_cause_pri <= cv32e40s_pkg::DBG_CAUSE_TRIGGER;
-            end else if(rvfi.is_ebreak() && ebreak_allowed) begin
+            end else if(rvfi.is_ebreak && ebreak_allowed) begin
                 debug_cause_pri <= cv32e40s_pkg::DBG_CAUSE_EBREAK;
             end else if(rvfi.rvfi_valid && csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) begin  // "step"
                 debug_cause_pri <= cv32e40s_pkg::DBG_CAUSE_STEP;
-            end else if(rvfi.is_dret() && !csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) begin
+            end else if(rvfi.is_dret && !csr_dcsr.rvfi_csr_rdata[DCSR_STEP_POS]) begin
                 debug_cause_pri <= 3'b000;  // (not a cause)
             end
         end
@@ -1049,9 +1049,9 @@ module uvmt_cv32e40s_debug_assert
     ////TODO:MT placeholder for new trigger support logic, this only works with 1 trigger.
     assign exception_trigger_hit =  (rvfi.rvfi_valid && rvfi.rvfi_trap.exception && csr_tdata1.rvfi_csr_rdata[31:28] == 5) &&
                                     (csr_tdata2.rvfi_csr_rdata[rvfi.rvfi_trap.exception_cause] == 1) &&
-                                    ((rvfi.is_mmode() && csr_tdata1.rvfi_csr_rdata[9]) ||
-                                    (rvfi.is_umode() && csr_tdata1.rvfi_csr_rdata[6]));
-    assign ebreak_allowed = (rvfi.is_mmode() && csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKM_POS]) || (rvfi.is_umode() && csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKU_POS]);
+                                    ((rvfi.is_mmode && csr_tdata1.rvfi_csr_rdata[9]) ||
+                                    (rvfi.is_umode && csr_tdata1.rvfi_csr_rdata[6]));
+    assign ebreak_allowed = (rvfi.is_mmode && csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKM_POS]) || (rvfi.is_umode && csr_dcsr.rvfi_csr_rdata[DCSR_EBREAKU_POS]);
 
 
     // count the number of rvalids while debug_req is stable

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_assert.sv
@@ -143,7 +143,7 @@ module  uvmt_cv32e40s_pma_assert
   // After PMA-deny, subsequent accesses are also suppressed  (vplan:"Multi-memory operation instructions")
 
   a_failure_denies_subsequents: assert property (
-    rvfi_instr_if.is_pma_instr_fault()
+    rvfi_instr_if.is_pma_instr_fault
     |->
     (rvfi_instr_if.rvfi_mem_wmask == '0)
     //TODO:ERROR:silabs-robin Zcmp should be able to break this. RVFI bug.

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -165,16 +165,7 @@ module uvmt_cv32e40s_tb;
                                                                    .rvfi_mem_rdata(rvfi_i.rvfi_mem_rdata[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN*0    +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN]),
                                                                    .rvfi_mem_rmask(rvfi_i.rvfi_mem_rmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8]),
                                                                    .rvfi_mem_wdata(rvfi_i.rvfi_mem_wdata[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN*0    +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN]),
-                                                                   .rvfi_mem_wmask(rvfi_i.rvfi_mem_wmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8]),
-                                                                   .gpr_rdata_array(),
-                                                                   .gpr_rmask_array(),
-                                                                   .gpr_wdata_array(),
-                                                                   .gpr_wmask_array(),
-                                                                   .mem_addr_array(),
-                                                                   .mem_rdata_array(),
-                                                                   .mem_rmask_array(),
-                                                                   .mem_wdata_array(),
-                                                                   .mem_wmask_array()
+                                                                   .rvfi_mem_wmask(rvfi_i.rvfi_mem_wmask[uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8*0  +:uvma_rvfi_pkg::NMEM*uvme_cv32e40s_pkg::XLEN/8])
                                                                    );
 
   // RVFI CSR binds

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -981,75 +981,75 @@ module uvmt_cv32e40s_triggers_assert_cov
     for (genvar t = 0; t < uvmt_cv32e40s_pkg::CORE_PARAM_DBG_NUM_TRIGGERS; t++) begin
 
       //Execute:
-      assign exe_eq_m_hit[t]  = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.rvfi_pc_rdata, t);
-      assign exe_eq_u_hit[t]  = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode() && eq_tdata2(rvfi_if.rvfi_pc_rdata, t);
-      assign exe_geq_m_hit[t] = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.rvfi_pc_rdata, t);
-      assign exe_geq_u_hit[t] = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode() && geq_tdata2(rvfi_if.rvfi_pc_rdata, t);
-      assign exe_l_m_hit[t]   = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode() && l_tdata2(rvfi_if.rvfi_pc_rdata, t);
-      assign exe_l_u_hit[t]   = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode() && l_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_eq_m_hit[t]  = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode && eq_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_eq_u_hit[t]  = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode && eq_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_geq_m_hit[t] = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode && geq_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_geq_u_hit[t] = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode && geq_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_l_m_hit[t]   = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode && l_tdata2(rvfi_if.rvfi_pc_rdata, t);
+      assign exe_l_u_hit[t]   = set_tdata1_mctrl_state(t, EXECUTE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode && l_tdata2(rvfi_if.rvfi_pc_rdata, t);
 
       //Make sure we check all possible memory entries:
       for (genvar m = 0; m < NMEM; m++) begin
         //Load:
         //Byte 0:
-        assign load_b0_eq_m_hit[t][m]   =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_rmask_byte(m, 0);
-        assign load_b0_eq_u_hit[t][m]   =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_rmask_byte(m, 0);
-        assign load_b0_geq_m_hit[t][m]  =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_rmask_byte(m, 0);
-        assign load_b0_geq_u_hit[t][m]  =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_rmask_byte(m, 0);
-        assign load_b0_l_m_hit[t][m]    =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_rmask_byte(m, 0);
-        assign load_b0_l_u_hit[t][m]    =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_rmask_byte(m, 0);
+        assign load_b0_eq_m_hit[t][m]   =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_rmask_byte(m, 0);
+        assign load_b0_eq_u_hit[t][m]   =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_rmask_byte(m, 0);
+        assign load_b0_geq_m_hit[t][m]  =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_rmask_byte(m, 0);
+        assign load_b0_geq_u_hit[t][m]  =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_rmask_byte(m, 0);
+        assign load_b0_l_m_hit[t][m]    =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_rmask_byte(m, 0);
+        assign load_b0_l_u_hit[t][m]    =  set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_rmask_byte(m, 0);
 
         //Byte +1:
-        assign load_b1_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_rmask_byte(m, 1);
-        assign load_b1_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_rmask_byte(m, 1);
-        assign load_b1_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_rmask_byte(m, 1);
-        assign load_b1_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_rmask_byte(m, 1);
-        assign load_b1_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_rmask_byte(m, 1);
-        assign load_b1_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_rmask_byte(m, 1);
+        assign load_b1_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_rmask_byte(m, 1);
+        assign load_b1_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_rmask_byte(m, 1);
+        assign load_b1_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_rmask_byte(m, 1);
+        assign load_b1_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_rmask_byte(m, 1);
+        assign load_b1_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_rmask_byte(m, 1);
+        assign load_b1_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_rmask_byte(m, 1);
         //Byte +2:
-        assign load_b2_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_rmask_byte(m, 2);
-        assign load_b2_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_rmask_byte(m, 2);
-        assign load_b2_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_rmask_byte(m, 2);
-        assign load_b2_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_rmask_byte(m, 2);
-        assign load_b2_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_rmask_byte(m, 2);
-        assign load_b2_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_rmask_byte(m, 2);
+        assign load_b2_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_rmask_byte(m, 2);
+        assign load_b2_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_rmask_byte(m, 2);
+        assign load_b2_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_rmask_byte(m, 2);
+        assign load_b2_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_rmask_byte(m, 2);
+        assign load_b2_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_rmask_byte(m, 2);
+        assign load_b2_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_rmask_byte(m, 2);
         //Byte +3:
-        assign load_b3_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_rmask_byte(m, 3);
-        assign load_b3_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_rmask_byte(m, 3);
-        assign load_b3_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_rmask_byte(m, 3);
-        assign load_b3_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_rmask_byte(m, 3);
-        assign load_b3_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_rmask_byte(m, 3);
-        assign load_b3_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_rmask_byte(m, 3);
+        assign load_b3_eq_m_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, M_MODE)             && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_rmask_byte(m, 3);
+        assign load_b3_eq_u_hit[t][m]   = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_EQUAL, U_MODE)             && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_rmask_byte(m, 3);
+        assign load_b3_geq_m_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE)  && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_rmask_byte(m, 3);
+        assign load_b3_geq_u_hit[t][m]  = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE)  && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_rmask_byte(m, 3);
+        assign load_b3_l_m_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, M_MODE)            && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_rmask_byte(m, 3);
+        assign load_b3_l_u_hit[t][m]    = set_tdata1_mctrl_state(t, LOAD, MATCH_WHEN_LESSER, U_MODE)            && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_rmask_byte(m, 3);
 
         //Store:
         //Byte 0:
-        assign store_b0_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_wmask_byte(m, 0);
-        assign store_b0_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_wmask_byte(m, 0);
-        assign store_b0_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_wmask_byte(m, 0);
-        assign store_b0_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_wmask_byte(m, 0);
-        assign store_b0_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_wmask_byte(m, 0);
-        assign store_b0_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_wmask_byte(m, 0);
+        assign store_b0_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_wmask_byte(m, 0);
+        assign store_b0_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m), t)  && get_mem_wmask_byte(m, 0);
+        assign store_b0_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_wmask_byte(m, 0);
+        assign store_b0_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m), t) && get_mem_wmask_byte(m, 0);
+        assign store_b0_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_wmask_byte(m, 0);
+        assign store_b0_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m), t)   && get_mem_wmask_byte(m, 0);
         //Byte +1:
-        assign store_b1_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_wmask_byte(m, 1);
-        assign store_b1_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_wmask_byte(m, 1);
-        assign store_b1_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_wmask_byte(m, 1);
-        assign store_b1_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_wmask_byte(m, 1);
-        assign store_b1_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_wmask_byte(m, 1);
-        assign store_b1_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_wmask_byte(m, 1);
+        assign store_b1_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_wmask_byte(m, 1);
+        assign store_b1_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+1, t)  && get_mem_wmask_byte(m, 1);
+        assign store_b1_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_wmask_byte(m, 1);
+        assign store_b1_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+1, t) && get_mem_wmask_byte(m, 1);
+        assign store_b1_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_wmask_byte(m, 1);
+        assign store_b1_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+1, t)   && get_mem_wmask_byte(m, 1);
         //Byte +2:
-        assign store_b2_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_wmask_byte(m, 2);
-        assign store_b2_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_wmask_byte(m, 2);
-        assign store_b2_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_wmask_byte(m, 2);
-        assign store_b2_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_wmask_byte(m, 2);
-        assign store_b2_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_wmask_byte(m, 2);
-        assign store_b2_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_wmask_byte(m, 2);
+        assign store_b2_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_wmask_byte(m, 2);
+        assign store_b2_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+2, t)  && get_mem_wmask_byte(m, 2);
+        assign store_b2_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_wmask_byte(m, 2);
+        assign store_b2_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+2, t) && get_mem_wmask_byte(m, 2);
+        assign store_b2_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_wmask_byte(m, 2);
+        assign store_b2_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+2, t)   && get_mem_wmask_byte(m, 2);
         //Byte +3:
-        assign store_b3_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode() && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_wmask_byte(m, 3);
-        assign store_b3_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode() && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_wmask_byte(m, 3);
-        assign store_b3_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode() && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_wmask_byte(m, 3);
-        assign store_b3_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode() && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_wmask_byte(m, 3);
-        assign store_b3_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode() && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_wmask_byte(m, 3);
-        assign store_b3_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode() && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_wmask_byte(m, 3);
+        assign store_b3_eq_m_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, M_MODE)            && rvfi_if.is_mmode && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_wmask_byte(m, 3);
+        assign store_b3_eq_u_hit[t][m]  = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_EQUAL, U_MODE)            && rvfi_if.is_umode && eq_tdata2(rvfi_if.get_mem_addr(m)+3, t)  && get_mem_wmask_byte(m, 3);
+        assign store_b3_geq_m_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, M_MODE) && rvfi_if.is_mmode && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_wmask_byte(m, 3);
+        assign store_b3_geq_u_hit[t][m] = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_GREATER_OR_EQUAL, U_MODE) && rvfi_if.is_umode && geq_tdata2(rvfi_if.get_mem_addr(m)+3, t) && get_mem_wmask_byte(m, 3);
+        assign store_b3_l_m_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, M_MODE)           && rvfi_if.is_mmode && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_wmask_byte(m, 3);
+        assign store_b3_l_u_hit[t][m]   = set_tdata1_mctrl_state(t, STORE, MATCH_WHEN_LESSER, U_MODE)           && rvfi_if.is_umode && l_tdata2(rvfi_if.get_mem_addr(m)+3, t)   && get_mem_wmask_byte(m, 3);
 
       end
     end

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -69,18 +69,10 @@ interface uvma_rvfi_instr_if
     input logic [(NMEM*XLEN)-1:0]    rvfi_mem_rdata,
     input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_rmask,
     input logic [(NMEM*XLEN)-1:0]    rvfi_mem_wdata,
-    input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_wmask,
+    input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_wmask
 
-    output logic [(32)-1:0][XLEN-1:0]       gpr_rdata_array,
-    output logic [(32)-1:0]                 gpr_rmask_array,
-    output logic [(32)-1:0][XLEN-1:0]       gpr_wdata_array,
-    output logic [(32)-1:0]                 gpr_wmask_array,
 
-    output logic [NMEM-1:0][XLEN-1:0]       mem_addr_array,
-    output logic [NMEM-1:0][XLEN-1:0]       mem_rdata_array,
-    output logic [NMEM-1:0][(XLEN/8)-1:0]   mem_rmask_array,
-    output logic [NMEM-1:0][XLEN-1:0]       mem_wdata_array,
-    output logic [NMEM-1:0][(XLEN/8)-1:0]   mem_wmask_array
+
 
   );
 
@@ -123,7 +115,36 @@ interface uvma_rvfi_instr_if
   // -------------------------------------------------------------------
   // Local variables
   // -------------------------------------------------------------------
-  bit [CYCLE_CNT_WL-1:0] cycle_cnt = 0;
+  bit   [CYCLE_CNT_WL-1:0]          cycle_cnt = 0;
+
+  logic [(32)-1:0][XLEN-1:0]        gpr_rdata_array;
+  logic [(32)-1:0]                  gpr_rmask_array;
+  logic [(32)-1:0][XLEN-1:0]        gpr_wdata_array;
+  logic [(32)-1:0]                  gpr_wmask_array;
+  logic [NMEM-1:0][XLEN-1:0]        mem_addr_array;
+  logic [NMEM-1:0][XLEN-1:0]        mem_rdata_array;
+  logic [NMEM-1:0][(XLEN/8)-1:0]    mem_rmask_array;
+  logic [NMEM-1:0][XLEN-1:0]        mem_wdata_array;
+  logic [NMEM-1:0][(XLEN/8)-1:0]    mem_wmask_array;
+
+  logic                             is_dret;
+  logic                             is_mret;
+  logic                             is_uret;
+  logic                             is_wfi;
+  logic                             is_wfe;
+  logic                             is_ebreak;
+  logic                             is_ebreak_compr;
+  logic                             is_ebreak_noncompr;
+  logic                             is_ecall;
+  logic                             is_nmi;
+  logic                             is_compressed;
+  logic                             is_dbg_trg;
+  logic                             is_mmode;
+  logic                             is_not_mmode;
+  logic                             is_umode;
+  logic                             is_not_umode;
+  logic                             is_pma_instr_fault;
+  logic                             is_instr_bus_valid;
 
   // -------------------------------------------------------------------
   // Begin module code
@@ -146,6 +167,28 @@ interface uvma_rvfi_instr_if
 
   always @(posedge clk) begin
     cycle_cnt <= cycle_cnt + 1;
+  end
+
+  // assigning signal aliases to helper functions
+  always_comb begin
+    is_dret             <= is_dret_f();
+    is_mret             <= is_mret_f();
+    is_uret             <= is_uret_f();
+    is_wfi              <= is_wfi_f();
+    is_wfe              <= is_wfe_f();
+    is_ebreak           <= is_ebreak_f();
+    is_ebreak_compr     <= is_ebreak_compr_f();
+    is_ebreak_noncompr  <= is_ebreak_noncompr_f();
+    is_ecall            <= is_ecall_f();
+    is_nmi              <= is_nmi_f();
+    is_compressed       <= is_compressed_f();
+    is_dbg_trg          <= is_dbg_trg_f();
+    is_mmode            <= is_mmode_f();
+    is_not_mmode        <= is_not_mmode_f();
+    is_umode            <= is_umode_f();
+    is_not_umode        <= is_not_umode_f();
+    is_pma_instr_fault  <= is_pma_instr_fault_f();
+    is_instr_bus_valid  <= is_instr_bus_valid_f();
   end
 
   /**
@@ -210,7 +253,7 @@ interface uvma_rvfi_instr_if
                               bit [ DEFAULT_XLEN-1:0] ref_mask
                               );
 
-  return rvfi_valid && is_instr_bus_valid() && ((rvfi_insn & ref_mask) == ref_instr);
+  return rvfi_valid && is_instr_bus_valid && ((rvfi_insn & ref_mask) == ref_instr);
 
   endfunction : match_instr
 
@@ -368,92 +411,92 @@ endfunction : check_mem_act
 
 // Short functions for recognising special functions
 
-function logic is_dret();
+function logic is_dret_f();
   return match_instr(INSTR_OPCODE_DRET, INSTR_MASK_FULL);
-endfunction : is_dret
+endfunction : is_dret_f
 
-function logic is_mret();
+function logic is_mret_f();
   return match_instr(INSTR_OPCODE_MRET, INSTR_MASK_FULL);
-endfunction : is_mret
+endfunction : is_mret_f
 
-function logic is_uret();
+function logic is_uret_f();
   return match_instr(INSTR_OPCODE_URET, INSTR_MASK_FULL);
-endfunction : is_uret
+endfunction : is_uret_f
 
-function logic is_wfi();
+function logic is_wfi_f();
   return match_instr(INSTR_OPCODE_WFI, INSTR_MASK_FULL);
-endfunction : is_wfi
+endfunction : is_wfi_f
 
-function logic is_wfe();
+function logic is_wfe_f();
   return match_instr(INSTR_OPCODE_WFE, INSTR_MASK_FULL);
-endfunction : is_wfe
+endfunction : is_wfe_f
 
-function logic is_ebreak();
+function logic is_ebreak_f();
   return match_instr(INSTR_OPCODE_EBREAK, INSTR_MASK_FULL) || match_instr(INSTR_OPCODE_C_EBREAK, INSTR_MASK_FULL);
-endfunction : is_ebreak
+endfunction : is_ebreak_f
 
-function logic is_ebreak_compr();
+function logic is_ebreak_compr_f();
   return match_instr(INSTR_OPCODE_C_EBREAK, INSTR_MASK_FULL);
-endfunction : is_ebreak_compr
+endfunction : is_ebreak_compr_f
 
-function logic is_ebreak_noncompr();
+function logic is_ebreak_noncompr_f();
   return match_instr(INSTR_OPCODE_EBREAK, INSTR_MASK_FULL);
-endfunction : is_ebreak_noncompr
+endfunction : is_ebreak_noncompr_f
 
 
-function logic is_ecall();
+function logic is_ecall_f();
   return match_instr(INSTR_OPCODE_ECALL, INSTR_MASK_FULL);
-endfunction : is_ecall
+endfunction : is_ecall_f
 
-function logic is_nmi();
+function logic is_nmi_f();
   return rvfi_valid && rvfi_intr.intr && (rvfi_intr.cause & INTR_CAUSE_NMI_MASK);
-endfunction : is_nmi
+endfunction : is_nmi_f
 
-function logic is_compressed();
+function logic is_compressed_f();
   return  rvfi_valid && (rvfi_insn[1:0] != 2'b11);
-endfunction : is_compressed
+endfunction : is_compressed_f
 
-function logic is_dbg_trg();
+function logic is_dbg_trg_f();
   return  rvfi_valid &&
           rvfi_trap.trap &&
           rvfi_trap.debug &&
          (rvfi_trap.debug_cause == cv32e40s_pkg::DBG_CAUSE_TRIGGER);
-endfunction : is_dbg_trg
+endfunction : is_dbg_trg_f
 
-function logic is_mmode();
+function logic is_mmode_f();
   return  rvfi_valid &&
           (rvfi_mode == cv32e40s_pkg::PRIV_LVL_M);
-endfunction : is_mmode
+endfunction : is_mmode_f
 
-function logic is_not_mmode();
+function logic is_not_mmode_f();
   return  rvfi_valid &&
           (rvfi_mode != cv32e40s_pkg::PRIV_LVL_M);
-endfunction : is_not_mmode
+endfunction : is_not_mmode_f
 
-function logic is_umode();
+function logic is_umode_f();
   return  rvfi_valid &&
           (rvfi_mode == cv32e40s_pkg::PRIV_LVL_U);
-endfunction : is_umode
+endfunction : is_umode_f
 
-function logic is_not_umode();
+function logic is_not_umode_f();
   return  rvfi_valid &&
           (rvfi_mode != cv32e40s_pkg::PRIV_LVL_U);
-endfunction : is_not_umode
+endfunction : is_not_umode_f
 
-function logic is_pma_instr_fault();
+function logic is_pma_instr_fault_f();
   return  rvfi_valid  &&
           rvfi_trap.trap  &&
           rvfi_trap.exception  &&
           (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_FAULT)  &&
           (rvfi_trap.cause_type == 'h 0);
-endfunction : is_pma_instr_fault
+endfunction : is_pma_instr_fault_f
 
-function logic is_instr_bus_valid();
+function logic is_instr_bus_valid_f();
   return !( (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_FAULT) ||
             (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_INTEGRITY_FAULT) ||
             (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_BUS_FAULT)
     );
-endfunction : is_instr_bus_valid
+endfunction : is_instr_bus_valid_f
 
 endinterface : uvma_rvfi_instr_if
 


### PR DESCRIPTION
To help with debugging and waveforms, we have decided that we want signal aliases of the "is_*()" functions of the the rvfi_instr_if. This PR adds those, changes the use in several assertion sets from function to signal, and renames the functions to keep them separate. The _array helper signals have also been fixed, as the previous implementation could cause problems.