### PR TITLE
instr_mem_*mask_f and signals to rvfi interface

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -74,17 +74,25 @@ interface uvma_rvfi_instr_if_t
     input logic [NMEM*3-1:0]         mem_prot
   );
 
+  typedef logic[4*NMEM-1:0] mem_mask_t;
+
   // -------------------------------------------------------------------
   // Local param
   // -------------------------------------------------------------------
   //instruction (rvfi_instr) masks
-  localparam INSTR_MASK_FULL        = 32'h FFFF_FFFF;
-  localparam INSTR_MASK_R_TYPE      = 32'h FE00_707F;
-  localparam INSTR_MASK_I_S_B_TYPE  = 32'h 0000_707F;
-  localparam INSTR_MASK_U_J_TYPE    = 32'h 0000_007F;
-  localparam INSTR_MASK_CSRADDR     = 32'h FFF0_0000;
-  localparam INSTR_MASK_CSRUIMM     = 32'h 000F_8000;
-  localparam INSTR_MASK_CMPR        = 32'h 0000_E003;
+  localparam INSTR_MASK_FULL          = 32'h FFFF_FFFF;
+  localparam INSTR_MASK_R_TYPE        = 32'h FE00_707F;
+  localparam INSTR_MASK_I_S_B_TYPE    = 32'h 0000_707F;
+  localparam INSTR_MASK_U_J_TYPE      = 32'h 0000_007F;
+  localparam INSTR_MASK_CSRADDR       = 32'h FFF0_0000;
+  localparam INSTR_MASK_CSRUIMM       = 32'h 000F_8000;
+  localparam INSTR_MASK_CMPR          = 32'h 0000_E003;
+  localparam INSTR_MASK_ZC_PUSHPOP    = 32'h 0000_FF03;
+  localparam INSTR_MASK_ZC_LOAD_STORE = 32'h 0000_FC03;
+  localparam INSTR_MASK_OPCODE        = 32'h 0000_007F;
+  localparam INSTR_MASK_CLH_CLHU_CSH = 32'b 00000000_00000000_111_111_000_1_0_000_11;
+
+
 
   //instruction (rvfi_instr) comparison values
   localparam INSTR_OPCODE_DRET      = 32'h 7B20_0073;
@@ -104,7 +112,6 @@ interface uvma_rvfi_instr_if_t
   localparam INSTR_OPCODE_CSRRSI    = 32'h 0000_6073;
   localparam INSTR_OPCODE_CSRRCI    = 32'h 0000_7073;
 
-  localparam INSTR_MASK_PUSHPOP   = 32'b 11111111_11111111_111_11111_0000_00_11;
   localparam INSTR_OPCODE_PUSH    = 32'b 00000000_00000000_101_11000_0000_00_10;
   localparam INSTR_OPCODE_POP     = 32'b 00000000_00000000_101_11010_0000_00_10;
   localparam INSTR_OPCODE_POPRET  = 32'b 00000000_00000000_101_11110_0000_00_10;
@@ -117,6 +124,29 @@ interface uvma_rvfi_instr_if_t
   localparam INSTR_OPCODE_FENCE  = 32'b 00000000000000000_000_00000_0001111;
   localparam INSTR_MASK_FENCEI   = 32'b 00000000000000000_111_00000_1111111;
   localparam INSTR_OPCODE_FENCEI = 32'b 00000000000000000_001_00000_0001111;
+
+  localparam INSTR_OPCODE_LOAD    = 32'b 0000_0000_0000_0000_0000_0000_0000_0011;
+  localparam INSTR_OPCODE_STORE  = 32'b 00000000_00000000_00000000_0_0100011;
+
+  localparam INSTR_OPCODE_LH    = 32'b00000000000000000_001_00000_0000011;
+  localparam INSTR_OPCODE_LHU   = 32'b00000000000000000_101_00000_0000011;
+  localparam INSTR_OPCODE_LW    = 32'b00000000000000000_010_00000_0000011;
+  localparam INSTR_OPCODE_SH    = 32'b00000000000000000_001_00000_0100011;
+  localparam INSTR_OPCODE_SHU   = 32'b00000000000000000_001_00000_0100011;
+  localparam INSTR_OPCODE_SW    = 32'b00000000000000000_010_00000_0100011;
+  localparam INSTR_OPCODE_CLW   = 32'b0000000000000000_010_000000000_0000;
+  localparam INSTR_OPCODE_CSW   = 32'b0000000000000000_110_000000000_0000;
+  localparam INSTR_OPCODE_CLWSP = 32'b0000000000000000_010_000000000_0010;
+  localparam INSTR_OPCODE_CSWSP = 32'b0000000000000000_110_000000000_0010;
+  localparam INSTR_OPCODE_CSH   = 32'b0000000000000000_100_011_000000_0010;
+  localparam INSTR_OPCODE_CSB   = 32'b0000000000000000_100_010_000000_0010;
+  localparam INSTR_OPCODE_CLBU  = 32'b 00000000_00000000_100_000_000_00_000_00;
+  localparam INSTR_OPCODE_CLHU  = 32'b 00000000_00000000_100_001_000_0_0_000_00;
+  localparam INSTR_OPCODE_CLH   = 32'b 00000000_00000000_100_001_000_1_0_000_00;
+
+  localparam INSTR_OPCODE_CMPOP      = 32'b 00000000_00000000_101_11010_0000_00_10;
+  localparam INSTR_OPCODE_CMPOPRET   = 32'b 00000000_00000000_101_11110_0000_00_10;
+  localparam INSTR_OPCODE_CMPOPRETZ  = 32'b 00000000_00000000_101_11100_0000_00_10;
 
   //positions
   localparam int INSTR_CSRADDR_POS  = 20;
@@ -144,7 +174,9 @@ interface uvma_rvfi_instr_if_t
   logic [NMEM-1:0][XLEN-1:0]        mem_wdata_array;
   logic [NMEM-1:0][(XLEN/8)-1:0]    mem_wmask_array;
 
+  logic [(5)-1:0]                   csri_uimm;
   logic [5:0]                       cslli_shamt;
+  logic [11:0]                      csr_addr;
 
   logic                             is_dret;
   logic                             is_mret;
@@ -171,9 +203,20 @@ interface uvma_rvfi_instr_if_t
   logic                             is_tablejump_raw;
   logic                             is_pma_fault;
   logic                             is_fencefencei;
+  logic                             is_load_halfword;
+  logic                             is_load_word;
+  logic                             is_store_halfword;
+  logic                             is_store_word;
+  logic                             is_load_word_cmp;
+  logic                             is_store_word_cmp;
+  logic                             is_spload_word_cmp;
+  logic                             is_spstore_word_cmp;
   logic [31:0]                      rvfi_mem_addr_word0highbyte;
-
+  logic                             is_store_instr;
+  logic                             is_loadstore_instr;
   logic                             is_nmi_triggered = 0;
+  logic [4*NMEM-1:0]                instr_mem_rmask;
+  logic [4*NMEM-1:0]                instr_mem_wmask;
 
   // -------------------------------------------------------------------
   // Begin module code
@@ -194,7 +237,9 @@ interface uvma_rvfi_instr_if_t
   assign {>>{mem_wdata_array}} = rvfi_mem_wdata;
   assign {>>{mem_wmask_array}} = rvfi_mem_wmask;
 
+  assign csri_uimm = rvfi_insn[19:15];
   assign cslli_shamt = {rvfi_i.rvfi_insn[12], rvfi_i.rvfi_insn[6:2]};
+  assign csr_addr = rvfi_insn[31:20];
 
   always @(posedge clk or negedge reset_n) begin
     if (!reset_n) begin
@@ -238,6 +283,8 @@ interface uvma_rvfi_instr_if_t
     is_pma_fault        <= is_pma_fault_f();
     is_fencefencei      <= is_fencefencei_f();
     rvfi_mem_addr_word0highbyte <= rvfi_mem_addr_word0highbyte_f();
+    instr_mem_rmask     <= instr_mem_rmask_f();
+    instr_mem_wmask     <= instr_mem_wmask_f();
   end
 
   /**
@@ -544,10 +591,10 @@ function logic is_cslli_f();
 endfunction : is_cslli_f
 
 function automatic logic is_pushpop_f();
-  return  match_instr(INSTR_OPCODE_PUSH,    INSTR_MASK_PUSHPOP)  ||
-          match_instr(INSTR_OPCODE_POP,     INSTR_MASK_PUSHPOP)  ||
-          match_instr(INSTR_OPCODE_POPRET,  INSTR_MASK_PUSHPOP)  ||
-          match_instr(INSTR_OPCODE_POPRETZ, INSTR_MASK_PUSHPOP);
+  return  match_instr(INSTR_OPCODE_PUSH,    INSTR_MASK_ZC_PUSHPOP)  ||
+          match_instr(INSTR_OPCODE_POP,     INSTR_MASK_ZC_PUSHPOP)  ||
+          match_instr(INSTR_OPCODE_POPRET,  INSTR_MASK_ZC_PUSHPOP)  ||
+          match_instr(INSTR_OPCODE_POPRETZ, INSTR_MASK_ZC_PUSHPOP);
 endfunction : is_pushpop_f
 
 function automatic logic is_tablejump_raw_f();
@@ -641,6 +688,210 @@ function automatic logic is_split_datatrans_f();
   return  is_mem_act && (low_addr[31:2] != high_addr[31:2]);
 endfunction : is_split_datatrans_f
 
+function logic is_mem_rmask_byte(int mem_txn, int byte_pos);
+  return (|((get_mem_rmask(mem_txn)) & (1 << byte_pos)));
+endfunction
+
+
+function logic [4*NMEM-1:0] instr_mem_rmask_f();
+  logic [NMEM-1:0][3:0] rmask;
+  logic [3:0] rlist;
+  rlist = rvfi_insn[7:4];
+
+  rmask[0][3] =
+    match_instr(INSTR_OPCODE_LW,        INSTR_MASK_I_S_B_TYPE)  ||
+    match_instr(INSTR_OPCODE_CLW,       INSTR_MASK_CMPR)        ||
+    match_instr(INSTR_OPCODE_CLWSP,     INSTR_MASK_CMPR)        ||
+    match_instr(INSTR_OPCODE_CMPOP,     INSTR_MASK_ZC_PUSHPOP)  ||
+    match_instr(INSTR_OPCODE_CMPOPRET,  INSTR_MASK_ZC_PUSHPOP)  ||
+    match_instr(INSTR_OPCODE_CMPOPRETZ, INSTR_MASK_ZC_PUSHPOP);
+
+  rmask[0][2] = rmask[0][3];
+
+  rmask[0][1] = rmask[0][2] ||
+    match_instr(INSTR_OPCODE_LH,        INSTR_MASK_I_S_B_TYPE)    ||
+    match_instr(INSTR_OPCODE_LHU,       INSTR_MASK_I_S_B_TYPE)    ||
+    match_instr(INSTR_OPCODE_CLHU,      INSTR_MASK_CLH_CLHU_CSH)  ||
+    match_instr(INSTR_OPCODE_CLH,       INSTR_MASK_CLH_CLHU_CSH);
+
+  rmask[0][0] = rmask[0][1] ||
+    match_instr(INSTR_OPCODE_LOAD,      INSTR_MASK_OPCODE)  ||
+    match_instr(INSTR_OPCODE_CLBU,      INSTR_MASK_ZC_LOAD_STORE);
+
+  if(rlist > 4 &&
+    (match_instr(INSTR_OPCODE_CMPOP,     INSTR_MASK_ZC_PUSHPOP) ||
+    match_instr(INSTR_OPCODE_CMPOPRET,  INSTR_MASK_ZC_PUSHPOP)  ||
+    match_instr(INSTR_OPCODE_CMPOPRETZ, INSTR_MASK_ZC_PUSHPOP))) begin
+
+    case (rlist)
+      5:  begin
+        rmask[1:0] = '1;
+        rmask[11:2] = '0;
+      end
+
+      6:  begin
+        rmask[2:0] = '1;
+        rmask[11:3] = '0;
+      end
+
+      7:  begin
+        rmask[3:0] = '1;
+        rmask[11:4] = '0;
+      end
+
+      8:  begin
+        rmask[4:0] = '1;
+        rmask[11:5] = '0;
+      end
+
+      9:  begin
+        rmask[5:0] = '1;
+        rmask[11:6] = '0;
+      end
+
+      10: begin
+        rmask[6:0] = '1;
+        rmask[11:7] = '0;
+      end
+
+      11: begin
+        rmask[7:0] = '1;
+        rmask[11:8] = '0;
+      end
+
+      12: begin
+        rmask[8:0] = '1;
+        rmask[11:9] = '0;
+      end
+
+      13: begin
+        rmask[9:0] = '1;
+        rmask[11:10] = '0;
+      end
+
+      14: begin
+        rmask[10:0] = '1;
+        rmask[11:11] = '0;
+      end
+
+      15: begin
+        rmask[11:0] = '1;
+      end
+
+      default: rmask = '0;
+    endcase
+  end
+  else begin
+    rmask[NMEM-1:1] = '0;
+  end
+  return mem_mask_t'(rmask);
+endfunction
+/*
+function logic [4*NMEM-1:0] instr_mem_wmask_f();
+  logic [NMEM-1:0][3:0] wmask;
+  logic [3:0] rlist;
+  rlist = rvfi_insn[7:4];
+
+  wmask[0][3] =
+    match_instr(INSTR_OPCODE_SW,      INSTR_MASK_I_S_B_TYPE)  ||
+    match_instr(INSTR_OPCODE_CSW,     INSTR_MASK_CMPR)           ||
+    match_instr(INSTR_OPCODE_CSWSP,   INSTR_MASK_CMPR)         ||
+    match_instr(INSTR_OPCODE_PUSH,    INSTR_MASK_ZC_PUSHPOP);
+
+  wmask[0][2] = wmask[0][3];
+
+  wmask[0][1] = wmask[0][2] ||
+    match_instr(INSTR_OPCODE_SH,    INSTR_MASK_I_S_B_TYPE)  ||
+    match_instr(INSTR_OPCODE_CSH,   INSTR_MASK_ZC_LOAD_STOREa  sk[0][0] = wmask[0][1] ||
+    match_instr(INSTR_OPCODE_STORE, INSTR_MASK_OPCODE)   ||
+    match_instr(INSTR_OPCODE_CSB,   INSTR_MASK_ZC_LOAD_STORE(rlist > 4 && match_instr(INSTR_OPCODE_PUSH, INSTR_MASK_ZC_PUSHPOP)) begin
+*/
+function logic [4*NMEM-1:0] instr_mem_wmask_f();
+  logic [NMEM-1:0][3:0] wmask;
+  logic [3:0] rlist;
+  rlist = rvfi_insn[7:4];
+
+  wmask[0][3] =
+    match_instr(INSTR_OPCODE_SW,      INSTR_MASK_I_S_B_TYPE) ||
+    match_instr(INSTR_OPCODE_CSW,     INSTR_MASK_CMPR)       ||
+    match_instr(INSTR_OPCODE_CSWSP,   INSTR_MASK_CMPR)       ||
+    match_instr(INSTR_OPCODE_PUSH,    INSTR_MASK_ZC_PUSHPOP);
+
+  wmask[0][2] = wmask[0][3];
+
+  wmask[0][1] = wmask[0][2] ||
+    match_instr(INSTR_OPCODE_SH,  INSTR_MASK_I_S_B_TYPE)  ||
+    match_instr(INSTR_OPCODE_CSH,    INSTR_MASK_ZC_LOAD_STORE);
+
+  wmask[0][0] = wmask[0][1] ||
+    match_instr(INSTR_OPCODE_STORE,    INSTR_MASK_OPCODE)   ||
+    match_instr(INSTR_OPCODE_CSB,      INSTR_MASK_ZC_LOAD_STORE);
+
+  if(rlist > 4 && match_instr(INSTR_OPCODE_PUSH, INSTR_MASK_ZC_PUSHPOP)) begin
+
+    case (rlist)
+      5:  begin
+        wmask[1:0] = '1;
+        wmask[11:2] = '0;
+      end
+
+      6:  begin
+        wmask[2:0] = '1;
+        wmask[11:3] = '0;
+      end
+
+      7:  begin
+        wmask[3:0] = '1;
+        wmask[11:4] = '0;
+      end
+
+      8:  begin
+        wmask[4:0] = '1;
+        wmask[11:5] = '0;
+      end
+
+      9:  begin
+        wmask[5:0] = '1;
+        wmask[11:6] = '0;
+      end
+
+      10: begin
+        wmask[6:0] = '1;
+        wmask[11:7] = '0;
+      end
+
+      11: begin
+        wmask[7:0] = '1;
+        wmask[11:8] = '0;
+      end
+
+      12: begin
+        wmask[8:0] = '1;
+        wmask[11:9] = '0;
+      end
+
+      13: begin
+        wmask[9:0] = '1;
+        wmask[11:10] = '0;
+      end
+
+      14: begin
+        wmask[10:0] = '1;
+        wmask[11:11] = '0;
+      end
+
+      15: begin
+        wmask[11:0] = '1;
+      end
+
+      default: wmask = '0;
+    endcase
+  end
+  else begin
+    wmask[NMEM-1:1] = '0;
+  end
+  return mem_mask_t'(wmask);
+endfunction
 
 endinterface : uvma_rvfi_instr_if_t
 


### PR DESCRIPTION
This PR adds instr_mem_rmask_f and instr_mem_wmask_f. 
instr_mem_*mask_f returns an array of bits that is similar to rvfi_mem_*mask.
The difference is that when rvfi_mem_*mask is not set due to various reasons, the instr_mem_*mask is set according to what the instruction intended to do.