### PR TITLE
Small modifications to regression generation

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -204,6 +204,7 @@ parser.add_argument('--sh', help='Select bash shell script output', action='stor
 parser.add_argument('--vsif', help='Select Vmanager VSIF output', action='store_true')
 parser.add_argument('--rmdb', help='Select Vrun RMDB output', action='store_true')
 parser.add_argument('--toolchain', help='Select toolchain to build with', choices=VALID_TOOLCHAINS, default=DEFAULT_TOOLCHAIN)
+parser.add_argument('--check_sim_results', help='Enable or not error code generation if simulation is failed', action='store_true')
 args = parser.parse_args()
 
 if args.debug:
@@ -309,8 +310,8 @@ if args.vsif:
 if args.rmdb:
     # Generate a Vrun-compatible rmdb file (--rmdb)
     template = env.get_template('regress_rmdb.j2')
-    if not args.cov:
-        logger.warning('Coverage option is not set, regression with Questa Vrun will not be able to detect any failing test')
+    if not args.cov and not args.check_sim_results:
+        logger.warning('Coverage and simulation checking results are not enabled, regression with Questa Vrun will not be able to detect any failing test')
     logger.info('Rendering template: regress_rmdb.j2 into: {}'.format(args.outfile))
     out_fh = open(args.outfile, 'w')
     out_fh.write(template.render(session=os.path.splitext(os.path.basename(args.outfile))[0],
@@ -326,5 +327,6 @@ if args.rmdb:
                                  filter_dir=get_filter_dir(),
                                  unique_builds=unique_builds,
                                  unique_tests=unique_tests,
-                                 coverage=args.cov))
+                                 coverage=args.cov,
+                                 check_sim_results=args.check_sim_results))
     out_fh.close()

--- a/bin/templates/regress_macros.j2
+++ b/bin/templates/regress_macros.j2
@@ -1,5 +1,5 @@
 {%- macro yesorno(val) -%}
-{%- if val == '0' -%}NO{%- elif val == '1' -%}YES{%- elif val == True-%}YES{%- else -%}{{val}}{%- endif -%}
+{%- if val == '0' -%}NO{%- elif val == '1' -%}YES{%- elif val == True-%}YES{%- elif val == False -%}NO{%- else -%}{{val}}{%- endif -%}
 {%- endmacro -%}
 
 {%- macro cv_results(arg) -%}

--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -59,8 +59,13 @@
 {% for k,t in unique_tests.items() %}
             <runnable name="{{t.name}}" type="task" repeat="{{t.num}}">
                 <parameters>
+{% if t.cfg is defined %}
+                    <parameter name="tst_cfg" >{{t.cfg}}</parameter>
+{% else %}
+                    <parameter name="tst_cfg" >(%build_config%)</parameter>
+{% endif %}
 {% if coverage != false %}
-                    <parameter name="ucdbfile" >{{t.abs_dir}}/vsim_results/(%build_config%)/{{t.testname}}/(%ITERATION%)/{{t.testname}}.ucdb</parameter>
+                    <parameter name="ucdbfile" >{{t.abs_dir}}/vsim_results/(%tst_cfg%)/{{t.testname}}/(%ITERATION%)/{{t.testname}}.ucdb</parameter>
 {% endif %}
                     <parameter name="log_file" >(%DATADIR%)/{{project}}/{{r.name}}/(%build_name%)/(%INSTANCE%)/execScript.log</parameter>
                 </parameters>

--- a/bin/templates/regress_rmdb.j2
+++ b/bin/templates/regress_rmdb.j2
@@ -75,7 +75,7 @@
                 </method>
 {% endif %}
                 <execScript launch="exec" usestderr="no">
-                    <command> cd {{t.abs_dir}} &amp;&amp; {{t.cmd}} CHECK_SIM_RESULT=YES CHECK_SIM_LOG=(%log_file%) COMP=0 CV_SIM_PREFIX= CV_CORE={{project}} {{toolchain|upper}}=1 CFG=(%build_config%) RISCVDV_CFG={{t.riscvdv_cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=(%ITERATION%) GEN_START_INDEX=(%ITERATION%) SEED=random {{regress_macros.cv_results(results)}} {{makeargs}} {{t.makearg}}</command>
+                    <command> cd {{t.abs_dir}} &amp;&amp; {{t.cmd}} CHECK_SIM_RESULT={{regress_macros.yesorno(check_sim_results)}} CHECK_SIM_LOG=(%log_file%) COMP=0 CV_SIM_PREFIX= CV_CORE={{project}} {{toolchain|upper}}=1 CFG=(%build_config%) RISCVDV_CFG={{t.riscvdv_cfg}} SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} COV={{regress_macros.yesorno(t.cov)}} RUN_INDEX=(%ITERATION%) GEN_START_INDEX=(%ITERATION%) SEED=random {{regress_macros.cv_results(results)}} {{makeargs}} {{t.makearg}}</command>
                 </execScript>
             </runnable>
 {% endfor %}


### PR DESCRIPTION
Added an option for cv_regress script to enable check_sim_results for questa CI

I also noticed that the yesorno jinja macro was somehow weird, if the variable is set to False, the macro will convert it to "False" instead of "NO" as I *think* it should be. 

By default, a test is supposed to inherit its configuration from its build, but I added a way to override this behavior if someone wants to, only for questa CI tool first.  
