### PR TITLE
Rvfi clicptr adaptions

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= a9c6c716e4d1a219775b968bafec239f1190ac16
+CV_CORE_HASH   ?= 6b9a356ec08e5e1b9c9394fe33cafb3cbf7bd08c
 CV_CORE_TAG    ?= none
 
 #RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -749,7 +749,7 @@ module uvmt_cv32e40s_debug_assert
         ##1 rvfi.rvfi_valid[->1]
         ##0 !rvfi.rvfi_dbg_mode
         |->
-        !rvfi.rvfi_intr.intr;
+        !rvfi.rvfi_intr.intr || (rvfi.rvfi_intr.intr && rvfi.rvfi_trap.clicptr);
     endproperty
 
     a_step_no_trap : assert property(p_step_no_trap)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_debug_assert.sv
@@ -185,13 +185,7 @@ module uvmt_cv32e40s_debug_assert
     property p_dpc_dbg_trigger;
         $rose(support_if.first_debug_ins) && rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_TRIGGER
         |->
-        csr_dpc.rvfi_csr_rdata == dpc_dbg_trg
-        or
-        // clic can hit an exception in it's pointer fetch stage without reporting to rvfi.
-        (rvfi.rvfi_intr.exception &&
-        (csr_mtvec.rvfi_csr_rdata[1:0] == 3) &&
-        csr_mcause.rvfi_csr_rdata[MCAUSE_MINHV_POS] &&
-        csr_dpc.rvfi_csr_rdata == mtvec_addr);
+        csr_dpc.rvfi_csr_rdata == dpc_dbg_trg;
     endproperty
 
     a_dpc_dbg_trigger: assert property(p_dpc_dbg_trigger)
@@ -318,14 +312,7 @@ module uvmt_cv32e40s_debug_assert
         |->
         (rvfi.rvfi_dbg == debug_cause_pri)
         or
-        (support_if.recorded_dbg_req && (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_HALTREQ))
-        or
-        // clic can hit an exception in it's pointer fetch stage without reporting to rvfi.
-        ((rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_TRIGGER) &&
-        rvfi.rvfi_intr.exception &&
-        (csr_mtvec.rvfi_csr_rdata[1:0] == 3) &&
-        csr_mcause.rvfi_csr_rdata[MCAUSE_MINHV_POS] &&
-        csr_dpc.rvfi_csr_rdata == mtvec_addr);
+        (support_if.recorded_dbg_req && (rvfi.rvfi_dbg == cv32e40s_pkg::DBG_CAUSE_HALTREQ));
     endproperty
 
     a_dcsr_cause: assert property(p_dcsr_cause)

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -273,7 +273,7 @@ function logic match_instr_r(bit [ DEFAULT_XLEN-1:0] ref_instr);
 endfunction : match_instr_r
 
 function logic match_instr_r_var(bit [6:0] funct7, bit [2:0] funct3, bit [6:0] opcode);
-  return match_instr_r({funct7, 10'b0, funct3, 5'b0, opcode}, INSTR_MASK_R_TYPE);
+  return match_instr_r({funct7, 10'b0, funct3, 5'b0, opcode});
 endfunction : match_instr_r_var
 
 function logic match_instr_isb(bit [ DEFAULT_XLEN-1:0] ref_instr);
@@ -281,7 +281,7 @@ function logic match_instr_isb(bit [ DEFAULT_XLEN-1:0] ref_instr);
 endfunction : match_instr_isb
 
 function logic match_instr_isb_var ( bit [2:0] funct3, bit [6:0] opcode);
-  return match_instr_isb({17'b0, funct3, 5'b0, opcode}, INSTR_MASK_I_S_B_TYPE);
+  return match_instr_isb({17'b0, funct3, 5'b0, opcode});
 endfunction : match_instr_isb_var
 
 function logic match_instr_uj(bit [ DEFAULT_XLEN-1:0] ref_instr);
@@ -289,7 +289,7 @@ function logic match_instr_uj(bit [ DEFAULT_XLEN-1:0] ref_instr);
 endfunction : match_instr_uj
 
 function logic match_instr_uj_var(bit [6:0] opcode);
-  return  match_instr_uj({25'b0, opcode} , INSTR_MASK_U_J_TYPE);
+  return  match_instr_uj({25'b0, opcode});
 endfunction : match_instr_uj_var
 
 // Match CSR functions

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -272,13 +272,25 @@ function logic match_instr_r(bit [ DEFAULT_XLEN-1:0] ref_instr);
   return match_instr(ref_instr, INSTR_MASK_R_TYPE);
 endfunction : match_instr_r
 
+function logic match_instr_r_var(bit [6:0] funct7, bit [2:0] funct3, bit [6:0] opcode);
+  return match_instr_r({funct7, 10'b0, funct3, 5'b0, opcode}, INSTR_MASK_R_TYPE);
+endfunction : match_instr_r_var
+
 function logic match_instr_isb(bit [ DEFAULT_XLEN-1:0] ref_instr);
   return match_instr(ref_instr, INSTR_MASK_I_S_B_TYPE);
 endfunction : match_instr_isb
 
+function logic match_instr_isb_var ( bit [2:0] funct3, bit [6:0] opcode);
+  return match_instr_isb({17'b0, funct3, 5'b0, opcode}, INSTR_MASK_I_S_B_TYPE);
+endfunction : match_instr_isb_var
+
 function logic match_instr_uj(bit [ DEFAULT_XLEN-1:0] ref_instr);
   return  match_instr(ref_instr, INSTR_MASK_U_J_TYPE);
 endfunction : match_instr_uj
+
+function logic match_instr_uj_var(bit [6:0] opcode);
+  return  match_instr_uj({25'b0, opcode} , INSTR_MASK_U_J_TYPE);
+endfunction : match_instr_uj_var
 
 // Match CSR functions
 // These instruction are used to check for csr activity.

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
@@ -33,6 +33,7 @@ typedef struct packed {
 } rvfi_intr_t;
 
 typedef struct packed {
+  logic        clicptr;
   logic [1:0]  cause_type;
   logic [2:0]  debug_cause;
   logic [5:0]  exception_cause;


### PR DESCRIPTION
RVFI will now report a trap when a clic pointer fetch fails synchronously, indicated by the new signal rvfi_trap.clicptr. This PR updates core-v-verif to deal with this.