### PR TITLE
UVMA RVFI - Remove 40s-dependency (again)

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
@@ -52,6 +52,8 @@ parameter logic[ 2:0]  DBG_CAUSE_TRIGGER               =  3'h 2;
 parameter logic[ 1:0]  PRIV_LVL_M                      =  2'b 11;
 parameter logic[ 1:0]  PRIV_LVL_U                      =  2'b 00;
 parameter logic[10:0]  EXC_CAUSE_INSTR_FAULT           = 11'h 1;
+parameter logic[10:0]  EXC_CAUSE_LOAD_FAULT            = 11'h 5;
+parameter logic[10:0]  EXC_CAUSE_STORE_FAULT           = 11'h 7;
 parameter logic[10:0]  EXC_CAUSE_INSTR_INTEGRITY_FAULT = 11'h 19;
 parameter logic[10:0]  EXC_CAUSE_INSTR_BUS_FAULT       = 11'h 18;
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -576,9 +576,9 @@ function automatic logic is_pma_fault_f();
           rvfi_trap.trap  &&
           rvfi_trap.exception  &&
           (rvfi_trap.exception_cause  inside {
-            cv32e40s_pkg::EXC_CAUSE_INSTR_FAULT,
-            cv32e40s_pkg::EXC_CAUSE_LOAD_FAULT,
-            cv32e40s_pkg::EXC_CAUSE_STORE_FAULT
+            EXC_CAUSE_INSTR_FAULT,
+            EXC_CAUSE_LOAD_FAULT,
+            EXC_CAUSE_STORE_FAULT
           })  &&
           (rvfi_trap.cause_type == 'h 0);
 endfunction : is_pma_fault_f


### PR DESCRIPTION
Sorry for doing this again, but there came in another PR merge (my own) which reintroduced the 40s dependency.

Ref: https://github.com/openhwgroup/core-v-verif/pull/1823

Test status:
* Hello world passes