### PR TITLE
Stretched bootset debug request

### DIFF
--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_random_debug_bootset_vseq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_random_debug_bootset_vseq.sv
@@ -38,7 +38,7 @@ task uvme_cv32e40s_random_debug_bootset_c::body();
     fork
         uvma_debug_seq_item_c debug_req;
         `uvm_do_on_with(debug_req, p_sequencer.debug_sequencer, {
-                active_cycles == 1;
+                active_cycles == 70;
         });
     join
 endtask : body


### PR DESCRIPTION
Stretched bootset debug request to ensure it is picked up by the core now that the request is no longer sticky.

This should at some point be updated to handshake the request with the debug_halted_o signal from the core (assert debug_req until debug_halted_o goes high) but increasing the pulse width will do for now, as it causes ~20 tests to fail in regressions.