### PR TITLE
Enable dummy instruction testing, remove no_bitmanip configuration

### DIFF
--- a/bin/templates/regress_vsif.j2
+++ b/bin/templates/regress_vsif.j2
@@ -73,7 +73,7 @@ group {{project}} {
 {% if t.precmd %}
 {{indent}}        depends_on: ../precmd;
 {% endif %}
-{{indent}}        timeout: 3600;
+{{indent}}        timeout: 7200;
 {{indent}}        test run {
 {{indent}}            sv_seed: gen_random;
 {{indent}}            count: {{t.num}};

--- a/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
@@ -30,6 +30,43 @@ class cv32e40s_asm_program_gen extends corev_asm_program_gen;
     super.new(name);
   endfunction
 
+  virtual function void gen_program_header();
+    string instr[];
+    cv32e40s_instr_gen_config corev_cfg;
+    `DV_CHECK_FATAL($cast(corev_cfg, cfg), "Could not cast cfg into corev_cfg")
+
+    super.gen_program_header();
+
+    if (corev_cfg.enable_dummy) begin
+      instr = {
+        // SECURESEED0
+        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
+        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
+        $sformatf("addi x%0d, x%0d, 0x57", cfg.gpr[0], cfg.gpr[0]),
+        $sformatf("csrrw x0, 0xbf9, x%0d", cfg.gpr[0]),
+
+        // SECURESEED1
+        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
+        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
+        $sformatf("addi x%0d, x%0d, 0x62", cfg.gpr[0], cfg.gpr[0]),
+        $sformatf("csrrw x0, 0xbfa, x%0d", cfg.gpr[0]),
+
+        // SECURESEED2
+        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
+        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
+        $sformatf("addi x%0d, x%0d, 0x7a", cfg.gpr[0], cfg.gpr[0]),
+        $sformatf("csrrw x0, 0xbfc, x%0d", cfg.gpr[0]),
+
+        // CPUCTRL
+        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
+        $sformatf("lui x%0d, 0xf0", cfg.gpr[0]),
+        $sformatf("addi x%0d, x%0d, 0x2", cfg.gpr[0], cfg.gpr[0]),
+        $sformatf("csrrs x0, 0xbf0, x%0d", cfg.gpr[0])
+      };
+      gen_section(get_label("enable_dummy_instr", hart), instr);
+    end
+  endfunction : gen_program_header
+
   virtual function void trap_vector_init(int hart);
     string instr[];
     privileged_reg_t trap_vec_reg;

--- a/cv32e40s/env/corev-dv/cv32e40s_instr_gen_config.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_instr_gen_config.sv
@@ -27,6 +27,7 @@ class cv32e40s_instr_gen_config extends riscv_instr_gen_config;
   // External config control (plusarg) to enable/disable fast_interrupt handlers
   bit enable_fast_interrupt_handler;
   bit enable_pma;
+  bit enable_dummy;
   bit exit_on_debug_exception;
   cv32e40s_pma_cfg pma_cfg;
 
@@ -93,6 +94,7 @@ class cv32e40s_instr_gen_config extends riscv_instr_gen_config;
     `uvm_field_int(use_fast_intr_handler,         UVM_DEFAULT)
     `uvm_field_int(enable_pma,                    UVM_DEFAULT)
     `uvm_field_int(exit_on_debug_exception,       UVM_DEFAULT)
+    `uvm_field_int(enable_dummy,                  UVM_DEFAULT)
   `uvm_object_utils_end
 
   function new(string name="");
@@ -101,6 +103,7 @@ class cv32e40s_instr_gen_config extends riscv_instr_gen_config;
     get_bool_arg_value("+enable_fast_interrupt_handler=", enable_fast_interrupt_handler);
     get_bool_arg_value("+enable_pma=", enable_pma);
     get_bool_arg_value("+exit_on_debug_exception=", exit_on_debug_exception);
+    get_bool_arg_value("+enable_dummy=", enable_dummy);
 
     if (enable_pma) begin
       pma_cfg = cv32e40s_pma_cfg::type_id::create("pma_cfg");

--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -79,9 +79,9 @@ builds:
     cfg: pmp
     dir: cv32e40s/sim/uvmt
 
-  uvmt_cv32e40s_no_bitmanip:
+  uvmt_cv32e40s_dummy_instr:
     cmd: make comp_corev-dv comp
-    cfg: no_bitmanip
+    cfg: dummy_instr
     dir: cv32e40s/sim/uvmt
 
   uvmt_cv32e40s_debug_trigger_cfg0:
@@ -114,203 +114,203 @@ builds:
 tests:
   hello-world:
     description: uvm_hello_world_test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hello-world
 
   csr_instructions:
     description: CSR instruction test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instructions
 
   generic_exception_test:
     description: Generic exception test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=generic_exception_test
 
   illegal_instr_test:
     description: Illegal instruction test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal_instr_test
 
   branch_zero:
     description: Branch test with zero offsets
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=branch_zero
 
   cv32e40s_csr_access_test:
     description: CSR Access Mode Test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=cv32e40s_csr_access_test
 
   cv32e40s_readonly_csr_access_test:
     description: CSR Read-only Access Mode Test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=cv32e40s_readonly_csr_access_test
 
   requested_csr_por:
     description: CSR PoR test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=requested_csr_por
 
   modeled_csr_por:
     description: Modeled CSR PoR test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=modeled_csr_por
 
   csr_instr_asm:
     description: CSR instruction assembly test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=csr_instr_asm
 
   hpmcounter_basic_test:
     description: Hardware performance counter basic test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_test
 
   hpmcounter_basic_nostall_test:
     description: Hardware performance counter basic test with no random stalls
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_basic_nostall_test
 
   hpmcounter_hazard_test:
     description: Hardware performance counter hazard test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=hpmcounter_hazard_test
 
   riscv_ebreak_test_0:
     description: Static corev-dv ebreak
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_ebreak_test_0
 
   riscv_arithmetic_basic_test_0:
     description: Static riscv-dv arithmetic test 0
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_0
     num: 1
 
   riscv_arithmetic_basic_test_1:
     description: Static riscv-dv arithmetic test 1
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=riscv_arithmetic_basic_test_1
     num: 1
 
   corev_rand_arithmetic_base_test:
     description: Generated corev-dv arithmetic test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_arithmetic_base_test
     num: 4
 
   corev_rand_instr_test:
     description: Generated corev-dv random instruction test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_test
     num: 5
 
   corev_rand_instr_long_stall:
     description: Generated corev-dv random instruction test with long stalls
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_long_stall
     num: 2
 
   corev_rand_illegal_instr_test:
     description: Generated corev-dv random instruction test with illegal instructions
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_illegal_instr_test
     num: 5
 
   corev_rand_jump_stress_test:
     description: Generated corev-dv jump stress test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_jump_stress_test
     num: 5
 
   corev_rand_interrupt:
     description: Generated corev-dv random interrupt test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt
     num: 5
 
   corev_rand_debug:
     description: Generated corev-dv random debug test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug
     num: 5
 
   corev_rand_debug_single_step:
     description: debug random test with single-stepping
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug_single_step
     num: 5
 
   corev_rand_debug_ebreak:
     description: debug random test with ebreaks from ROM
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_debug_ebreak
     num: 5
 
   corev_rand_interrupt_wfi:
     description: Generated corev-dv random interrupt WFI test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi
     num: 5
 
   corev_rand_fencei:
     description: Generated corev-dv random fence.i test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_fencei
     num: 2
 
   corev_rand_interrupt_wfi_mem_stress:
     description: Generated corev-dv random interrupt WFI test with memory stress
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_wfi_mem_stress
     num: 5
 
   corev_rand_interrupt_debug:
     description: Generated corev-dv random interrupt WFI test with debug
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_debug
     num: 5
 
   corev_rand_interrupt_exception:
     description: Generated corev-dv random interrupt WFI test with exceptions
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_exception
     num: 5
 
   corev_rand_interrupt_nested:
     description: Generated corev-dv random interrupt WFI test with random nested interrupts
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_interrupt_nested
     num: 5
@@ -324,90 +324,90 @@ tests:
 
   corev_rand_instr_obi_err:
     description: Random OBI instruction bus error test
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err
     num: 6
 
   corev_rand_instr_obi_err_debug:
     description: Random OBI instruction bus error test with debug
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_instr_obi_err_debug
     num: 6
 
   corev_rand_data_obi_err:
     description: Random OBI data bus error test
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err
     num: 6
 
   corev_rand_data_obi_err_debug:
     description: Random OBI data bus error test with debug
-    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s_pma_1, uvmt_cv32e40s_pma_2, uvmt_cv32e40s_pma_3, uvmt_cv32e40s_pma_4, uvmt_cv32e40s_pma_5, uvmt_cv32e40s_dummy_instr, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make gen_corev-dv test TEST=corev_rand_data_obi_err_debug
     num: 10
 
   illegal:
     description: Illegal-riscv-tests
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=illegal
 
   fibonacci:
     description: Fibonacci test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=fibonacci
 
   misalign:
     description: Misalign test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=misalign
 
   dhrystone:
     description: Dhrystone test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=dhrystone
 
   debug_test2:
     description: Debug Test 2
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test2
 
   debug_test_reset:
     description: Debug reset test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_reset
 
   debug_test_trigger:
     description: Debug trigger test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_trigger
 
   debug_test_boot_set:
     description: Debug test target debug_req at BOOT_SET
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_boot_set
     num: 10
 
   interrupt_bootstrap:
     description: Interrupt bootstrap test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=interrupt_bootstrap
 
   interrupt_test:
     description: Interrupt test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip]
+    builds: [ uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=interrupt_test
 
@@ -419,25 +419,25 @@ tests:
 
   isa_fcov_holes:
     description: ISA function coverage test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=isa_fcov_holes
 
   instr_bus_error:
     description: Directed instruction bus error test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=instr_bus_error
 
   data_bus_error:
     description: Directed data bus error test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=data_bus_error
 
   load_store_rs1_zero:
     description: Directed rs1 coverage test
-    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_no_bitmanip, uvmt_cv32e40s_clic]
+    builds: [ uvmt_cv32e40s, uvmt_cv32e40s_clic]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=load_store_rs1_zero
 
@@ -448,7 +448,7 @@ tests:
       - uvmt_cv32e40s_pma_1
       - uvmt_cv32e40s_pma_2
       - uvmt_cv32e40s_pma_5
-      - uvmt_cv32e40s_no_bitmanip
+      - uvmt_cv32e40s_dummy_instr
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=fencei
 

--- a/cv32e40s/tests/cfg/dummy_instr.yaml
+++ b/cv32e40s/tests/cfg/dummy_instr.yaml
@@ -1,13 +1,32 @@
-name: no_bitmanip
-description: Default configuration for CV32E40S simulations
+name: dummy_instr
+description: Default configuration for CV32E40S simulations that includes dummy instructions
+compile_flags:
+    +define+ZBA_ZBB_ZBC_ZBS
+    +define+CLIC_EN
+    +define+PMP_ENABLE_64
 plusargs: >
+    +enable_clic=1
+    +enable_zba_extension=1
+    +enable_zbb_extension=1
+    +enable_zbc_extension=1
+    +enable_zbs_extension=1
     +fix_sp=1
     +fix_ra=1
     +enable_zca_extension=1
     +enable_zcb_extension=1
     +enable_zcmt_extension=1
     +enable_zcmp_extension=1
+    +enable_dummy=1
 ovpsim: >
+    --override cpu/CLICLEVELS=256
+    --override cpu/CLICXCSW=T
+    --override cpu/CLICXNXTI=T
+    --override cpu/CLICSELHVEC=T
+    --override cpu/CLICINTCTLBITS=8
+    --override cpu/CLIC_version=master
+    --override cpu/externalCLIC=T
+    --override cpu/mtvt_mask=0xffffffffffffff80
+    --override cpu/PMP_registers=64
     --override cpu/PMP_registers=64
     --override cpu/PMP_undefined=T
     --override cpu/PMP_initialparams=T
@@ -175,4 +194,4 @@ ovpsim: >
     # --showoverrides
     # --trace --tracechange --traceshowicount --monitornets
 cflags: >
-cv_sw_march: rv32im_zicsr_zca_zcb_zcmp_zcmt_zifencei
+cv_sw_march: rv32im_zicsr_zba1p00_zbb1p00_zbc1p00_zbs1p00_zca_zcb_zcmp_zcmt_zifencei


### PR DESCRIPTION
- Made dummy instruction generation available for riscv-dv
- Replaced no_bitmanip configuration with dummy_instr
- Increased per-test timeout to two hours (expect that dummy instr. tests may cause some tests that otherwise would not time out to fail)
- Removed dummy_instr cfg from running in regression with directed tests, as these needs modifications to enable dummy instructions.

ci_check OK