### PR TITLE
cv32e40p riscof default config change for sail model to run without docker

### DIFF
--- a/cv32e40p/sim/riscof/README.md
+++ b/cv32e40p/sim/riscof/README.md
@@ -37,7 +37,10 @@ The riscof work directory path will be available here `riscof_work`.
            
         - **sw_toolchain_prefix** : to provide chosen riscv toolchain's prefix. Example: `unknown` for riscv32-unknown-elf-gcc.
         - **yaml files** : it is possible to add different ispec/pspec yaml files with needed isa/platform values and modify the path for such files in config file.
-        - **docker** : it is required to be set True or False based on how SAIL ref model is setup in your machine. The executable could be installed and available in your PATH, in which case docker is not used and must be set as False. Otherwise if docker image is used for this purpose then this must be set as True.
+        - **docker** : for sail_cSim it is required to be set to :
+            - True : indicating that docker image is used for SAIL ref model and the docker image to be used is set by the **image** config.
+            - False : SAIL is installed and available directly on the machine.
+            The SAIL executable path, if installed, could be added to env PATH variable or alternatively the **PATH** config of sail_cSim can be used to set it.
         - **imperas_iss** : set it to yes or no based on decision to run with imperas iss enabled for DUT simulations or not.
 
 ## NOTES:
@@ -56,5 +59,7 @@ v2 config_cv32e40p_v2.ini : RV32IMFCZicsr_Zifencei
         - dut_cfg=pulp_fpu
         - SIMULATOR = vsim
         - jobs = 8
-        - Used same RISCV toolchain for both: riscv32-unknown-gcc-elf
-        - SAIL Ref model run with docker. The sail reference model plugin supports both docker and normal execution methods. Currently config.ini is default set to run with docker
+        - Used same RISCV toolchain for both DUT and Ref model: riscv32-unknown-gcc-elf. The Path of toolchain is set from env PATH variable
+        - SAIL Ref model installed on machine. The sail reference model plugin supports running this with both docker image or from local installation. Currently config.ini is default set to run with locally installed Sail model without docker and this installation path is set from env PATH variable.
+        - RISCOF package is installed on the machine and path is set from env PATH variable.
+        - A supported DUT simulator is installed. Currently plugin supports these -> vsim, xrun, vcs

--- a/cv32e40p/sim/riscof/config.ini
+++ b/cv32e40p/sim/riscof/config.ini
@@ -18,11 +18,11 @@ sw_toolchain_prefix=unknown
 
 [sail_cSim]
 pluginpath=./sail_cSim
-docker=True
+#docker=True
 image=registry.gitlab.com/incoresemi/docker-images/compliance
 target_run=1
 jobs=1
-PATH=/usr/bin/
+#PATH=/usr/bin/
 make=make
 sw_toolchain_prefix=unknown
 

--- a/cv32e40p/sim/riscof/config_cv32e40p_v2.ini
+++ b/cv32e40p/sim/riscof/config_cv32e40p_v2.ini
@@ -18,11 +18,11 @@ sw_toolchain_prefix=unknown
 
 [sail_cSim]
 pluginpath=./sail_cSim
-docker=True
+#docker=True
 image=registry.gitlab.com/incoresemi/docker-images/compliance
 target_run=1
 jobs=1
-PATH=/usr/bin/
+#PATH=/usr/bin/
 make=make
 sw_toolchain_prefix=unknown
 

--- a/cv32e40p/sim/riscof/sail_cSim/riscof_sail_cSim.py
+++ b/cv32e40p/sim/riscof/sail_cSim/riscof_sail_cSim.py
@@ -30,7 +30,12 @@ class sail_cSim(pluginTemplate):
             logger.error("Config node for sail_cSim missing.")
             raise SystemExit(1)
         self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
-        self.docker = bool(config['docker']) if 'docker' in config else False
+
+        if 'docker' in config and config['docker']=='True':
+            self.docker = True
+        else:
+            self.docker = False
+
         self.docker_img = str(config['image']) if 'image' in config else 'riscv_compliance'
         self.pluginpath = os.path.abspath(config['pluginpath'])
         path = config['PATH'] if 'PATH' in config else ""
@@ -151,8 +156,11 @@ class sail_cSim(pluginTemplate):
                 cmd = self.sail_exe[self.xlen]+' -C'
             else:
                 cmd = self.sail_exe[self.xlen]
-            
-            execute += cmd + ' {0} --test-signature={1} {2} > {3}.log 2>&1;'.format(self.enable_data_misaligned, sig_file, elf, test_name)
+
+            if self.docker:
+                execute += cmd + ' {0} --test-signature={1} {2} > {3}.log 2>&1;'.format(self.enable_data_misaligned, sig_file, elf, test_name)
+            else:
+                execute += cmd + ' {0} --test-signature={1} {2} > {3}.log;'.format(self.enable_data_misaligned, sig_file, elf, test_name)
 
             cov_str = ' '
             for label in testentry['coverage_labels']:


### PR DESCRIPTION
This PR is for changes to modify the default riscof sail model config to run without docker.

Earlier we had made the default config to run with docker. But going forward we wanted to reverse this and use the more general solution of running SAIL model from a local installation without the need of docker.
Also since we were not able to verify this flow previously, it had minor issues which required a small update to the sail python plugin.
README also updated to indicate this change in default config for Sail.
This is just default config change, internally now flow supports both mechanisms.