### PR TITLE
OBI Assert - Parity

### DIFF
--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_1p2_assert.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_1p2_assert.sv
@@ -262,4 +262,25 @@ module uvma_obi_memory_1p2_assert
   else
     `uvm_error(info_tag, "EXOKAY may only asserted in response to an LR or SC transaction (signaled via atop)")
 
+  // R-13: The reqpar signal shall be the inverse of req at each rising clk edge (when not in reset).
+  a_reqpar: assert property (
+    reqpar == !req
+  ) else `uvm_error(info_tag, "bad reqpar")
+
+  // R-14: The gntpar signal shall be the inverse of gnt at each rising clk edge (when not in reset).
+  a_gntpar: assert property (
+    gntpar == !gnt
+  ) else `uvm_error(info_tag, "bad gntpar")
+
+  // R-15: The rvalidpar signal shall be the inverse of rvalid at each rising clk edge (when not in reset).
+  a_rvalidpar: assert property (
+    rvalidpar == !rvalid
+  ) else `uvm_error(info_tag, "bad rvalidpar")
+
+  // R-16: The rreadypar signal shall be the inverse of rready at each rising clk edge (when not in reset)
+  a_rreadypar: assert property (
+    rreadypar == !rready
+  ) else `uvm_error(info_tag, "bad rreadypar")
+
+
 endmodule : uvma_obi_memory_1p2_assert


### PR DESCRIPTION
This PR adds parity asserts (reqpar, etc) to the OBI assertion set, according to [OBI v1.2](https://raw.githubusercontent.com/openhwgroup/obi/main/OBI-v1.2.pdf).

Test status:
* ci_check - Passes
* Internal formal - N/A, not used (passes when enabled)
* Cvverif formal - Works as expected (core-side pass, env-side fail)

I did not expect to write this today, but I wanted to see if one of the latest RVFI bug fixes were reproducable with the core-v-verif formal setup and this is the only piece missing that I'm aware of. _(OBI parity assumes were already in cvverif fv, but lazily used xsecure asserts.)_