### PR TITLE
Add support for E40X core simulation using Verilator/Questa Vsim

### DIFF
--- a/cv32e40x/sim/core/Makefile
+++ b/cv32e40x/sim/core/Makefile
@@ -66,13 +66,10 @@ SIM_BSP_RESULTS          = $(SIM_TEST_PROGRAM_RESULTS)/bsp
 
 # Test-Program directores.
 # Relative path is used for Verilator which cannot seem to handle loooong pathnames.
-TEST_PROGRAM_PATH    = $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/custom
-TEST_PROGRAM_RELPATH = ../../tests/programs/custom
-
-# Default "custom test-program"
-CUSTOM       = $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/custom
-CUSTOM_PROG  ?= hello-world
-TEST         ?= hello-world
+TEST_PROGRAM_PATH    ?= $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/custom
+TEST_PROGRAM_RELPATH ?= ../../tests/programs/custom
+# Default test-program
+TEST                 ?= hello-world
 
 ###############################################################################
 # Generate and include TEST_FLAGS_MAKE, based on the YAML test description.
@@ -376,13 +373,13 @@ vsim-run-gui: vsim-all
 	$(RTLSRC_VOPT_TB_TOP) -do $(VSIM_SCRIPT)
 
 .PHONY: questa-custom
-questa-custom: vsim-all $(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
-questa-custom: ALL_VSIM_FLAGS += +firmware=$(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
+questa-custom: vsim-all $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
+questa-custom: ALL_VSIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 questa-custom: vsim-run
 
 .PHONY: questa-custom-gui
-questa-custom-gui: vsim-all $(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
-questa-custom-gui: ALL_VSIM_FLAGS += +firmware=$(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
+questa-custom-gui: vsim-all $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
+questa-custom-gui: ALL_VSIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 questa-custom-gui: vsim-run-gui
 
 .PHONY: questa-cv32_riscv_tests
@@ -451,7 +448,7 @@ xrun-test: xrun-all $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 		$(XRUN_FLAGS) \
 		-f $(CV_CORE_MANIFEST) \
 		$(TBSRC_PKG) $(TBSRC) \
-		+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(CUSTOM_PROG).hex
+		+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 
 # Cadence Xcelium xrun cleanup
 .PHONY: xrun-clean xrun-clean-all
@@ -538,13 +535,13 @@ vcs-run-gui: vcsify
 	$(SIMV) $(ALL_VCS_FLAGS) -gui -do $(VCS_SCRIPT_GUI)
 
 .PHONY: vcs-hello-world
-vcs-hello-world: vcsify $(CUSTOM)/hello-world.hex
-vcs-hello-world: ALL_VCS_FLAGS += +firmware=$(CUSTOM)/hello-world.hex
+vcs-hello-world: vcsify $(TEST_PROGRAM_PATH)/hello-world.hex
+vcs-hello-world: ALL_VCS_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/hello-world.hex
 vcs-hello-world: vcs-run
 
 .PHONY: vcs-custom
-vcs-custom: vcsify $(CUSTOM)/$(CUSTOM_PROG).hex
-vcs-custom: ALL_VCS_FLAGS += +firmware=$(CUSTOM)/$(CUSTOM_PROG).hex
+vcs-custom: vcsify $(TEST_PROGRAM_PATH)/$(TEST).hex
+vcs-custom: ALL_VCS_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/$(TEST).hex
 vcs-custom: vcs-run
 
 .PHONY: vcs-cv32_riscv_tests
@@ -631,23 +628,23 @@ asim-run-gui: rvr-build-rtl
 	$(RTLSRC_VLOG_TB_TOP) -do "run -all"
 
 .PHONY: riviera-hello-world
-riviera-hello-world: rvr-build-rtl $(CUSTOM)/hello-world/hello-world.hex
-riviera-hello-world: ALL_ASIM_FLAGS += +firmware=$(CUSTOM)/hello-world/hello-world.hex
+riviera-hello-world: rvr-build-rtl $(TEST_PROGRAM_PATH)/hello-world/hello-world.hex
+riviera-hello-world: ALL_ASIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/hello-world/hello-world.hex
 riviera-hello-world: asim-run
 
 .PHONY: riviera-hello-world-gui
-riviera-hello-world-gui: rvr-build-rtl $(CUSTOM)/hello-world/hello-world.hex
-riviera-hello-world-gui: ALL_ASIM_FLAGS += +firmware=$(CUSTOM)/hello-world/hello-world.hex
+riviera-hello-world-gui: rvr-build-rtl $(TEST_PROGRAM_PATH)/hello-world/hello-world.hex
+riviera-hello-world-gui: ALL_ASIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/hello-world/hello-world.hex
 riviera-hello-world-gui: asim-run-gui
 
 .PHONY: riviera-custom
-riviera-custom: rvr-build-rtl $(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
-riviera-custom: ALL_ASIM_FLAGS += +firmware=$(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
+riviera-custom: rvr-build-rtl $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
+riviera-custom: ALL_ASIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 riviera-custom: asim-run
 
 .PHONY: riviera-custom-gui
-riviera-custom-gui: rvr-build-rtl $(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
-riviera-custom-gui: ALL_ASIM_FLAGS += +firmware=$(CUSTOM)/$(CUSTOM_PROG)/$(CUSTOM_PROG).hex
+riviera-custom-gui: rvr-build-rtl $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
+riviera-custom-gui: ALL_ASIM_FLAGS += +firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 riviera-custom-gui: asim-run-gui
 
 riviera-clean:

--- a/cv32e40x/sim/core/Makefile
+++ b/cv32e40x/sim/core/Makefile
@@ -56,11 +56,40 @@ CV_CORE_UC     = $(shell echo $(CV_CORE) | tr a-z A-Z)
 # Compile compile flags for all simulators
 SV_CMP_FLAGS =
 
+# Common output directories
+RUN_INDEX               ?= 0
+SIM_RESULTS              = simulation_results
+SIM_TEST_RESULTS         = $(SIM_RESULTS)/$(TEST)
+SIM_RUN_RESULTS          = $(SIM_TEST_RESULTS)/$(RUN_INDEX)
+SIM_TEST_PROGRAM_RESULTS = $(SIM_RUN_RESULTS)/test_program
+SIM_BSP_RESULTS          = $(SIM_TEST_PROGRAM_RESULTS)/bsp
+
+# Test-Program directores.
+# Relative path is used for Verilator which cannot seem to handle loooong pathnames.
+TEST_PROGRAM_PATH    = $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/custom
+TEST_PROGRAM_RELPATH = ../../tests/programs/custom
+
 # Default "custom test-program"
-CUSTOM_PROG  ?= requested_csr_por
+CUSTOM       = $(CORE_V_VERIF)/$(CV_CORE_LC)/tests/programs/custom
+CUSTOM_PROG  ?= hello-world
 TEST         ?= hello-world
 
 ###############################################################################
+# Generate and include TEST_FLAGS_MAKE, based on the YAML test description.
+# An example of what is generated is below (not all of these flags are used):
+#       TEST_DESCRIPTION=Simple hello-world sanity test
+#       TEST_NAME=hello-world
+#       TEST_PROGRAM=hello-world
+#       TEST_TEST_DIR=/home/mike/GitHubRepos/MikeOpenHWGroup/core-v-verif/master/cv32e40p/tests/programs/custom/hello-world
+#       TEST_UVM_TEST=uvmt_$(CV_CORE_LC)_firmware_test_c
+###############################################################################
+YAML2MAKE = $(CORE_V_VERIF)/bin/yaml2make
+TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(u) --prefix=TEST --core=$(CV_CORE))
+ifeq ($(TEST_FLAGS_MAKE),)
+$(error ERROR Could not find test.yaml for test: $(TEST))
+endif
+include $(TEST_FLAGS_MAKE)
+
 # Common Makefiles:
 #  -Variables for RTL and other dependencies (e.g. RISCV-DV)
 include ../ExternalRepos.mk
@@ -74,7 +103,7 @@ VLIB      = vlib
 VWORK     = work
 
 VLOG          = vlog
-VLOG_FLAGS    = -pedanticerrors -suppress 2577 -suppress 2583
+VLOG_FLAGS    = -pedanticerrors -suppress 2577 -suppress 2583 +define+COREV_ASSERT_OFF
 VLOG_LOG      = vloggy
 
 VOPT          = vopt
@@ -124,7 +153,7 @@ XRUN_DIR          = xcelium.d
 # verilator configuration
 VERILATOR           = verilator
 VERI_FLAGS         +=
-VERI_COMPILE_FLAGS += -Wno-BLKANDNBLK +define+COREV_ASSERT_OFF $(SV_CMP_FLAGS) # hope this doesn't hurt us in the long run
+VERI_COMPILE_FLAGS += -Wno-COMBDLY -Wno-BLKANDNBLK +define+COREV_ASSERT_OFF $(SV_CMP_FLAGS) # hope this doesn't hurt us in the long run
 VERI_TRACE         ?=
 VERI_OBJ_DIR       ?= cobj_dir
 VERI_LOG_DIR       ?= cobj_dir/logs
@@ -272,7 +301,7 @@ dsim-custom:
 	@echo "This target is depreciated.  Please use 'make dsim-test TEST=<test-program>'"
 	@echo "                             Example:   'make dsim-test TEST=fibonacci'"
 
-dsim-test: dsim-comp $(VERI_CUSTOM)/$(TEST)/$(TEST).hex
+dsim-test: dsim-comp $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 	@echo "$(BANNER)"
 	@echo "* Running with Metrics DSIM"
 	@echo "$(BANNER)"
@@ -283,7 +312,7 @@ dsim-test: dsim-comp $(VERI_CUSTOM)/$(TEST)/$(TEST).hex
 		$(DSIM_RUN_FLAGS) \
 		-sv_lib $(UVM_HOME)/src/dpi/libuvm_dpi.so \
 		-sv_lib $(OVP_MODEL_DPI)  \
-		+firmware=../../$(VERI_CUSTOM)/$(TEST)/$(TEST).hex
+		+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 
 # Metrics dsim cleanup
 .PHONY: dsim-clean
@@ -308,7 +337,7 @@ dsim-clean: tc-clean
 	touch .lib-rtl
 
 
-.build-rtl: .lib-rtl $(CV_CORE_PKG) $(TBSRC_PKG) $(TBSRC)
+.build-rtl: .lib-rtl CV_CORE_pkg $(CV_CORE_PKG) $(TBSRC_PKG) $(TBSRC)
 	$(VLOG) \
 		-work $(VWORK) \
 		$(VLOG_FLAGS) \
@@ -327,7 +356,7 @@ vsim-all:  .opt-rtl
 .PHONY: vsim-run
 vsim-run: ALL_VSIM_FLAGS += -c
 vsim-run: vsim-all
-	$(VSIM) -work $(VWORK) $(DPILIB_VSIM_OPT) $(ALL_VSIM_FLAGS)\
+	$(VSIM) -work $(VWORK) $(DPILIB_VSIM_OPT) $(ALL_VSIM_FLAGS) \
 	$(RTLSRC_VOPT_TB_TOP) -do 'source $(VSIM_SCRIPT); exit -f'
 
 
@@ -417,12 +446,12 @@ xrun-custom:
 	@echo "                             Example:   'make xrun-test TEST=fibonacci'"
 
 .PHONY: xrun-test
-xrun-test: xrun-all $(VERI_CUSTOM)/$(TEST)/$(TEST).hex
+xrun-test: xrun-all $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 	$(XRUN) \
 		$(XRUN_FLAGS) \
 		-f $(CV_CORE_MANIFEST) \
 		$(TBSRC_PKG) $(TBSRC) \
-		+firmware=$(VERI_CUSTOM)/$(TEST)/$(CUSTOM_PROG).hex
+		+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(CUSTOM_PROG).hex
 
 # Cadence Xcelium xrun cleanup
 .PHONY: xrun-clean xrun-clean-all
@@ -470,13 +499,13 @@ testbench_verilator: CV_CORE_pkg $(TBSRC_VERI) $(TBSRC_PKG)
 	$(MAKE) -C $(VERI_OBJ_DIR) -f Vtb_top_verilator.mk
 	cp $(VERI_OBJ_DIR)/Vtb_top_verilator testbench_verilator
 
-veri-test: verilate $(VERI_CUSTOM)/$(TEST)/$(TEST).hex
+veri-test: verilate $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 	@echo "$(BANNER)"
 	@echo "* Running with Verilator: logfile in $(VERI_LOG_DIR)/$(TEST).log"
 	@echo "$(BANNER)"
 	mkdir -p $(VERI_LOG_DIR)
 	./testbench_verilator $(VERI_FLAGS) \
-		"+firmware=$(VERI_CUSTOM)/$(TEST)/$(TEST).hex" \
+		"+firmware=$(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex" \
 		| tee $(VERI_LOG_DIR)/$(TEST).log
 
 # verilator specific cleanup

--- a/cv32e40x/sim/core/README.md
+++ b/cv32e40x/sim/core/README.md
@@ -1,49 +1,62 @@
 Simulation Directory for CV32E Core Testbench
 ==================================
 This is the directory in which you should run all tests of the Core Testbench.
-The testbench itself is located at `../../tb/core` and the test-programs are at
-`../../tests`.  See the README in those directories for more information.
+The testbench itself is located at `cv32e40*/tb/core` and the test-programs are at
+`cv32e40*/tests/programs`.  See the README in those directories for more information.
 
 To run the core testbench you will need a SystemVerilog simulator and RISC-V GCC compiler.
 
 Supported SystemVerilog Simulators
 ----------------------------------
-The core testbench and associated test-programs can be run using **_Verilator_**, the Metrics
-**_dsim_**, Mentor's **_Questa_**, Cadence **_Xcelium_**, Synopsys **_vcs_** and Aldec **_Riviera-PRO_**
+The core testbench and associated test-programs were only tested with 
+ **_Verilator_** and Mentor's **_Questa_**. But the Makefile also provides simuation commands for the Metrics
+**_dsim_**,  Cadence **_Xcelium_**, Synopsys **_vcs_** and Aldec **_Riviera-PRO_**
 simulators. Note that **_Icarus_** verilog cannot compile the RTL and there are no plans
 to support Icarus in the future.
 
 RISC-V GCC Compiler "Toolchain"
 -------------------------------
-Pointers to the recommended toolchain for CV32E40X are in `../TOOLCHAIN`.
+See the `TOOLCHAIN.md` in `core-v-verif/mk/` to choose the recommended toolchain for CV32E40X .
 
 Running your own C programs
 ---------------------
 A hello world program is available and you can run it in the CV32E Core testbench.
-Invoke the `dsim-hello_world` or `hello-world-veri-run` makefile rules to run it with
-`dsim` or `verilator` respectively.
+Invoke the `make questa-custom TEST=hello-world` or `make veri-test TEST=hello-world` makefile rules to run it with
+`vsim` or `verilator` respectively.
 
-The hello world program is located in the `custom` folder. The relevant sections
-in the Makefile on how to compile and link this program can be found under `Running
-custom programs`.  Make sure you have a working C compiler (see above) and keep in
+The hello world program is located in the `cv32e40x/tests/programs/custom` folder. The `hello-world.c` is compiled and then linked with the BSP objects to generate the ELF file.  You can reset the default values of `TEST_PROGRAM_PATH` and `TEST` in the command line to point to your own C programs. Make sure you have a working C compiler (see above) and keep in
 mind that you are running on a very basic machine.
 
 Running the testbench with [verilator](https://www.veripool.org/wiki/verilator)
 ----------------------
-Point your environment variable `RISCV` to your RISC-V toolchain. Call `make`
-to run the default test (hello_world).
-
-Running your own Assembler programs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Admittedly, this needs work. If you have a C or assembly program in `../../tests/core/custom`
+Point your environment variable `RISCV` to your RISC-V toolchain. If you have a C or assembly program in `cv32e40*/tests/programs/custom/`
 then the following will work with Verilator:<br>
 ```
-make custom CUSTOM_PROG=dhrystone
-make custom CUSTOM_PROG=misalign
-make custom CUSTOM_PROG=fibonacci
-make custom CUSTOM_PROG=illegal
-make custom CUSTOM_PROG=riscv_ebreak_test_0
+make veri-test TEST=hello-world
+make veri-test TEST=csr_instructions
+make veri-test TEST=misalign
+...
 ```
+
+Running the testbench with Questa (vsim)
+---------------------------------------------------------
+Point your environment variable `RISCV` to your RISC-V toolchain. Call the following commands to work with Vsim:<br>
+```
+make questa-custom TEST=hello-world
+make questa-custom TEST=csr_instructions
+make questa-custom TEST=misalign
+...
+```
+
+Run `make firmware-vsim-run` to build the testbench and the firmware. Use
+`VSIM_FLAGS` to configure the simulator e.g. `make firmware-vsim-run
+VSIM_FLAGS="-gui -debugdb"`.
+<br>The Makefile also supports running individual assembler tests from either
+the riscv_tests or riscv_compliance_tests directories using vsim. For example,
+to run the ADD IMMEDIATE test from riscv_tests:
+* `make questa-unit-test addi`
+<br>To run I-LBU-01.S from the riscv_compliance_tests:
+* `make questa-unit-test I_LBU_01`
 
 Running the testbench with Metrics [dsim](https://metrics.ca)
 ----------------------
@@ -68,19 +81,6 @@ Point your environment variable `RISCV` to your RISC-V toolchain. Call
 test in the custom directory. Other rules of interest:
 * `make xrun-firmware` to build and run the testbench with all the testcases in the riscv_tests/ and riscv_compliance_tests/ directories.
 * Clean up your mess: `make xsim-clean` (deletes xsim intermediate files) and `xrun-clean-all` (deletes xsim intermedaites and all testcase object files).
-
-Running the testbench with Questa (vsim)
----------------------------------------------------------
-Point your environment variable `RISCV` to your RISC-V toolchain. Call `make
-firmware-vsim-run` to build the testbench and the firmware, and run it. Use
-`VSIM_FLAGS` to configure the simulator e.g. `make firmware-vsim-run
-VSIM_FLAGS="-gui -debugdb"`.
-<br>The Makefile also supports running individual assembler tests from either
-the riscv_tests or riscv_compliance_tests directories using vsim. For example,
-to run the ADD IMMEDIATE test from riscv_tests:
-* `make questa-unit-test addi`
-<br>To run I-LBU-01.S from the riscv_compliance_tests:
-* `make questa-unit-test I_LBU_01`
 
 Running the testbench with VCS (vcs)
 ----------------------

--- a/cv32e40x/tb/core/cv32e40x_tb_wrapper.sv
+++ b/cv32e40x/tb/core/cv32e40x_tb_wrapper.sv
@@ -16,187 +16,193 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
 
 module cv32e40x_tb_wrapper
-    #(parameter // Parameters used by TB
-                INSTR_RDATA_WIDTH = 32,
-                RAM_ADDR_WIDTH    = 20,
-                BOOT_ADDR         = 'h80,
-                DM_HALTADDRESS    = 32'h1A11_0800,
-                HART_ID           = 32'h0000_0000,
-                IMP_PATCH_ID      = 4'h0,
-                // Parameters used by DUT
-                NUM_MHPMCOUNTERS  = 1
-    )
-    (input logic         clk_i,
-     input logic         rst_ni,
+#(parameter // Parameters used by TB
+            INSTR_RDATA_WIDTH = 32,
+            RAM_ADDR_WIDTH    = 20,
+            BOOT_ADDR         = 'h80,
+            DM_HALTADDRESS    = 32'h1A11_0800,
+            HART_ID           = 32'h0000_0000,
+            IMP_PATCH_ID      = 4'h0,
+            // Parameters used by DUT
+            NUM_MHPMCOUNTERS  = 1
+)
+(input logic         clk_i,
+ input logic         rst_ni,
 
-     input logic         fetch_enable_i,
-     output logic        tests_passed_o,
-     output logic        tests_failed_o,
-     output logic [31:0] exit_value_o,
-     output logic        exit_valid_o);
+ input logic         fetch_enable_i,
+ output logic        tests_passed_o,
+ output logic        tests_failed_o,
+ output logic [31:0] exit_value_o,
+ output logic        exit_valid_o);
 
-    // signals connecting core to memory
-    logic                         instr_req;
-    logic                         instr_gnt;
-    logic                         instr_rvalid;
-    logic [31:0]                  instr_addr;
-    logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
+// signals connecting core to memory
+logic                         instr_req;
+logic                         instr_gnt;
+logic                         instr_rvalid;
+logic [31:0]                  instr_addr;
+logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
 
-    logic                         data_req;
-    logic                         data_gnt;
-    logic                         data_rvalid;
-    logic [31:0]                  data_addr;
-    logic                         data_we;
-    logic [3:0]                   data_be;
-    logic [31:0]                  data_rdata;
-    logic [31:0]                  data_wdata;
+logic                         data_req;
+logic                         data_gnt;
+logic                         data_rvalid;
+logic [31:0]                  data_addr;
+logic                         data_we;
+logic [3:0]                   data_be;
+logic [31:0]                  data_rdata;
+logic [31:0]                  data_wdata;
 
-    // signals to debug unit
-    logic                         debug_req;
+// signals to debug unit
+logic                         debug_req;
 
-    // irq signals (not used)
-    logic [0:31]                  irq;
-    logic [0:4]                   irq_id_in;
-    logic                         irq_ack;
-    logic [0:4]                   irq_id_out;
-    logic                         irq_sec;
-
-
-    // interrupts (only timer for now)
-    assign irq_sec     = '0;
-
-   // eXtension Interface
-    if_xif #(
-        .X_NUM_RS    ( 2  ),
-        .X_MEM_WIDTH ( 32 ),
-        .X_RFR_WIDTH ( 32 ),
-        .X_RFW_WIDTH ( 32 ),
-        .X_MISA      ( '0 )
-    ) ext_if();
+// irq signals (not used)
+logic [0:31]                  irq;
+logic [0:4]                   irq_id_in;
+logic                         irq_ack;
+logic [0:4]                   irq_id_out;
+logic                         irq_sec;
 
 
-    // instantiate the core
-    cv32e40x_core #(
-                 .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS)
-                )
-    cv32e40x_core_i
-        (
-         // Clock and Reset
-         .clk_i                  ( clk_i                 ),
-         .rst_ni                 ( rst_ni                ),
+// interrupts (only timer for now)
+assign irq_sec     = '0;
 
-         .scan_cg_en_i           ( '0                    ),
-
-         // Control interface: more or less static
-         .boot_addr_i            ( BOOT_ADDR             ),
-         .mtvec_addr_i           ( '0                    ), // TODO
-         .dm_halt_addr_i         ( DM_HALTADDRESS        ),
-         .mhartid_i              ( HART_ID               ),
-         .mimpid_patch_i         ( IMP_PATCH_ID          ),
-         .dm_exception_addr_i    ( '0                    ), // TODO
-         .nmi_addr_i             ( '0                    ), // TODO
-
-         // Instruction memory interface
-         .instr_req_o            ( instr_req             ),
-         .instr_gnt_i            ( instr_gnt             ),
-         .instr_rvalid_i         ( instr_rvalid          ),
-         .instr_addr_o           ( instr_addr            ),
-         .instr_memtype_o        (                       ), // TODO: should the core tb check this?
-         .instr_prot_o           (                       ), // TODO: should the core tb check this?
-         .instr_dbg_o            (                       ), // TODO: should the core tb check this?
-         .instr_rdata_i          ( instr_rdata           ),
-         .instr_err_i            ( 1'b0                  ),
-
-         // Data memory interface
-         .data_req_o             ( data_req              ),
-         .data_gnt_i             ( data_gnt              ),
-         .data_rvalid_i          ( data_rvalid           ),
-         .data_we_o              ( data_we               ),
-         .data_be_o              ( data_be               ),
-         .data_addr_o            ( data_addr             ),
-         .data_memtype_o         (                       ), // TODO: should the core tb check this?
-         .data_prot_o            (                       ), // TODO: should the core tb check this?
-         .data_dbg_o             (                       ), // TODO
-         .data_err_i             ( 1'b0                  ),
-         .data_atop_o            (                       ),
-         .data_exokay_i          ( 1'b1                  ),
-
-         // Cycle Count
-         .mcycle_o               (                       ), // TODO
-
-         // eXtension interface
-         .xif_compressed_if      ( ext_if                ),
-         .xif_issue_if           ( ext_if                ),
-         .xif_commit_if          ( ext_if                ),
-         .xif_mem_if             ( ext_if                ),
-         .xif_mem_result_if      ( ext_if                ),
-         .xif_result_if          ( ext_if                ),
-
-         // Interrupts
-         .irq_i                  ( {32{1'b0}}            ),
-
-         .clic_irq_i             (  1'b0                 ), // TODO
-         .clic_irq_id_i          ( 12'h0                 ), // TODO
-         .clic_irq_il_i          (  8'h0                 ), // TODO
-         .clic_irq_priv_i        (  2'h0                 ), // TODO
-         .clic_irq_hv_i          (  1'b0                 ), // TODO
-         .clic_irq_id_o          (                       ), // TODO
-         .clic_irq_mode_o        (                       ),
-         .clic_irq_exit_o        (                       ),
+// eXtension Interface
+if_xif #(
+    .X_NUM_RS    ( 2  ),
+    .X_MEM_WIDTH ( 32 ),
+    .X_RFR_WIDTH ( 32 ),
+    .X_RFW_WIDTH ( 32 ),
+    .X_MISA      ( '0 )
+) ext_if();
 
 
-         
-         // Fencei flush handshake
-         .fencei_flush_req_o     (                       ),
-         .fencei_flush_ack_i     ( 1'b0                  ),
+// instantiate the core
+cv32e40x_core #(
+             .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS)
+            )
+cv32e40x_core_i
+    (
+     // Clock and Reset
+     .clk_i                  ( clk_i                 ),
+     .rst_ni                 ( rst_ni                ),
 
-         .debug_req_i            ( debug_req             ),
-         .debug_havereset_o      (                       ),
-         .debug_running_o        (                       ),
-         .debug_halted_o         (                       ),
+     .scan_cg_en_i           ( 1'b0                  ),
 
-         // CPU Control Signals
-         .fetch_enable_i         ( fetch_enable_i        ),
-         .core_sleep_o           ( core_sleep_o          )
-       );
+     // Static configuration
+     .boot_addr_i            ( BOOT_ADDR             ),
+     .dm_exception_addr_i    ( '0                    ),
+     .dm_halt_addr_i         ( DM_HALTADDRESS        ),
+     .mhartid_i              ( HART_ID               ),
+     .mimpid_patch_i         ( IMP_PATCH_ID          ),
+     .mtvec_addr_i           ( '0                    ), 
+     
+     // Instruction memory interface
+     .instr_req_o            ( instr_req             ),
+     .instr_gnt_i            ( instr_gnt             ),
+     .instr_rvalid_i         ( instr_rvalid          ),
+     .instr_addr_o           ( instr_addr            ),
+     .instr_memtype_o        (                       ),
+     .instr_prot_o           (                       ),
+     .instr_dbg_o            (                       ),
+     .instr_rdata_i          ( instr_rdata           ),
+     .instr_err_i            ( 1'b0                  ),
 
-    // this handles read to RAM and memory mapped pseudo peripherals
-    mm_ram
-        #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
-          .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH))
-    ram_i
-        (.clk_i          ( clk_i                                     ),
-         .rst_ni         ( rst_ni                                    ),
-         .dm_halt_addr_i ( DM_HALTADDRESS                            ),
+     // Data memory interface
+     .data_req_o             ( data_req              ),
+     .data_gnt_i             ( data_gnt              ),
+     .data_rvalid_i          ( data_rvalid           ),
+     .data_addr_o            ( data_addr             ),
+     .data_be_o              ( data_be               ),
+     .data_we_o              ( data_we               ),
+     .data_wdata_o           ( data_wdata            ),
+     .data_memtype_o         (                       ), 
+     .data_prot_o            (                       ),
+     .data_dbg_o             (                       ),
+     .data_err_i             ( 1'b0                  ),
+     .data_atop_o            (                       ),
+     .data_rdata_i           ( data_rdata            ),
+     .data_exokay_i          ( 1'b1                  ),
 
-         .instr_req_i    ( instr_req                                 ),
-         .instr_addr_i   ( { {10{1'b0}},
-                             instr_addr[RAM_ADDR_WIDTH-1:0]
-                           }                                         ),
-         .instr_rdata_o  ( instr_rdata                               ),
-         .instr_rvalid_o ( instr_rvalid                              ),
-         .instr_gnt_o    ( instr_gnt                                 ),
+     // Cycle Count
+     .mcycle_o               (                       ),
 
-         .data_req_i     ( data_req                                  ),
-         .data_addr_i    ( data_addr                                 ),
-         .data_we_i      ( data_we                                   ),
-         .data_be_i      ( data_be                                   ),
-         .data_wdata_i   ( data_wdata                                ),
-         .data_rdata_o   ( data_rdata                                ),
-         .data_rvalid_o  ( data_rvalid                               ),
-         .data_gnt_o     ( data_gnt                                  ),
+     // Time input
+     .time_i                 ( '0                   ),
 
-         .irq_id_i       ( irq_id_out                                ),
-         .irq_ack_i      ( irq_ack                                   ),
-         .irq_o          ( irq                                       ),
+     // eXtension interface
+     .xif_compressed_if      ( ext_if                ),
+     .xif_issue_if           ( ext_if                ),
+     .xif_commit_if          ( ext_if                ),
+     .xif_mem_if             ( ext_if                ),
+     .xif_mem_result_if      ( ext_if                ),
+     .xif_result_if          ( ext_if                ),
 
-         .debug_req_o    ( debug_req                                 ),
+     // Basic interrupt architecture
+     .irq_i                  ( {32{1'b0}}            ),
 
-         .pc_core_id_i   ( cv32e40x_core_i.if_id_pipe.pc             ),
+     // Event wakeup signals
+     .wu_wfe_i               ( 1'b0                  ),
+     .wu_wrs_i               ( 1'b0                  ),
 
-         .tests_passed_o ( tests_passed_o                            ),
-         .tests_failed_o ( tests_failed_o                            ),
-         .exit_valid_o   ( exit_valid_o                              ),
-         .exit_value_o   ( exit_value_o                              ));
+     .clic_irq_i             (  '0                   ),
+     .clic_irq_id_i          (  '0                   ),
+     .clic_irq_level_i       (  '0                   ),
+     .clic_irq_priv_i        (  '0                   ),
+     .clic_irq_shv_i         (  '0                   ),
+     
+     // Fencei flush handshake
+     .fencei_flush_req_o     (                       ),
+     .fencei_flush_ack_i     ( 1'b0                  ),
+
+     // Debug interface
+     .debug_req_i            ( 1'b0                  ),
+     .debug_havereset_o      (                       ),
+     .debug_running_o        (                       ),
+     .debug_halted_o         (                       ),
+     .debug_pc_valid_o       (                       ),
+     .debug_pc_o             (                       ),
+
+     // CPU Control Signals
+     .fetch_enable_i         ( fetch_enable_i        ),
+     .core_sleep_o           (                       )
+   );
+
+// this handles read to RAM and memory mapped pseudo peripherals
+mm_ram
+    #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
+      .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH))
+ram_i
+    (.clk_i          ( clk_i                                     ),
+     .rst_ni         ( rst_ni                                    ),
+     .dm_halt_addr_i ( DM_HALTADDRESS                            ),
+
+     .instr_req_i    ( instr_req                                 ),
+     .instr_addr_i   ( { {10{1'b0}},
+                         instr_addr[RAM_ADDR_WIDTH-1:0]
+                       }                                         ),
+     .instr_rdata_o  ( instr_rdata                               ),
+     .instr_rvalid_o ( instr_rvalid                              ),
+     .instr_gnt_o    ( instr_gnt                                 ),
+
+     .data_req_i     ( data_req                                  ),
+     .data_addr_i    ( data_addr                                 ),
+     .data_we_i      ( data_we                                   ),
+     .data_be_i      ( data_be                                   ),
+     .data_wdata_i   ( data_wdata                                ),
+     .data_rdata_o   ( data_rdata                                ),
+     .data_rvalid_o  ( data_rvalid                               ),
+     .data_gnt_o     ( data_gnt                                  ),
+
+     .irq_id_i       ( irq_id_out                                ),
+     .irq_ack_i      ( irq_ack                                   ),
+     .irq_o          ( irq                                       ),
+
+     .debug_req_o    ( debug_req                                 ),
+
+     .pc_core_id_i   ( cv32e40x_core_i.if_id_pipe.pc             ),
+
+     .tests_passed_o ( tests_passed_o                            ),
+     .tests_failed_o ( tests_failed_o                            ),
+     .exit_valid_o   ( exit_valid_o                              ),
+     .exit_value_o   ( exit_value_o                              ));
 
 endmodule // cv32e40x_tb_wrapper

--- a/cv32e40x/tb/core/cv32e40x_tb_wrapper.sv
+++ b/cv32e40x/tb/core/cv32e40x_tb_wrapper.sv
@@ -16,193 +16,193 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
 
 module cv32e40x_tb_wrapper
-#(parameter // Parameters used by TB
-            INSTR_RDATA_WIDTH = 32,
-            RAM_ADDR_WIDTH    = 20,
-            BOOT_ADDR         = 'h80,
-            DM_HALTADDRESS    = 32'h1A11_0800,
-            HART_ID           = 32'h0000_0000,
-            IMP_PATCH_ID      = 4'h0,
-            // Parameters used by DUT
-            NUM_MHPMCOUNTERS  = 1
-)
-(input logic         clk_i,
- input logic         rst_ni,
+    #(parameter // Parameters used by TB
+                INSTR_RDATA_WIDTH = 32,
+                RAM_ADDR_WIDTH    = 20,
+                BOOT_ADDR         = 'h80,
+                DM_HALTADDRESS    = 32'h1A11_0800,
+                HART_ID           = 32'h0000_0000,
+                IMP_PATCH_ID      = 4'h0,
+                // Parameters used by DUT
+                NUM_MHPMCOUNTERS  = 1
+    )
+    (input logic         clk_i,
+     input logic         rst_ni,
 
- input logic         fetch_enable_i,
- output logic        tests_passed_o,
- output logic        tests_failed_o,
- output logic [31:0] exit_value_o,
- output logic        exit_valid_o);
+     input logic         fetch_enable_i,
+     output logic        tests_passed_o,
+     output logic        tests_failed_o,
+     output logic [31:0] exit_value_o,
+     output logic        exit_valid_o);
 
-// signals connecting core to memory
-logic                         instr_req;
-logic                         instr_gnt;
-logic                         instr_rvalid;
-logic [31:0]                  instr_addr;
-logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
+    // signals connecting core to memory
+    logic                         instr_req;
+    logic                         instr_gnt;
+    logic                         instr_rvalid;
+    logic [31:0]                  instr_addr;
+    logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
 
-logic                         data_req;
-logic                         data_gnt;
-logic                         data_rvalid;
-logic [31:0]                  data_addr;
-logic                         data_we;
-logic [3:0]                   data_be;
-logic [31:0]                  data_rdata;
-logic [31:0]                  data_wdata;
+    logic                         data_req;
+    logic                         data_gnt;
+    logic                         data_rvalid;
+    logic [31:0]                  data_addr;
+    logic                         data_we;
+    logic [3:0]                   data_be;
+    logic [31:0]                  data_rdata;
+    logic [31:0]                  data_wdata;
 
-// signals to debug unit
-logic                         debug_req;
+    // signals to debug unit
+    logic                         debug_req;
 
-// irq signals (not used)
-logic [0:31]                  irq;
-logic [0:4]                   irq_id_in;
-logic                         irq_ack;
-logic [0:4]                   irq_id_out;
-logic                         irq_sec;
-
-
-// interrupts (only timer for now)
-assign irq_sec     = '0;
-
-// eXtension Interface
-if_xif #(
-    .X_NUM_RS    ( 2  ),
-    .X_MEM_WIDTH ( 32 ),
-    .X_RFR_WIDTH ( 32 ),
-    .X_RFW_WIDTH ( 32 ),
-    .X_MISA      ( '0 )
-) ext_if();
+    // irq signals (not used)
+    logic [0:31]                  irq;
+    logic [0:4]                   irq_id_in;
+    logic                         irq_ack;
+    logic [0:4]                   irq_id_out;
+    logic                         irq_sec;
 
 
-// instantiate the core
-cv32e40x_core #(
-             .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS)
-            )
-cv32e40x_core_i
-    (
-     // Clock and Reset
-     .clk_i                  ( clk_i                 ),
-     .rst_ni                 ( rst_ni                ),
+    // interrupts (only timer for now)
+    assign irq_sec     = '0;
 
-     .scan_cg_en_i           ( 1'b0                  ),
+    // eXtension Interface
+    if_xif #(
+        .X_NUM_RS    ( 2  ),
+        .X_MEM_WIDTH ( 32 ),
+        .X_RFR_WIDTH ( 32 ),
+        .X_RFW_WIDTH ( 32 ),
+        .X_MISA      ( '0 )
+    ) ext_if();
 
-     // Static configuration
-     .boot_addr_i            ( BOOT_ADDR             ),
-     .dm_exception_addr_i    ( '0                    ),
-     .dm_halt_addr_i         ( DM_HALTADDRESS        ),
-     .mhartid_i              ( HART_ID               ),
-     .mimpid_patch_i         ( IMP_PATCH_ID          ),
-     .mtvec_addr_i           ( '0                    ), 
-     
-     // Instruction memory interface
-     .instr_req_o            ( instr_req             ),
-     .instr_gnt_i            ( instr_gnt             ),
-     .instr_rvalid_i         ( instr_rvalid          ),
-     .instr_addr_o           ( instr_addr            ),
-     .instr_memtype_o        (                       ),
-     .instr_prot_o           (                       ),
-     .instr_dbg_o            (                       ),
-     .instr_rdata_i          ( instr_rdata           ),
-     .instr_err_i            ( 1'b0                  ),
 
-     // Data memory interface
-     .data_req_o             ( data_req              ),
-     .data_gnt_i             ( data_gnt              ),
-     .data_rvalid_i          ( data_rvalid           ),
-     .data_addr_o            ( data_addr             ),
-     .data_be_o              ( data_be               ),
-     .data_we_o              ( data_we               ),
-     .data_wdata_o           ( data_wdata            ),
-     .data_memtype_o         (                       ), 
-     .data_prot_o            (                       ),
-     .data_dbg_o             (                       ),
-     .data_err_i             ( 1'b0                  ),
-     .data_atop_o            (                       ),
-     .data_rdata_i           ( data_rdata            ),
-     .data_exokay_i          ( 1'b1                  ),
+    // instantiate the core
+    cv32e40x_core #(
+                .NUM_MHPMCOUNTERS (NUM_MHPMCOUNTERS)
+                )
+    cv32e40x_core_i
+        (
+        // Clock and Reset
+        .clk_i                  ( clk_i                 ),
+        .rst_ni                 ( rst_ni                ),
 
-     // Cycle Count
-     .mcycle_o               (                       ),
+        .scan_cg_en_i           ( 1'b0                  ),
 
-     // Time input
-     .time_i                 ( '0                   ),
+        // Static configuration
+        .boot_addr_i            ( BOOT_ADDR             ),
+        .dm_exception_addr_i    ( '0                    ),
+        .dm_halt_addr_i         ( DM_HALTADDRESS        ),
+        .mhartid_i              ( HART_ID               ),
+        .mimpid_patch_i         ( IMP_PATCH_ID          ),
+        .mtvec_addr_i           ( '0                    ), 
+        
+        // Instruction memory interface
+        .instr_req_o            ( instr_req             ),
+        .instr_gnt_i            ( instr_gnt             ),
+        .instr_rvalid_i         ( instr_rvalid          ),
+        .instr_addr_o           ( instr_addr            ),
+        .instr_memtype_o        (                       ),
+        .instr_prot_o           (                       ),
+        .instr_dbg_o            (                       ),
+        .instr_rdata_i          ( instr_rdata           ),
+        .instr_err_i            ( 1'b0                  ),
 
-     // eXtension interface
-     .xif_compressed_if      ( ext_if                ),
-     .xif_issue_if           ( ext_if                ),
-     .xif_commit_if          ( ext_if                ),
-     .xif_mem_if             ( ext_if                ),
-     .xif_mem_result_if      ( ext_if                ),
-     .xif_result_if          ( ext_if                ),
+        // Data memory interface
+        .data_req_o             ( data_req              ),
+        .data_gnt_i             ( data_gnt              ),
+        .data_rvalid_i          ( data_rvalid           ),
+        .data_addr_o            ( data_addr             ),
+        .data_be_o              ( data_be               ),
+        .data_we_o              ( data_we               ),
+        .data_wdata_o           ( data_wdata            ),
+        .data_memtype_o         (                       ), 
+        .data_prot_o            (                       ),
+        .data_dbg_o             (                       ),
+        .data_err_i             ( 1'b0                  ),
+        .data_atop_o            (                       ),
+        .data_rdata_i           ( data_rdata            ),
+        .data_exokay_i          ( 1'b1                  ),
 
-     // Basic interrupt architecture
-     .irq_i                  ( {32{1'b0}}            ),
+        // Cycle Count
+        .mcycle_o               (                       ),
 
-     // Event wakeup signals
-     .wu_wfe_i               ( 1'b0                  ),
-     .wu_wrs_i               ( 1'b0                  ),
+        // Time input
+        .time_i                 ( '0                   ),
 
-     .clic_irq_i             (  '0                   ),
-     .clic_irq_id_i          (  '0                   ),
-     .clic_irq_level_i       (  '0                   ),
-     .clic_irq_priv_i        (  '0                   ),
-     .clic_irq_shv_i         (  '0                   ),
-     
-     // Fencei flush handshake
-     .fencei_flush_req_o     (                       ),
-     .fencei_flush_ack_i     ( 1'b0                  ),
+        // eXtension interface
+        .xif_compressed_if      ( ext_if                ),
+        .xif_issue_if           ( ext_if                ),
+        .xif_commit_if          ( ext_if                ),
+        .xif_mem_if             ( ext_if                ),
+        .xif_mem_result_if      ( ext_if                ),
+        .xif_result_if          ( ext_if                ),
 
-     // Debug interface
-     .debug_req_i            ( 1'b0                  ),
-     .debug_havereset_o      (                       ),
-     .debug_running_o        (                       ),
-     .debug_halted_o         (                       ),
-     .debug_pc_valid_o       (                       ),
-     .debug_pc_o             (                       ),
+        // Basic interrupt architecture
+        .irq_i                  ( {32{1'b0}}            ),
 
-     // CPU Control Signals
-     .fetch_enable_i         ( fetch_enable_i        ),
-     .core_sleep_o           (                       )
-   );
+        // Event wakeup signals
+        .wu_wfe_i               ( 1'b0                  ),
+        .wu_wrs_i               ( 1'b0                  ),
 
-// this handles read to RAM and memory mapped pseudo peripherals
-mm_ram
-    #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
-      .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH))
-ram_i
-    (.clk_i          ( clk_i                                     ),
-     .rst_ni         ( rst_ni                                    ),
-     .dm_halt_addr_i ( DM_HALTADDRESS                            ),
+        .clic_irq_i             (  '0                   ),
+        .clic_irq_id_i          (  '0                   ),
+        .clic_irq_level_i       (  '0                   ),
+        .clic_irq_priv_i        (  '0                   ),
+        .clic_irq_shv_i         (  '0                   ),
+        
+        // Fencei flush handshake
+        .fencei_flush_req_o     (                       ),
+        .fencei_flush_ack_i     ( 1'b0                  ),
 
-     .instr_req_i    ( instr_req                                 ),
-     .instr_addr_i   ( { {10{1'b0}},
-                         instr_addr[RAM_ADDR_WIDTH-1:0]
-                       }                                         ),
-     .instr_rdata_o  ( instr_rdata                               ),
-     .instr_rvalid_o ( instr_rvalid                              ),
-     .instr_gnt_o    ( instr_gnt                                 ),
+        // Debug interface
+        .debug_req_i            ( 1'b0                  ),
+        .debug_havereset_o      (                       ),
+        .debug_running_o        (                       ),
+        .debug_halted_o         (                       ),
+        .debug_pc_valid_o       (                       ),
+        .debug_pc_o             (                       ),
 
-     .data_req_i     ( data_req                                  ),
-     .data_addr_i    ( data_addr                                 ),
-     .data_we_i      ( data_we                                   ),
-     .data_be_i      ( data_be                                   ),
-     .data_wdata_i   ( data_wdata                                ),
-     .data_rdata_o   ( data_rdata                                ),
-     .data_rvalid_o  ( data_rvalid                               ),
-     .data_gnt_o     ( data_gnt                                  ),
+        // CPU Control Signals
+        .fetch_enable_i         ( fetch_enable_i        ),
+        .core_sleep_o           (                       )
+      );
 
-     .irq_id_i       ( irq_id_out                                ),
-     .irq_ack_i      ( irq_ack                                   ),
-     .irq_o          ( irq                                       ),
+    // this handles read to RAM and memory mapped pseudo peripherals
+    mm_ram
+        #(.RAM_ADDR_WIDTH (RAM_ADDR_WIDTH),
+          .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH))
+    ram_i
+        (.clk_i          ( clk_i                                     ),
+         .rst_ni         ( rst_ni                                    ),
+         .dm_halt_addr_i ( DM_HALTADDRESS                            ),
 
-     .debug_req_o    ( debug_req                                 ),
+         .instr_req_i    ( instr_req                                 ),
+         .instr_addr_i   ( { {10{1'b0}},
+                             instr_addr[RAM_ADDR_WIDTH-1:0]
+                           }                                         ),
+         .instr_rdata_o  ( instr_rdata                               ),
+         .instr_rvalid_o ( instr_rvalid                              ),
+         .instr_gnt_o    ( instr_gnt                                 ),
 
-     .pc_core_id_i   ( cv32e40x_core_i.if_id_pipe.pc             ),
+         .data_req_i     ( data_req                                  ),
+         .data_addr_i    ( data_addr                                 ),
+         .data_we_i      ( data_we                                   ),
+         .data_be_i      ( data_be                                   ),
+         .data_wdata_i   ( data_wdata                                ),
+         .data_rdata_o   ( data_rdata                                ),
+         .data_rvalid_o  ( data_rvalid                               ),
+         .data_gnt_o     ( data_gnt                                  ),
 
-     .tests_passed_o ( tests_passed_o                            ),
-     .tests_failed_o ( tests_failed_o                            ),
-     .exit_valid_o   ( exit_valid_o                              ),
-     .exit_value_o   ( exit_value_o                              ));
+         .irq_id_i       ( irq_id_out                                ),
+         .irq_ack_i      ( irq_ack                                   ),
+         .irq_o          ( irq                                       ),
+
+         .debug_req_o    ( debug_req                                 ),
+
+         .pc_core_id_i   ( cv32e40x_core_i.if_id_pipe.pc             ),
+
+         .tests_passed_o ( tests_passed_o                            ),
+         .tests_failed_o ( tests_failed_o                            ),
+         .exit_valid_o   ( exit_valid_o                              ),
+         .exit_value_o   ( exit_value_o                              ));
 
 endmodule // cv32e40x_tb_wrapper

--- a/cv32e40x/tb/core/mm_ram.sv
+++ b/cv32e40x/tb/core/mm_ram.sv
@@ -75,19 +75,58 @@ module mm_ram
 
     localparam int                        RND_IRQ_ID     = 31;
 
-    localparam int                        MMADDR_PRINT          = 32'h1000_0000;
-    localparam int                        MMADDR_TESTSTATUS     = 32'h2000_0000;
-    localparam int                        MMADDR_EXIT           = 32'h2000_0004;
-    localparam int                        MMADDR_SIGBEGIN       = 32'h2000_0008;
-    localparam int                        MMADDR_SIGEND         = 32'h2000_000C;
-    localparam int                        MMADDR_SIGDUMP        = 32'h2000_0010;
-    localparam int                        MMADDR_TIMERREG       = 32'h1500_0000;
-    localparam int                        MMADDR_TIMERVAL       = 32'h1500_0004;
-    localparam int                        MMADDR_DBG            = 32'h1500_0008;
+    // Map the virtual peripheral registers. See bsp/corev_uvmt.h
+    parameter CV_VP_REGISTER_BASE          = 32'h0080_0000;
+    parameter CV_VP_REGISTER_SIZE          = 32'h0000_1000;
+
+    parameter CV_VP_VIRTUAL_PRINTER_OFFSET = 32'h0000_0000;
+    parameter CV_VP_RANDOM_NUM_OFFSET      = 32'h0000_0040;
+    parameter CV_VP_CYCLE_COUNTER_OFFSET   = 32'h0000_0080;
+    parameter CV_VP_STATUS_FLAGS_OFFSET    = 32'h0000_00c0;
+    parameter CV_VP_FENCEI_TAMPER_OFFSET   = 32'h0000_0100;
+    parameter CV_VP_INTR_TIMER_OFFSET      = 32'h0000_0140;
+    parameter CV_VP_DEBUG_CONTROL_OFFSET   = 32'h0000_0180;
+    parameter CV_VP_OBI_SLV_RESP_OFFSET    = 32'h0000_01c0;
+    parameter CV_VP_SIG_WRITER_OFFSET      = 32'h0000_0200;
+
+    parameter CV_VP_VIRTUAL_PRINTER_BASE   = CV_VP_REGISTER_BASE + CV_VP_VIRTUAL_PRINTER_OFFSET;
+    parameter CV_VP_RANDOM_NUM_BASE        = CV_VP_REGISTER_BASE + CV_VP_RANDOM_NUM_OFFSET;
+    parameter CV_VP_CYCLE_COUNTER_BASE     = CV_VP_REGISTER_BASE + CV_VP_CYCLE_COUNTER_OFFSET;
+    parameter CV_VP_STATUS_FLAGS_BASE      = CV_VP_REGISTER_BASE + CV_VP_STATUS_FLAGS_OFFSET;
+    parameter CV_VP_INTR_TIMER_BASE        = CV_VP_REGISTER_BASE + CV_VP_INTR_TIMER_OFFSET;
+    parameter CV_VP_DEBUG_CONTROL_BASE     = CV_VP_REGISTER_BASE + CV_VP_DEBUG_CONTROL_OFFSET;
+    parameter CV_VP_OBI_SLV_RESP_BASE      = CV_VP_REGISTER_BASE + CV_VP_OBI_SLV_RESP_OFFSET;
+    parameter CV_VP_SIG_WRITER_BASE        = CV_VP_REGISTER_BASE + CV_VP_SIG_WRITER_OFFSET;
+    parameter CV_VP_FENCEI_TAMPER_BASE     = CV_VP_REGISTER_BASE + CV_VP_FENCEI_TAMPER_OFFSET;
+
+    localparam int                        MMADDR_PRINT          = CV_VP_VIRTUAL_PRINTER_BASE;
+    localparam int                        MMADDR_TESTSTATUS     = CV_VP_STATUS_FLAGS_BASE;
+    localparam int                        MMADDR_EXIT           = CV_VP_STATUS_FLAGS_BASE + 32'h0000_0004;
+    localparam int                        MMADDR_SIGBEGIN       = CV_VP_SIG_WRITER_BASE;
+    localparam int                        MMADDR_SIGEND         = CV_VP_SIG_WRITER_BASE + 32'h0000_0004;
+    localparam int                        MMADDR_SIGDUMP        = CV_VP_SIG_WRITER_BASE + 32'h0000_0008;;
+    localparam int                        MMADDR_TIMERREG       = CV_VP_INTR_TIMER_BASE;
+    localparam int                        MMADDR_TIMERVAL       = CV_VP_INTR_TIMER_BASE + 32'h0000_0004;
+    localparam int                        MMADDR_DBG            = CV_VP_DEBUG_CONTROL_BASE;
     localparam int                        MMADDR_RNDSTALL       = 16'h1600;
-    localparam int                        MMADDR_RNDNUM         = 32'h1500_1000;
-    localparam int                        MMADDR_TICKS          = 32'h1500_1004;
-    localparam int                        MMADDR_TICKS_PRINT    = 32'h1500_1008;
+    localparam int                        MMADDR_RNDNUM         = CV_VP_RANDOM_NUM_BASE;
+    localparam int                        MMADDR_TICKS          = CV_VP_CYCLE_COUNTER_BASE;
+    localparam int                        MMADDR_TICKS_PRINT    = CV_VP_CYCLE_COUNTER_BASE + 32'h0000_0004;
+
+    // Old virtual peripheral register map for RI5CY
+    // localparam int                        MMADDR_PRINT          = 32'h1000_0000;
+    // localparam int                        MMADDR_TESTSTATUS     = 32'h2000_0000;
+    // localparam int                        MMADDR_EXIT           = 32'h2000_0004;
+    // localparam int                        MMADDR_SIGBEGIN       = 32'h2000_0008;
+    // localparam int                        MMADDR_SIGEND         = 32'h2000_000C;
+    // localparam int                        MMADDR_SIGDUMP        = 32'h2000_0010;
+    // localparam int                        MMADDR_TIMERREG       = 32'h1500_0000;
+    // localparam int                        MMADDR_TIMERVAL       = 32'h1500_0004;
+    // localparam int                        MMADDR_DBG            = 32'h1500_0008;
+    // localparam int                        MMADDR_RNDSTALL       = 16'h1600;
+    // localparam int                        MMADDR_RNDNUM         = 32'h1500_1000;
+    // localparam int                        MMADDR_TICKS          = 32'h1500_1004;
+    // localparam int                        MMADDR_TICKS_PRINT    = 32'h1500_1008;
 
     // UVM info tags
     localparam string                     MM_RAM_TAG = "MM_RAM";


### PR DESCRIPTION
This PR is to set up the  "core" testbench for E40X core.  Related issues could be #1777, #1259. 

The major modifications include:

1. cv32e40x/sim/core/Makefile:  Some redefinition of variables. Remove  redundant variable that have the same function(e.g., `CUSTOM` with `TEST_PROGRAM_PATH`, `CUSTOM_PROG` with `TEST`).

2. cv32e40x/tb/core/cv32e40x_tb_wrapper.sv: Correct the instance of cv32e40x core.

3. cv32e40x/tb/core/mm_ram.sv: Remap the virtual peripheral registers according to [corev_uvmt.h](https://github.com/openhwgroup/core-v-verif/blob/master/cv32e40x/bsp/corev_uvmt.h). 
4. cv32e40x/sim/core/readme.md: Update the usage of makefile commands.

Only verilator 5.008 and vsim 2021 were tested.  For verilator,  try `make veri-test TEST=hello-world`  in `cv32e40x/sim/core/` path to simualte the hello-word program. For vsim,  try `make questa-custom TEST=hello-world`  instead. 



 


