### PR TITLE
Optional compile of ImperasDV

### DIFF
--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p.flist
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p.flist
@@ -47,9 +47,6 @@
 +incdir+${TBSRC_HOME}
 ${DV_UVMT_PATH}/uvmt_cv32e40p_pkg.sv
 
-// ImperasDV
--f ${TBSRC_HOME}/uvmt/imperas_dv.flist
-
 // CV32E40P test bench files
 ${DV_UVMT_PATH}/uvmt_cv32e40p_dut_wrap.sv
 ${DV_UVMT_PATH}/uvmt_cv32e40p_tb.sv

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -35,7 +35,9 @@ module uvmt_cv32e40p_tb;
    import uvmt_cv32e40p_pkg::*;
    import uvme_cv32e40p_pkg::*;
    `ifndef FORMAL
+   `ifdef USE_ISS
    import rvviApiPkg::*;
+   `endif
    `endif
    // DUT (core) parameters: refer to the CV32E40P User Manual.
 `ifdef NO_PULP
@@ -135,7 +137,9 @@ module uvmt_cv32e40p_tb;
 
    // RVVI SystemVerilog Interface
    `ifndef FORMAL
+   `ifdef USE_ISS
       rvviTrace #( .NHART(1), .RETIRE(1)) rvvi_if();
+   `endif
    `endif
 
   /**
@@ -696,7 +700,7 @@ module uvmt_cv32e40p_tb;
      uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("ENV_PARAM_RAM_ADDR_WIDTH"),    .value(ENV_PARAM_RAM_ADDR_WIDTH)   );
 
      // Run test
-     uvm_top.enable_print_topology = 1; // ENV coders enable this as a debug aid
+     uvm_top.enable_print_topology = 0; // ENV coders enable this as a debug aid
      uvm_top.finish_on_completion  = 1;
      uvm_top.run_test();
    end : test_bench_entry_point
@@ -775,10 +779,10 @@ module uvmt_cv32e40p_tb;
       void'(uvm_config_db#(bit)::get(null, "", "sim_finished", sim_finished));
 
       // Shutdown the Reference Model
-      if ($test$plusargs("USE_ISS")) begin
-         // Exit handler for ImperasDV
-         void'(rvviRefShutdown());
-      end
+      `ifdef USE_ISS
+      // Exit handler for ImperasDV
+      void'(rvviRefShutdown());
+      `endif
 
       // In most other contexts, calls to $display() in a UVM environment are
       // illegal. Here they are OK because the UVM environment has shut down

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -176,9 +176,10 @@ XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI
 XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_CORE_LOG
 XRUN_USER_COMPILE_ARGS += +define+UVM
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
-	XRUN_PLUSARGS += +USE_ISS
-	XRUN_USER_COMPILE_ARGS += +define+USE_IMPERASDV
-	XRUN_USER_COMPILE_ARGS += +define+USE_ISS
+    XRUN_PLUSARGS          += +USE_ISS
+    XRUN_USER_COMPILE_ARGS += +define+USE_IMPERASDV
+    XRUN_USER_COMPILE_ARGS += +define+USE_ISS
+    XRUN_FILE_LIST         += -f $(TBSRC_HOME)/uvmt/imperas_dv.flist
 else
     XRUN_PLUSARGS += +DISABLE_OVPSIM
 endif
@@ -511,7 +512,7 @@ cov: $(COV_MERGE)
 
 clean:
 	@echo "$(MAKEFILE_LIST)"
-	rm -rf $(SIM_RUN_RESULTS)
+	rm -rf $(SIM_RESULTS)
 
 # Files created by Eclipse when using the Imperas ISS + debugger
 clean_eclipse:


### PR DESCRIPTION
This PR restores the functionality of the `USE_ISS` Makefile variable.  Setting this variable to "NO" on any `make test` invocation will compile the environment excluding the ImperasDV model.  For example:
```
$ make test TEST=hello-world USE_ISS=NO
```