### PR TITLE
[cv32e40p] tb update for debug and debug coverage with f and xpulp instructions

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_debug_rom_gen.sv
@@ -68,6 +68,11 @@ class cv32e40p_debug_rom_gen extends riscv_debug_rom_gen;
             end
             // Need to save off GPRs to avoid modifying program flow
             push_gpr_to_debugger_stack(cfg_corev, debug_main);
+
+            // Need to save off FPRs incase f-extension instructions are used to avoid modifying program flow
+            if(cfg.enable_floating_point && !cfg.enable_fp_in_x_regs) begin
+                push_fpr_to_debugger_stack(cfg_corev, debug_main);
+            end
             // Signal that the core entered debug rom only if the rom is actually
             // being filled with random instructions to prevent stress tests from
             // having to execute unnecessary push/pop of GPRs on the stack ever
@@ -116,6 +121,12 @@ class cv32e40p_debug_rom_gen extends riscv_debug_rom_gen;
             if (cfg.enable_ebreak_in_debug_rom) begin
                 gen_ebreak_footer();
             end            
+
+            //pop FPRs for f-extension instructions
+            if(cfg.enable_floating_point && !cfg.enable_fp_in_x_regs) begin
+                pop_fpr_from_debugger_stack(cfg_corev, debug_end);
+            end
+
             pop_gpr_from_debugger_stack(cfg_corev, debug_end);
             if (cfg.enable_ebreak_in_debug_rom) begin
                 gen_restore_ebreak_scratch_reg();

--- a/cv32e40p/env/corev-dv/target/cv32e40p/riscv_core_setting.sv
+++ b/cv32e40p/env/corev-dv/target/cv32e40p/riscv_core_setting.sv
@@ -25,6 +25,7 @@
 //-----------------------------------------------------------------------------
 // XLEN
 parameter int XLEN = 32;
+parameter int FLEN = 32;
 
 // Parameter for SATP mode, set to BARE if address translation is not supported
 parameter satp_mode_t SATP_MODE = BARE;

--- a/cv32e40p/env/uvme/cov/uvme_debug_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_debug_covg.sv
@@ -2,6 +2,7 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 BTA Design Services
 // Copyright 2020 Silicon Labs, Inc.
+// Copyright 2023 Dolphin Design
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -273,16 +274,16 @@ class uvme_debug_covg extends uvm_component;
         ill : coverpoint cntxt.debug_cov_vif.mon_cb.illegal_insn_i {
             bins hit = {1};
         }
-         ebreak : coverpoint cntxt.debug_cov_vif.mon_cb.is_ebreak {
+        ebreak : coverpoint cntxt.debug_cov_vif.mon_cb.is_ebreak {
             bins active= {1'b1};
         }
-         cebreak : coverpoint cntxt.debug_cov_vif.mon_cb.is_cebreak {
+        cebreak : coverpoint cntxt.debug_cov_vif.mon_cb.is_cebreak {
             bins active= {1'b1};
         }
-         branch : coverpoint cntxt.debug_cov_vif.mon_cb.branch_in_decode {
+        branch : coverpoint cntxt.debug_cov_vif.mon_cb.branch_in_decode {
             bins active= {1'b1};
         }
-         mulhsu : coverpoint cntxt.debug_cov_vif.mon_cb.is_mulhsu {
+        mulhsu : coverpoint cntxt.debug_cov_vif.mon_cb.is_mulhsu {
             bins active= {1'b1};
         }
         dreq_and_ill : cross dreq, ill;
@@ -298,7 +299,7 @@ class uvme_debug_covg extends uvm_component;
     covergroup cg_debug_regs_d_mode;
         `per_instance_fcov
         mode : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
-            bins M = {1} ;
+            bins M = {1};
         }
 
         access : coverpoint cntxt.debug_cov_vif.mon_cb.csr_access {
@@ -314,14 +315,14 @@ class uvme_debug_covg extends uvm_component;
             bins dscratch0 = {'h7B2};
             bins dscratch1 = {'h7B3};
         }
-        dregs_access : cross mode, access, op,addr;
+        dregs_access : cross mode, access, op, addr;
     endgroup
 
     // Cover access to dcsr, dpc and dscratch0/1 in M-mode
     covergroup cg_debug_regs_m_mode;
         `per_instance_fcov
         mode : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
-            bins M = {0} ;
+            bins M = {0};
         }
 
         access : coverpoint cntxt.debug_cov_vif.mon_cb.csr_access {
@@ -337,7 +338,7 @@ class uvme_debug_covg extends uvm_component;
             bins dscratch0 = {'h7B2};
             bins dscratch1 = {'h7B3};
         }
-        dregs_access : cross mode, access, op,addr;
+        dregs_access : cross mode, access, op, addr;
     endgroup
     // Cover access to trigger registers
     // Do we need to cover all READ/WRITE/SET/CLEAR from m-mode?
@@ -358,7 +359,7 @@ class uvme_debug_covg extends uvm_component;
             bins tdata3 = {'h7A3};
             bins tinfo  = {'h7A4};
         }
-        tregs_access : cross mode, access, op,addr;
+        tregs_access : cross mode, access, op, addr;
     endgroup
 
     // Cover that we run with counters mcycle and minstret enabled
@@ -425,6 +426,454 @@ class uvme_debug_covg extends uvm_component;
         dbg_req_vs_step : cross dbg_req, step;
     endgroup
 
+    covergroup cg_debug_with_f_inst;
+        `per_instance_fcov
+        dbg_req : coverpoint cntxt.debug_cov_vif.mon_cb.debug_req_i {
+            bins dbg_req_active = {1'b1};
+            bins dbg_req_0_to_1 = (0 => 1);
+        }
+        step : coverpoint cntxt.debug_cov_vif.mon_cb.dcsr_q[2] & !cntxt.debug_cov_vif.mon_cb.debug_mode_q {
+            bins debug_step_mode_set = {1'b1};
+        }
+        ebreak: coverpoint cntxt.debug_cov_vif.mon_cb.is_ebreak {
+                bins ebreak_ex = {1};
+        }
+        cebreak : coverpoint cntxt.debug_cov_vif.mon_cb.is_cebreak {
+            bins cebreak_ex= {1'b1};
+        }
+        ebreakm_set: coverpoint cntxt.debug_cov_vif.mon_cb.dcsr_q[15] {
+                bins ebreakm_is_set = {1};
+        }
+        dm : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
+                bins in_debug_mode = {1};
+        }
+        irq  : coverpoint |cntxt.debug_cov_vif.mon_cb.irq_i {
+                bins irq_trans_0_to_1 = (1'b0 => 1'b1);
+        }
+        ill : coverpoint cntxt.debug_cov_vif.mon_cb.illegal_insn_i {
+            bins ill_inst_hit = {1};
+        }
+
+        f_inst : coverpoint cntxt.debug_cov_vif.mon_cb.rvfi_insn {
+            wildcard bins fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
+            wildcard bins fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
+            wildcard bins fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
+            wildcard bins fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
+            wildcard bins fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
+            wildcard bins fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
+            wildcard bins fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
+            wildcard bins fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
+            wildcard bins fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
+            wildcard bins fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
+            wildcard bins fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
+            wildcard bins fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
+            wildcard bins fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
+            wildcard bins feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
+            wildcard bins flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
+            wildcard bins fles = {cv32e40p_tracer_pkg::INSTR_FLES};
+            wildcard bins fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
+            wildcard bins fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
+            wildcard bins fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
+            wildcard bins fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
+            wildcard bins fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
+            wildcard bins fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
+            wildcard bins fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
+            wildcard bins fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+        }
+
+        rvfi_valid : coverpoint cntxt.debug_cov_vif.mon_cb.rvfi_valid {
+            bins rvfi_valid = {1};
+        }
+
+        apu_req_valid : coverpoint cntxt.debug_cov_vif.mon_cb.apu_req {
+            bins apu_req_valid = {1'b1};
+        }
+
+        apu_grant_valid : coverpoint cntxt.debug_cov_vif.mon_cb.apu_gnt {
+            bins apu_gnt_valid[] = {1'b1};
+        }
+
+        apu_busy : coverpoint cntxt.debug_cov_vif.mon_cb.apu_busy {
+            bins apu_busy[] = {1'b0, 1'b1};
+            bins apu_busy_0_to_1 = (0 => 1);
+            bins apu_busy_1_to_0 = (1 => 0);
+        }
+
+        dbg_x_finst : cross dbg_req, f_inst;
+
+        step_x_finst : cross step, f_inst;
+
+        f_inst_in_dbg_mode : cross dm, f_inst;
+
+        //debug mode entry with debug_halt_req during multi cycle fp inst
+        dbg_while_multi_cyc_f_A : cross apu_req_valid, apu_grant_valid, dbg_req;
+        dbg_while_multi_cyc_f_B : cross apu_busy, dbg_req;
+
+        //debug_halt_req with irq during multi cycle fp inst
+        dbg_irq_while_multi_cyc_f_A : cross apu_req_valid, apu_grant_valid, dbg_req, irq;
+        dbg_irq_while_multi_cyc_f_B : cross apu_busy, dbg_req, irq;
+
+        //debug_halt_req with illegal instr during multi cycle fp inst
+        dbg_ill_while_multi_cyc_f_A : cross apu_req_valid, apu_grant_valid, dbg_req, ill;
+        dbg_ill_while_multi_cyc_f_B : cross apu_busy, dbg_req, ill;
+
+        //debug mode entry with ebreak during multi cycle fp inst
+        ebreak_while_multi_cyc_f_A : cross apu_req_valid, apu_grant_valid, ebreak, ebreakm_set;
+        ebreak_while_multi_cyc_f_B : cross apu_busy, ebreak, ebreakm_set;
+
+        //debug mode entry with cebreak during multi cycle fp inst
+        cebreak_while_multi_cyc_f_A : cross apu_req_valid, apu_grant_valid, cebreak, ebreakm_set;
+        cebreak_while_multi_cyc_f_B : cross apu_busy, cebreak, ebreakm_set;
+
+    endgroup
+
+    covergroup cg_debug_with_xpulp_inst;
+        `per_instance_fcov
+        dbg_req : coverpoint cntxt.debug_cov_vif.mon_cb.debug_req_i {
+            bins dbg_req_active = {1'b1};
+            bins dbg_req_0_to_1 = (0 => 1);
+        }
+        step : coverpoint cntxt.debug_cov_vif.mon_cb.dcsr_q[2] & !cntxt.debug_cov_vif.mon_cb.debug_mode_q {
+            bins debug_step_mode_set = {1'b1};
+        }
+        dm : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
+                bins in_debug_mode = {1};
+        }
+
+        xpulp_instruction : coverpoint cntxt.debug_cov_vif.mon_cb.rvfi_insn {
+            wildcard bins cv_lb_pi_ri           =    {INSTR_CV_LB_PI_RI};
+            wildcard bins cv_lh_pi_ri           =    {INSTR_CV_LH_PI_RI};
+            wildcard bins cv_lw_pi_ri           =    {INSTR_CV_LW_PI_RI};
+            wildcard bins cv_elw_pi_ri          =    {INSTR_CV_ELW_PI_RI};
+            wildcard bins cv_lbu_pi_ri          =    {INSTR_CV_LBU_PI_RI};
+            wildcard bins cv_lhu_pi_ri          =    {INSTR_CV_LHU_PI_RI};
+            wildcard bins cv_beqimm             =    {INSTR_CV_BEQIMM};
+            wildcard bins cv_bneimm             =    {INSTR_CV_BNEIMM};
+            wildcard bins  cv_lb_pi_rr          =    {INSTR_CV_LB_PI_RR};
+            wildcard bins  cv_lh_pi_rr          =    {INSTR_CV_LH_PI_RR};
+            wildcard bins  cv_lw_pi_rr          =    {INSTR_CV_LW_PI_RR};
+            wildcard bins  cv_lbu_pi_rr         =    {INSTR_CV_LBU_PI_RR};
+            wildcard bins  cv_lhu_pi_rr         =    {INSTR_CV_LHU_PI_RR};
+            wildcard bins  cv_lb_rr             =    {INSTR_CV_LB_RR};
+            wildcard bins  cv_lh_rr             =    {INSTR_CV_LH_RR};
+            wildcard bins  cv_lw_rr             =    {INSTR_CV_LW_RR};
+            wildcard bins  cv_lbu_rr            =    {INSTR_CV_LBU_RR};
+            wildcard bins  cv_lhu_rr            =    {INSTR_CV_LHU_RR};
+            wildcard bins  cv_sb_pi_ri          =    {INSTR_CV_SB_PI_RI};
+            wildcard bins  cv_sh_pi_ri          =    {INSTR_CV_SH_PI_RI};
+            wildcard bins  cv_sw_pi_ri          =    {INSTR_CV_SW_PI_RI};
+            wildcard bins  cv_sb_pi_rr          =    {INSTR_CV_SB_PI_RR};
+            wildcard bins  cv_sh_pi_rr          =    {INSTR_CV_SH_PI_RR};
+            wildcard bins  cv_sw_pi_rr          =    {INSTR_CV_SW_PI_RR};
+            wildcard bins  cv_sb_rr             =    {INSTR_CV_SB_RR};
+            wildcard bins  cv_sh_rr             =    {INSTR_CV_SH_RR};
+            wildcard bins  cv_sw_rr             =    {INSTR_CV_SW_RR};
+            wildcard bins  cv_starti            =    {INSTR_CV_STARTI};
+            wildcard bins  cv_start             =    {INSTR_CV_START};
+            wildcard bins  cv_endi              =    {INSTR_CV_ENDI};
+            wildcard bins  cv_end               =    {INSTR_CV_END};
+            wildcard bins  cv_counti            =    {INSTR_CV_COUNTI};
+            wildcard bins  cv_count             =    {INSTR_CV_COUNT};
+            wildcard bins  cv_setupi            =    {INSTR_CV_SETUPI};
+            wildcard bins  cv_setup             =    {INSTR_CV_SETUP};
+            wildcard bins  cv_extractr          =    {INSTR_CV_EXTRACTR};
+            wildcard bins  cv_extractur         =    {INSTR_CV_EXTRACTUR};
+            wildcard bins  cv_insertr           =    {INSTR_CV_INSERTR};
+            wildcard bins  cv_bclrr             =    {INSTR_CV_BCLRR};
+            wildcard bins  cv_bsetr             =    {INSTR_CV_BSETR};
+            wildcard bins  cv_ror               =    {INSTR_CV_ROR};
+            wildcard bins  cv_ff1               =    {INSTR_CV_FF1};
+            wildcard bins  cv_fl1               =    {INSTR_CV_FL1};
+            wildcard bins  cv_clb               =    {INSTR_CV_CLB};
+            wildcard bins  cv_cnt               =    {INSTR_CV_CNT};
+            wildcard bins  cv_abs               =    {INSTR_CV_ABS};
+            wildcard bins  cv_slet              =    {INSTR_CV_SLET};
+            wildcard bins  cv_sletu             =    {INSTR_CV_SLETU};
+            wildcard bins  cv_min               =    {INSTR_CV_MIN};
+            wildcard bins  cv_minu              =    {INSTR_CV_MINU};
+            wildcard bins  cv_max               =    {INSTR_CV_MAX};
+            wildcard bins  cv_maxu              =    {INSTR_CV_MAXU};
+            wildcard bins  cv_exths             =    {INSTR_CV_EXTHS};
+            wildcard bins  cv_exthz             =    {INSTR_CV_EXTHZ};
+            wildcard bins  cv_extbs             =    {INSTR_CV_EXTBS};
+            wildcard bins  cv_extbz             =    {INSTR_CV_EXTBZ};
+            wildcard bins  cv_clip              =    {INSTR_CV_CLIP};
+            wildcard bins  cv_clipu             =    {INSTR_CV_CLIPU};
+            wildcard bins  cv_clipr             =    {INSTR_CV_CLIPR};
+            wildcard bins  cv_clipur            =    {INSTR_CV_CLIPUR};
+            wildcard bins  cv_addnr             =    {INSTR_CV_ADDNR};
+            wildcard bins  cv_addunr            =    {INSTR_CV_ADDUNR};
+            wildcard bins  cv_addrnr            =    {INSTR_CV_ADDRNR};
+            wildcard bins  cv_addurnr           =    {INSTR_CV_ADDURNR};
+            wildcard bins  cv_subnr             =    {INSTR_CV_SUBNR};
+            wildcard bins  cv_subunr            =    {INSTR_CV_SUBUNR};
+            wildcard bins  cv_subrnr            =    {INSTR_CV_SUBRNR};
+            wildcard bins  cv_suburnr           =    {INSTR_CV_SUBURNR};
+            wildcard bins  cv_mac               =    {INSTR_CV_MAC};
+            wildcard bins  cv_msu               =    {INSTR_CV_MSU};
+            wildcard bins  cv_extract           =    {INSTR_CV_EXTRACT};
+            wildcard bins  cv_extractu          =    {INSTR_CV_EXTRACTU};
+            wildcard bins  cv_insert            =    {INSTR_CV_INSERT};
+            wildcard bins  cv_bclr              =    {INSTR_CV_BCLR};
+            wildcard bins  cv_bset              =    {INSTR_CV_BSET};
+            wildcard bins  cv_bitrev            =    {INSTR_CV_BITREV};
+            wildcard bins  cv_addn              =    {INSTR_CV_ADDN};
+            wildcard bins  cv_addun             =    {INSTR_CV_ADDUN};
+            wildcard bins  cv_addrn             =    {INSTR_CV_ADDRN};
+            wildcard bins  cv_addurn            =    {INSTR_CV_ADDURN};
+            wildcard bins  cv_subn              =    {INSTR_CV_SUBN};
+            wildcard bins  cv_subun             =    {INSTR_CV_SUBUN};
+            wildcard bins  cv_subrn             =    {INSTR_CV_SUBRN};
+            wildcard bins  cv_suburn            =    {INSTR_CV_SUBURN};
+            wildcard bins  cv_mulsn             =    {INSTR_CV_MULSN};
+            wildcard bins  cv_mulhhsn           =    {INSTR_CV_MULHHSN};
+            wildcard bins  cv_mulsrn            =    {INSTR_CV_MULSRN};
+            wildcard bins  cv_mulhhsrn          =    {INSTR_CV_MULHHSRN};
+            wildcard bins  cv_mulun             =    {INSTR_CV_MULUN};
+            wildcard bins  cv_mulhhun           =    {INSTR_CV_MULHHUN};
+            wildcard bins  cv_mulurn            =    {INSTR_CV_MULURN};
+            wildcard bins  cv_mulhhurn          =    {INSTR_CV_MULHHURN};
+            wildcard bins  cv_macsn             =    {INSTR_CV_MACSN};
+            wildcard bins  cv_machhsn           =    {INSTR_CV_MACHHSN};
+            wildcard bins  cv_macsrn            =    {INSTR_CV_MACSRN};
+            wildcard bins  cv_machhsrn          =    {INSTR_CV_MACHHSRN};
+            wildcard bins  cv_macun             =    {INSTR_CV_MACUN};
+            wildcard bins  cv_machhun           =    {INSTR_CV_MACHHUN};
+            wildcard bins  cv_macurn            =    {INSTR_CV_MACURN};
+            wildcard bins  cv_machhurn          =    {INSTR_CV_MACHHURN};
+            wildcard bins  cv_add_h             =    {INSTR_CV_ADD_H};
+            wildcard bins  cv_add_sc_h          =    {INSTR_CV_ADD_SC_H};
+            wildcard bins  cv_add_sci_h         =    {INSTR_CV_ADD_SCI_H};
+            wildcard bins  cv_add_b             =    {INSTR_CV_ADD_B};
+            wildcard bins  cv_add_sc_b          =    {INSTR_CV_ADD_SC_B};
+            wildcard bins  cv_add_sci_b         =    {INSTR_CV_ADD_SCI_B};
+            wildcard bins  cv_sub_h             =    {INSTR_CV_SUB_H};
+            wildcard bins  cv_sub_sc_h          =    {INSTR_CV_SUB_SC_H};
+            wildcard bins  cv_sub_sci_h         =    {INSTR_CV_SUB_SCI_H};
+            wildcard bins  cv_sub_b             =    {INSTR_CV_SUB_B};
+            wildcard bins  cv_sub_sc_b          =    {INSTR_CV_SUB_SC_B};
+            wildcard bins  cv_sub_sci_b         =    {INSTR_CV_SUB_SCI_B};
+            wildcard bins  cv_avg_h             =    {INSTR_CV_AVG_H};
+            wildcard bins  cv_avg_sc_h          =    {INSTR_CV_AVG_SC_H};
+            wildcard bins  cv_avg_sci_h         =    {INSTR_CV_AVG_SCI_H};
+            wildcard bins  cv_avg_b             =    {INSTR_CV_AVG_B};
+            wildcard bins  cv_avg_sc_b          =    {INSTR_CV_AVG_SC_B};
+            wildcard bins  cv_avg_sci_b         =    {INSTR_CV_AVG_SCI_B};
+            wildcard bins  cv_avgu_h            =    {INSTR_CV_AVGU_H};
+            wildcard bins  cv_avgu_sc_h         =    {INSTR_CV_AVGU_SC_H};
+            wildcard bins  cv_avgu_sci_h        =    {INSTR_CV_AVGU_SCI_H};
+            wildcard bins  cv_avgu_b            =    {INSTR_CV_AVGU_B};
+            wildcard bins  cv_avgu_sc_b         =    {INSTR_CV_AVGU_SC_B};
+            wildcard bins  cv_avgu_sci_b        =    {INSTR_CV_AVGU_SCI_B};
+            wildcard bins  cv_min_h             =    {INSTR_CV_MIN_H};
+            wildcard bins  cv_min_sc_h          =    {INSTR_CV_MIN_SC_H};
+            wildcard bins  cv_min_sci_h         =    {INSTR_CV_MIN_SCI_H};
+            wildcard bins  cv_min_b             =    {INSTR_CV_MIN_B};
+            wildcard bins  cv_min_sc_b          =    {INSTR_CV_MIN_SC_B};
+            wildcard bins  cv_min_sci_b         =    {INSTR_CV_MIN_SCI_B};
+            wildcard bins  cv_minu_h            =    {INSTR_CV_MINU_H};
+            wildcard bins  cv_minu_sc_h         =    {INSTR_CV_MINU_SC_H};
+            wildcard bins  cv_minu_sci_h        =    {INSTR_CV_MINU_SCI_H};
+            wildcard bins  cv_minu_b            =    {INSTR_CV_MINU_B};
+            wildcard bins  cv_minu_sc_b         =    {INSTR_CV_MINU_SC_B};
+            wildcard bins  cv_minu_sci_b        =    {INSTR_CV_MINU_SCI_B};
+            wildcard bins  cv_max_h             =    {INSTR_CV_MAX_H};
+            wildcard bins  cv_max_sc_h          =    {INSTR_CV_MAX_SC_H};
+            wildcard bins  cv_max_sci_h         =    {INSTR_CV_MAX_SCI_H};
+            wildcard bins  cv_max_b             =    {INSTR_CV_MAX_B};
+            wildcard bins  cv_max_sc_b          =    {INSTR_CV_MAX_SC_B};
+            wildcard bins  cv_max_sci_b         =    {INSTR_CV_MAX_SCI_B};
+            wildcard bins  cv_maxu_h            =    {INSTR_CV_MAXU_H};
+            wildcard bins  cv_maxu_sc_h         =    {INSTR_CV_MAXU_SC_H};
+            wildcard bins  cv_maxu_sci_h        =    {INSTR_CV_MAXU_SCI_H};
+            wildcard bins  cv_maxu_b            =    {INSTR_CV_MAXU_B};
+            wildcard bins  cv_maxu_sc_b         =    {INSTR_CV_MAXU_SC_B};
+            wildcard bins  cv_maxu_sci_b        =    {INSTR_CV_MAXU_SCI_B};
+            wildcard bins  cv_srl_h             =    {INSTR_CV_SRL_H};
+            wildcard bins  cv_srl_sc_h          =    {INSTR_CV_SRL_SC_H};
+            wildcard bins  cv_srl_sci_h         =    {INSTR_CV_SRL_SCI_H};
+            wildcard bins  cv_srl_b             =    {INSTR_CV_SRL_B};
+            wildcard bins  cv_srl_sc_b          =    {INSTR_CV_SRL_SC_B};
+            wildcard bins  cv_srl_sci_b         =    {INSTR_CV_SRL_SCI_B};
+            wildcard bins  cv_sra_h             =    {INSTR_CV_SRA_H};
+            wildcard bins  cv_sra_sc_h          =    {INSTR_CV_SRA_SC_H};
+            wildcard bins  cv_sra_sci_h         =    {INSTR_CV_SRA_SCI_H};
+            wildcard bins  cv_sra_b             =    {INSTR_CV_SRA_B};
+            wildcard bins  cv_sra_sc_b          =    {INSTR_CV_SRA_SC_B};
+            wildcard bins  cv_sra_sci_b         =    {INSTR_CV_SRA_SCI_B};
+            wildcard bins  cv_sll_h             =    {INSTR_CV_SLL_H};
+            wildcard bins  cv_sll_sc_h          =    {INSTR_CV_SLL_SC_H};
+            wildcard bins  cv_sll_sci_h         =    {INSTR_CV_SLL_SCI_H};
+            wildcard bins  cv_sll_b             =    {INSTR_CV_SLL_B};
+            wildcard bins  cv_sll_sc_b          =    {INSTR_CV_SLL_SC_B};
+            wildcard bins  cv_sll_sci_b         =    {INSTR_CV_SLL_SCI_B};
+            wildcard bins  cv_or_h              =    {INSTR_CV_OR_H};
+            wildcard bins  cv_or_sc_h           =    {INSTR_CV_OR_SC_H};
+            wildcard bins  cv_or_sci_h          =    {INSTR_CV_OR_SCI_H};
+            wildcard bins  cv_or_b              =    {INSTR_CV_OR_B};
+            wildcard bins  cv_or_sc_b           =    {INSTR_CV_OR_SC_B};
+            wildcard bins  cv_or_sci_b          =    {INSTR_CV_OR_SCI_B};
+            wildcard bins  cv_xor_h             =    {INSTR_CV_XOR_H};
+            wildcard bins  cv_xor_sc_h          =    {INSTR_CV_XOR_SC_H};
+            wildcard bins  cv_xor_sci_h         =    {INSTR_CV_XOR_SCI_H};
+            wildcard bins  cv_xor_b             =    {INSTR_CV_XOR_B};
+            wildcard bins  cv_xor_sc_b          =    {INSTR_CV_XOR_SC_B};
+            wildcard bins  cv_xor_sci_b         =    {INSTR_CV_XOR_SCI_B};
+            wildcard bins  cv_and_h             =    {INSTR_CV_AND_H};
+            wildcard bins  cv_and_sc_h          =    {INSTR_CV_AND_SC_H};
+            wildcard bins  cv_and_sci_h         =    {INSTR_CV_AND_SCI_H};
+            wildcard bins  cv_and_b             =    {INSTR_CV_AND_B};
+            wildcard bins  cv_and_sc_b          =    {INSTR_CV_AND_SC_B};
+            wildcard bins  cv_and_sci_b         =    {INSTR_CV_AND_SCI_B};
+            wildcard bins  cv_abs_h             =    {INSTR_CV_ABS_H};
+            wildcard bins  cv_abs_b             =    {INSTR_CV_ABS_B};
+            wildcard bins  cv_dotup_h           =    {INSTR_CV_DOTUP_H};
+            wildcard bins  cv_dotup_sc_h        =    {INSTR_CV_DOTUP_SC_H};
+            wildcard bins  cv_dotup_sci_h       =    {INSTR_CV_DOTUP_SCI_H};
+            wildcard bins  cv_dotup_b           =    {INSTR_CV_DOTUP_B};
+            wildcard bins  cv_dotup_sc_b        =    {INSTR_CV_DOTUP_SC_B};
+            wildcard bins  cv_dotup_sci_b       =    {INSTR_CV_DOTUP_SCI_B};
+            wildcard bins  cv_dotusp_h          =    {INSTR_CV_DOTUSP_H};
+            wildcard bins  cv_dotusp_sc_h       =    {INSTR_CV_DOTUSP_SC_H};
+            wildcard bins  cv_dotusp_sci_h      =    {INSTR_CV_DOTUSP_SCI_H};
+            wildcard bins  cv_dotusp_b          =    {INSTR_CV_DOTUSP_B};
+            wildcard bins  cv_dotusp_sc_b       =    {INSTR_CV_DOTUSP_SC_B};
+            wildcard bins  cv_dotusp_sci_b      =    {INSTR_CV_DOTUSP_SCI_B};
+            wildcard bins  cv_dotsp_h           =    {INSTR_CV_DOTSP_H};
+            wildcard bins  cv_dotsp_sc_h        =    {INSTR_CV_DOTSP_SC_H};
+            wildcard bins  cv_dotsp_sci_h       =    {INSTR_CV_DOTSP_SCI_H};
+            wildcard bins  cv_dotsp_b           =    {INSTR_CV_DOTSP_B};
+            wildcard bins  cv_dotsp_sc_b        =    {INSTR_CV_DOTSP_SC_B};
+            wildcard bins  cv_dotsp_sci_b       =    {INSTR_CV_DOTSP_SCI_B};
+            wildcard bins  cv_sdotup_h          =    {INSTR_CV_SDOTUP_H};
+            wildcard bins  cv_sdotup_sc_h       =    {INSTR_CV_SDOTUP_SC_H};
+            wildcard bins  cv_sdotup_sci_h      =    {INSTR_CV_SDOTUP_SCI_H};
+            wildcard bins  cv_sdotup_b          =    {INSTR_CV_SDOTUP_B};
+            wildcard bins  cv_sdotup_sc_b       =    {INSTR_CV_SDOTUP_SC_B};
+            wildcard bins  cv_sdotup_sci_b      =    {INSTR_CV_SDOTUP_SCI_B};
+            wildcard bins  cv_sdotusp_h         =    {INSTR_CV_SDOTUSP_H};
+            wildcard bins  cv_sdotusp_sc_h      =    {INSTR_CV_SDOTUSP_SC_H};
+            wildcard bins  cv_sdotusp_sci_h     =    {INSTR_CV_SDOTUSP_SCI_H};
+            wildcard bins  cv_sdotusp_b         =    {INSTR_CV_SDOTUSP_B};
+            wildcard bins  cv_sdotusp_sc_b      =    {INSTR_CV_SDOTUSP_SC_B};
+            wildcard bins  cv_sdotusp_sci_b     =    {INSTR_CV_SDOTUSP_SCI_B};
+            wildcard bins  cv_sdotsp_h          =    {INSTR_CV_SDOTSP_H};
+            wildcard bins  cv_sdotsp_sc_h       =    {INSTR_CV_SDOTSP_SC_H};
+            wildcard bins  cv_sdotsp_sci_h      =    {INSTR_CV_SDOTSP_SCI_H};
+            wildcard bins  cv_sdotsp_b          =    {INSTR_CV_SDOTSP_B};
+            wildcard bins  cv_sdotsp_sc_b       =    {INSTR_CV_SDOTSP_SC_B};
+            wildcard bins  cv_sdotsp_sci_b      =    {INSTR_CV_SDOTSP_SCI_B};
+            wildcard bins  cv_extract_h         =    {INSTR_CV_EXTRACT_H};
+            wildcard bins  cv_extract_b         =    {INSTR_CV_EXTRACT_B};
+            wildcard bins  cv_extractu_h        =    {INSTR_CV_EXTRACTU_H};
+            wildcard bins  cv_extractu_b        =    {INSTR_CV_EXTRACTU_B};
+            wildcard bins  cv_insert_h          =    {INSTR_CV_INSERT_H};
+            wildcard bins  cv_insert_b          =    {INSTR_CV_INSERT_B};
+            wildcard bins  cv_shuffle_h         =    {INSTR_CV_SHUFFLE_H};
+            wildcard bins  cv_shuffle_sci_h     =    {INSTR_CV_SHUFFLE_SCI_H};
+            wildcard bins  cv_shuffle_b         =    {INSTR_CV_SHUFFLE_B};
+            wildcard bins  cv_shufflei0_sci_b   =    {INSTR_CV_SHUFFLEI0_SCI_B};
+            wildcard bins  cv_shufflei1_sci_b   =    {INSTR_CV_SHUFFLEI1_SCI_B};
+            wildcard bins  cv_shufflei2_sci_b   =    {INSTR_CV_SHUFFLEI2_SCI_B};
+            wildcard bins  cv_shufflei3_sci_b   =    {INSTR_CV_SHUFFLEI3_SCI_B};
+            wildcard bins  cv_shuffle2_h        =    {INSTR_CV_SHUFFLE2_H};
+            wildcard bins  cv_shuffle2_b        =    {INSTR_CV_SHUFFLE2_B};
+            wildcard bins  cv_pack              =    {INSTR_CV_PACK};
+            wildcard bins  cv_pack_h            =    {INSTR_CV_PACK_H};
+            wildcard bins  cv_packhi_b          =    {INSTR_CV_PACKHI_B};
+            wildcard bins  cv_packlo_b          =    {INSTR_CV_PACKLO_B};
+            wildcard bins  cv_cmpeq_h           =    {INSTR_CV_CMPEQ_H};
+            wildcard bins  cv_cmpeq_sc_h        =    {INSTR_CV_CMPEQ_SC_H};
+            wildcard bins  cv_cmpeq_sci_h       =    {INSTR_CV_CMPEQ_SCI_H};
+            wildcard bins  cv_cmpeq_b           =    {INSTR_CV_CMPEQ_B};
+            wildcard bins  cv_cmpeq_sc_b        =    {INSTR_CV_CMPEQ_SC_B};
+            wildcard bins  cv_cmpeq_sci_b       =    {INSTR_CV_CMPEQ_SCI_B};
+            wildcard bins  cv_cmpne_h           =    {INSTR_CV_CMPNE_H};
+            wildcard bins  cv_cmpne_sc_h        =    {INSTR_CV_CMPNE_SC_H};
+            wildcard bins  cv_cmpne_sci_h       =    {INSTR_CV_CMPNE_SCI_H};
+            wildcard bins  cv_cmpne_b           =    {INSTR_CV_CMPNE_B};
+            wildcard bins  cv_cmpne_sc_b        =    {INSTR_CV_CMPNE_SC_B};
+            wildcard bins  cv_cmpne_sci_b       =    {INSTR_CV_CMPNE_SCI_B};
+            wildcard bins  cv_cmpgt_h           =    {INSTR_CV_CMPGT_H};
+            wildcard bins  cv_cmpgt_sc_h        =    {INSTR_CV_CMPGT_SC_H};
+            wildcard bins  cv_cmpgt_sci_h       =    {INSTR_CV_CMPGT_SCI_H};
+            wildcard bins  cv_cmpgt_b           =    {INSTR_CV_CMPGT_B};
+            wildcard bins  cv_cmpgt_sc_b        =    {INSTR_CV_CMPGT_SC_B};
+            wildcard bins  cv_cmpgt_sci_b       =    {INSTR_CV_CMPGT_SCI_B};
+            wildcard bins  cv_cmpge_h           =    {INSTR_CV_CMPGE_H};
+            wildcard bins  cv_cmpge_sc_h        =    {INSTR_CV_CMPGE_SC_H};
+            wildcard bins  cv_cmpge_sci_h       =    {INSTR_CV_CMPGE_SCI_H};
+            wildcard bins  cv_cmpge_b           =    {INSTR_CV_CMPGE_B};
+            wildcard bins  cv_cmpge_sc_b        =    {INSTR_CV_CMPGE_SC_B};
+            wildcard bins  cv_cmpge_sci_b       =    {INSTR_CV_CMPGE_SCI_B};
+            wildcard bins  cv_cmplt_h           =    {INSTR_CV_CMPLT_H};
+            wildcard bins  cv_cmplt_sc_h        =    {INSTR_CV_CMPLT_SC_H};
+            wildcard bins  cv_cmplt_sci_h       =    {INSTR_CV_CMPLT_SCI_H};
+            wildcard bins  cv_cmplt_b           =    {INSTR_CV_CMPLT_B};
+            wildcard bins  cv_cmplt_sc_b        =    {INSTR_CV_CMPLT_SC_B};
+            wildcard bins  cv_cmplt_sci_b       =    {INSTR_CV_CMPLT_SCI_B};
+            wildcard bins  cv_cmple_h           =    {INSTR_CV_CMPLE_H};
+            wildcard bins  cv_cmple_sc_h        =    {INSTR_CV_CMPLE_SC_H};
+            wildcard bins  cv_cmple_sci_h       =    {INSTR_CV_CMPLE_SCI_H};
+            wildcard bins  cv_cmple_b           =    {INSTR_CV_CMPLE_B};
+            wildcard bins  cv_cmple_sc_b        =    {INSTR_CV_CMPLE_SC_B};
+            wildcard bins  cv_cmple_sci_b       =    {INSTR_CV_CMPLE_SCI_B};
+            wildcard bins  cv_cmpgtu_h          =    {INSTR_CV_CMPGTU_H};
+            wildcard bins  cv_cmpgtu_sc_h       =    {INSTR_CV_CMPGTU_SC_H};
+            wildcard bins  cv_cmpgtu_sci_h      =    {INSTR_CV_CMPGTU_SCI_H};
+            wildcard bins  cv_cmpgtu_b          =    {INSTR_CV_CMPGTU_B};
+            wildcard bins  cv_cmpgtu_sc_b       =    {INSTR_CV_CMPGTU_SC_B};
+            wildcard bins  cv_cmpgtu_sci_b      =    {INSTR_CV_CMPGTU_SCI_B};
+            wildcard bins  cv_cmpgeu_h          =    {INSTR_CV_CMPGEU_H};
+            wildcard bins  cv_cmpgeu_sc_h       =    {INSTR_CV_CMPGEU_SC_H};
+            wildcard bins  cv_cmpgeu_sci_h      =    {INSTR_CV_CMPGEU_SCI_H};
+            wildcard bins  cv_cmpgeu_b          =    {INSTR_CV_CMPGEU_B};
+            wildcard bins  cv_cmpgeu_sc_b       =    {INSTR_CV_CMPGEU_SC_B};
+            wildcard bins  cv_cmpgeu_sci_b      =    {INSTR_CV_CMPGEU_SCI_B};
+            wildcard bins  cv_cmpltu_h          =    {INSTR_CV_CMPLTU_H};
+            wildcard bins  cv_cmpltu_sc_h       =    {INSTR_CV_CMPLTU_SC_H};
+            wildcard bins  cv_cmpltu_sci_h      =    {INSTR_CV_CMPLTU_SCI_H};
+            wildcard bins  cv_cmpltu_b          =    {INSTR_CV_CMPLTU_B};
+            wildcard bins  cv_cmpltu_sc_b       =    {INSTR_CV_CMPLTU_SC_B};
+            wildcard bins  cv_cmpltu_sci_b      =    {INSTR_CV_CMPLTU_SCI_B};
+            wildcard bins  cv_cmpleu_h          =    {INSTR_CV_CMPLEU_H};
+            wildcard bins  cv_cmpleu_sc_h       =    {INSTR_CV_CMPLEU_SC_H};
+            wildcard bins  cv_cmpleu_sci_h      =    {INSTR_CV_CMPLEU_SCI_H};
+            wildcard bins  cv_cmpleu_b          =    {INSTR_CV_CMPLEU_B};
+            wildcard bins  cv_cmpleu_sc_b       =    {INSTR_CV_CMPLEU_SC_B};
+            wildcard bins  cv_cmpleu_sci_b      =    {INSTR_CV_CMPLEU_SCI_B};
+            wildcard bins  cv_cplxmul_r         =    {INSTR_CV_CPLXMUL_R};
+            wildcard bins  cv_cplxmul_r_div2    =    {INSTR_CV_CPLXMUL_R_DIV2};
+            wildcard bins  cv_cplxmul_r_div4    =    {INSTR_CV_CPLXMUL_R_DIV4};
+            wildcard bins  cv_cplxmul_r_div8    =    {INSTR_CV_CPLXMUL_R_DIV8};
+            wildcard bins  cv_cplxmul_i         =    {INSTR_CV_CPLXMUL_I};
+            wildcard bins  cv_cplxmul_i_div2    =    {INSTR_CV_CPLXMUL_I_DIV2};
+            wildcard bins  cv_cplxmul_i_div4    =    {INSTR_CV_CPLXMUL_I_DIV4};
+            wildcard bins  cv_cplxmul_i_div8    =    {INSTR_CV_CPLXMUL_I_DIV8};
+            wildcard bins  cv_cplxconj          =    {INSTR_CV_CPLXCONJ};
+            wildcard bins  cv_subrotmj          =    {INSTR_CV_SUBROTMJ};
+            wildcard bins  cv_subrotmj_div2     =    {INSTR_CV_SUBROTMJ_DIV2};
+            wildcard bins  cv_subrotmj_div4     =    {INSTR_CV_SUBROTMJ_DIV4};
+            wildcard bins  cv_subrotmj_div8     =    {INSTR_CV_SUBROTMJ_DIV8};
+            wildcard bins  cv_add_div2          =    {INSTR_CV_ADD_DIV2};
+            wildcard bins  cv_add_div4          =    {INSTR_CV_ADD_DIV4};
+            wildcard bins  cv_add_div8          =    {INSTR_CV_ADD_DIV8};
+            wildcard bins  cv_sub_div2          =    {INSTR_CV_SUB_DIV2};
+            wildcard bins  cv_sub_div4          =    {INSTR_CV_SUB_DIV4};
+            wildcard bins  cv_sub_div8          =    {INSTR_CV_SUB_DIV8};
+        }
+
+        //cross xpulp instr while in debug mode
+        xpulp_instructions_in_dbg_mode : cross dm, xpulp_instruction;
+
+        //cross xpulp instr excution at debug req
+        dbg_req_at_xpulp_instr : cross dbg_req, xpulp_instruction;
+
+        //cross debug single stepping for each xpulp instr
+        dbg_single_step_xpulp_instr : cross step, xpulp_instruction;
+
+    endgroup
+
 endclass : uvme_debug_covg
 
 function uvme_debug_covg::new(string name = "debug_covg", uvm_component parent = null);
@@ -452,6 +901,8 @@ function uvme_debug_covg::new(string name = "debug_covg", uvm_component parent =
     cg_debug_at_reset = new();
     cg_fence_in_debug = new();
     cg_debug_causes = new();
+    cg_debug_with_f_inst = new();
+    cg_debug_with_xpulp_inst = new();
 endfunction : new
 
 function void uvme_debug_covg::build_phase(uvm_phase phase);
@@ -507,5 +958,7 @@ task uvme_debug_covg::sample_clk_i();
     cg_debug_at_reset.sample();
     cg_fence_in_debug.sample();
     cg_debug_causes.sample();
+    cg_debug_with_f_inst.sample();
+    cg_debug_with_xpulp_inst.sample();
   end
 endtask  : sample_clk_i

--- a/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
@@ -1,5 +1,6 @@
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2023 Dolphin Design
 // 
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@ parameter uvme_cv32e40p_debug_default_clk_period = 10_000; // 10ns
 // For RVFI/RVVI
 parameter ILEN = 32;
 parameter XLEN = 32;
+parameter FLEN = 32;
 parameter RVFI_NRET = 1;
 
 // Control how often to print core scoreboard checked heartbeat messages
@@ -52,5 +54,393 @@ parameter CV_VP_DEBUG_CONTROL_BASE     = CV_VP_REGISTER_BASE + CV_VP_DEBUG_CONTR
 parameter CV_VP_OBI_SLV_RESP_BASE      = CV_VP_REGISTER_BASE + CV_VP_OBI_SLV_RESP_OFFSET;
 parameter CV_VP_SIG_WRITER_BASE        = CV_VP_REGISTER_BASE + CV_VP_SIG_WRITER_OFFSET;
 parameter CV_VP_FENCEI_TAMPER_BASE     = CV_VP_REGISTER_BASE + CV_VP_FENCEI_TAMPER_OFFSET;
+
+//XPULP instructions custom opcodes
+parameter OPCODE_CUSTOM_0 = 7'h0b;
+parameter OPCODE_CUSTOM_1 = 7'h2b;
+parameter OPCODE_CUSTOM_2 = 7'h5b;
+parameter OPCODE_CUSTOM_3 = 7'h7b;
+
+//Xpulp instr coverpoints for each xpulp instr encoding is derived from
+//xpulp encodings defined in User-Manual-en-cv32e40p_xxxxxx.pdf
+
+// XPULP CUSTOM_0 ENCODING
+parameter INSTR_CV_LB_PI_RI         =    {17'b?, 3'b000, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_LH_PI_RI         =    {17'b?, 3'b001, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_LW_PI_RI         =    {17'b?, 3'b010, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_ELW_PI_RI        =    {17'b?, 3'b011, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_LBU_PI_RI        =    {17'b?, 3'b100, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_LHU_PI_RI        =    {17'b?, 3'b101, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_BEQIMM           =    {17'b?, 3'b110, 5'b?, OPCODE_CUSTOM_0};
+parameter INSTR_CV_BNEIMM           =    {17'b?, 3'b111, 5'b?, OPCODE_CUSTOM_0};
+
+// XPULP CUSTOM_1 ENCODING
+parameter INSTR_CV_LB_PI_RR         =    {7'b0000000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LH_PI_RR         =    {7'b0000001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LW_PI_RR         =    {7'b0000010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LBU_PI_RR        =    {7'b0001000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LHU_PI_RR        =    {7'b0001001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_LB_RR            =    {7'b0000100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LH_RR            =    {7'b0000101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LW_RR            =    {7'b0000110, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LBU_RR           =    {7'b0001100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_LHU_RR           =    {7'b0001101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_SB_PI_RI         =    {7'b???????, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SH_PI_RI         =    {7'b???????, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SW_PI_RI         =    {7'b???????, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_SB_PI_RR         =    {7'b0010000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SH_PI_RR         =    {7'b0010001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SW_PI_RR         =    {7'b0010010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_SB_RR            =    {7'b0010100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SH_RR            =    {7'b0010101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SW_RR            =    {7'b0010110, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_STARTI           =    {12'b?, 5'b00000, 3'b100, 4'b0000, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_START            =    {12'b0, 5'b?????, 3'b100, 4'b0001, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_ENDI             =    {12'b?, 5'b00000, 3'b100, 4'b0010, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_END              =    {12'b0, 5'b?????, 3'b100, 4'b0011, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_COUNTI           =    {12'b?, 5'b00000, 3'b100, 4'b0100, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_COUNT            =    {12'b0, 5'b?????, 3'b100, 4'b0101, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SETUPI           =    {12'b?, 5'b?????, 3'b100, 4'b0110, 1'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SETUP            =    {12'b?, 5'b?????, 3'b100, 4'b0111, 1'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_EXTRACTR         =    {7'b0011000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_EXTRACTUR        =    {7'b0011001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_INSERTR          =    {7'b0011010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_BCLRR            =    {7'b0011100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_BSETR            =    {7'b0011101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_ROR              =    {7'b0100000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_FF1              =    {7'b0100001, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_FL1              =    {7'b0100010, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CLB              =    {7'b0100011, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CNT              =    {7'b0100100, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_ABS              =    {7'b0101000, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SLET             =    {7'b0101001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SLETU            =    {7'b0101010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_MIN              =    {7'b0101011, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_MINU             =    {7'b0101100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_MAX              =    {7'b0101101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_MAXU             =    {7'b0101110, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_EXTHS            =    {7'b0110000, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_EXTHZ            =    {7'b0110001, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_EXTBS            =    {7'b0110010, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_EXTBZ            =    {7'b0110011, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CLIP             =    {7'b0111000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CLIPU            =    {7'b0111001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CLIPR            =    {7'b0111010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_CLIPUR           =    {7'b0111011, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_ADDNR            =    {7'b1000000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_ADDUNR           =    {7'b1000001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_ADDRNR           =    {7'b1000010, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_ADDURNR          =    {7'b1000011, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SUBNR            =    {7'b1000100, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SUBUNR           =    {7'b1000101, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SUBRNR           =    {7'b1000110, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_SUBURNR          =    {7'b1000111, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+parameter INSTR_CV_MAC              =    {7'b1001000, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+parameter INSTR_CV_MSU              =    {7'b1001001, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
+
+// XPULP CUSTOM_2 ENCODING
+parameter INSTR_CV_EXTRACT          =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_EXTRACTU         =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_INSERT           =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_BCLR             =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_BSET             =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_BITREV           =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_2};
+
+parameter INSTR_CV_ADDN             =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_ADDUN            =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_ADDRN            =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_ADDURN           =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_SUBN             =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_SUBUN            =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_SUBRN            =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_SUBURN           =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_2};
+
+parameter INSTR_CV_MULSN            =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULHHSN          =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULSRN           =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULHHSRN         =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULUN            =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULHHUN          =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULURN           =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MULHHURN         =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACSN            =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACHHSN          =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACSRN           =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACHHSRN         =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACUN            =    {2'b00, 5'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACHHUN          =    {2'b01, 5'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACURN           =    {2'b10, 5'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_2};
+parameter INSTR_CV_MACHHURN         =    {2'b11, 5'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_2};
+
+// XPULP CUSTOM_3 ENCODING
+parameter INSTR_CV_ADD_H            =    {5'b00000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_SC_H         =    {5'b00000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_SCI_H        =    {5'b00000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_B            =    {5'b00000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_SC_B         =    {5'b00000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_SCI_B        =    {5'b00000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SUB_H            =    {5'b00001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_SC_H         =    {5'b00001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_SCI_H        =    {5'b00001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_B            =    {5'b00001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_SC_B         =    {5'b00001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_SCI_B        =    {5'b00001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_AVG_H            =    {5'b00010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVG_SC_H         =    {5'b00010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVG_SCI_H        =    {5'b00010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVG_B            =    {5'b00010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVG_SC_B         =    {5'b00010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVG_SCI_B        =    {5'b00010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_AVGU_H           =    {5'b00011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVGU_SC_H        =    {5'b00011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVGU_SCI_H       =    {5'b00011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVGU_B           =    {5'b00011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVGU_SC_B        =    {5'b00011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AVGU_SCI_B       =    {5'b00011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_MIN_H            =    {5'b00100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MIN_SC_H         =    {5'b00100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MIN_SCI_H        =    {5'b00100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MIN_B            =    {5'b00100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MIN_SC_B         =    {5'b00100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MIN_SCI_B        =    {5'b00100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_MINU_H           =    {5'b00101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MINU_SC_H        =    {5'b00101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MINU_SCI_H       =    {5'b00101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MINU_B           =    {5'b00101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MINU_SC_B        =    {5'b00101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MINU_SCI_B       =    {5'b00101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_MAX_H            =    {5'b00110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAX_SC_H         =    {5'b00110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAX_SCI_H        =    {5'b00110, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAX_B            =    {5'b00110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAX_SC_B         =    {5'b00110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAX_SCI_B        =    {5'b00110, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_MAXU_H           =    {5'b00111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAXU_SC_H        =    {5'b00111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAXU_SCI_H       =    {5'b00111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAXU_B           =    {5'b00111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAXU_SC_B        =    {5'b00111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_MAXU_SCI_B       =    {5'b00111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SRL_H            =    {5'b01000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRL_SC_H         =    {5'b01000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRL_SCI_H        =    {5'b01000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRL_B            =    {5'b01000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRL_SC_B         =    {5'b01000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRL_SCI_B        =    {5'b01000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SRA_H            =    {5'b01001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRA_SC_H         =    {5'b01001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRA_SCI_H        =    {5'b01001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRA_B            =    {5'b01001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRA_SC_B         =    {5'b01001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SRA_SCI_B        =    {5'b01001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SLL_H            =    {5'b01010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SLL_SC_H         =    {5'b01010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SLL_SCI_H        =    {5'b01010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SLL_B            =    {5'b01010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SLL_SC_B         =    {5'b01010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SLL_SCI_B        =    {5'b01010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_OR_H             =    {5'b01011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_OR_SC_H          =    {5'b01011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_OR_SCI_H         =    {5'b01011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_OR_B             =    {5'b01011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_OR_SC_B          =    {5'b01011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_OR_SCI_B         =    {5'b01011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_XOR_H            =    {5'b01100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_XOR_SC_H         =    {5'b01100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_XOR_SCI_H        =    {5'b01100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_XOR_B            =    {5'b01100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_XOR_SC_B         =    {5'b01100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_XOR_SCI_B        =    {5'b01100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_AND_H            =    {5'b01101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AND_SC_H         =    {5'b01101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AND_SCI_H        =    {5'b01101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AND_B            =    {5'b01101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AND_SC_B         =    {5'b01101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_AND_SCI_B        =    {5'b01101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_ABS_H            =    {5'b01110, 1'b0, 1'b0, 5'b0, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ABS_B            =    {5'b01110, 1'b0, 1'b0, 5'b0, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_DOTUP_H          =    {5'b10000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUP_SC_H       =    {5'b10000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUP_SCI_H      =    {5'b10000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUP_B          =    {5'b10000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUP_SC_B       =    {5'b10000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUP_SCI_B      =    {5'b10000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_DOTUSP_H         =    {5'b10001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUSP_SC_H      =    {5'b10001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUSP_SCI_H     =    {5'b10001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUSP_B         =    {5'b10001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUSP_SC_B      =    {5'b10001, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTUSP_SCI_B     =    {5'b10001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_DOTSP_H          =    {5'b10010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTSP_SC_H       =    {5'b10010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTSP_SCI_H      =    {5'b10010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTSP_B          =    {5'b10010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTSP_SC_B       =    {5'b10010, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_DOTSP_SCI_B      =    {5'b10010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SDOTUP_H         =    {5'b10011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUP_SC_H      =    {5'b10011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUP_SCI_H     =    {5'b10011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUP_B         =    {5'b10011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUP_SC_B      =    {5'b10011, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUP_SCI_B     =    {5'b10011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SDOTUSP_H        =    {5'b10100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUSP_SC_H     =    {5'b10100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUSP_SCI_H    =    {5'b10100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUSP_B        =    {5'b10100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUSP_SC_B     =    {5'b10100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTUSP_SCI_B    =    {5'b10100, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SDOTSP_H         =    {5'b10101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTSP_SC_H      =    {5'b10101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTSP_SCI_H     =    {5'b10101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTSP_B         =    {5'b10101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTSP_SC_B      =    {5'b10101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SDOTSP_SCI_B     =    {5'b10101, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_EXTRACT_H        =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_EXTRACT_B        =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_EXTRACTU_H       =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_EXTRACTU_B       =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_INSERT_H         =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_INSERT_B         =    {5'b10111, 1'b0, 1'b?, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SHUFFLE_H        =    {5'b11000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLE_SCI_H    =    {5'b11000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLE_B        =    {5'b11000, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLEI0_SCI_B  =    {5'b11000, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLEI1_SCI_B  =    {5'b11001, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLEI2_SCI_B  =    {5'b11010, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLEI3_SCI_B  =    {5'b11011, 1'b0, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLE2_H       =    {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SHUFFLE2_B       =    {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_PACK             =    {5'b11110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_PACK_H           =    {5'b11110, 1'b0, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_PACKHI_B         =    {5'b11111, 1'b0, 1'b1, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_PACKLO_B         =    {5'b11111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPEQ_H          =    {5'b00000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPEQ_SC_H       =    {5'b00000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPEQ_SCI_H      =    {5'b00000, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPEQ_B          =    {5'b00000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPEQ_SC_B       =    {5'b00000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPEQ_SCI_B      =    {5'b00000, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPNE_H          =    {5'b00001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPNE_SC_H       =    {5'b00001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPNE_SCI_H      =    {5'b00001, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPNE_B          =    {5'b00001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPNE_SC_B       =    {5'b00001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPNE_SCI_B      =    {5'b00001, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPGT_H          =    {5'b00010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGT_SC_H       =    {5'b00010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGT_SCI_H      =    {5'b00010, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGT_B          =    {5'b00010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGT_SC_B       =    {5'b00010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGT_SCI_B      =    {5'b00010, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPGE_H          =    {5'b00011, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGE_SC_H       =    {5'b00011, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGE_SCI_H      =    {5'b00011, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGE_B          =    {5'b00011, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGE_SC_B       =    {5'b00011, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGE_SCI_B      =    {5'b00011, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPLT_H          =    {5'b00100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLT_SC_H       =    {5'b00100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLT_SCI_H      =    {5'b00100, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLT_B          =    {5'b00100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLT_SC_B       =    {5'b00100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLT_SCI_B      =    {5'b00100, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPLE_H          =    {5'b00101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLE_SC_H       =    {5'b00101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLE_SCI_H      =    {5'b00101, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLE_B          =    {5'b00101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLE_SC_B       =    {5'b00101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLE_SCI_B      =    {5'b00101, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPGTU_H         =    {5'b00110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGTU_SC_H      =    {5'b00110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGTU_SCI_H     =    {5'b00110, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGTU_B         =    {5'b00110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGTU_SC_B      =    {5'b00110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGTU_SCI_B     =    {5'b00110, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPGEU_H         =    {5'b00111, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGEU_SC_H      =    {5'b00111, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGEU_SCI_H     =    {5'b00111, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGEU_B         =    {5'b00111, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGEU_SC_B      =    {5'b00111, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPGEU_SCI_B     =    {5'b00111, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPLTU_H         =    {5'b01000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLTU_SC_H      =    {5'b01000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLTU_SCI_H     =    {5'b01000, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLTU_B         =    {5'b01000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLTU_SC_B      =    {5'b01000, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLTU_SCI_B     =    {5'b01000, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CMPLEU_H         =    {5'b01001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLEU_SC_H      =    {5'b01001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLEU_SCI_H     =    {5'b01001, 1'b1, 1'b?, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLEU_B         =    {5'b01001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLEU_SC_B      =    {5'b01001, 1'b1, 1'b0, 5'b?, 5'b?, 3'b101, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CMPLEU_SCI_B     =    {5'b01001, 1'b1, 1'b?, 5'b?, 5'b?, 3'b111, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CPLXMUL_R        =    {5'b01010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_R_DIV2   =    {5'b01010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_R_DIV4   =    {5'b01010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_R_DIV8   =    {5'b01010, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CPLXMUL_I        =    {5'b01010, 1'b1, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_I_DIV2   =    {5'b01010, 1'b1, 1'b1, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_I_DIV4   =    {5'b01010, 1'b1, 1'b1, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_CPLXMUL_I_DIV8   =    {5'b01010, 1'b1, 1'b1, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_CPLXCONJ         =    {5'b01011, 1'b1, 1'b0, 5'b0, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SUBROTMJ         =    {5'b01100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUBROTMJ_DIV2    =    {5'b01100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUBROTMJ_DIV4    =    {5'b01100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUBROTMJ_DIV8    =    {5'b01100, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_ADD_DIV2         =    {5'b01101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_DIV4         =    {5'b01101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_ADD_DIV8         =    {5'b01101, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
+
+parameter INSTR_CV_SUB_DIV2         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b010, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_DIV4         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
+parameter INSTR_CV_SUB_DIV8         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
 
 `endif // __UVME_CV32E40P_CONSTANTS_SV__

--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -464,7 +464,7 @@ function void uvme_cv32e40p_env_c::assemble_vsequencer();
 
    vsequencer.clknrst_sequencer          = clknrst_agent         .sequencer;
    vsequencer.interrupt_sequencer        = interrupt_agent       .sequencer;
-   //vsequencer.debug_sequencer            = debug_agent           .sequencer;
+   vsequencer.debug_sequencer            = debug_agent           .sequencer;
    vsequencer.obi_memory_instr_sequencer = obi_memory_instr_agent.sequencer;
    vsequencer.obi_memory_data_sequencer  = obi_memory_data_agent .sequencer;
 

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -481,6 +481,11 @@ module uvmt_cv32e40p_tb;
     .pc_set(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.pc_set_o),
     .boot_addr_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.boot_addr_i),
     .branch_in_decode(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.controller_i.branch_in_id),
+    .rvfi_valid(dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_valid),
+    .rvfi_insn(dut_wrap.cv32e40p_tb_wrapper_i.rvfi_instr_if_0_i.rvfi_insn),
+    .apu_req(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_req_o),
+    .apu_gnt(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_gnt_i),
+    .apu_busy(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_busy_i),
 
     .is_wfi(),
     .in_wfi(),

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
@@ -217,6 +217,12 @@ interface uvmt_cv32e40p_debug_cov_assert_if
 
     input  [31:0] boot_addr_i,
 
+    input         rvfi_valid,
+    input  [31:0] rvfi_insn,
+    input         apu_req,
+    input         apu_gnt,
+    input         apu_busy,
+
     // Debug signals
     input         debug_req_i, // From controller
     input         debug_mode_q, // From controller
@@ -283,7 +289,12 @@ interface uvmt_cv32e40p_debug_cov_assert_if
     illegal_insn_i,
     illegal_insn_q,
     ecall_insn_i,
-    boot_addr_i, 
+    boot_addr_i,
+    rvfi_valid,
+    rvfi_insn,
+    apu_req,
+    apu_gnt,
+    apu_busy,
     debug_req_i,
     debug_mode_q,
     dcsr_q,


### PR DESCRIPTION
This PR is doing following things:

1.) reconnect debug_sequencer -> was preventing debug tests to run
2.) update debug rom for FPR push and pop for floating point random stream tests
3.) create all xpulp instruction encodings as params in uvme tb for use. At the moment use case is for coverage but can be used with assertions or scoreboards if needed.
4.) add new debug cover groups for floating point and xpulp instructions according to v2 test plans