### PR TITLE
Fixed wrong secureseed configuration, updated dummy instr. assertion

### DIFF
--- a/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
+++ b/cv32e40s/env/corev-dv/cv32e40s_asm_program_gen.sv
@@ -39,24 +39,6 @@ class cv32e40s_asm_program_gen extends corev_asm_program_gen;
 
     if (corev_cfg.enable_dummy) begin
       instr = {
-        // SECURESEED0
-        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
-        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
-        $sformatf("addi x%0d, x%0d, 0x57", cfg.gpr[0], cfg.gpr[0]),
-        $sformatf("csrrw x0, 0xbf9, x%0d", cfg.gpr[0]),
-
-        // SECURESEED1
-        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
-        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
-        $sformatf("addi x%0d, x%0d, 0x62", cfg.gpr[0], cfg.gpr[0]),
-        $sformatf("csrrw x0, 0xbfa, x%0d", cfg.gpr[0]),
-
-        // SECURESEED2
-        $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
-        $sformatf("lui x%0d, 0x80000", cfg.gpr[0]),
-        $sformatf("addi x%0d, x%0d, 0x7a", cfg.gpr[0], cfg.gpr[0]),
-        $sformatf("csrrw x0, 0xbfc, x%0d", cfg.gpr[0]),
-
         // CPUCTRL
         $sformatf("add x%0d, x0, x0", cfg.gpr[0]),
         $sformatf("lui x%0d, 0xf0", cfg.gpr[0]),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1213,6 +1213,8 @@ module uvmt_cv32e40s_tb;
       .if_dummy (core_i.if_stage_i.dummy_insert),
       .kill_if  (core_i.controller_i.controller_fsm_i.ctrl_fsm_o.kill_if),
       .if_valid (core_i.if_valid),
+      .ptr_in_if (core_i.if_stage_i.ptr_in_if_o),
+      .if_first_op (core_i.if_stage_i.first_op),
 
       //ID:
       .operand_a (core_i.id_stage_i.operand_a),

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1240,8 +1240,7 @@ module uvmt_cv32e40s_tb;
 
       //Controller:
       .debug_mode (core_i.controller_i.controller_fsm_i.debug_mode_q),
-      .stopcount_in_debug (core_i.cs_registers_i.debug_stopcount),
-      .allow_dummy (core_i.ctrl_fsm.allow_dummy_instr)
+      .stopcount_in_debug (core_i.cs_registers_i.debug_stopcount)
     );
 
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
@@ -91,8 +91,7 @@ module uvmt_cv32e40s_xsecure_dummy_and_hint_assert
 
     //Controller:
     input logic debug_mode,
-    input logic stopcount_in_debug,
-    input logic allow_dummy
+    input logic stopcount_in_debug
 
   );
 

--- a/cv32e40s/tests/cfg/dummy_instr.yaml
+++ b/cv32e40s/tests/cfg/dummy_instr.yaml
@@ -4,6 +4,7 @@ compile_flags:
     +define+ZBA_ZBB_ZBC_ZBS
     +define+CLIC_EN
     +define+PMP_ENABLE_64
+    +define+LFSR_CFG_0
 plusargs: >
     +enable_clic=1
     +enable_zba_extension=1

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
@@ -179,6 +179,10 @@ parameter logic CLIC = CORE_PARAM_CLIC;
    // Sat from the include file
 `elsif PARAM_SET_1
    // Sat from the include file
+`elsif LFSR_CFG_0
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR0_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h80000057, default_seed : 32'habbacafe };
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h80000062, default_seed : 32'hbeef1234 };
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h8000007a, default_seed : 32'ha5a5a5a5 };
 `else
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR0_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;


### PR DESCRIPTION
- Fixed: Default LFSR coefficients used as seed
- Added: Default LFSR configuration for the dummy instruction configuration
- Fixed: Dummy instruction frequency assertion

