### PR TITLE
update trigger asserts to account for spec updates

### DIFF
--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
@@ -181,9 +181,9 @@ module uvmt_cv32e40s_support_logic
   logic [MAX_NUM_TRIGGERS-1:0] pc_addr_match;
   logic [MAX_NUM_TRIGGERS-1:0][4*MAX_MEM_ACCESS-1:0] mem_addr_match;
   logic [MAX_NUM_TRIGGERS-1:0] general_trigger_match_conditions;
-  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_load;
-  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_store;
-  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_execute;
+  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_load_array;
+  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_store_array;
+  logic [MAX_NUM_TRIGGERS-1:0] trigger_match_execute_array;
 
   always @(posedge in_support_if.clk, negedge in_support_if.rst_n ) begin
     if(!in_support_if.rst_n) begin
@@ -262,14 +262,14 @@ module uvmt_cv32e40s_support_logic
         ((rvfi.is_mmode && tdata1_array[t][TDATA1_M2_M6_M_MODE]) ||
         (rvfi.is_umode && tdata1_array[t][TDATA1_M2_M6_U_MODE]));
 
-    assign trigger_match_execute[t] =
+    assign trigger_match_execute_array[t] =
       t >= (CORE_PARAM_DBG_NUM_TRIGGERS) ?
         1'b0 :
         general_trigger_match_conditions[t] &&
         tdata1_array[t][TDATA1_EXECUTE] &&
         pc_addr_match[t];
 
-    assign trigger_match_load[t] =
+    assign trigger_match_load_array[t] =
       t >= (CORE_PARAM_DBG_NUM_TRIGGERS) ?
         1'b0 :
         general_trigger_match_conditions[t] &&
@@ -277,7 +277,7 @@ module uvmt_cv32e40s_support_logic
         tdata1_array[t][TDATA1_LOAD] &&
         |(rvfi.instr_mem_rmask & mem_addr_match[t]);
 
-    assign trigger_match_store[t] =
+    assign trigger_match_store_array[t] =
       t >= (CORE_PARAM_DBG_NUM_TRIGGERS) ?
         1'b0 :
         general_trigger_match_conditions[t] &&
@@ -291,9 +291,14 @@ module uvmt_cv32e40s_support_logic
   assign out_support_if.tdata2_array = tdata2_array;
 
   assign out_support_if.is_trigger_match_exception = |trigger_match_exception;
-  assign out_support_if.is_trigger_match_execute = |trigger_match_execute;
-  assign out_support_if.is_trigger_match_load = |trigger_match_load;
-  assign out_support_if.is_trigger_match_store = |trigger_match_store;
+  assign out_support_if.is_trigger_match_execute = |trigger_match_execute_array;
+  assign out_support_if.is_trigger_match_load = |trigger_match_load_array;
+  assign out_support_if.is_trigger_match_store = |trigger_match_store_array;
+
+  assign out_support_if.trigger_match_execute_array = trigger_match_execute_array;
+  assign out_support_if.trigger_match_load_array = trigger_match_load_array;
+  assign out_support_if.trigger_match_store_array = trigger_match_store_array;
+
 
   // Count "irq_ack"
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -374,6 +374,9 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
    logic is_trigger_match_load;
    logic is_trigger_match_store;
    logic is_trigger_match_execute;
+   logic [4:0] trigger_match_load_array;
+   logic [4:0] trigger_match_store_array;
+   logic [4:0] trigger_match_execute_array;
    logic [4:0][31:0] tdata1_array;
    logic [4:0][31:0] tdata2_array;
 
@@ -431,6 +434,9 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
          is_trigger_match_load,
          is_trigger_match_store,
          is_trigger_match_execute,
+         trigger_match_load_array,
+         trigger_match_store_array,
+         trigger_match_execute_array,
          tdata1_array,
          tdata2_array,
 
@@ -474,6 +480,9 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
          is_trigger_match_load,
          is_trigger_match_store,
          is_trigger_match_execute,
+         trigger_match_load_array,
+         trigger_match_store_array,
+         trigger_match_execute_array,
          tdata1_array,
          tdata2_array,
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -17,6 +17,8 @@
 //You will find this number in the file vplan_coverage.txt,
 //and they describe what vplan tasks the assertions aim to cover.
 
+
+//TODO: removed tcontrol here
 module uvmt_cv32e40s_triggers_assert_cov
   import uvm_pkg::*;
   import cv32e40s_pkg::*;
@@ -40,10 +42,8 @@ module uvmt_cv32e40s_triggers_assert_cov
 
     uvma_rvfi_csr_if_t tdata1,
     uvma_rvfi_csr_if_t tdata2,
-    uvma_rvfi_csr_if_t tdata3,
     uvma_rvfi_csr_if_t tinfo,
     uvma_rvfi_csr_if_t tselect,
-    uvma_rvfi_csr_if_t tcontrol,
     uvma_rvfi_csr_if_t dcsr,
     uvma_rvfi_csr_if_t dpc
   );
@@ -57,17 +57,13 @@ module uvmt_cv32e40s_triggers_assert_cov
   //Reads and writes of CSR values
   logic [31:0] tdata1_pre_state;
   logic [31:0] tdata2_pre_state;
-  logic [31:0] tdata3_pre_state;
   logic [31:0] tinfo_pre_state;
   logic [31:0] tselect_pre_state;
-  logic [31:0] tcontrol_pre_state;
 
   logic [31:0] tdata1_post_state;
   logic [31:0] tdata2_post_state;
-  logic [31:0] tdata3_post_state;
   logic [31:0] tinfo_post_state;
   logic [31:0] tselect_post_state;
-  logic [31:0] tcontrol_post_state;
 
   logic [MAX_MEM_ACCESS-1:0][31:0] rvfi_mem_addrs;
 
@@ -75,19 +71,15 @@ module uvmt_cv32e40s_triggers_assert_cov
   always_comb begin
     tdata1_pre_state = tdata1.pre_state();
     tdata2_pre_state = tdata2.pre_state();
-    tdata3_pre_state = tdata3.pre_state();
     tinfo_pre_state = tinfo.pre_state();
     tselect_pre_state = tselect.pre_state();
-    tcontrol_pre_state = tcontrol.pre_state();
   end
 
   always_comb begin
     tdata1_post_state = tdata1.post_state();
     tdata2_post_state = tdata2.post_state();
-    tdata3_post_state = tdata3.post_state();
     tinfo_post_state = tinfo.post_state();
     tselect_post_state = tselect.post_state();
-    tcontrol_post_state = tcontrol.post_state();
   end
 
   generate
@@ -98,21 +90,27 @@ module uvmt_cv32e40s_triggers_assert_cov
 
   /////////// Local Parameters ///////////
 
-  //common tdata1 mcontrol and mcontrol6 values:
+  //tinfo:
+  localparam VERSION_MSB = 31;
+  localparam VERSION_LSB = 24;
+  localparam INFO_MSB = 15;
+  localparam INFO_LSB = 0;
+
+  //common tdata1 values:
+  localparam LSB_TYPE = 28;
+  localparam MSB_TYPE = 31;
   localparam DMODE = 27;
+
+  //common tdata1 mcontrol and mcontrol6 values:
   localparam LOAD = 0;
   localparam STORE = 1;
   localparam EXECUTE = 2;
-  localparam U_MODE = 3;
-  localparam S_MODE = 4;
-  localparam M_MODE = 6;
+  localparam M2_M6_S_MODE = 4;
   localparam LSB_MATCH = 7;
   localparam MSB_MATCH = 10;
   localparam CHAIN = 11;
   localparam LSB_ACTION = 12;
   localparam MSB_ACTION = 15;
-  localparam LSB_TYPE = 28;
-  localparam MSB_TYPE = 31;
 
   //tdata1 mcontrol:
   localparam MSB_MASKMAX = 26;
@@ -124,13 +122,16 @@ module uvmt_cv32e40s_triggers_assert_cov
   localparam M2_LSB_SIZELO = 16;
 
   //tdata1 mcontrol6:
+  localparam M6_UNCERTAIN = 26;
+  localparam M6_HIT1 = 25;
   localparam M6_VS = 24;
   localparam M6_VU = 23;
-  localparam M6_HIT = 22;
+  localparam M6_HIT0 = 22;
   localparam M6_SELECT = 21;
   localparam M6_TIMING = 20;
   localparam M6_MSB_SIZE = 19;
   localparam M6_LSB_SIZE = 16;
+  localparam M6_UNCERTAINEN = 5;
 
   //tdata1 etriggers:
   localparam ET_HIT = 26;
@@ -145,21 +146,6 @@ module uvmt_cv32e40s_triggers_assert_cov
   //tdata1 disabled:
   localparam DIS_MSB_DATA = 26;
   localparam DIS_LSB_DATA = 0;
-
-  //tdata2:
-  localparam ET2_DATA_31 = 31;
-  localparam ET2_DATA_26 = 26;
-  localparam ET2_DATA_23 = 23;
-  localparam ET2_DATA_12 = 12;
-  localparam ET2_DATA_10 = 10;
-  localparam ET2_DATA_9 = 9;
-  localparam ET2_DATA_6 = 6;
-  localparam ET2_DATA_4 = 4;
-  localparam ET2_DATA_0 = 0;
-
-  //tcontrol:
-  localparam MPTE = 7;
-  localparam MTE = 3;
 
   //Actions:
   localparam ENTER_DBG_ON_MATCH = 1;
@@ -176,9 +162,9 @@ module uvmt_cv32e40s_triggers_assert_cov
   localparam ADDR_TSELECT = 12'h7A0;
   localparam ADDR_TDATA1 = 12'h7A1;
   localparam ADDR_TDATA2 = 12'h7A2;
-  localparam ADDR_TDATA3 = 12'h7A3;
+  localparam ADDR_TDATA3 = 12'h7A3; //TODO: make sure is not implemented
   localparam ADDR_TINFO = 12'h7A4;
-  localparam ADDR_TCONTROL = 12'h7A5;
+  localparam ADDR_TCONTROL = 12'h7A5; //TODO: make sure is not implemented
   localparam ADDR_MCONTEXT = 12'h7A8;
   localparam ADDR_MSCONTEXT = 12'h7AA;
   localparam ADDR_HCONTEXT = 12'h6A8;
@@ -190,29 +176,17 @@ module uvmt_cv32e40s_triggers_assert_cov
   localparam MSB_CAUSE = 8;
   localparam LSB_CAUSE = 6;
 
-  //Hardwired to zero:
-  localparam HW_ZERO_31 = 31;
-  localparam HW_ZERO_26 = 26;
-  localparam HW_ZERO_25 = 25;
-  localparam HW_ZERO_16 = 16;
-  localparam HW_ZERO_14 = 14;
-  localparam HW_ZERO_13 = 13;
-  localparam HW_ZERO_10 = 10;
-  localparam HW_ZERO_8 = 8;
-  localparam HW_ZERO_7 = 7;
-  localparam HW_ZERO_6 = 6;
-  localparam HW_ZERO_5 = 5;
-  localparam HW_ZERO_4 = 4;
-  localparam HW_ZERO_3 = 3;
-  localparam HW_ZERO_2 = 2;
-  localparam HW_ZERO_1 = 1;
-  localparam HW_ZERO_0 = 0;
-
+  //Initial settings
   localparam TDATA1_DISABLED = 32'hF800_0000;
   localparam MAX_NUM_TRIGGERS = 5;
 
 
   /////////// Signals ///////////
+  logic tdata1_pre_state_m6_hits;
+  assign tdata1_pre_state_m6_hits = {tdata1_pre_state[M6_HIT1], tdata1_pre_state[M6_HIT0]};
+
+  logic tdata1_post_state_m6_hits;
+  assign tdata1_post_state_m6_hits = {tdata1_post_state[M6_HIT1], tdata1_post_state[M6_HIT0]};
 
   logic valid_instr_in_mmode;
   assign valid_instr_in_mmode = rvfi_if.rvfi_valid
@@ -402,9 +376,68 @@ module uvmt_cv32e40s_triggers_assert_cov
   //4) PC is updated to value on dm_haltaddr_i input
   //5) Core starts executing debug code
 
-
   //1) see a_dt_instr_trigger_hit_*
   //2) - 5): Debug assertions uvmt_cv32e40s_debug_assert.sv
+
+
+  //- Vplan:
+  //Check that attempts to access "tcontrol" raise an illegal instruction exception, always. (Unless overruled by a higher priority.)
+
+  //- Assertion verification:
+  //1) Check that attempts to access "tcontrol" raise an illegal instruction exception, always. (Unless overruled by a higher priority.)
+
+  //1)
+  a_dt_tcontrol_not_implemented: assert property (
+    rvfi_if.is_csr_instr(ADDR_TCONTROL) //make sure no bus fault exceptions has occured
+    |->
+    rvfi_if.rvfi_trap.trap
+    && rvfi_if.rvfi_trap.exception
+    && (rvfi_if.rvfi_trap.exception_cause == EXC_CAUSE_ILLEGAL_INSN)
+  ) else `uvm_error(info_tag, "Access to tcontrol does not cause an illegal exception (when no higher priority exception has occured)\n");
+
+
+  //- Vplan:
+  //Check that attempts to access "tdata3" raise an illegal instruction exception, always. (Unless overruled by a higher priority.)
+  //Verify that tdata3 is illegal for all tdata2 types.
+
+  //- Assertion verification:
+  //1) Check that attempts to access "tdata3" raise an illegal instruction exception, always. (Unless overruled by a higher priorit
+  //2) Verify that tdata3 is illegal for all tdata2 types.
+
+  //1) //TODO: fix in vplan
+  a_dt_tdata3_not_implemented: assert property (
+    rvfi_if.is_csr_instr(ADDR_TDATA3) //make sure no bus fault exceptions has occured
+    |->
+    rvfi_if.rvfi_trap.trap
+    && rvfi_if.rvfi_trap.exception
+    && (rvfi_if.rvfi_trap.exception_cause == EXC_CAUSE_ILLEGAL_INSN)
+  ) else `uvm_error(info_tag, "Access to tdata3 does not cause an illegal exception (when no higher priority exception has occured)\n");
+
+
+  // Assertions and coverages for when there are debug triggers:
+  if (CORE_PARAM_DBG_NUM_TRIGGERS != 0) begin
+
+    //2)
+    c_dt_access_tdata3_m2: assert property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL2
+    );
+
+    c_dt_access_tdata3_etrigger: assert property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
+    );
+
+    c_dt_access_tdata3_m6: assert property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
+    );
+
+    c_dt_access_tdata3_disabled: assert property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_DISABLED
+    );
+  end
 
 
   //- Vplan:
@@ -415,17 +448,14 @@ module uvmt_cv32e40s_triggers_assert_cov
   //1) Have 0 triggers, access any trigger register and check that illegal instruction exception occurs
   //2) Have 0 triggers, No trigger ever fires
 
-
-  // Assertions and coverages for when there are no debug triggers:
   if (CORE_PARAM_DBG_NUM_TRIGGERS == 0) begin
+
     //1)
     a_dt_0_triggers_tdata1_access: assert property (
         (rvfi_if.is_csr_instr(ADDR_TSELECT)
       || rvfi_if.is_csr_instr(ADDR_TDATA1)
       || rvfi_if.is_csr_instr(ADDR_TDATA2)
-      || rvfi_if.is_csr_instr(ADDR_TDATA3)
-      || rvfi_if.is_csr_instr(ADDR_TINFO)
-      || rvfi_if.is_csr_instr(ADDR_TCONTROL))
+      || rvfi_if.is_csr_instr(ADDR_TINFO))
 
       |->
       rvfi_if.rvfi_trap.trap
@@ -542,8 +572,8 @@ module uvmt_cv32e40s_triggers_assert_cov
       && !tdata1_pre_state[M2_MSB_SIZELO:M2_LSB_SIZELO]
       && tdata1_pre_state[MSB_ACTION:LSB_ACTION] == ENTER_DBG_ON_MATCH
       && !tdata1_pre_state[CHAIN]
-      && !tdata1_pre_state[HW_ZERO_5]
-      && !tdata1_pre_state[S_MODE]
+      && !tdata1_pre_state[5]
+      && !tdata1_pre_state[M2_M6_S_MODE]
     ) else `uvm_error(info_tag, "There is a problem with tdata1-mcontrol's tied off fields.\n");
 
     //etrigger
@@ -554,11 +584,11 @@ module uvmt_cv32e40s_triggers_assert_cov
       |->
       tdata1_pre_state[DMODE]
       && !tdata1_pre_state[ET_HIT]
-      && !tdata1_pre_state[HW_ZERO_25:HW_ZERO_13]
+      && !tdata1_pre_state[25:13]
       && !tdata1_pre_state[ET_VS]
       && !tdata1_pre_state[ET_VU]
-      && !tdata1_pre_state[HW_ZERO_10]
-      && !tdata1_pre_state[HW_ZERO_8]
+      && !tdata1_pre_state[10]
+      && !tdata1_pre_state[8]
       && !tdata1_pre_state[ET_S]
       && tdata1_pre_state[ET_MSB_ACTION:ET_LSB_ACTION] == ENTER_DBG_ON_MATCH
     ) else `uvm_error(info_tag, "There is a problem with tdata1-etrigger's tied off fields.\n");
@@ -570,17 +600,16 @@ module uvmt_cv32e40s_triggers_assert_cov
 
       |->
       tdata1_pre_state[DMODE]
-      && !tdata1_pre_state[HW_ZERO_26:HW_ZERO_25]
+      && !tdata1_pre_state[M6_UNCERTAIN]
       && !tdata1_pre_state[M6_VS]
       && !tdata1_pre_state[M6_VU]
-      && !tdata1_pre_state[M6_HIT]
       && !tdata1_pre_state[M6_SELECT]
-      && !tdata1_pre_state[M6_TIMING]
+      && !tdata1_pre_state[20:19]
       && !tdata1_pre_state[M6_MSB_SIZE:M6_LSB_SIZE]
       && tdata1_pre_state[MSB_ACTION:LSB_ACTION] == ENTER_DBG_ON_MATCH
       && !tdata1_pre_state[CHAIN]
-      && !tdata1_pre_state[HW_ZERO_5]
-      && !tdata1_pre_state[S_MODE]
+      && !tdata1_pre_state[M6_UNCERTAINEN]
+      && !tdata1_pre_state[M2_M6_S_MODE]
     ) else `uvm_error(info_tag, "There is a problem with tdata1-mcontrol6's tied off fields.\n");
 
     //disabled
@@ -599,36 +628,22 @@ module uvmt_cv32e40s_triggers_assert_cov
       && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
 
       |->
-      !tdata2_pre_state[ET2_DATA_31:ET2_DATA_26]
-      && !tdata2_pre_state[ET2_DATA_23:ET2_DATA_12]
-      && !tdata2_pre_state[ET2_DATA_10:ET2_DATA_9]
-      && !tdata2_pre_state[ET2_DATA_6]
-      && !tdata2_pre_state[ET2_DATA_4]
-      && !tdata2_pre_state[ET2_DATA_0]
+      !tdata2_pre_state[31:26]
+      && !tdata2_pre_state[23:12]
+      && !tdata2_pre_state[10:9]
+      && !tdata2_pre_state[6]
+      && !tdata2_pre_state[4]
+      && !tdata2_pre_state[0]
     ) else `uvm_error(info_tag, "There is a problem with tdata2-etrigger's tied off fields.\n");
-
-
-    a_dt_tie_offs_tdata3: assert property (
-      rvfi_if.rvfi_valid
-      |->
-      !tdata3_pre_state
-    ) else `uvm_error(info_tag, "There is a problem with tdata3's tied off fields.\n");
 
 
     a_dt_tie_offs_tinfo: assert property (
       rvfi_if.rvfi_valid
       |->
-      !tinfo_pre_state[HW_ZERO_31:HW_ZERO_16]
+      tinfo_pre_state[VERSION_MSB:VERSION_LSB] == 1
+      && !tinfo_pre_state[23:16]
+      && tinfo_pre_state[INFO_MSB:INFO_LSB] == 15'h8064
     ) else `uvm_error(info_tag, "There is a problem with tinfo's tied off fields.\n");
-
-
-    a_dt_tie_offs_tcontrol: assert property (
-      rvfi_if.rvfi_valid
-      |->
-      !tcontrol_pre_state[HW_ZERO_31:HW_ZERO_8]
-      && !tcontrol_pre_state[HW_ZERO_6:HW_ZERO_4]
-      && !tcontrol_pre_state[HW_ZERO_2:HW_ZERO_0]
-    ) else `uvm_error(info_tag, "There is a problem with tcontrol's tied off fields.\n");
 
 
     //- Vplan:
@@ -673,14 +688,12 @@ module uvmt_cv32e40s_triggers_assert_cov
     a_dt_access_csr_not_dbg_mode: assert property (
       !rvfi_if.rvfi_dbg_mode
       && (rvfi_if.is_csr_instr(ADDR_TDATA1)
-      || rvfi_if.is_csr_instr(ADDR_TDATA2)
-      || rvfi_if.is_csr_instr(ADDR_TDATA3))
+      || rvfi_if.is_csr_instr(ADDR_TDATA2))
 
       |->
       !tdata1.rvfi_csr_wmask
       && !tdata2.rvfi_csr_wmask
-      && !tdata3.rvfi_csr_wmask
-    ) else `uvm_error(info_tag, "Writing tdata1, tdata2 or tdata3 in non-debug mode succeeds.\n");
+    ) else `uvm_error(info_tag, "Writing tdata1 or tdata2 in non-debug mode succeeds.\n");
 
     //2)
     a_dt_dmode: assert property (
@@ -692,24 +705,25 @@ module uvmt_cv32e40s_triggers_assert_cov
 
 
     //- Vplan:
-    //When num triggers is more than 0, check that "tinfo.info" is "1" for the three supported types, and that the remaining bits are 0.
+    //When num triggers is more than 0, check that "tinfo.info" is "1" for the three supported types, "tinfo.version" is 0x1, and that the remaining bits are 0.
 
     //- Assertion verification:
-    //1) When num triggers is more than 0, check that "tinfo.info" is "1" for the three supported types, and that the remaining bits are 0.
+    //1) When num triggers is more than 0, check that "tinfo.info" is "1" for the three supported types, "tinfo.version" is 0x1, and that the remaining bits are 0.
 
     //1)
     a_dt_triggers_tinfo: assert property (
       CORE_PARAM_DBG_NUM_TRIGGERS != '0
       && rvfi_if.rvfi_valid
       |->
-      !tinfo_pre_state[HW_ZERO_1:HW_ZERO_0]
+      !tinfo_pre_state[1:0]
       && tinfo_pre_state[TTYPE_MCONTROL]
-      && !tinfo_pre_state[HW_ZERO_4:HW_ZERO_3]
+      && !tinfo_pre_state[4:3]
       && tinfo_pre_state[TTYPE_ETRIGGER]
       && tinfo_pre_state[TTYPE_MCONTROL6]
-      && !tinfo_pre_state[HW_ZERO_14:HW_ZERO_7]
+      && !tinfo_pre_state[14:7]
       && tinfo_pre_state[TTYPE_DISABLED]
-      && !tinfo_pre_state[HW_ZERO_31:HW_ZERO_16]
+      && tinfo_pre_state[VERSION_MSB:VERSION_LSB] == 1
+
     ) else `uvm_error(info_tag, "tinfo does not indicated that only tdata type mcontrol, etrigger, mcontrol6 and disabled are allowed.\n");
 
 
@@ -757,8 +771,8 @@ module uvmt_cv32e40s_triggers_assert_cov
       && (tdata1_post_state[MSB_MATCH:LSB_MATCH] == MATCH_WHEN_EQUAL
       || tdata1_post_state[MSB_MATCH:LSB_MATCH] == MATCH_WHEN_GREATER_OR_EQUAL
       || tdata1_post_state[MSB_MATCH:LSB_MATCH] == MATCH_WHEN_LESSER)
-      && !tdata1_post_state[HW_ZERO_5]
-      && !tdata1_post_state[S_MODE]
+      && !tdata1_post_state[5]
+      && !tdata1_post_state[M2_M6_S_MODE]
     ) else `uvm_error(info_tag, "There is a problem with tdata1-mcontrol's WARL fields.\n");
 
     a_dt_warl_tdata1_etrigger: assert property (
@@ -767,11 +781,11 @@ module uvmt_cv32e40s_triggers_assert_cov
       && tdata1_post_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
       |->
       !tdata1_post_state[ET_HIT]
-      && !tdata1_post_state[HW_ZERO_25:HW_ZERO_13]
+      && !tdata1_post_state[25:13]
       && !tdata1_post_state[ET_VS]
       && !tdata1_post_state[ET_VU]
-      && !tdata1_post_state[HW_ZERO_10]
-      && !tdata1_post_state[HW_ZERO_8]
+      && !tdata1_post_state[10]
+      && !tdata1_post_state[8]
       && !tdata1_post_state[ET_S]
       && tdata1_post_state[ET_MSB_ACTION:ET_LSB_ACTION] == ENTER_DBG_ON_MATCH
     ) else `uvm_error(info_tag, "There is a problem with tdata1-etrigger's WARL fields.\n");
@@ -781,20 +795,22 @@ module uvmt_cv32e40s_triggers_assert_cov
       && |tdata1.rvfi_csr_wmask != 0
       && tdata1_post_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
       |->
-      !tdata1_post_state[HW_ZERO_26:HW_ZERO_25]
-      && !tdata1_post_state[M6_VS]
-      && !tdata1_post_state[M6_VU]
-      && !tdata1_post_state[M6_HIT]
-      && !tdata1_post_state[M6_SELECT]
-      && !tdata1_post_state[M6_TIMING]
-      && !tdata1_post_state[M6_MSB_SIZE:M6_LSB_SIZE]
-      && tdata1_post_state[MSB_ACTION:LSB_ACTION] == ENTER_DBG_ON_MATCH
-      && !tdata1_post_state[CHAIN]
-      && (tdata1_post_state[MSB_MATCH:LSB_MATCH] == MATCH_WHEN_EQUAL
-      || tdata1_post_state[MSB_MATCH:LSB_MATCH] ==  MATCH_WHEN_GREATER_OR_EQUAL
-      || tdata1_post_state[MSB_MATCH:LSB_MATCH] ==  MATCH_WHEN_LESSER)
-      && !tdata1_post_state[HW_ZERO_5]
-      && !tdata1_post_state[S_MODE]
+      tdata1_pre_state[DMODE]
+      && !tdata1_pre_state[M6_UNCERTAIN]
+      && ({tdata1_pre_state[M6_HIT1], tdata1_pre_state[M6_HIT0]} == 0
+      || {tdata1_pre_state[M6_HIT1], tdata1_pre_state[M6_HIT0]} == 1)
+      && !tdata1_pre_state[M6_VS]
+      && !tdata1_pre_state[M6_VU]
+      && !tdata1_pre_state[M6_SELECT]
+      && !tdata1_pre_state[20:19]
+      && !tdata1_pre_state[M6_MSB_SIZE:M6_LSB_SIZE]
+      && tdata1_pre_state[MSB_ACTION:LSB_ACTION] == ENTER_DBG_ON_MATCH
+      && !tdata1_pre_state[CHAIN]
+      && (tdata1_pre_state[MSB_MATCH:LSB_MATMSB_MATCH] == MATCH_WHEN_EQUAL
+      || tdata1_pre_state[MSB_MATCH:LSB_MATMSB_MATCH] == MATCH_WHEN_GREATER_OR_EQUAL
+      || tdata1_pre_state[MSB_MATCH:LSB_MATMSB_MATCH] == MATCH_WHEN_LESSER)
+      && !tdata1_pre_state[M6_UNCERTAINEN]
+      && !tdata1_pre_state[M2_M6_S_MODE]
     ) else `uvm_error(info_tag, "There is a problem with tdata1-mcontrol6's WARL fields.\n");
 
     a_dt_warl_tdata1_disabled: assert property (
@@ -810,20 +826,13 @@ module uvmt_cv32e40s_triggers_assert_cov
       && |tdata2.rvfi_csr_wmask != 0
       && tdata1_post_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
       |->
-      !tdata2_post_state[ET2_DATA_31:ET2_DATA_26]
-      && !tdata2_post_state[ET2_DATA_23:ET2_DATA_12]
-      && !tdata2_post_state[ET2_DATA_10:ET2_DATA_9]
-      && !tdata2_post_state[ET2_DATA_6]
-      && !tdata2_post_state[ET2_DATA_4]
-      && !tdata2_post_state[ET2_DATA_0]
+      !tdata2_post_state[31:26]
+      && !tdata2_post_state[23:12]
+      && !tdata2_post_state[10:9]
+      && !tdata2_post_state[6]
+      && !tdata2_post_state[4]
+      && !tdata2_post_state[0]
     ) else `uvm_error(info_tag, "There is a problem with tdata1-etrigger's WARL fields.\n");
-
-    a_dt_warl_tdata3: assert property (
-      rvfi_if.rvfi_valid
-      && |tdata3.rvfi_csr_wmask != 0
-      |->
-      !tdata3_post_state
-    ) else `uvm_error(info_tag, "There is a problem with tdata3's WARL fields.\n");
 
     a_dt_warl_tinfo: assert property (
       rvfi_if.rvfi_valid
@@ -831,17 +840,6 @@ module uvmt_cv32e40s_triggers_assert_cov
       |->
       !tinfo_post_state[31:16]
     ) else `uvm_error(info_tag, "There is a problem with tinfo's WARL fields.\n");
-
-    a_dt_warl_tcontrol: assert property (
-      rvfi_if.rvfi_valid
-      && |tcontrol.rvfi_csr_wmask != 0
-      |->
-      !tcontrol_post_state[HW_ZERO_31:HW_ZERO_8]
-      && !tcontrol_post_state[MPTE]
-      && !tcontrol_post_state[HW_ZERO_6:HW_ZERO_4]
-      && !tcontrol_post_state[MTE]
-      && !tcontrol_post_state[HW_ZERO_2:HW_ZERO_0]
-    ) else `uvm_error(info_tag, "There is a problem with tcontrol's WARL fields.\n");
 
 
     //- Vplan:
@@ -863,8 +861,6 @@ module uvmt_cv32e40s_triggers_assert_cov
       |->
       tdata1_post_state == tdata1_pre_state
       && tdata2_post_state == tdata2_pre_state
-      && tdata3_post_state == tdata3_pre_state
-
     ) else `uvm_error(info_tag, "The t-CSRs are written in machine mode (not debug mode), and the write changes the CSRs values.\n");
 
 
@@ -874,10 +870,6 @@ module uvmt_cv32e40s_triggers_assert_cov
 
     c_dt_write_tdata2_in_mmode: cover property (
       seq_csr_write_mmode(ADDR_TDATA2)
-    );
-
-    c_dt_write_tdata3_in_mmode: cover property (
-      seq_csr_write_mmode(ADDR_TDATA3)
     );
 
 
@@ -892,12 +884,6 @@ module uvmt_cv32e40s_triggers_assert_cov
       |->
       rvfi_if.rvfi_rd1_wdata == tdata2_pre_state
     ) else `uvm_error(info_tag, "No read access to tdata2 in machine mode.\n");
-
-    a_dt_read_access_to_tdata3_in_mmode: assert property (
-      seq_csr_read_mmode(ADDR_TDATA3)
-      |->
-      rvfi_if.rvfi_rd1_wdata == tdata3_pre_state
-    ) else `uvm_error(info_tag, "No read access to tdata3 in machine mode.\n");
 
 
     //2)
@@ -919,15 +905,6 @@ module uvmt_cv32e40s_triggers_assert_cov
       or p_csrrci_in_dmode(ADDR_TDATA2, tdata2_post_state)
     ) else `uvm_error(info_tag, "No write access to tdata2 in debug mode.\n");
 
-    a_dt_write_access_to_tdata3_in_dmode: assert property (
-      p_csrrw_in_dmode(ADDR_TDATA3, tdata3_post_state)
-      or p_csrrs_in_dmode(ADDR_TDATA3, tdata3_post_state)
-      or p_csrrc_in_dmode(ADDR_TDATA3, tdata3_post_state)
-      or p_csrrwi_in_dmode(ADDR_TDATA3, tdata3_post_state)
-      or p_csrrsi_in_dmode(ADDR_TDATA3, tdata3_post_state)
-      or p_csrrci_in_dmode(ADDR_TDATA3, tdata3_post_state)
-    ) else `uvm_error(info_tag, "No write access to tdata3 in debug mode.\n");
-
 
     a_dt_read_access_to_tdata1_in_dmode: assert property (
       seq_csr_read_dmode(ADDR_TDATA1)
@@ -941,12 +918,6 @@ module uvmt_cv32e40s_triggers_assert_cov
       rvfi_if.rvfi_rd1_wdata == tdata2_pre_state
     ) else `uvm_error(info_tag, "No read access to tdata2 in debug mode.\n");
 
-    a_dt_read_access_to_tdata3_in_dmode: assert property (
-      seq_csr_read_dmode(ADDR_TDATA3)
-      |->
-      rvfi_if.rvfi_rd1_wdata == tdata3_pre_state
-    ) else `uvm_error(info_tag, "No read access to tdata3 in debug mode.\n");
-
 
     //3)
     a_dt_no_access_to_tdata_in_umode: assert property (
@@ -954,8 +925,7 @@ module uvmt_cv32e40s_triggers_assert_cov
       valid_instr_in_umode
 
       && (rvfi_if.is_csr_instr(ADDR_TDATA1)
-      || rvfi_if.is_csr_instr(ADDR_TDATA2)
-      || rvfi_if.is_csr_instr(ADDR_TDATA3))
+      || rvfi_if.is_csr_instr(ADDR_TDATA2))
 
       |->
       rvfi_if.rvfi_trap.trap
@@ -998,7 +968,7 @@ module uvmt_cv32e40s_triggers_assert_cov
     //2) see a_dt_enter_dbg_reason
 
     //A not fully covering extra check:
-    a_dt_tdata1s_disabled_no_dbg: assert property (
+    a_dt_tdata1_disabled_no_dbg: assert property (
       rvfi_if.rvfi_valid
       && rvfi_if.rvfi_trap.debug
 
@@ -1013,7 +983,7 @@ module uvmt_cv32e40s_triggers_assert_cov
 
 
     //- Vplan:
-    //Read the state of all triggers, write to tdata1/2/3 (using all types in tdata1), read back the state of all triggers and
+    //Read the state of all triggers, write to tdata1/2 (using all types in tdata1), read back the state of all triggers and
     //check that nothing got changes except the one "tdata*" register that was written.
 
     //- Assertion verification:
@@ -1024,22 +994,13 @@ module uvmt_cv32e40s_triggers_assert_cov
       seq_csr_write_dmode(ADDR_TDATA1)
       |->
       !tdata2.rvfi_csr_wmask
-      && !tdata3.rvfi_csr_wmask
-    ) else `uvm_error(info_tag, "A write to tdata1 writes tdata2 or tdata3 as well.\n");
+    ) else `uvm_error(info_tag, "A write to tdata1 writes tdata2 as well.\n");
 
     a_dt_write_only_tdata2: assert property (
       seq_csr_write_dmode(ADDR_TDATA2)
       |->
       !tdata1.rvfi_csr_wmask
-      && !tdata3.rvfi_csr_wmask
-    ) else `uvm_error(info_tag, "A write to tdata2 writes tdata1 or tdata3 as well.\n");
-
-    a_dt_write_only_tdata3: assert property (
-      seq_csr_write_dmode(ADDR_TDATA3)
-      |->
-      !tdata1.rvfi_csr_wmask
-      && !tdata2.rvfi_csr_wmask
-    ) else `uvm_error(info_tag, "A write to tdata3 writes tdata1 or tdata2 as well.\n");
+    ) else `uvm_error(info_tag, "A write to tdata2 writes tdata1 as well.\n");
 
 
     //- Vplan:
@@ -1400,11 +1361,10 @@ module uvmt_cv32e40s_triggers_assert_cov
 
 
     //- Vplan:
-    //Change the type to 2/6/15 and write any data to "tdata2", read it back and check that it always gets set. Do the same for "tdata3" and check that it always reads back 0.
+    //Change the type to 2/6/15 and write any data to "tdata2", read it back and check that it always gets set.
 
     //- Assertion verification:
     //1) Change the type to 2/6/15 and write any data to "tdata2", read it back and check that it always gets set.
-    //2) Do the same for "tdata3" and check that it always reads back 0.
 
 
     //1)
@@ -1465,9 +1425,51 @@ module uvmt_cv32e40s_triggers_assert_cov
         && rvfi_if.rvfi_insn[31:20] == ADDR_TDATA2
       );
 
-    end
 
-    //2) see a_dt_warl_tdata3
+      //- Vplan:
+      //Induce firing of a trigger. Check that the corresponding "hit" field gets set. Do the same for variations of multiple triggers firing at once.
+      //Also verify that the inital value of the "hit" field is 0x0. Check that the field is WARL 0x0, 0x1.
+
+      //- Assertion verification:
+      //1) Induce firing of a trigger. Check that the corresponding "hit" field gets set
+      //2) Verify that the inital value of the "hit" field is 0x0
+      //3) Check that the field is WARL 0x0, 0x1
+
+      //TODO: verify that these assertions passes!
+
+      //1)
+      a_dt_set_m6_hit_bits_pre_state: assert property(
+        support_if.tdata1_array[t][MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
+        && support_if.trigger_match_execute_array[t]
+        && support_if.trigger_match_load_array[t]
+        && support_if.trigger_match_store_array[t]
+        && tselect_pre_state == t
+
+        |->
+        tdata1_pre_state_m6_hits == 1
+      ) else `uvm_error(info_tag, "Tdata1 in mcontrol6 state does not set the hit bits even though there was a trigger match on (hit on tdata currently selected with tselect).\n");
+
+      a_dt_set_m6_hit_bits_post_state: assert property(
+        support_if.tdata1_array[t][MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
+        && support_if.trigger_match_execute_array[t]
+        && support_if.trigger_match_load_array[t]
+        && support_if.trigger_match_store_array[t]
+        && (tselect_post_state == t)[->1]
+        |->
+
+        tdata1_post_state_m6_hits == 1
+      ) else `uvm_error(info_tag, "Tdata1 in mcontrol6 state does not set the hit bits even though there was a trigger match on (first shown when tselect selects the tdata that was triggered).\n");
+
+      //2)
+      a_dt_m6_hit_bits_initial_value: assert property(
+        $rose(clknrst_if.reset_n)
+        tdata1_post_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
+        |->
+        tdata1_post_state_m6_hits == 0
+      ) else `uvm_error(info_tag, "The hit bits of tdata1 in mcontrol6 state is not initially 0.\n");
+
+      //3) see a_dt_warl_tdata1_m6
+    end
 
   end // if CORE_PARAM_DBG_NUM_TRIGGERS > 0
 


### PR DESCRIPTION
Update the assertions to follow the new debug spec.
Changes:
- tcotrol and tdata3 is removed
- the upper bits of tinfo is called tversion
- mcontrol6 uses 2 hit bits

Additional changes:
- removed localparam HW_ZERO* as it is unnecessary. 