### PR TITLE
Stand-up the ci_check regression for CV32E20

### DIFF
--- a/.metrics.json
+++ b/.metrics.json
@@ -9,6 +9,12 @@
   "builds": {
     "list": [
       {
+        "name":     "uvmt_cv32e20",
+        "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
+        "cmd":      "cd cv32e20/sim/uvmt; make corev-dv CV_CORE=cv32e20 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e20 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
+        "wavesCmd": "cd cv32e20/sim/uvmt; make corev-dv CV_CORE=cv32e20 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e20 SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results WAVES=1"
+      },
+      {
         "name":     "uvmt_cv32e40p",
         "image":    "gcr.io/openhwgroup-metrics-project/cv32-simulation-tools:20211122.7.0-02Feb2022",
         "cmd":      "cd cv32e40p/sim/uvmt; make corev-dv CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results; make comp CV_CORE=cv32e40p SIMULATOR=dsim DSIM_WORK=/mux-flow/build/repo/dsim_work SIM_RESULTS=/mux-flow/build/results",
@@ -128,6 +134,17 @@
         "builds":    ["uvmt_cv32e40p_compliance_build"],
         "listCmd":   "/mux-flow/build/repo/bin/cv_regress --core=cv32e40p --file=cv32e40p_compliance --metrics --outfile=/mux-flow/build/repo/cv32e40p_compliance.json",
         "listFile":  "/mux-flow/build/repo/cv32e40p_compliance.json"
+      }
+    },
+    {
+      "name":        "cv32e20_ci_check_dev",
+      "description": "Commit sanity for CV32E20 using dynamic test generation",
+      "verbose":     "true",
+      "tests": {
+        "resultsDir": "/mux-flow/build/results",
+        "builds":    ["uvmt_cv32e20"],
+        "listCmd":   "/mux-flow/build/repo/bin/cv_regress --core=cv32e20 --file=cv32e20_ci_check --metrics --outfile=/mux-flow/build/repo/cv32e20_ci_check.json",
+        "listFile":  "/mux-flow/build/repo/cv32e20_ci_check.json"
       }
     },
     {

--- a/bin/ci_check
+++ b/bin/ci_check
@@ -264,8 +264,8 @@ if not (prcmd):
         ask_user()
         os.chdir(os.path.abspath(os.path.join(topdir, args.core.lower(), 'sim/uvmt')))
         os.system('make clean_all')
-        os.chdir(os.path.join(topdir, '{}/sim/core'.format(args.core.lower())))
-        os.system('make clean_all')
+        #os.chdir(os.path.join(topdir, '{}/sim/core'.format(args.core.lower())))
+        #os.system('make clean_all')
         os.chdir(os.path.join(topdir, 'bin'))
 
 ################################################################################

--- a/cv32e20/bsp/Makefile
+++ b/cv32e20/bsp/Makefile
@@ -13,7 +13,7 @@ RISCV_AR = $(RISCV_EXE_PREFIX)ar
 SRC = crt0.S handlers.S syscalls.c vectors.S
 OBJ = crt0.o handlers.o syscalls.o vectors.o
 LIBCV-VERIF = libcv-verif.a 
-CFLAGS ?= -Os -g -static -mabi=ilp32 -march=rv32imc -Wall -pedantic
+CFLAGS ?= -Os -g -static -mabi=ilp32 -march=$(CV_SW_MARCH) -Wall -pedantic
 
 all: $(LIBCV-VERIF)
 
@@ -33,6 +33,7 @@ clean:
 vars:
 	@echo "make bsp variables:"
 	@echo "   CV_SW_TOOLCHAIN  = $(CV_SW_TOOLCHAIN)"
+	@echo "   CV_SW_MARCH      = $(CV_SW_MARCH)"
 	@echo "   RISCV            = $(RISCV)"
 	@echo "   RISCV_EXE_PREFIX = $(RISCV_EXE_PREFIX)"
 	@echo "   RISCV_GCC        = $(RISCV_GCC)"

--- a/cv32e20/regress/cv32e20_ci_check.yaml
+++ b/cv32e20/regress/cv32e20_ci_check.yaml
@@ -1,0 +1,77 @@
+# YAML file to specify the ci_check regression testlist.
+name: cv32e20_ci_check
+description: Commit sanity for the cv32e20
+
+builds:
+  corev-dv:
+    cmd: make comp_corev-dv
+    dir: cv32e20/sim/uvmt
+    
+  uvmt_cv32e20:
+    cmd: make comp
+    dir: cv32e20/sim/uvmt
+
+tests:
+  hello-world:
+    build: uvmt_cv32e20
+    description: UVM Hello World Test
+    dir: cv32e20/sim/uvmt
+    cmd: make hello-world
+    cmd: make test COREV=YES TEST=hello-world
+    
+#  interrupt_test:
+#    build: uvmt_cv32e20
+#    description: Interrupt directed test  
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=interrupt_test
+    
+#  corev_rand_interrupt:
+#    build: uvmt_cv32e20
+#    description: Interrupt random test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+#    num: 2
+
+  illegal:
+    build: uvmt_cv32e20
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=illegal
+
+#  debug_test:
+#    build: uvmt_cv32e20
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=debug_test
+
+#  csr_instructions:
+#    build: uvmt_cv32e20
+#    description: CSR Instruction Test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=csr_instructions
+
+  riscv_arithmetic_basic_test_0:
+    build: uvmt_cv32e20
+    description: Static riscv-dv arithmetic test 0
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_0
+
+#  corev_rand_arithmetic_base_test:
+#    build: uvmt_cv32e20
+#    description: Generated corev-dv random arithmetic test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_arithmetic_base_test
+#    num: 2
+
+#  corev_rand_instr_test:
+#    build: uvmt_cv32e20  
+#    description: Generated corev-dv random instruction test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_test
+#    num: 2
+
+#  corev_rand_jump_stress_test:
+#    build: uvmt_cv32e20  
+#    description: Generated corev-dv jump stress test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
+#    num: 2
+


### PR DESCRIPTION
This PR sets up a preliminary CI regression for CV32E20.  The command-line to run it:
```
$ cd bin
$ ./ci_check --core cv32e20 --simulator xrun --iss 0
```

If you have an ImperasDV license, omit the `--iss 0` switch.