### PR TITLE
ISACOV : Add ifdef to avoid VCS compilation error due to unsupported 'with' key word

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -15,6 +15,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
+`ifdef UNSUPPORTED_WITH //TODO - Remove ifdef when the issue in VCS simulator is fixed
+  `define WITH iff
+`else
+   `define WITH with
+`endif
+
 covergroup cg_executed_type(
     string name,
     instr_name_t instr_name
@@ -49,24 +55,24 @@ covergroup cg_zb_rstype(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs: cross cp_rd, cp_rs {
-    ignore_bins IGN_OFF = cross_rd_rs with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs `WITH (!reg_crosses_enabled);
   }
 
   cp_rs_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs_is_signed);
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs_toggle, instr.rs1_value, 1)
@@ -90,18 +96,18 @@ covergroup cg_zb_itype_shift (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs: cross cp_rd, cp_rs {
-    ignore_bins IGN_OFF = cross_rd_rs with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs `WITH (!reg_crosses_enabled);
   }
 
   cp_rs_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs_is_signed);
   }
 
   cp_shamt: coverpoint instr.immi {
@@ -109,9 +115,9 @@ covergroup cg_zb_itype_shift (
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs_toggle,  instr.rs1_value, 1)
@@ -137,23 +143,23 @@ covergroup cg_zb_rstype_ext(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_index: coverpoint instr.rs2[4:0] {
@@ -186,18 +192,18 @@ covergroup cg_zb_itype_ext(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs: cross cp_rd, cp_rs {
-    ignore_bins IGN_OFF = cross_rd_rs with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs `WITH (!reg_crosses_enabled);
   }
 
   cp_rs_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs_is_signed);
   }
 
   cp_shift: coverpoint instr.immi {
@@ -231,37 +237,37 @@ covergroup cg_rtype(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cross_rs1_rs2_value: cross cp_rs1_value, cp_rs2_value;
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle, instr.rs1_value, 1)
@@ -286,24 +292,24 @@ covergroup cg_rtype_lr_w(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!unaligned_access_amo_supported);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!unaligned_access_amo_supported);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -331,35 +337,35 @@ covergroup cg_rtype_sc_w (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cross_rs1_rs2_value: cross cp_rs1_value, cp_rs2_value;
 
   cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!unaligned_access_amo_supported);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!unaligned_access_amo_supported);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -389,27 +395,27 @@ covergroup cg_rtype_amo (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!unaligned_access_amo_supported);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!unaligned_access_amo_supported);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -438,29 +444,29 @@ covergroup cg_rtype_slt(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cross_rs1_rs2_value: cross cp_rs1_value, cp_rs2_value;
@@ -492,23 +498,23 @@ covergroup cg_rtype_shift (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rd_rs1_rs2: cross cp_rd, cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rd_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint (instr.rs2_value[4:0]) {
@@ -518,9 +524,9 @@ covergroup cg_rtype_shift (
   cross_rs1_rs2_value: cross cp_rs1_value, cp_rs2_value;
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle, instr.rs1_value, 1)
@@ -544,7 +550,11 @@ covergroup cg_div_special_results(
 
   cp_div_arithmetic_overflow : coverpoint instr.rs1_value {
     //ignore_bins IGN_OVERFLOW = {[0:$]} with (!check_overflow);
-    bins OFLOW = {32'h8000_0000} with (check_overflow) iff (instr.rs2_value == 32'hffff_ffff);
+    `ifdef UNSUPPORTED_WITH
+     bins OFLOW = {32'h8000_0000} iff (check_overflow && instr.rs2_value == 32'hffff_ffff); //TODO
+    `else
+     bins OFLOW = {32'h8000_0000} with (check_overflow) iff (instr.rs2_value == 32'hffff_ffff);
+    `endif
   }
 
 endgroup : cg_div_special_results
@@ -566,32 +576,32 @@ covergroup cg_itype(
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs1: cross cp_rd, cp_rs1 {
-    ignore_bins IGN_OFF = cross_rd_rs1 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_immi_value: coverpoint instr.immi_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!immi_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!immi_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (immi_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!immi_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!immi_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (immi_is_signed);
   }
 
   cross_rs1_immi_value: cross cp_rs1_value, cp_immi_value;
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle,  instr.rs1_value, 1)
@@ -619,32 +629,32 @@ covergroup cg_itype_load (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs1: cross cp_rd, cp_rs1 {
-    ignore_bins IGN_OFF = cross_rd_rs1 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_immi_value: coverpoint instr.immi_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!immi_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!immi_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (immi_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!immi_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!immi_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (immi_is_signed);
   }
 
   cross_rs1_immi_value: cross cp_rs1_value, cp_immi_value;
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle,  instr.rs1_value, 1)
@@ -652,13 +662,13 @@ covergroup cg_itype_load (
   `ISACOV_CP_BITWISE(cp_rd_toggle,   instr.rd_value,  1)
 
   cp_align_halfword: coverpoint (instr.rvfi.mem_addr[0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!align_halfword);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!align_halfword);
     bins ALIGNED  = {0};
     bins UNALIGNED = {1};
   }
 
   cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!align_word);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!align_word);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -682,24 +692,24 @@ covergroup cg_itype_slt (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs1: cross cp_rd, cp_rs1 {
-    ignore_bins IGN_OFF = cross_rd_rs1 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_immi_value: coverpoint instr.immi_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!immi_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!immi_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (immi_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!immi_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!immi_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (immi_is_signed);
   }
 
   cross_rs1_immi_value: cross cp_rs1_value, cp_immi_value;
@@ -730,18 +740,18 @@ covergroup cg_itype_shift (
   cp_rd: coverpoint instr.rd;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs1: cross cp_rd, cp_rs1 {
-    ignore_bins IGN_OFF = cross_rd_rs1 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1 `WITH (!reg_crosses_enabled);
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_immi_value: coverpoint (instr.immi[4:0]) {
@@ -751,9 +761,9 @@ covergroup cg_itype_shift (
   cross_rs1_immi_value: cross cp_rs1_value, cp_immi_value;
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle,  instr.rs1_value, 1)
@@ -776,7 +786,7 @@ covergroup cg_stype(
   cp_rs2: coverpoint instr.rs2;
 
   cross_rs1_rs2: cross cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_imms_value: coverpoint instr.imms_value_type {
@@ -788,13 +798,13 @@ covergroup cg_stype(
   `ISACOV_CP_BITWISE_11_0(cp_imms_toggle, instr.imms, 1)
 
   cp_align_halfword: coverpoint (instr.rvfi.mem_addr[0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!align_halfword);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!align_halfword);
     bins ALIGNED  = {0};
     bins UNALIGNED = {1};
   }
 
   cp_align_word: coverpoint (instr.rvfi.mem_addr[1:0]) {
-    ignore_bins IGN_OFF = {[0:$]} with (!align_word);
+    ignore_bins IGN_OFF = {[0:$]} `WITH (!align_word);
     bins ALIGNED     = {0};
     bins UNALIGNED[] = {[1:3]};
   }
@@ -815,7 +825,7 @@ covergroup cg_btype(
   cp_rs2: coverpoint instr.rs2;
 
   cross_rs1_rs2: cross cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   cp_immb_value: coverpoint instr.immb_value_type {
@@ -888,12 +898,12 @@ covergroup cg_csrtype(
   }
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
   cross_rd_rs1: cross cp_rd, cp_rs1 {
-    ignore_bins IGN_OFF = cross_rd_rs1 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rd_rs1 `WITH (!reg_crosses_enabled);
   }
 endgroup : cg_csrtype
 
@@ -935,32 +945,32 @@ covergroup cg_cr(
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins  OFF     = cp_rs1_value    with (!has_rs1);
-    ignore_bins POS_OFF = {POSITIVE} with (!rdrs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rdrs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rdrs1_is_signed);
+    ignore_bins  OFF     = cp_rs1_value    `WITH (!has_rs1);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rdrs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rdrs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rdrs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rdrs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rdrs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rdrs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rdrs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rdrs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rdrs1_is_signed);
   }
 
 
   cp_rd_rs2_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS2_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[1:31]} iff (instr.rd == instr.rs2);
   }
 
   cross_rdrs1_rs2: cross cp_c_rdrs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rdrs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rdrs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle, instr.rs1_value, has_rs1)
@@ -985,9 +995,9 @@ covergroup cg_cr_j(
   }
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   `ISACOV_CP_BITWISE(cp_rs1_toggle, instr.rs1_value, 1)
@@ -1009,23 +1019,23 @@ covergroup cg_ci(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins  OFF     = cp_rs1_value    with (!has_rs1);
-    illegal_bins POS_OFF = {POSITIVE}      with (!rs1_is_signed);
-    illegal_bins NEG_OFF = {NEGATIVE}      with (!rs1_is_signed);
-    illegal_bins NON_ZERO_OFF = {NON_ZERO} with ( rs1_is_signed);
+    ignore_bins  OFF     = cp_rs1_value    `WITH (!has_rs1);
+    illegal_bins POS_OFF = {POSITIVE}      `WITH (!rs1_is_signed);
+    illegal_bins NEG_OFF = {NEGATIVE}      `WITH (!rs1_is_signed);
+    illegal_bins NON_ZERO_OFF = {NON_ZERO} `WITH ( rs1_is_signed);
   }
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    illegal_bins POS_OFF      = {POSITIVE} with (!imm_is_signed);
-    illegal_bins NEG_OFF      = {NEGATIVE} with (!imm_is_signed);
-    illegal_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
-    ignore_bins  ZERO_OFF     = {ZERO}     with (imm_is_nonzero);  // Not illegal, because of HINT instrs
+    illegal_bins POS_OFF      = {POSITIVE} `WITH (!imm_is_signed);
+    illegal_bins NEG_OFF      = {NEGATIVE} `WITH (!imm_is_signed);
+    illegal_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
+    ignore_bins  ZERO_OFF     = {ZERO}     `WITH (imm_is_nonzero);  // Not illegal, because of HINT instrs
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    illegal_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    illegal_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    illegal_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    illegal_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    illegal_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    illegal_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   cp_rdrs1: coverpoint instr.c_rdrs1 {
@@ -1049,15 +1059,15 @@ covergroup cg_ci_shift(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   cp_shamt: coverpoint instr.get_field_imm() {
@@ -1121,15 +1131,15 @@ covergroup cg_css(
   cp_rs2: coverpoint instr.rs2;
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!imm_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!imm_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!imm_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!imm_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
   }
 
   `ISACOV_CP_BITWISE    (cp_rs2_toggle, instr.rs2_value,         1)
@@ -1165,22 +1175,22 @@ covergroup cg_cl(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!imm_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!imm_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!imm_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!imm_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
   }
 
   cp_rs1: coverpoint instr.c_rs1s;
   cp_rd:  coverpoint instr.c_rdp;
 
   cp_rd_rs1_hazard: coverpoint instr.rd {
-    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} with (!reg_hazards_enabled);
+    ignore_bins IGN_RS1_HAZARD_OFF = {[0:$]} `WITH (!reg_hazards_enabled);
     bins RD[] = {[0:31]} iff (instr.rd == instr.rs1);
   }
 
@@ -1203,15 +1213,15 @@ covergroup cg_cs(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cp_rs1: coverpoint instr.c_rs1s;
@@ -1237,21 +1247,21 @@ covergroup cg_ca(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_rs2_value: coverpoint instr.rs2_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs2_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs2_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs2_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs2_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs2_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs2_is_signed);
   }
 
   cp_rd_value: coverpoint instr.rd_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rd_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rd_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rd_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rd_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rd_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rd_is_signed);
   }
 
   cp_rs1: coverpoint instr.c_rs1s;
@@ -1259,7 +1269,7 @@ covergroup cg_ca(
   cp_rd: coverpoint instr.c_rdp;
 
   cross_rs1_rs2: cross cp_rs1, cp_rs2 {
-    ignore_bins IGN_OFF = cross_rs1_rs2 with (!reg_crosses_enabled);
+    ignore_bins IGN_OFF = cross_rs1_rs2 `WITH (!reg_crosses_enabled);
   }
 
   `ISACOV_CP_BITWISE(cp_rd_toggle, instr.rd_value, 1)
@@ -1279,15 +1289,15 @@ covergroup cg_cb(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!imm_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!imm_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!imm_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!imm_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
   }
 
   cp_rs1: coverpoint instr.c_rs1s;
@@ -1308,15 +1318,15 @@ covergroup cg_cb_andi(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!imm_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!imm_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!imm_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!imm_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
   }
 
   cp_rs1: coverpoint instr.rs1;
@@ -1336,9 +1346,9 @@ covergroup cg_cb_shift(
   option.name = name;
 
   cp_rs1_value: coverpoint instr.rs1_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!rs1_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!rs1_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (rs1_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!rs1_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!rs1_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (rs1_is_signed);
   }
 
   cp_shamt: coverpoint instr.get_field_imm() {
@@ -1362,9 +1372,9 @@ covergroup cg_cj(
   option.name = name;
 
   cp_imm_value: coverpoint instr.c_imm_value_type {
-    ignore_bins POS_OFF = {POSITIVE} with (!imm_is_signed);
-    ignore_bins NEG_OFF = {NEGATIVE} with (!imm_is_signed);
-    ignore_bins NON_ZERO_OFF = {NON_ZERO} with (imm_is_signed);
+    ignore_bins POS_OFF = {POSITIVE} `WITH (!imm_is_signed);
+    ignore_bins NEG_OFF = {NEGATIVE} `WITH (!imm_is_signed);
+    ignore_bins NON_ZERO_OFF = {NON_ZERO} `WITH (imm_is_signed);
   }
 
   `ISACOV_CP_BITWISE_10_0(cp_imm_toggle, instr.get_field_imm(), 1)
@@ -1398,32 +1408,32 @@ covergroup cg_sequential(string name,
 
   cp_instr_prev_x2: coverpoint(instr_prev.name) iff (instr_prev != null) {
     `ISACOV_IGN_BINS
-    ignore_bins IGN_X2_OFF = {[0:$]} with (!seq_instr_x2_enabled);
+    ignore_bins IGN_X2_OFF = {[0:$]} `WITH (!seq_instr_x2_enabled);
   }
 
   cross_seq_instr_x2: cross cp_instr, cp_instr_prev_x2;
 
   cp_group: coverpoint (instr.group) {
-    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} with (!ext_m_supported);
-    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} with (!ext_a_supported);
+    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} `WITH (!ext_m_supported);
+    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} `WITH (!ext_a_supported);
   }
 
   cp_group_pipe_x2:  coverpoint (instr_prev.group) iff (instr_prev != null) {
-    ignore_bins IGN_X2_OFF = {[0:$]} with (!seq_instr_group_x2_enabled);
-    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} with (!ext_m_supported);
-    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} with (!ext_a_supported);
+    ignore_bins IGN_X2_OFF = {[0:$]} `WITH (!seq_instr_group_x2_enabled);
+    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} `WITH (!ext_m_supported);
+    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} `WITH (!ext_a_supported);
   }
 
   cp_group_pipe_x3: coverpoint (instr_prev2.group) iff (instr_prev2 != null) {
-    ignore_bins IGN_X3_OFF = {[0:$]} with (!seq_instr_group_x3_enabled);
-    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} with (!ext_m_supported);
-    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} with (!ext_a_supported);
+    ignore_bins IGN_X3_OFF = {[0:$]} `WITH (!seq_instr_group_x3_enabled);
+    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} `WITH (!ext_m_supported);
+    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} `WITH (!ext_a_supported);
   }
 
   cp_group_pipe_x4: coverpoint (instr_prev3.group) iff (instr_prev3 != null) {
-    ignore_bins IGN_X4_OFF = {[0:$]} with (!seq_instr_group_x4_enabled);
-    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} with (!ext_m_supported);
-    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} with (!ext_a_supported);
+    ignore_bins IGN_X4_OFF = {[0:$]} `WITH (!seq_instr_group_x4_enabled);
+    illegal_bins ILL_EXT_M = {MUL_GROUP, MULTI_MUL_GROUP, DIV_GROUP} `WITH (!ext_m_supported);
+    illegal_bins ILL_EXT_A = {ALOAD_GROUP, ASTORE_GROUP, AMEM_GROUP} `WITH (!ext_a_supported);
   }
 
   cp_gpr_raw_hazard: coverpoint(raw_hazard) {

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
@@ -19,24 +19,30 @@
 `define __UVMA_ISACOV_MACROS_SV__
 
 // Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
+`ifdef UNSUPPORTED_WITH
+  `define WITH iff
+`else
+   `define WITH with
+`endif
+
 `define ISACOV_IGN_BINS \
     ignore_bins IGN_UNKNOWN = {UNKNOWN}; \
     ignore_bins IGN_M = {MUL, MULH, MULHSU, MULHU, \
-                         DIV, DIVU, REM, REMU} with (!ext_m_supported); \
+                         DIV, DIVU, REM, REMU} `WITH (!ext_m_supported); \
     ignore_bins IGN_C = {C_ADDI4SPN, C_LW, C_SW, C_NOP, \
                          C_ADDI, C_JAL, C_LI, C_ADDI16SP, C_LUI, C_SRLI, C_SRAI, \
                          C_ANDI, C_SUB, C_XOR, C_OR, C_AND, C_J, C_BEQZ, C_BNEZ, \
-                         C_SLLI, C_LWSP, C_JR, C_MV, C_EBREAK, C_JALR, C_ADD, C_SWSP} with (!ext_c_supported); \
+                         C_SLLI, C_LWSP, C_JR, C_MV, C_EBREAK, C_JALR, C_ADD, C_SWSP} `WITH (!ext_c_supported); \
     ignore_bins IGN_A = {LR_W, SC_W, \
                          AMOSWAP_W, AMOADD_W, AMOXOR_W, AMOAND_W, \
-                         AMOOR_W, AMOMIN_W, AMOMAX_W, AMOMINU_W, AMOMAXU_W} with (!ext_a_supported); \
-    ignore_bins IGN_ZBA = {SH1ADD,SH2ADD,SH3ADD} with (!ext_zba_supported); \
+                         AMOOR_W, AMOMIN_W, AMOMAX_W, AMOMINU_W, AMOMAXU_W} `WITH (!ext_a_supported); \
+    ignore_bins IGN_ZBA = {SH1ADD,SH2ADD,SH3ADD} `WITH (!ext_zba_supported); \
     ignore_bins IGN_ZBB = {CLZ,CTZ,CPOP,MIN,MINU,MAX,MAXU, \
                            SEXT_B,SEXT_H,ZEXT_H,ANDN,ORN,XNOR, \
-                           ROL,ROR,RORI,REV8,ORC_B} with (!ext_zbb_supported); \
-    ignore_bins IGN_ZBC = {CLMUL,CLMULH,CLMULR} with (!ext_zbc_supported); \
+                           ROL,ROR,RORI,REV8,ORC_B} `WITH (!ext_zbb_supported); \
+    ignore_bins IGN_ZBC = {CLMUL,CLMULH,CLMULR} `WITH (!ext_zbc_supported); \
     ignore_bins IGN_ZBS = {BSET,BSETI,BCLR,BCLRI, \
-                           BINV,BINVI,BEXT,BEXTI} with (!ext_zbs_supported);
+                           BINV,BINVI,BEXT,BEXTI} `WITH (!ext_zbs_supported);
 
 
 `define ISACOV_CP_BITWISE(name, field, iff_exp) \
@@ -105,6 +111,12 @@
     wildcard bins BIT29_1 = {32'b??1?????????????????????????????}; \
     wildcard bins BIT30_1 = {32'b?1??????????????????????????????}; \
     wildcard bins BIT31_1 = {32'b1???????????????????????????????}; \
+}
+
+`define ISACOV_CP_BITWISE_0_0(name, field, iff_exp) \
+``name``: coverpoint(``field``) iff (``iff_exp``) { \
+    wildcard bins BIT0_0  = {1'b0}; \
+    wildcard bins BIT0_1  = {1'b1}; \
 }
 
 `define ISACOV_CP_BITWISE_31_12(name, field, iff_exp) \


### PR DESCRIPTION
As we discuss, for the CVA6 env we have a vcs compilation error related to the vcs version, the 'with' isn't supported for now, the fix is programmed for July, so to integrate the ISACOV in the CVA6 env, I add ifdef (a final solution after a lot of discuss) as a temporary fix.