### PR TITLE
adding CV_TOOL_PREFIX to XRUN executable to account for separate LSF …

### DIFF
--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -32,7 +32,7 @@ ifeq ($(OS_IS_UBUNTU),Ubuntu)
 endif
 
 # Executables
-XRUN              = $(CV_SIM_PREFIX) xrun
+XRUN              = $(CV_SIM_PREFIX) $(CV_TOOL_PREFIX) xrun
 SIMVISION         = $(CV_TOOL_PREFIX) simvision
 INDAGO            = $(CV_TOOL_PREFIX) indago
 IMC               = $(CV_SIM_PREFIX) imc


### PR DESCRIPTION
…and Tool strings

I am using CV_SIM_PREFIX for my LSF command, but I also need to load the module file for xcelium before the xrun command. I am using CV_TOOL_PREFIX = "module load xcelium;"  