### PR TITLE
Add HWLoops tests and improved cv_regress script for tb build without ISS

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -126,6 +126,8 @@ def read_file(args, file):
             build.set_cov()
         if args.make:
             build.sub_make(args.make)
+        if args.iss != None:
+            build.iss = args.iss
         if args.cfg:
             build.cfg = args.cfg
 

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -62,7 +62,7 @@ incr_test_counts () {
 
 {% for b in unique_builds.values() %}
 # Build:{{b.name}} {{b.description}}
-{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + b.cfg + ' SIMULATOR=' + b.simulator + ' COV=' + regress_macros.yesorno(b.cov) + ' ' + regress_macros.cv_results(results) + ' ' + makeargs %}
+{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + b.cfg + ' SIMULATOR=' + b.simulator + ' USE_ISS=' + regress_macros.yesorno(b.iss) + ' COV=' + regress_macros.yesorno(b.cov) + ' ' + regress_macros.cv_results(results) + ' ' + makeargs %}
 echo "{{session}}: Running build: [cd {{b.abs_dir}} && {{cmd}}]"
 pushd {{b.abs_dir}} > /dev/null
 {{cmd}}

--- a/cv32e40p/regress/cv32e40p_xpulp_isa.yaml
+++ b/cv32e40p/regress/cv32e40p_xpulp_isa.yaml
@@ -8,6 +8,7 @@ builds:
   uvmt_cv32e40p:    
     cmd: make comp
     dir: cv32e40p/sim/uvmt
+    iss: 0
 
 tests:
   pulp_bit_manipulation:
@@ -141,5 +142,19 @@ tests:
     description: pulp_vectorial_shuffle_pack
     dir: cv32e40p/sim/uvmt
     cmd: make test TEST=pulp_vectorial_shuffle_pack CFG=pulp
+    iss: 0
+
+  pulp_hardware_loop:
+    build: uvmt_cv32e40p
+    description: pulp_hardware_loop
+    dir: cv32e40p/sim/uvmt
+    cmd: make test TEST=pulp_hardware_loop CFG=pulp
+    iss: 0
+
+  pulp_hardware_loop_interrupt_test:
+    build: uvmt_cv32e40p
+    description: pulp_hardware_loop_interrupt_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test TEST=pulp_hardware_loop_interrupt_test CFG=pulp
     iss: 0
 

--- a/cv32e40p/tests/cfg/pulp.yaml
+++ b/cv32e40p/tests/cfg/pulp.yaml
@@ -15,6 +15,6 @@ ovpsim: >
     --override cpu/misa_Extensions=0x801104
     --override cpu/marchid=4
     --override cpu/noinhibit_mask=0xFFFFFFF0
-cv_sw_march: rv32imc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP

--- a/cv32e40p/tests/cfg/pulp_cluster.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster.yaml
@@ -9,6 +9,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_1cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_2cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_3cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_3cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_4cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_4cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_1cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_2cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_3cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_3cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_4cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_cluster_fpu_zfinx_4cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0_xcorevelw1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0_xcvelw1p0
 cflags: >
     -DPULP -DCLUSTER -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_fpu.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU

--- a/cv32e40p/tests/cfg/pulp_fpu_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_1cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU

--- a/cv32e40p/tests/cfg/pulp_fpu_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_2cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU

--- a/cv32e40p/tests/cfg/pulp_fpu_3cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_3cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU

--- a/cv32e40p/tests/cfg/pulp_fpu_4cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_4cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imfc_zicsr_zifencei_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imfc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_1cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_1cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_2cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_2cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_3cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_3cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU -DZFINX

--- a/cv32e40p/tests/cfg/pulp_fpu_zfinx_4cyclat.yaml
+++ b/cv32e40p/tests/cfg/pulp_fpu_zfinx_4cyclat.yaml
@@ -10,6 +10,6 @@ ovpsim: >
 # Debug options (add to ovpsim section as needed)
 #--trace --tracechange --traceshowicount --tracemode --monitornets
 #--showoverrides
-cv_sw_march: rv32imc_zicsr_zifencei_zfinx_xcorevmem1p0_xcorevmac1p0_xcorevbi1p0_xcorevalu1p0_xcorevsimd1p0_xcorevbitmanip1p0
+cv_sw_march: rv32imc_zfinx_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
 cflags: >
     -DPULP -DFPU -DZFINX

--- a/cv32e40p/tests/programs/custom/matmul_32b_float/stimuli.h
+++ b/cv32e40p/tests/programs/custom/matmul_32b_float/stimuli.h
@@ -1,3 +1,4 @@
+// Copyright 2020 ETH Zurich
 // Copyright 2020 OpenHW Group
 // Copyright 2023 Dolphin Design
 //
@@ -14,8 +15,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
-// Floating Point Input and Expected result Matrices
+// 
+// Description : Floating Point Input and Expected result Matrices
+// 
 
 float A[N*M] __attribute__ ((aligned (4))) = {
   0x4e3a67f8,  0x4e1da87f,  0x4e70c7b1,  0x4eb4f9e3,  0x4eddc42f,  0x4e94ada5,  0x4e8aa0ca,  0x4ebc7985,  0x4dfbd0cc,  0x4dc30d16,  0x4ec33e42,  0x4ede6e96,  0x4e791541,  0x4eed253d,  0x4ebbcbf3,  0x4e119ed5,

--- a/cv32e40p/tests/programs/custom/matmul_32b_float/test.c
+++ b/cv32e40p/tests/programs/custom/matmul_32b_float/test.c
@@ -1,3 +1,4 @@
+// Copyright 2020 ETH Zurich
 // Copyright 2020 OpenHW Group
 // Copyright 2023 Dolphin Design
 //

--- a/cv32e40p/tests/programs/custom/matmul_32b_float/test.yaml
+++ b/cv32e40p/tests/programs/custom/matmul_32b_float/test.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2023 Dolphin Design
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
 name: matmul_32b_float
 uvm_test: uvmt_cv32e40p_firmware_test_c
 default_cflags: >

--- a/cv32e40p/tests/programs/custom/matmul_32b_int/stimuli.h
+++ b/cv32e40p/tests/programs/custom/matmul_32b_int/stimuli.h
@@ -1,3 +1,4 @@
+// Copyright 2020 ETH Zurich
 // Copyright 2020 OpenHW Group
 // Copyright 2023 Dolphin Design
 //
@@ -14,8 +15,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
-
-// Floating Point Input and Expected result Matrices
+// 
+// Description : Floating Point Input and Expected result Matrices
+// 
 
 long int A[N*M] __attribute__ ((aligned (4))) = {
   0x4b0e8cfc,  0x0370572d,  0x6fb420f2,  0x79c744e3,  0x4deffe69,  0x5493ed96,  0x52b6ad8b,  0x135f7dda,  0x2fc8683a,  0x75aa2806,  0x735bcca7,  0x179ea6cb,  0x44e40180,  0x26056396,  0x46ba54c6,  0x274c5fb9,

--- a/cv32e40p/tests/programs/custom/matmul_32b_int/test.c
+++ b/cv32e40p/tests/programs/custom/matmul_32b_int/test.c
@@ -1,3 +1,4 @@
+// Copyright 2020 ETH Zurich
 // Copyright 2020 OpenHW Group
 // Copyright 2023 Dolphin Design
 //

--- a/cv32e40p/tests/programs/custom/matmul_32b_int/test.yaml
+++ b/cv32e40p/tests/programs/custom/matmul_32b_int/test.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2023 Dolphin Design
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
 name: matmul_32b_int
 uvm_test: uvmt_cv32e40p_firmware_test_c
 default_cflags: >

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
@@ -1,0 +1,313 @@
+#
+# Copyright (C) EM Microelectronic US Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.globl _start
+.globl main
+.globl exit
+.section .text
+.global test_results
+test_results:
+	.word 123456789
+#tests hardware loops instructions. NOTE: value of register x15 at the end of the test is the error count
+main:
+# enable interrupts
+    li        t0, (0x1 << 3)
+    csrs      mstatus, t0
+# main test
+    li x0, 0xf21ee7dc
+    li x1, 0x80000000
+//  li x3, 0xccda4374
+    li x4, 0x0
+    li x5, 0xf4cb539d
+    li x6, 0x80000000
+    li x7, 0x3
+    li x8, 0xfdef1f09
+    li x9, 0x80000000
+    li x10, 0x4
+    li x11, 0xf58fad61
+    li x12, 0xfb6606db
+    li x13, 0x0
+    li x14, 0x0
+    li x15, 0x0
+    li x16, 0x0
+    li x17, 0xf61163af
+    li x18, 0x0
+    li x19, 0x0
+    li x20, 0xc552e854
+    li x21, 0xc553e854
+    li x22, 0xf3ae47cd
+    li x23, 0x0
+    li x24, 0x0
+    li x25, 0x80000000
+    li x26, 0xaad8efdc
+    li x27, 0xffa38c28
+    li x28, 0xf915a8c7
+    li x29, 0x9
+    li x30, 0x5
+    li x31, 0x5912efde
+    li x4, 0x40001104
+
+#test1 hardware loops programmed using immediates starti, endi and counti instructions
+test1:
+    li x17, 0
+    li x18, 0
+
+    .align 4
+
+    cv.counti 1, 10
+    cv.endi 1, endO_1
+    cv.starti 1, startO_1
+    cv.endi 0, endZ_1
+    cv.starti 0, startZ_1
+startO_1:
+    cv.counti 0, 10
+
+    .option norvc
+
+startZ_1:
+    addi x17, x17, 1
+    addi x17, x17, 1
+    addi x17, x17, 1
+endZ_1:
+    addi x18, x18, 2
+    addi x18, x18, 2
+endO_1:
+
+    .option rvc
+
+    li x20, 300
+    beq x20, x17, test1_1
+    c.addi x15, 0x1
+test1_1:
+    li x21, 40
+    beq x21, x18, test2
+    c.addi x15, 0x1
+
+#test2 hardware loops programmed using registers start, end and count instructions
+test2:
+    li x17, 0
+    li x18, 0
+
+    li x5, 10
+1:	auipc x6, %pcrel_hi(endO_2)
+	  addi  x6, x6, %pcrel_lo(1b)
+2:	auipc x7, %pcrel_hi(startO_2)
+	  addi  x7, x7, %pcrel_lo(2b)
+3:	auipc x8, %pcrel_hi(endZ_2)
+	  addi  x8, x8, %pcrel_lo(3b)
+4:	auipc x9, %pcrel_hi(startZ_2)
+	  addi  x9, x9, %pcrel_lo(4b)
+
+    .align 4
+
+    cv.count 1, x5
+    cv.end 1, x6
+    cv.start 1, x7
+    cv.end 0, x8
+    cv.start 0, x9
+startO_2:
+    cv.count 0, x5
+
+    .option norvc
+
+startZ_2:
+    addi x17, x17, 1
+    addi x17, x17, 1
+    addi x17, x17, 1
+endZ_2:
+    addi x18, x18, 2
+    addi x18, x18, 2
+endO_2:
+
+    .option rvc
+
+    li x20, 300
+    beq x20, x17, test2_1
+    c.addi x15, 0x1
+test2_1:
+    li x21, 40
+    beq x21, x18, test3
+    c.addi x15, 0x1
+
+#test3 hardware loops programmed using immediates setupi instruction
+test3:
+    li x17, 0
+    li x18, 0
+
+    .align 4
+
+    cv.setupi 1, 10, endO_3
+startO_3:
+    cv.setupi 0, 10, endZ_3
+
+    .option norvc
+
+startZ_3:
+    addi x17, x17, 1
+    addi x17, x17, 1
+    addi x17, x17, 1
+endZ_3:
+    addi x18, x18, 2
+    addi x18, x18, 2
+endO_3:
+
+    .option rvc
+
+    li x20, 300
+    beq x20, x17, test3_1
+    c.addi x15, 0x1
+test3_1:
+    li x21, 40
+    beq x21, x18, test4
+    c.addi x15, 0x1
+
+#test4 hardware loops programmed using immediates setup instruction
+test4:
+    li x17, 0
+    li x18, 0
+
+    li x5, 10
+
+    .align 4
+
+    cv.setup 1, x5, endO_4
+startO_4:
+    cv.setup 0, x5, endZ_4
+
+    .option norvc
+
+startZ_4:
+    addi x17, x17, 1
+    addi x17, x17, 1
+    addi x17, x17, 1
+endZ_4:
+    addi x18, x18, 2
+    addi x18, x18, 2
+endO_4:
+
+    .option rvc
+
+    li x20, 300
+    beq x20, x17, test4_1
+    c.addi x15, 0x1
+test4_1:
+    li x21, 40
+    beq x21, x18, test5
+    c.addi x15, 0x1
+
+#test5 hardware read checks
+test5:
+
+    li x5, 0x12345678
+    li x6, 0x9abcdef0
+    li x7, 0x55555555
+    li x8, 0xaaaaaaaa
+    li x9, 0xffffffff
+    li x10, 0x5afc6257
+
+    cv.start 0, x5
+    cv.end 0, x6
+    cv.count 0, x7
+
+    cv.start 1, x8
+    cv.end 1, x9
+    cv.count 1, x10
+
+    csrr x20, 0xCC0
+    beq x20, x5, test5_1
+    c.addi x15, 0x1
+test5_1:
+    csrr x20, 0xCC1
+    beq x20, x6, test5_2
+    c.addi x15, 0x1
+test5_2:
+    csrr x20, 0xCC2
+    beq x20, x7, test5_3
+    c.addi x15, 0x1
+test5_3:
+    csrr x20, 0xCC4
+    beq x20, x8, test5_4
+    c.addi x15, 0x1
+test5_4:
+    csrr x20, 0xCC5
+    beq x20, x9, test5_5
+    c.addi x15, 0x1
+test5_5:
+    csrr x20, 0xCC6
+    beq x20, x10, test6
+    c.addi x15, 0x1
+
+#test6 hardware write checks
+test6:
+
+    csrwi 0xCC1, 0x5
+    csrwi 0xCC0, 0x6
+    csrwi 0xCC2, 0x7
+    csrwi 0xCC5, 0x8
+    csrwi 0xCC4, 0x9
+    csrwi 0xCC6, 0xa
+
+#if 0
+    // Not trapping CSRW
+    li x5, 0x5
+    li x6, 0x6
+    li x7, 0x7
+    li x8, 0x8
+    li x9, 0x9
+    li x10, 0xa
+#else
+    // Trapping CSRW
+    li x5, 0x9abcdef0
+    li x6, 0x12345678
+    li x7, 0x55555555
+    li x8, 0xffffffff
+    li x9, 0xaaaaaaaa
+    li x10, 0x5afc6257
+#endif
+
+    csrr x20, 0xCC0
+    beq x20, x6, test6_1
+    c.addi x15, 0x1
+test6_1:
+    csrr x20, 0xCC1
+    beq x20, x5, test6_2
+    c.addi x15, 0x1
+test6_2:
+    csrr x20, 0xCC2
+    beq x20, x7, test6_3
+    c.addi x15, 0x1
+test6_3:
+    csrr x20, 0xCC4
+    beq x20, x9, test6_4
+    c.addi x15, 0x1
+test6_4:
+    csrr x20, 0xCC5
+    beq x20, x8, test6_5
+    c.addi x15, 0x1
+test6_5:
+    csrr x20, 0xCC6
+    beq x20, x10, exit_check
+    c.addi x15, 0x1
+
+exit_check:
+    lw x18, test_results /* report result */
+    beq x15, x0, exit
+    li x18, 1
+exit:
+    li x17, 0x20000000
+    sw x18,0(x17)
+    wfi

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop/pulp_hardware_loop.S
@@ -1,20 +1,24 @@
-#
-# Copyright (C) EM Microelectronic US Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-# either express or implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+// Copyright 2020 EM Microelectronic US Inc.
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+// 
+// Description : PULP Hardware Loops instructions test
+// 
+
 .globl _start
 .globl main
 .globl exit

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop/test.yaml
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop/test.yaml
@@ -1,0 +1,4 @@
+name: pulp_hardware_loop
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    PULP hardware loops test

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop/test.yaml
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop/test.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2023 Dolphin Design
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
 name: pulp_hardware_loop
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
@@ -1,0 +1,251 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "pulp_hardware_loop_interrupt_test.h"
+
+volatile uint32_t irq_id                  = 0;
+volatile uint32_t irq_id_q[IRQ_NUM];
+volatile uint32_t irq_id_q_ptr            = 0;
+volatile uint32_t mmcause                 = 0;
+volatile uint32_t active_test             = 0;
+volatile uint32_t nested_irq              = 0;
+volatile uint32_t nested_irq_valid        = 0;
+volatile uint32_t in_direct_handler       = 0;
+volatile uint32_t nested_hwloop_error     = 0;
+
+uint32_t IRQ_ID_PRIORITY [IRQ_NUM] = {
+    FAST15_IRQ_ID   ,
+    FAST14_IRQ_ID   ,
+    FAST13_IRQ_ID   ,
+    FAST12_IRQ_ID   ,
+    FAST11_IRQ_ID   ,
+    FAST10_IRQ_ID   ,
+    FAST9_IRQ_ID    ,
+    FAST8_IRQ_ID    ,
+    FAST7_IRQ_ID    ,
+    FAST6_IRQ_ID    ,
+    FAST5_IRQ_ID    ,
+    FAST4_IRQ_ID    ,
+    FAST3_IRQ_ID    ,
+    FAST2_IRQ_ID    ,
+    FAST1_IRQ_ID    ,
+    FAST0_IRQ_ID    ,
+    EXTERNAL_IRQ_ID ,
+    SOFTWARE_IRQ_ID ,
+    TIMER_IRQ_ID
+};
+
+void mstatus_mie_enable() {
+    int mie_bit = 0x1 << MSTATUS_MIE_BIT;
+    asm volatile("csrrs x0, mstatus, %0" : : "r" (mie_bit));
+}
+
+void mm_ram_assert_irq(uint32_t mask, uint32_t cycle_delay) {
+    *TIMER_REG_ADDR = mask;
+    *TIMER_VAL_ADDR = 1 + cycle_delay;
+}
+
+extern void __no_irq_handler();
+
+void nested_hwloop_use() {
+    volatile uint32_t in_result = 0, out_result = 0;
+    // First stack start, end and count for both hardware loops
+    volatile uint32_t start[2], end[2], count[2];    
+    asm volatile("csrr %0, 0xCC0" : "=r" (start[0]));
+    asm volatile("csrr %0, 0xCC1" : "=r" (end[0]));
+    asm volatile("csrr %0, 0xCC2" : "=r" (count[0]));
+    asm volatile("csrr %0, 0xCC4" : "=r" (start[1]));
+    asm volatile("csrr %0, 0xCC5" : "=r" (end[1]));
+    asm volatile("csrr %0, 0xCC6" : "=r" (count[1]));
+
+    asm volatile(".align 4\n\t"
+                 "cv.setupi 1, 10, endO_1\n\t"
+                 "startO_1:\n\t"
+                 "    cv.setupi 0, 10, endZ_1\n\t"
+                 "    .option norvc\n\t"
+                 "    startZ_1:\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "    endZ_1:\n\t"
+                 "    addi %1, %1, 2\n\t"
+                 "    addi %1, %1, 2\n\t"
+                 "    addi %1, %1, 2\n\t"
+                 "endO_1:\n\t"
+                 : "+r" (in_result), "+r" (out_result));
+
+    if (in_result != 400) nested_hwloop_error++;
+    if (out_result != 60) nested_hwloop_error++;
+
+    // Restore from critical section
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.start 0, t6\n\t"
+                 : : "r" (start[0]));
+
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.end 0, t6\n\t"
+                 : : "r" (end[0]));
+
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.count 0, t6\n\t"
+                 : : "r" (count[0]));
+
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.start 1, t6\n\t"
+                 : : "r" (start[1]));
+
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.end 1, t6\n\t"
+                 : : "r" (end[1]));
+
+    asm volatile("add t6, x0, %0\n\t"
+                 "cv.count 1, t6\n\t"
+                 : : "r" (count[1]));
+}
+
+void generic_irq_handler(uint32_t id) {
+    asm volatile("csrr %0, mcause": "=r" (mmcause));
+    irq_id = id;
+
+    if (active_test == 1) {
+        nested_hwloop_use();
+    }    
+}
+
+void m_software_irq_handler(void) { generic_irq_handler(SOFTWARE_IRQ_ID); }
+void m_timer_irq_handler(void) { generic_irq_handler(TIMER_IRQ_ID); }
+void m_external_irq_handler(void) { generic_irq_handler(EXTERNAL_IRQ_ID); }
+void m_fast0_irq_handler(void) { generic_irq_handler(FAST0_IRQ_ID); }
+void m_fast1_irq_handler(void) { generic_irq_handler(FAST1_IRQ_ID); }
+void m_fast2_irq_handler(void) { generic_irq_handler(FAST2_IRQ_ID); }
+void m_fast3_irq_handler(void) { generic_irq_handler(FAST3_IRQ_ID); }
+void m_fast4_irq_handler(void) { generic_irq_handler(FAST4_IRQ_ID); }
+void m_fast5_irq_handler(void) { generic_irq_handler(FAST5_IRQ_ID); }
+void m_fast6_irq_handler(void) { generic_irq_handler(FAST6_IRQ_ID); }
+void m_fast7_irq_handler(void) { generic_irq_handler(FAST7_IRQ_ID); }
+void m_fast8_irq_handler(void) { generic_irq_handler(FAST8_IRQ_ID); }
+void m_fast9_irq_handler(void) { generic_irq_handler(FAST9_IRQ_ID); }
+void m_fast10_irq_handler(void) { generic_irq_handler(FAST10_IRQ_ID); }
+void m_fast11_irq_handler(void) { generic_irq_handler(FAST11_IRQ_ID); }
+void m_fast12_irq_handler(void) { generic_irq_handler(FAST12_IRQ_ID); }
+void m_fast13_irq_handler(void) { generic_irq_handler(FAST13_IRQ_ID); }
+void m_fast14_irq_handler(void) { generic_irq_handler(FAST14_IRQ_ID); }
+void m_fast15_irq_handler(void) { generic_irq_handler(FAST15_IRQ_ID); }
+
+// A Special version of the SW Handler (vector 0) used in the direct mode
+__attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void)  {
+    in_direct_handler = 1;
+    asm volatile("csrr %0, mcause" : "=r" (mmcause));
+}
+
+    asm (
+        ".global alt_vector_table\n"
+        ".option norvc\n"
+        ".align 8\n"
+        "alt_vector_table:\n"
+	    "j u_sw_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_software_irq_handler\n"
+	    "j __no_irq_handler\n"        
+        "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_timer_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_external_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j __no_irq_handler\n"
+	    "j m_fast0_irq_handler\n"
+	    "j m_fast1_irq_handler\n"
+	    "j m_fast2_irq_handler\n"
+	    "j m_fast3_irq_handler\n"
+	    "j m_fast4_irq_handler\n"
+	    "j m_fast5_irq_handler\n"
+	    "j m_fast6_irq_handler\n"
+	    "j m_fast7_irq_handler\n"
+	    "j m_fast8_irq_handler\n"
+	    "j m_fast9_irq_handler\n"
+	    "j m_fast10_irq_handler\n"
+	    "j m_fast11_irq_handler\n"
+	    "j m_fast12_irq_handler\n"
+	    "j m_fast13_irq_handler\n"
+	    "j m_fast14_irq_handler\n"
+	    "j m_fast15_irq_handler\n"
+    );
+
+    asm (
+        ".global alt_direct_vector_table\n"
+        ".option norvc\n"
+        ".align 8\n"
+        "alt_direct_vector_table:\n"
+	    "j u_sw_direct_irq_handler\n"	
+    );
+
+    asm (
+        ".global alt_direct_ecall_table\n"
+        ".option norvc\n"
+        ".align 8\n"
+        "alt_direct_ecall_table:\n"
+        "wfi\n"
+	    "j u_sw_irq_handler\n"	
+    );
+
+int main(int argc, char *argv[]) {
+    int retval;
+
+    // Test 1
+    retval = test1();
+    if (retval != EXIT_SUCCESS)
+        return retval;
+
+    return EXIT_SUCCESS;
+}
+
+    //-------------------------------------------------------------------------------------------------------------------------------------------
+    //-------------------------------------------------------------------------------------------------------------------------------------------
+
+// Test 1 will check Hardware loops use inside Interrupt handler
+int test1() {
+    volatile uint32_t error = 0;
+    volatile uint32_t in_result = 0, out_result = 0;
+    printf("TEST 1 - TRIGGER ONE IRQ DURING HARDWARE LOOP:\n");
+
+    active_test = 1;
+
+    // Enable all interrupts (MIE and MSTATUS.MIE)
+    uint32_t mie = (uint32_t) -1;
+    asm volatile("csrw mie, %0" : : "r" (mie));            
+    mstatus_mie_enable();
+
+    mm_ram_assert_irq(0x1 << 31, 40);
+
+    asm volatile(".align 4\n\t"
+                 "cv.setupi 1, 10, endO_0\n\t"
+                 "startO_0:\n\t"
+                 "    cv.setupi 0, 10, endZ_0\n\t"
+                 "    .option norvc\n\t"
+                 "    startZ_0:\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "        addi %0, %0, 1\n\t"
+                 "    endZ_0:\n\t"
+                 "    addi %1, %1, 2\n\t"
+                 "    addi %1, %1, 2\n\t"
+                 "endO_0:\n\t"
+                 : "+r" (in_result), "+r" (out_result));
+
+    if (in_result != 300) error++;
+    if (out_result != 40) error++;
+    if (nested_hwloop_error != 0) error++;
+    if (error != 0)
+        return ERR_CODE_TEST_1;
+
+    return EXIT_SUCCESS;
+}
+

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.c
@@ -1,3 +1,23 @@
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+// 
+// Description : Interrupt during PULP Hardware Loops execution with save/restore
+// 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.h
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.h
@@ -1,0 +1,104 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+#ifndef __INTERRUPT_TEST_H__
+#define __INTERRUPT_TEST_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Enable debug messages, note that this will change test timing
+//#define DEBUG_MSG
+
+#define ERR_CODE_TEST_1      1
+#define ERR_CODE_TEST_2      2
+#define ERR_CODE_TEST_3      3
+#define ERR_CODE_TEST_4      4
+#define ERR_CODE_TEST_5      5
+#define ERR_CODE_TEST_6      6
+#define ERR_CODE_TEST_7      7
+
+#define TIMER_REG_ADDR         ((volatile uint32_t *) 0x15000000)  
+#define TIMER_VAL_ADDR         ((volatile uint32_t *) 0x15000004) 
+
+#define MSTATUS_MIE_BIT 3
+
+#define MCAUSE_IRQ_MASK 0x1f
+
+#define IRQ_NUM 19
+#define IRQ_MASK 0xFFFF0888
+
+#define SOFTWARE_IRQ_ID  3
+#define TIMER_IRQ_ID     7
+#define EXTERNAL_IRQ_ID  11
+#define FAST0_IRQ_ID     16
+#define FAST1_IRQ_ID     17
+#define FAST2_IRQ_ID     18
+#define FAST3_IRQ_ID     19
+#define FAST4_IRQ_ID     20
+#define FAST5_IRQ_ID     21
+#define FAST6_IRQ_ID     22
+#define FAST7_IRQ_ID     23
+#define FAST8_IRQ_ID     24
+#define FAST9_IRQ_ID     25
+#define FAST10_IRQ_ID    26
+#define FAST11_IRQ_ID    27
+#define FAST12_IRQ_ID    28
+#define FAST13_IRQ_ID    29
+#define FAST14_IRQ_ID    30
+#define FAST15_IRQ_ID    31
+
+void mstatus_mie_enable();
+void mm_ram_assert_irq(uint32_t mask, uint32_t cycle_delay);
+extern void __no_irq_handler();
+void nested_hwloop_use();
+void generic_irq_handler(uint32_t id);
+
+__attribute__((interrupt ("machine"))) void m_software_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_timer_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_external_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast0_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast1_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast2_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast3_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast4_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast5_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast6_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast7_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast8_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast9_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast10_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast11_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast12_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast13_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast14_irq_handler(void);
+__attribute__((interrupt ("machine"))) void m_fast15_irq_handler(void);
+
+// A Special version of the SW Handler (vector 0) used in the direct mode
+__attribute__((interrupt ("machine"))) void u_sw_direct_irq_handler(void);
+
+extern void alt_vector_table();
+extern void alt_direct_vector_table();
+extern void alt_direct_ecall_table();
+
+// Function prototypes for individual tests
+int test1();
+int test2();
+int test3();
+int test4();
+int test5();
+int test6();
+int test7();
+int test8();
+int test9();
+int test10();
+
+// Test1 (all irqs in sequence) used in multiple tests so break out implementation
+int test1_impl(int direct_mode);
+
+#endif
+

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.h
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/pulp_hardware_loop_interrupt_test.h
@@ -1,9 +1,19 @@
-// This is free and unencumbered software released into the public domain.
+// Copyright 2020 OpenHW Group
+// Copyright 2023 Dolphin Design
 //
-// Anyone is free to copy, modify, publish, use, compile, sell, or
-// distribute this software, either in source code form or as a compiled
-// binary, for any purpose, commercial or non-commercial, and by any
-// means.
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
 
 #ifndef __INTERRUPT_TEST_H__
 #define __INTERRUPT_TEST_H__

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/test.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 OpenHW Group
+# Copyright 2023 Dolphin Design
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
 name: pulp_hardware_loop_interrupt_test
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >

--- a/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/pulp_hardware_loop_interrupt_test/test.yaml
@@ -1,0 +1,5 @@
+name: pulp_hardware_loop_interrupt_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Interrupt during Hardware Loop test
+


### PR DESCRIPTION
- Updated march option with respect to names, zfinx and added hwloops compatible with 20230310 Embecosm toolchain (except zfinx).
- Added 2 new XPULP Hardware Loop assembly tests.
- Updated cv_regress and template to allow tb compilation without ISS.