### PR TITLE
ci: notification from Dashboard

### DIFF
--- a/.github/workflows/dashboard-done.yml
+++ b/.github/workflows/dashboard-done.yml
@@ -1,0 +1,33 @@
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'ID of the PR to comment'
+        required: true
+        type: string
+      success:
+        description: 'Is the workflow successful?'
+        required: true
+        type: boolean
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const inputs = context.payload.inputs
+            const pr = inputs.pr_number
+            const success = inputs.success == 'true'
+            const status_text = success ? ":heavy_check_mark: successful" : ":x: failed"
+            const url = `https://riscv-ci.pages.thales-invia.fr/dashboard/dashboard_core-v-verif_${pr}.html`
+            await github.rest.issues.createComment({
+              issue_number: pr,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${status_text} run, report available [here](${url}).`
+            })

--- a/.gitlab-ci/scripts/github_integration.py
+++ b/.gitlab-ci/scripts/github_integration.py
@@ -1,0 +1,59 @@
+"""
+This module makes it possible to trigger GitHub workflows.
+"""
+
+from os import environ as env
+import requests
+
+def api_url(owner, repo):
+    "Build API url for a given repository"
+    return f"https://api.github.com/repos/{owner}/{repo}"
+
+def pulls(owner, repo):
+    "Get (public) pull requests from a given repository"
+    response = requests.get(api_url(owner, repo) + '/pulls')
+    assert response.status_code == 200
+    return response.json()
+
+class Workflow:
+    "GitHub Workflow that can be triggered on a dispatch event"
+    def __init__(self, owner, repo, workflow_id, ref):
+        dispatches = f"/actions/workflows/{workflow_id}/dispatches"
+        self.url = api_url(owner, repo) + dispatches
+        self.ref = ref
+
+    def _trigger(self, inputs):
+        "Trigger the workflow"
+        data = {
+            'ref': self.ref,
+            'inputs': inputs,
+        }
+        token = env['GH_TOKEN']
+        headers = {
+            'Accept': 'application/vnd.github+json',
+            'Authorization': f"Bearer {token}",
+            'X-GitHub-Api-Version': '2022-11-28',
+        }
+        return requests.post(url=self.url, json=data, headers=headers)
+
+class DashboardDone(Workflow):
+    "`dashboard-done.yml` GitHub workflow"
+    def __init__(self, owner, repo, ref):
+        workflow_id = 'dashboard-done.yml'
+        Workflow.__init__(self, owner, repo, workflow_id, ref)
+
+    def send(self, pr, success):
+        "Send success or failure message"
+        inputs = {
+            'pr_number': str(pr),
+            'success': success,
+        }
+        return self._trigger(inputs)
+
+    def send_success(self, pr):
+        "Send message stating that job is successful"
+        return self.send(pr, True)
+
+    def send_failure(self, pr):
+        "Send message stating that job is failed"
+        return self.send(pr, False)

--- a/.gitlab-ci/scripts/github_integration.py
+++ b/.gitlab-ci/scripts/github_integration.py
@@ -11,7 +11,11 @@ def api_url(owner, repo):
 
 def pulls(owner, repo):
     "Get (public) pull requests from a given repository"
-    response = requests.get(api_url(owner, repo) + '/pulls')
+    url = api_url(owner, repo) + '/pulls'
+    headers = {}
+    if 'GH_TOKEN' in env:
+        headers["Authorization"] = f"Token {env['GH_TOKEN']}"
+    response = requests.get(url, headers=headers)
     assert response.status_code == 200
     return response.json()
 

--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -157,4 +157,5 @@ pr = find_pr(workflow_commit_ref_name, pulls)
 if pr is not None:
     ref_branch = pr['base']['ref']
     wf = gh.DashboardDone('openhwgroup', workflow_repo, ref_branch)
-    wf.send(pr['number'], success)
+    response = wf.send(pr['number'], success)
+    print(response.text)

--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -14,6 +14,7 @@ import yaml
 import datetime
 import sys
 import subprocess
+import github_integration as gh
 
 # arguments: inputdir outputfile
 
@@ -105,12 +106,14 @@ pipeline = {
     'jobs': []
 }
 
+success = True
 dir_list = os.listdir(sys.argv[1])
 for f in dir_list:
     with open(sys.argv[1] + "/" + f, 'r') as job_report:
         report = safe_load(job_report)
         pipeline["jobs"].append(report)
         if report['status'] != 'pass':
+            success = False
             pipeline["status"] = 'fail'
             pipeline["label"] = 'FAIL'
 
@@ -139,3 +142,25 @@ cd -
 ''', shell=True))
 except subprocess.CalledProcessError as e:
     print(f"Error: {e.output}")
+
+ref_branch = None
+if workflow_repo == 'cva6':
+    ref_branch = 'master'
+elif workflow_repo == 'core-v-verif':
+    ref_branch = 'cva6/dev'
+
+def find_pr(branch, prs):
+    match = re.search(r'(.*)_PR_([a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,38})', branch)
+    if match:
+        label = f'{match.group(2)}:{match.group(1)}'
+        for pr in prs:
+            if label == pr['head']['label']:
+                return pr
+    return None
+
+if ref_branch is not None:
+    pulls = gh.pulls('openhwgroup', workflow_repo)
+    pr = find_pr(workflow_commit_ref_name, pulls)
+    if pr is not None:
+        wf = gh.DashboardDone('openhwgroup', workflow_repo, ref_branch)
+        wf.send(pr['number'], success)

--- a/.gitlab-ci/scripts/merge_job_reports.py
+++ b/.gitlab-ci/scripts/merge_job_reports.py
@@ -143,12 +143,6 @@ cd -
 except subprocess.CalledProcessError as e:
     print(f"Error: {e.output}")
 
-ref_branch = None
-if workflow_repo == 'cva6':
-    ref_branch = 'master'
-elif workflow_repo == 'core-v-verif':
-    ref_branch = 'cva6/dev'
-
 def find_pr(branch, prs):
     match = re.search(r'(.*)_PR_([a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){0,38})', branch)
     if match:
@@ -158,9 +152,9 @@ def find_pr(branch, prs):
                 return pr
     return None
 
-if ref_branch is not None:
-    pulls = gh.pulls('openhwgroup', workflow_repo)
-    pr = find_pr(workflow_commit_ref_name, pulls)
-    if pr is not None:
-        wf = gh.DashboardDone('openhwgroup', workflow_repo, ref_branch)
-        wf.send(pr['number'], success)
+pulls = gh.pulls('openhwgroup', workflow_repo)
+pr = find_pr(workflow_commit_ref_name, pulls)
+if pr is not None:
+    ref_branch = pr['base']['ref']
+    wf = gh.DashboardDone('openhwgroup', workflow_repo, ref_branch)
+    wf.send(pr['number'], success)


### PR DESCRIPTION
### Context

Pull requests targeting branch [`cva6/dev`](https://github.com/openhwgroup/core-v-verif/tree/cva6/dev) trigger jobs on [an external infrastructure](https://riscv-ci.pages.thales-invia.fr/dashboard/dashboard_core-v-verif_0.html). However, results are not easily accessible from the GitHub PR.

### PR description

To make it easier for PR authors and reviewers to access the results of these jobs, the external infrastructure will send a comment in the PR with a link to the job results when they are available. It is done in a two-step process:

#### GitHub side

So that the comment is created by a bot and not a specific individual, the comment should be created [by a workflow](https://github.com/openhwgroup/core-v-verif/pull/1810/files#diff-8dc0736c177c4c030c66c3fc1fc15282e2faf57a598fe80993f53648cacb6b7b). This new workflow is triggered only manually, and takes two parameters: the PR number and the exit status of the job, to write a comment accordingly.

#### GitLab side

We [use GitHub API](https://github.com/openhwgroup/core-v-verif/pull/1810/files#diff-be505d6e2f38551820085b975b7d3a68283954375c44468497aa9d7ff1003661) to [trigger the workflow when the job ends](https://github.com/openhwgroup/core-v-verif/pull/1810/files#diff-f4590e3c06d1f22d20414ebe13f5002d39abc3e298e17ca2f4e6d6c598712e68).