### PR TITLE
CVA6: Adapt install-spike for bash source

### DIFF
--- a/cva6/regress/install-spike.sh
+++ b/cva6/regress/install-spike.sh
@@ -20,6 +20,7 @@ if [ "$SPIKE_ROOT" = "NO" ]; then
   echo "Skipping Spike setup on user's request (\$SPIKE_ROOT = \"NO\")."
 else
   if [ ! -f "$SPIKE_ROOT/bin/spike"  ]; then
+    PDIR=$(readlink -f .)
     echo "Installing Spike"
     PATCH_DIR=$(pwd)/cva6/regress
     mkdir -p $SPIKE_ROOT
@@ -39,6 +40,7 @@ else
     cd build
     ../configure --enable-commitlog --prefix="$SPIKE_ROOT"
     make -j${NUM_JOBS} install
+    cd $PDIR
   else
     echo "Using Spike from cached directory $SPIKE_ROOT."
   fi


### PR DESCRIPTION
#1846 changed `install-cva6`  to source `verilator` and `spike`. 

`Spike` script was not prepared to be sourced, it  changes the working directory, which now has collateral effects `install-cva6` script.