### PR TITLE
Switch Verilator testing to use v5.008 instead of v4.110

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -102,6 +102,7 @@ pub_check_env:
     - echo $RISCV
     - echo $RISCV_PREFIX
     - echo $VERILATOR_ROOT
+    - echo $VERILATOR_INSTALL_DIR
     - echo $SPIKE_ROOT
     - echo $BBL_ROOT
     - echo $SYN_VCS_BASHRC

--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -149,15 +149,21 @@ pub_smoke:
     DASHBOARD_SORT_INDEX: 0
     DASHBOARD_JOB_CATEGORY: "Basic"
   script:
-    - mkdir -p artifacts/reports
+    - mkdir -p artifacts/reports artifacts/logs
     - python3 .gitlab-ci/scripts/report_fail.py
     - echo $SYN_VCS_BASHRC; source $SYN_VCS_BASHRC
-    - source cva6/regress/smoke-tests.sh
+    # In order to capture logs in case of test failure, the test script cannot fail.
+    - source cva6/regress/smoke-tests.sh || true
+    # The list of files must NOT fail on various DV_SIMULATORS values, so use 'v*_sim' to match
+    # 'veri-testharness_sim', 'vcs-testharness_sim' and 'vcs-uvm_sim' (one of them always applies,
+    # at least until new RTL simulator configurations are added.)
+    - for i in cva6/sim/*/v*_sim/*.log.iss ; do head -5000 $i > artifacts/logs/$(basename $i).head ; done
     - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log
   artifacts:
     when: always
     paths:
       - artifacts/reports/*.yml
+      - artifacts/logs/*.log.iss.head
 
 pub_riscv_arch_test:
   stage: two

--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -157,7 +157,7 @@ pub_smoke:
     # The list of files must NOT fail on various DV_SIMULATORS values, so use 'v*_sim' to match
     # 'veri-testharness_sim', 'vcs-testharness_sim' and 'vcs-uvm_sim' (one of them always applies,
     # at least until new RTL simulator configurations are added.)
-    - for i in cva6/sim/*/v*_sim/*.log.iss ; do head -5000 $i > artifacts/logs/$(basename $i).head ; done
+    - for i in cva6/sim/*/v*_sim/*.log.iss ; do head -10000 $i > artifacts/logs/$(basename $i).head ; done
     - python3 .gitlab-ci/scripts/report_simu.py cva6/sim/logfile.log
   artifacts:
     when: always

--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -433,7 +433,8 @@ pub_wb_dcache:
     - source ci/make-tmp.sh
     - source ci/build-riscv-tests.sh
     - cd ../../../
-    - make run-asm-tests-verilator defines=WB_DCACHE
+    # Use 'verilator --no-timing' until the timing issues in corev_apu RTL are fixed.
+    - make verilator="verilator --no-timing" run-asm-tests-verilator defines=WB_DCACHE
     - cd ../..
     - python3 .gitlab-ci/scripts/report_pass.py
   artifacts:

--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -522,8 +522,8 @@ pub_fpga-boot:
     - job: pub_fpga-build
       artifacts: true
   variables:
-    VERILATOR_ROOT: "/shares/tools/dummy/verilator" # to avoid install of verilator
-    SPIKE_ROOT: "/shares/tools/dummy/spike"  # to avoid install of spike
+    VERILATOR_INSTALL_DIR: "NO" # Skip install and checks of verilator
+    SPIKE_ROOT: "NO"  # Skip install and checks of spike
     DASHBOARD_JOB_TITLE: "FPGA Linux64 Boot "
     DASHBOARD_JOB_DESCRIPTION: "Test of Linux 64 bits boot on FPGA Genesys2"
     DASHBOARD_SORT_INDEX: 10

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -33,6 +33,12 @@ if [ -z "$VERILATOR_INSTALL_DIR" ]; then
 fi
 cva6/regress/install-verilator.sh
 
+# With Verilator v5, it is (FORNOW) necessary to either maintain a copy
+# of the source+build directory at $VERILATOR_ROOT, or to unset VERILATOR_ROOT
+# so that 'verilator_bin' is searched in the PATH.  The former is not
+# applicable to Continuous Integration environments, so...
+unset VERILATOR_ROOT
+
 export PATH=$RISCV/bin:$VERILATOR_INSTALL_DIR/bin:$PATH
 export LIBRARY_PATH=$RISCV/lib
 export LD_LIBRARY_PATH=$RISCV/lib

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -13,33 +13,21 @@ export TOP=$ROOT_PROJECT/tools
 
 # where to install the tools
 if ! [ -n "$RISCV" ]; then
-  echo "Error: RISCV variable undefined"
+  echo "Error: RISCV variable undefined."
   return
 fi
 
-# install Verilator
-# Use historical variable VERILATOR_ROOT to check/specify VL configuration.
-if [ -z "$VERILATOR_ROOT" ]; then
-  # Verilator installation dir should be separate from the VL source root.
-  # Source code will be unpacked, built and tested in the 'verilator'
-  # subdir of the install dir.
-  export VERILATOR_ROOT=$TOP/verilator-5.008/verilator
-fi
-
-# If the installation directory of Verilator is not set,
-# default to the parent directory of the Verilator source.
-if [ -z "$VERILATOR_INSTALL_DIR" ]; then
-  export VERILATOR_INSTALL_DIR=$(dirname $VERILATOR_ROOT)
-fi
+# Install Verilator v5.
 cva6/regress/install-verilator.sh
 
-# With Verilator v5, it is (FORNOW) necessary to either maintain a copy
-# of the source+build directory at $VERILATOR_ROOT, or to unset VERILATOR_ROOT
-# so that 'verilator_bin' is searched in the PATH.  The former is not
-# applicable to Continuous Integration environments, so...
-unset VERILATOR_ROOT
+# Complain if the installation directory of Verilator still is not set
+# after running the installer.
+if [ -z "$VERILATOR_INSTALL_DIR" ]; then
+  echo "Error: VERILATOR_INSTALL_DIR variable still undefined after running Verilator installer."
+  return
+fi
 
-export PATH=$RISCV/bin:$VERILATOR_INSTALL_DIR/bin:$PATH
+export PATH=$RISCV/bin:$PATH
 export LIBRARY_PATH=$RISCV/lib
 export LD_LIBRARY_PATH=$RISCV/lib
 export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -27,7 +27,7 @@ if [ -z "$VERILATOR_INSTALL_DIR" ]; then
   return
 fi
 
-export PATH=$RISCV/bin:$PATH
+export PATH=$RISCV/bin:$VERILATOR_INSTALL_DIR/bin:$PATH
 export LIBRARY_PATH=$RISCV/lib
 export LD_LIBRARY_PATH=$RISCV/lib
 export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -19,11 +19,16 @@ fi
 
 # install Verilator
 # Use historical variable VERILATOR_ROOT to check/specify VL configuration.
-if ! [ -n "$VERILATOR_ROOT" ]; then
+if [ -z "$VERILATOR_ROOT" ]; then
   # Verilator installation dir should be separate from the VL source root.
   # Source code will be unpacked, built and tested in the 'verilator'
   # subdir of the install dir.
   export VERILATOR_ROOT=$TOP/verilator-5.008/verilator
+fi
+
+# If the installation directory of Verilator is not set,
+# default to the parent directory of the Verilator source.
+if [ -z "$VERILATOR_INSTALL_DIR" ]; then
   export VERILATOR_INSTALL_DIR=$(dirname $VERILATOR_ROOT)
 fi
 cva6/regress/install-verilator.sh

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -39,6 +39,11 @@ export LD_LIBRARY_PATH=$RISCV/lib
 export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include
 export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include
 
+# Check proper Verilator installation given current $PATH.
+echo PATH=\"$PATH\"
+echo "Verilator version:"
+verilator --version
+
 # number of parallel jobs to use for make commands and simulation
 export NUM_JOBS=24
 

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -36,7 +36,7 @@ export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/
 # Check proper Verilator installation given current $PATH.
 echo PATH=\"$PATH\"
 echo "Verilator version:"
-verilator --version
+verilator --version || { echo "Error: Verilator not in \$PATH." ; return ; }
 
 # number of parallel jobs to use for make commands and simulation
 export NUM_JOBS=24

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -18,16 +18,21 @@ if ! [ -n "$RISCV" ]; then
 fi
 
 # install Verilator
+# Use historical variable VERILATOR_ROOT to check/specify VL configuration.
 if ! [ -n "$VERILATOR_ROOT" ]; then
-  export VERILATOR_ROOT=$TOP/verilator-5.006/
+  # Verilator installation dir should be separate from the VL source root.
+  # Source code will be unpacked, built and tested in the 'verilator'
+  # subdir of the install dir.
+  export VERILATOR_ROOT=$TOP/verilator-5.008/verilator
+  export VERILATOR_INSTALL_DIR=$(dirname $VERILATOR_ROOT)
 fi
 cva6/regress/install-verilator.sh
 
-export PATH=$RISCV/bin:$VERILATOR_ROOT/bin:$PATH
+export PATH=$RISCV/bin:$VERILATOR_INSTALL_DIR/bin:$PATH
 export LIBRARY_PATH=$RISCV/lib
 export LD_LIBRARY_PATH=$RISCV/lib
-export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
-export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_ROOT/include
+export C_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include
+export CPLUS_INCLUDE_PATH=$RISCV/include:$VERILATOR_INSTALL_DIR/share/verilator/include
 
 # number of parallel jobs to use for make commands and simulation
 export NUM_JOBS=24

--- a/cva6/regress/install-cva6.sh
+++ b/cva6/regress/install-cva6.sh
@@ -19,7 +19,7 @@ fi
 
 # install Verilator
 if ! [ -n "$VERILATOR_ROOT" ]; then
-  export VERILATOR_ROOT=$TOP/verilator-4.110/
+  export VERILATOR_ROOT=$TOP/verilator-5.006/
 fi
 cva6/regress/install-verilator.sh
 

--- a/cva6/regress/install-spike.sh
+++ b/cva6/regress/install-spike.sh
@@ -14,7 +14,12 @@ if [ -z ${NUM_JOBS} ]; then
     NUM_JOBS=1
 fi
 
-if [ ! -f "$SPIKE_ROOT/bin/spike"  ]; then
+# Set SPIKE_ROOT to 'NO' to skip the installation/checks of Spike altogether.
+# This is useful for CI jobs not depending on Spike in any way.
+if [ "$SPIKE_ROOT" = "NO" ]; then
+  echo "Skipping Spike setup on user's request (\$SPIKE_ROOT = \"NO\")."
+else
+  if [ ! -f "$SPIKE_ROOT/bin/spike"  ]; then
     echo "Installing Spike"
     PATCH_DIR=`pwd`/cva6/regress
     mkdir -p $SPIKE_ROOT
@@ -35,7 +40,8 @@ if [ ! -f "$SPIKE_ROOT/bin/spike"  ]; then
     ../configure --enable-commitlog --prefix="$SPIKE_ROOT"
     make -j${NUM_JOBS}
     make install
-else
-    echo "Using Spike from cached directory."
+  else
+    echo "Using Spike from cached directory $SPIKE_ROOT."
+  fi
 fi
 

--- a/cva6/regress/install-verilator.sh
+++ b/cva6/regress/install-verilator.sh
@@ -13,20 +13,39 @@ if [ -z ${NUM_JOBS} ]; then
     NUM_JOBS=1
 fi
 
-if [ ! -f "$VERILATOR_ROOT/bin/verilator" ]; then
-    echo "Installing Verilator"
+VERILATOR_REPO="https://github.com/verilator/verilator.git"
+VERILATOR_BRANCH="master"
+# Use the release tag instead of a full SHA1 hash.
+VERILATOR_HASH="v5.008"
+VERILATOR_PATCH="../../../cva6/regress/verilator-v5.patch"
+
+# VERILATOR_ROOT must point to the root of the Verilator source tree.
+# This is not necessarily the installation prefix.
+# The two should be kept separate ==> use VERILATOR_INSTALL_DIR to specify
+# the installation location of Verilator.
+if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
+    echo "Building Verilator in $VERILATOR_ROOT..."
+    echo "VERILATOR_REPO=$VERILATOR_REPO"
+    echo "VERILATOR_BRANCH=$VERILATOR_BRANCH"
+    echo "VERILATOR_HASH=$VERILATOR_HASH"
+    echo "VERILATOR_PATCH=$VERILATOR_PATCH"
     mkdir -p $VERILATOR_ROOT
     cd $VERILATOR_ROOT
-    rm -f verilator*.tgz v4.*.tar.gz
-    wget https://github.com/verilator/verilator/archive/refs/tags/v4.110.tar.gz
-    tar xzf v4.*.tar.gz
-    rm -f v4.*.tar.gz
-    cd verilator-4.110
-    mkdir -p $VERILATOR_ROOT
-    # copy scripts
-    autoconf && ./configure --prefix="$VERILATOR_ROOT" && make -j${NUM_JOBS}
-    cp -r * $VERILATOR_ROOT/
+    # Clone only if the ".git" directory does not exist.
+    # Do not remove the content arbitrarily if ".git" does not exist in order
+    # to preserve user content - let git fail instead.
+    [ -d .git ] || git clone $VERILATOR_REPO -b $VERILATOR_BRANCH .
+    git checkout $VERILATOR_HASH
+    if [ ! -z "$VERILATOR_PATCH" ] ; then
+      git apply $VERILATOR_PATCH
+    fi
+    # Generate the config script and configure Verilator.
+    autoconf && ./configure --prefix="$VERILATOR_INSTALL_DIR" && make -j${NUM_JOBS}
     make test
+    echo "Installing Verilator in $VERILATOR_INSTALL_DIR..."
+    make install
+    #make test || echo "### 'make test' in $VERILATOR_ROOT: some tests failed."
+    cd -
 else
     echo "Using Verilator from cached directory."
 fi

--- a/cva6/regress/install-verilator.sh
+++ b/cva6/regress/install-verilator.sh
@@ -25,6 +25,7 @@ VERILATOR_PATCH="../../../cva6/regress/verilator-v5.patch"
 # the installation location of Verilator.
 if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
     echo "Building Verilator in $VERILATOR_ROOT..."
+    echo "Verilator will be installed in $VERILATOR_INSTALL_DIR"
     echo "VERILATOR_REPO=$VERILATOR_REPO"
     echo "VERILATOR_BRANCH=$VERILATOR_BRANCH"
     echo "VERILATOR_HASH=$VERILATOR_HASH"
@@ -37,7 +38,7 @@ if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
     [ -d .git ] || git clone $VERILATOR_REPO -b $VERILATOR_BRANCH .
     git checkout $VERILATOR_HASH
     if [ ! -z "$VERILATOR_PATCH" ] ; then
-      git apply $VERILATOR_PATCH
+      git apply $VERILATOR_PATCH || true
     fi
     # Generate the config script and configure Verilator.
     autoconf && ./configure --prefix="$VERILATOR_INSTALL_DIR" && make -j${NUM_JOBS}

--- a/cva6/regress/install-verilator.sh
+++ b/cva6/regress/install-verilator.sh
@@ -41,7 +41,8 @@ if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
     fi
     # Generate the config script and configure Verilator.
     autoconf && ./configure --prefix="$VERILATOR_INSTALL_DIR" && make -j${NUM_JOBS}
-    make test
+    # FORNOW: Accept failure in 'make test' (segfault issue on Debian10)
+    make test || true
     echo "Installing Verilator in $VERILATOR_INSTALL_DIR..."
     make install
     #make test || echo "### 'make test' in $VERILATOR_ROOT: some tests failed."

--- a/cva6/regress/install-verilator.sh
+++ b/cva6/regress/install-verilator.sh
@@ -49,5 +49,5 @@ if [ ! -f "$VERILATOR_INSTALL_DIR/bin/verilator" ]; then
     #make test || echo "### 'make test' in $VERILATOR_ROOT: some tests failed."
     cd -
 else
-    echo "Using Verilator from cached directory."
+    echo "Using Verilator from cached directory $VERILATOR_INSTALL_DIR."
 fi

--- a/cva6/regress/verilator-v5.patch
+++ b/cva6/regress/verilator-v5.patch
@@ -1,0 +1,26 @@
+diff --git a/docs/CONTRIBUTORS b/docs/CONTRIBUTORS
+index 215fb6bd8..829752e6b 100644
+--- a/docs/CONTRIBUTORS
++++ b/docs/CONTRIBUTORS
+@@ -154,5 +154,6 @@ Yuri Victorovich
+ Yutetsu TAKATSUKASA
+ Yu-Sheng Lin
+ Yves Mathieu
++Zbigniew Chamski
+ Zhanglei Wang
+ Zixi Li
+diff --git a/include/verilated_types.h b/include/verilated_types.h
+index cb7265e32..f1d482d8e 100644
+--- a/include/verilated_types.h
++++ b/include/verilated_types.h
+@@ -1012,8 +1012,8 @@ struct VlUnpacked final {
+ 
+     // METHODS
+     // Raw access
+-    WData* data() { return &m_storage[0]; }
+-    const WData* data() const { return &m_storage[0]; }
++    WData* data() { return (WData*)&m_storage[0]; }
++    const WData* data() const { return (const WData*)&m_storage[0]; }
+ 
+     T_Value& operator[](size_t index) { return m_storage[index]; }
+     const T_Value& operator[](size_t index) const { return m_storage[index]; }

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -116,7 +116,7 @@ vcs-testharness:
 	grep $(isspostrun_opts) ./trace_rvfi_hart_00.dasm
 
 veri-testharness:
-	make -C $(path_var) verilate target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	make -C $(path_var) verilate verilator="verilator --no-timing" target=$(target) defines=$(subst +define+,,$(isscomp_opts))
 	$(path_var)/work-ver/Variane_testharness $(if $(TRACE_COMPACT), -f verilator.fst) $(if $(TRACE_FAST), -v verilator.vcd) $(elf) $(issrun_opts) +PRELOAD=$(elf) \
 	  +tohost_addr=$(shell $$RISCV/bin/riscv-none-elf-nm -B $(elf) | grep -w tohost | cut -d' ' -f1)
 	$(tool_path)/spike-dasm --isa=$(variant) < ./trace_rvfi_hart_00.dasm > $(log)


### PR DESCRIPTION
This PR introduces support for Verilator v5 (v5.008 at the time of PR creation).  The main modifications are:
*  A change in the use of shell variables to configure Verilator:
  * In Verilator v5, `VERILATOR_ROOT` is required to point to the root of the _source_ tree of Verilator
  * A separate variable (currently named `VERILATOR_INSTALL_DIR`) is needed to designate the installation directory of Verilator
  * If not defined explicitly by the user, `VERILATOR_INSTALL_DIR` is set to the parent directory of `$VERILATOR_ROOT`.
  * Path settings for Verilator-related executables and include files are expressed using `$VERILATOR_INSTALL_DIR`. 
* A change in the build flow of Verilator: instead of downloading and untarring a source package tarball, the source code is cloned from Verilator Github repository.
* A patch is applied to the source code of Verilator (it will be upstreamed shortly.)
* FORNOW, the `cva6/sim/Makefile` rule for Verilator invocation passes the `--no-timing` Verilator option as part of the value of Makefile variable `verilator`.