### PR TITLE
Remove OpenHW/SiLabs copyright headers from unmodified Coremark files

### DIFF
--- a/cv32e40p/tests/programs/custom/coremark/core_list_join.c
+++ b/cv32e40p/tests/programs/custom/coremark/core_list_join.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /*
 Topic: Description

--- a/cv32e40p/tests/programs/custom/coremark/core_main.c
+++ b/cv32e40p/tests/programs/custom/coremark/core_main.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 /* File: core_main.c
         This file contains the framework to acquire a block of memory, seed
    initial parameters, tun t he benchmark and report the results.

--- a/cv32e40p/tests/programs/custom/coremark/core_matrix.c
+++ b/cv32e40p/tests/programs/custom/coremark/core_matrix.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /*
 Topic: Description

--- a/cv32e40p/tests/programs/custom/coremark/core_state.c
+++ b/cv32e40p/tests/programs/custom/coremark/core_state.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /* local functions */
 enum CORE_STATE core_state_transition(ee_u8 **instr, ee_u32 *transition_count);

--- a/cv32e40p/tests/programs/custom/coremark/core_util.c
+++ b/cv32e40p/tests/programs/custom/coremark/core_util.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /* Function: get_seed
         Get a values that cannot be determined at compile time.

--- a/cv32e40p/tests/programs/custom/coremark/coremark.h
+++ b/cv32e40p/tests/programs/custom/coremark/coremark.h
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 /* Topic: Description
         This file contains  declarations of the various benchmark functions.
 */

--- a/cv32e40p/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40p/tests/programs/custom/coremark/test.yaml
@@ -3,5 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 name: coremark
 uvm_test: uvmt_cv32e40p_firmware_test_c
+default_cflags: >
+    -O3
+    -mabi=ilp32
+    -march=rv32im
+    -falign-functions=16
+    -funroll-all-loops
+    -falign-jumps=4
+    -finline-functions
+    -Wall
+    -static
+    -pedantic
+    -DPERFORMANCE_RUN=1
+    -DITERATIONS=10
+    -DFLAGS_STR=\""-mabi=ilp32 -O3 -falign-functions=16 -funroll-all-loops -falign-jumps=4 -finline-functions -Wall -pedanic -nostartfiles -static"\"
 description: >
     Runs the CoreMark benchmark

--- a/cv32e40p/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40p/tests/programs/custom/coremark/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 OpenHW Group
+# Copyright 2020, 2023 OpenHW Group
 # Copyright 2020 Silicon Labs, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 name: coremark

--- a/cv32e40p/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40p/tests/programs/custom/coremark/test.yaml
@@ -1,3 +1,6 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Silicon Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 name: coremark
 uvm_test: uvmt_cv32e40p_firmware_test_c
 description: >

--- a/cv32e40s/tests/programs/custom/coremark/core_list_join.c
+++ b/cv32e40s/tests/programs/custom/coremark/core_list_join.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /*
 Topic: Description

--- a/cv32e40s/tests/programs/custom/coremark/core_main.c
+++ b/cv32e40s/tests/programs/custom/coremark/core_main.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 /* File: core_main.c
         This file contains the framework to acquire a block of memory, seed
    initial parameters, tun t he benchmark and report the results.

--- a/cv32e40s/tests/programs/custom/coremark/core_matrix.c
+++ b/cv32e40s/tests/programs/custom/coremark/core_matrix.c
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 #include "coremark.h"
 /*

--- a/cv32e40s/tests/programs/custom/coremark/core_state.c
+++ b/cv32e40s/tests/programs/custom/coremark/core_state.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /* local functions */
 enum CORE_STATE core_state_transition(ee_u8 **instr, ee_u32 *transition_count);

--- a/cv32e40s/tests/programs/custom/coremark/core_util.c
+++ b/cv32e40s/tests/programs/custom/coremark/core_util.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /* Function: get_seed
         Get a values that cannot be determined at compile time.

--- a/cv32e40s/tests/programs/custom/coremark/coremark.h
+++ b/cv32e40s/tests/programs/custom/coremark/coremark.h
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 /* Topic: Description
         This file contains  declarations of the various benchmark functions.
 */

--- a/cv32e40s/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40s/tests/programs/custom/coremark/test.yaml
@@ -1,3 +1,6 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Silicon Labs, Inc.
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
 name: coremark
 uvm_test: uvmt_cv32e40s_firmware_test_c
 default_cflags: >

--- a/cv32e40s/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40s/tests/programs/custom/coremark/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 OpenHW Group
+# Copyright 2020, 2023 OpenHW Group
 # Copyright 2020 Silicon Labs, Inc.
 # SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
 name: coremark

--- a/cv32e40x/tests/programs/custom/coremark/core_list_join.c
+++ b/cv32e40x/tests/programs/custom/coremark/core_list_join.c
@@ -16,23 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
 #include "coremark.h"
 /*
 Topic: Description

--- a/cv32e40x/tests/programs/custom/coremark/core_main.c
+++ b/cv32e40x/tests/programs/custom/coremark/core_main.c
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 /* File: core_main.c
         This file contains the framework to acquire a block of memory, seed

--- a/cv32e40x/tests/programs/custom/coremark/core_matrix.c
+++ b/cv32e40x/tests/programs/custom/coremark/core_matrix.c
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 #include "coremark.h"
 /*

--- a/cv32e40x/tests/programs/custom/coremark/core_state.c
+++ b/cv32e40x/tests/programs/custom/coremark/core_state.c
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 #include "coremark.h"
 /* local functions */

--- a/cv32e40x/tests/programs/custom/coremark/core_util.c
+++ b/cv32e40x/tests/programs/custom/coremark/core_util.c
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 #include "coremark.h"
 /* Function: get_seed

--- a/cv32e40x/tests/programs/custom/coremark/coremark.h
+++ b/cv32e40x/tests/programs/custom/coremark/coremark.h
@@ -16,22 +16,6 @@ limitations under the License.
 Original Author: Shay Gal-on
 */
 
-// Copyright 2020 OpenHW Group
-// Copyright 2020 Silicon Labs, Inc.
-//
-// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://solderpad.org/licenses/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 /* Topic: Description
         This file contains  declarations of the various benchmark functions.

--- a/cv32e40x/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40x/tests/programs/custom/coremark/test.yaml
@@ -1,6 +1,6 @@
-# Copyright 2020 OpenHW Group
+# Copyright 2020, 2023 OpenHW Group
 # Copyright 2020 Silicon Labs, Inc.
-# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.1
 name: coremark
 uvm_test: uvmt_cv32e40x_firmware_test_c
 default_cflags: >

--- a/cv32e40x/tests/programs/custom/coremark/test.yaml
+++ b/cv32e40x/tests/programs/custom/coremark/test.yaml
@@ -1,3 +1,6 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2020 Silicon Labs, Inc.
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 name: coremark
 uvm_test: uvmt_cv32e40x_firmware_test_c
 default_cflags: >


### PR DESCRIPTION
This PR is the first step to resolve #1623.

It updates all of the Coremark license headers in `core-v-verif/<core>/tests/programs/custom/coremark` to remove the OpenHW/SiLabs copyright from unmodified files.

@christian-herber-nxp, if/when you sign off on this I will make the same changes to the `cv32e20` branch.