### PR TITLE
UVMA RVFI - Remove 40s-dependency

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
@@ -18,6 +18,7 @@
 `ifndef __UVMA_RVFI_CONSTANTS_SV__
 `define __UVMA_RVFI_CONSTANTS_SV__
 
+
 // RVFI field widths
 localparam ORDER_WL         = 64;
 localparam MODE_WL          = 2;
@@ -41,8 +42,18 @@ localparam TRAP_CAUSE_WL         = 6;
 localparam TRAP_DBG_CAUSE_LSB    = 9;
 localparam TRAP_DBG_CAUSE_WL     = 3;
 
+// Lengths & Sizes
 localparam DEFAULT_ILEN     = 32;
 localparam DEFAULT_XLEN     = 32;
 localparam DEFAULT_NRET     = 1;
+
+// RISC-V Constants
+parameter logic[ 2:0]  DBG_CAUSE_TRIGGER               =  3'h 2;
+parameter logic[ 1:0]  PRIV_LVL_M                      =  2'b 11;
+parameter logic[ 1:0]  PRIV_LVL_U                      =  2'b 00;
+parameter logic[10:0]  EXC_CAUSE_INSTR_FAULT           = 11'h 1;
+parameter logic[10:0]  EXC_CAUSE_INSTR_INTEGRITY_FAULT = 11'h 19;
+parameter logic[10:0]  EXC_CAUSE_INSTR_BUS_FAULT       = 11'h 18;
+
 
 `endif // __UVMA_RVFI_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -26,7 +26,6 @@ interface uvma_rvfi_instr_if_t
   import uvma_rvfi_pkg::*;
   #(int ILEN=DEFAULT_ILEN,
     int XLEN=DEFAULT_XLEN)
-  //import uvma_rvfi_pkg::*;
   (
     input logic                      clk,
     input logic                      reset_n,
@@ -493,41 +492,41 @@ function automatic logic is_dbg_trg_f();
   return  rvfi_valid &&
           rvfi_trap.trap &&
           rvfi_trap.debug &&
-         (rvfi_trap.debug_cause == cv32e40s_pkg::DBG_CAUSE_TRIGGER);
+         (rvfi_trap.debug_cause == DBG_CAUSE_TRIGGER);
 endfunction : is_dbg_trg_f
 
 function automatic logic is_mmode_f();
   return  rvfi_valid &&
-          (rvfi_mode == cv32e40s_pkg::PRIV_LVL_M);
+          (rvfi_mode == PRIV_LVL_M);
 endfunction : is_mmode_f
 
 function automatic logic is_not_mmode_f();
   return  rvfi_valid &&
-          (rvfi_mode != cv32e40s_pkg::PRIV_LVL_M);
+          (rvfi_mode != PRIV_LVL_M);
 endfunction : is_not_mmode_f
 
 function automatic logic is_umode_f();
   return  rvfi_valid &&
-          (rvfi_mode == cv32e40s_pkg::PRIV_LVL_U);
+          (rvfi_mode == PRIV_LVL_U);
 endfunction : is_umode_f
 
 function automatic logic is_not_umode_f();
   return  rvfi_valid &&
-          (rvfi_mode != cv32e40s_pkg::PRIV_LVL_U);
+          (rvfi_mode != PRIV_LVL_U);
 endfunction : is_not_umode_f
 
 function automatic logic is_pma_instr_fault_f();
   return  rvfi_valid  &&
           rvfi_trap.trap  &&
           rvfi_trap.exception  &&
-          (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_FAULT)  &&
+          (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_FAULT)  &&
           (rvfi_trap.cause_type == 'h 0);
 endfunction : is_pma_instr_fault_f
 
 function automatic logic is_instr_bus_valid_f();
-  return !( (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_FAULT) ||
-            (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_INTEGRITY_FAULT) ||
-            (rvfi_trap.exception_cause == cv32e40s_pkg::EXC_CAUSE_INSTR_BUS_FAULT)
+  return !( (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_FAULT) ||
+            (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_INTEGRITY_FAULT) ||
+            (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_BUS_FAULT)
     );
 endfunction : is_instr_bus_valid_f
 


### PR DESCRIPTION
The current `uvma_rvfi` is locked to only work with the 40s.
This PR removes that dependency.

Test status:
* Hello world passes