### PR TITLE
cva6/uvm: update the AXI interface and parameters of the CVA6

### DIFF
--- a/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -14,11 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-module uvmt_cva6_dut_wrap # ( parameter int unsigned AXI_USER_WIDTH    = 1,
-  parameter int unsigned AXI_USER_EN       = 0,
-  parameter int unsigned AXI_ADDRESS_WIDTH = 64,
-  parameter int unsigned AXI_DATA_WIDTH    = 64,
-  parameter int unsigned NUM_WORDS         = 2**25
+module uvmt_cva6_dut_wrap # (
+    parameter int unsigned AXI_USER_EN = 0,
+    parameter int unsigned NUM_WORDS   = 2**25
 )
 
                            (
@@ -34,10 +32,7 @@ module uvmt_cva6_dut_wrap # ( parameter int unsigned AXI_USER_WIDTH    = 1,
 
 
     cva6_tb_wrapper #(
-     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),
-     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
-     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
      .NUM_WORDS         (NUM_WORDS)
 )
     cva6_tb_wrapper_i        (

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -30,11 +30,8 @@ module uvmt_cva6_tb;
    import uvmt_cva6_pkg::*;
    import uvme_cva6_pkg::*;
 
-   localparam AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH;
-   localparam AXI_USER_EN       = ariane_pkg::AXI_USER_EN;
-   localparam AXI_ADDRESS_WIDTH = 64;
-   localparam AXI_DATA_WIDTH    = 64;
-   localparam NUM_WORDS         = 2**24;
+   localparam AXI_USER_EN = ariane_pkg::AXI_USER_EN;
+   localparam NUM_WORDS   = 2**24;
 
    // ENV (testbench) parameters
    parameter int ENV_PARAM_INSTR_ADDR_WIDTH  = 32;
@@ -77,10 +74,7 @@ module uvmt_cva6_tb;
    */
 
    uvmt_cva6_dut_wrap #(
-     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),
-     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
-     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
      .NUM_WORDS         (NUM_WORDS)
    ) cva6_dut_wrap (
                     .clknrst_if(clknrst_if),


### PR DESCRIPTION
This PR is related to CVA6 PR (https://github.com/openhwgroup/cva6/pull/1223)

The modifications in the CVA6 repository remove redundant definitions of AXI parameters in the CVA6 core. AXI parameters are only passed through the top parameters and propagated.

Actual definition of AXI parameters must be performed at SoC level and pass during the CVA6 instantiation. This allows different instances of CVA6 in the same SoC to have different AXI parameters.

Because of this change in the CVA6 interface, we need to align CORE-V-VERIF testbenches dedicated to CVA6.

Thank you
