### PR TITLE
Cv32e40p/dev baoshan update fp stream tests stage1

### DIFF
--- a/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Base class for RISC-V instruction stream
+// A instruction stream here is a  queue of RISC-V basic instructions.
+// This class also provides some functions to manipulate the instruction stream, like insert a new
+// instruction, mix two instruction streams etc.
+class riscv_instr_stream extends uvm_object;
+
+  riscv_instr           instr_list[$];
+  int unsigned          instr_cnt;
+  string                label = "";
+  // User can specify a small group of available registers to generate various hazard condition
+  rand riscv_reg_t      avail_regs[];
+  // Some additional reserved registers that should not be used as rd register
+  // by this instruction stream
+  riscv_reg_t           reserved_rd[];
+  int                   hart;
+
+  `uvm_object_utils(riscv_instr_stream)
+  `uvm_object_new
+
+  // Initialize the instruction stream, create each instruction instance
+  function void initialize_instr_list(int unsigned instr_cnt);
+    instr_list = {};
+    this.instr_cnt = instr_cnt;
+    create_instr_instance();
+  endfunction
+
+  virtual function void create_instr_instance();
+    riscv_instr instr;
+    for(int i = 0; i < instr_cnt; i++) begin
+      instr = riscv_instr::type_id::create($sformatf("instr_%0d", i));
+      instr_list.push_back(instr);
+    end
+  endfunction
+
+  // Insert an instruction to the existing instruction stream at the given index
+  // When index is -1, the instruction is injected at a random location
+  function void insert_instr(riscv_instr instr, int idx = -1);
+    int current_instr_cnt = instr_list.size();
+    if (current_instr_cnt == 0) begin
+      idx = 0;
+    end else if (idx == -1) begin
+      idx = $urandom_range(0, current_instr_cnt-1);
+      while(instr_list[idx].atomic) begin
+       idx += 1;
+       if (idx == current_instr_cnt - 1) begin
+         instr_list = {instr_list, instr};
+         return;
+       end
+      end
+    end else if((idx > current_instr_cnt) || (idx < 0)) begin
+      `uvm_error(`gfn, $sformatf("Cannot insert instr:%0s at idx %0d",
+                       instr.convert2asm(), idx))
+    end
+    instr_list.insert(idx, instr);
+  endfunction
+
+  // Insert an instruction to the existing instruction stream at the given index
+  // When index is -1, the instruction is injected at a random location
+  // When replace is 1, the original instruction at the inserted position will be replaced
+  function void insert_instr_stream(riscv_instr new_instr[], int idx = -1, bit replace = 1'b0);
+    int current_instr_cnt = instr_list.size();
+    int new_instr_cnt = new_instr.size();
+    if(current_instr_cnt == 0) begin
+      instr_list = new_instr;
+      return;
+    end
+    if(idx == -1) begin
+      idx = $urandom_range(0, current_instr_cnt-1);
+      repeat(10) begin
+       if (instr_list[idx].atomic) break;
+       idx = $urandom_range(0, current_instr_cnt-1);
+      end
+      if (instr_list[idx].atomic) begin
+        foreach (instr_list[i]) begin
+          if (!instr_list[i].atomic) begin
+            idx = i;
+            break;
+          end
+        end
+        if (instr_list[idx].atomic) begin
+          `uvm_fatal(`gfn, $sformatf("Cannot inject the instruction"))
+        end
+      end
+    end else if((idx > current_instr_cnt) || (idx < 0)) begin
+      `uvm_error(`gfn, $sformatf("Cannot insert instr stream at idx %0d", idx))
+    end
+    // When replace is 1, the original instruction at this index will be removed. The label of the
+    // original instruction will be copied to the head of inserted instruction stream.
+    if(replace) begin
+      new_instr[0].label = instr_list[idx].label;
+      new_instr[0].has_label = instr_list[idx].has_label;
+      if (idx == 0) begin
+        instr_list = {new_instr, instr_list[idx+1:current_instr_cnt-1]};
+      end else begin
+        instr_list = {instr_list[0:idx-1], new_instr, instr_list[idx+1:current_instr_cnt-1]};
+      end
+    end else begin
+      if (idx == 0) begin
+        instr_list = {new_instr, instr_list[idx:current_instr_cnt-1]};
+      end else begin
+        instr_list = {instr_list[0:idx-1], new_instr, instr_list[idx:current_instr_cnt-1]};
+      end
+    end
+  endfunction
+
+  // Mix the input instruction stream with the original instruction, the instruction order is
+  // preserved. When 'contained' is set, the original instruction stream will be inside the
+  // new instruction stream with the first and last instruction from the input instruction stream.
+  function void mix_instr_stream(riscv_instr new_instr[], bit contained = 1'b0);
+    int current_instr_cnt = instr_list.size();
+    int insert_instr_position[];
+    int new_instr_cnt = new_instr.size();
+    insert_instr_position = new[new_instr_cnt];
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(insert_instr_position,
+      foreach(insert_instr_position[i]) {
+        insert_instr_position[i] inside {[0:current_instr_cnt-1]};
+      })
+    if (insert_instr_position.size() > 0) begin
+      insert_instr_position.sort();
+    end
+    if(contained) begin
+      insert_instr_position[0] = 0;
+      if(new_instr_cnt > 1)
+        insert_instr_position[new_instr_cnt-1] = current_instr_cnt-1;
+    end
+    foreach(new_instr[i]) begin
+      insert_instr(new_instr[i], insert_instr_position[i] + i);
+    end
+  endfunction
+
+  function string convert2string();
+    string str;
+    foreach(instr_list[i])
+      str = {str, instr_list[i].convert2asm(), "\n"};
+    return str;
+  endfunction
+
+endclass
+
+// Generate a random instruction stream based on the configuration
+// There are two ways to use this class to generate instruction stream
+// 1. For short instruction stream, you can call randomize() directly.
+// 2. For long instruction stream (>1K), randomize() all instructions together might take a long
+// time for the constraint solver. In this case, you can call gen_instr to generate instructions
+// one by one. The time only grows linearly with the instruction count
+class riscv_rand_instr_stream extends riscv_instr_stream;
+
+  riscv_instr_gen_config  cfg;
+  bit                     kernel_mode;
+  riscv_instr_name_t      allowed_instr[$];
+  int unsigned            category_dist[riscv_instr_category_t];
+
+  `uvm_object_utils(riscv_rand_instr_stream)
+  `uvm_object_new
+
+  virtual function void create_instr_instance();
+    riscv_instr instr;
+    for (int i = 0; i < instr_cnt; i++) begin
+      instr_list.push_back(null);
+    end
+  endfunction
+
+  virtual function void setup_allowed_instr(bit no_branch = 1'b0, bit no_load_store = 1'b1);
+    allowed_instr = riscv_instr::basic_instr;
+    if (no_branch == 0) begin
+      allowed_instr = {allowed_instr, riscv_instr::instr_category[BRANCH]};
+    end
+    if (no_load_store == 0) begin
+      allowed_instr = {allowed_instr, riscv_instr::instr_category[LOAD],
+                                      riscv_instr::instr_category[STORE]};
+    end
+    setup_instruction_dist(no_branch, no_load_store);
+  endfunction
+
+  virtual function void randomize_avail_regs();
+    if(avail_regs.size() > 0) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(avail_regs,
+                                         unique{avail_regs};
+                                         avail_regs[0] inside {[S0 : A5]};
+                                         foreach(avail_regs[i]) {
+                                           !(avail_regs[i] inside {cfg.reserved_regs, reserved_rd});
+                                         },
+                                         "Cannot randomize avail_regs")
+    end
+  endfunction
+
+  function void setup_instruction_dist(bit no_branch = 1'b0, bit no_load_store = 1'b1);
+    if (cfg.dist_control_mode) begin
+      category_dist = cfg.category_dist;
+      if (no_branch) begin
+        category_dist[BRANCH] = 0;
+      end
+      if (no_load_store) begin
+        category_dist[LOAD] = 0;
+        category_dist[STORE] = 0;
+      end
+      `uvm_info(`gfn, $sformatf("setup_instruction_dist: %0d", category_dist.size()), UVM_LOW)
+    end
+  endfunction
+
+  virtual function void gen_instr(bit no_branch = 1'b0, bit no_load_store = 1'b1,
+                                  bit is_debug_program = 1'b0);
+    setup_allowed_instr(no_branch, no_load_store);
+    foreach(instr_list[i]) begin
+      randomize_instr(instr_list[i], is_debug_program);
+    end
+    // Do not allow branch instruction as the last instruction because there's no
+    // forward branch target
+    while (instr_list[$].category == BRANCH) begin
+      void'(instr_list.pop_back());
+      if (instr_list.size() == 0) break;
+    end
+  endfunction
+
+  function void randomize_instr(output riscv_instr instr,
+                                input  bit is_in_debug = 1'b0,
+                                input  bit disable_dist = 1'b0,
+                                input  riscv_instr_group_t include_group[$] = {});
+    riscv_instr_name_t exclude_instr[];
+    if ((SP inside {reserved_rd, cfg.reserved_regs}) ||
+        ((avail_regs.size() > 0) && !(SP inside {avail_regs}))) begin
+      exclude_instr = {C_ADDI4SPN, C_ADDI16SP, C_LWSP, C_LDSP};
+    end
+    // Post-process the allowed_instr and exclude_instr lists to handle
+    // adding ebreak instructions to the debug rom.
+    if (is_in_debug) begin
+      if (cfg.no_ebreak && cfg.enable_ebreak_in_debug_rom) begin
+        allowed_instr = {allowed_instr, EBREAK, C_EBREAK};
+      end else if (!cfg.no_ebreak && !cfg.enable_ebreak_in_debug_rom) begin
+        exclude_instr = {exclude_instr, EBREAK, C_EBREAK};
+      end
+    end
+    instr = riscv_instr::get_rand_instr(.include_instr(allowed_instr),
+                                        .exclude_instr(exclude_instr),
+                                        .include_group(include_group));
+    instr.m_cfg = cfg;
+    randomize_gpr(instr);
+  endfunction
+
+  function void randomize_gpr(riscv_instr instr);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
+      if (avail_regs.size() > 0) {
+        if (has_rs1) {
+          rs1 inside {avail_regs};
+        }
+        if (has_rs2) {
+          rs2 inside {avail_regs};
+        }
+        if (has_rd) {
+          rd  inside {avail_regs};
+        }
+      }
+      foreach (reserved_rd[i]) {
+        if (has_rd) {
+          rd != reserved_rd[i];
+        }
+        if (format == CB_FORMAT) {
+          rs1 != reserved_rd[i];
+        }
+      }
+      foreach (cfg.reserved_regs[i]) {
+        if (has_rd) {
+          rd != cfg.reserved_regs[i];
+        }
+        if (format == CB_FORMAT) {
+          rs1 != cfg.reserved_regs[i];
+        }
+      }
+      // TODO: Add constraint for CSR, floating point register
+    )
+  endfunction
+
+  function riscv_instr get_init_gpr_instr(riscv_reg_t gpr, bit [XLEN-1:0] val);
+    riscv_pseudo_instr li_instr;
+    li_instr = riscv_pseudo_instr::type_id::create("li_instr");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(li_instr,
+       pseudo_instr_name == LI;
+       rd == gpr;
+    )
+    li_instr.imm_str = $sformatf("0x%0x", val);
+    return li_instr;
+  endfunction
+
+  function void add_init_vector_gpr_instr(riscv_vreg_t gpr, bit [XLEN-1:0] val);
+    riscv_vector_instr instr;
+    $cast(instr, riscv_instr::get_instr(VMV));
+    instr.m_cfg = cfg;
+    instr.avoid_reserved_vregs_c.constraint_mode(0);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
+      va_variant == VX;
+      vd == gpr;
+      rs1 == cfg.gpr[0];
+    )
+    instr_list.push_front(instr);
+    instr_list.push_front(get_init_gpr_instr(cfg.gpr[0], val));
+  endfunction
+
+endclass

--- a/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
@@ -73,7 +73,7 @@ class riscv_instr_stream extends uvm_object;
   // Insert an instruction to the existing instruction stream at the given index
   // When index is -1, the instruction is injected at a random location
   // When replace is 1, the original instruction at the inserted position will be replaced
-  function void insert_instr_stream(riscv_instr new_instr[], int idx = -1, bit replace = 1'b0);
+  virtual function void insert_instr_stream(riscv_instr new_instr[], int idx = -1, bit replace = 1'b0);
     int current_instr_cnt = instr_list.size();
     int new_instr_cnt = new_instr.size();
     if(current_instr_cnt == 0) begin

--- a/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/custom/riscv_instr_stream.sv
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google LLC
+ * Copyright 2023 Dolphin Design
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// [Dolphin Design updates] Changed insert_instr_stream into virtual function for overridden method in extended class
 
 // Base class for RISC-V instruction stream
 // A instruction stream here is a  queue of RISC-V basic instructions.

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_base_test.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_base_test.sv
@@ -36,6 +36,7 @@ class cv32e40p_instr_base_test extends corev_instr_base_test;
     override_illegal_instr();
     override_privil_reg();
     override_debug_rom_gen();
+    override_instr_stream();
     super.build_phase(phase);
   endfunction
 
@@ -67,6 +68,17 @@ class cv32e40p_instr_base_test extends corev_instr_base_test;
   virtual function void override_debug_rom_gen();
     uvm_factory::get().set_type_override_by_type(riscv_debug_rom_gen::get_type(),
                                                  cv32e40p_debug_rom_gen::get_type());
+  endfunction
+
+  virtual function void override_instr_stream();
+    int test_override_riscv_instr_stream = 0;
+    if ($value$plusargs("test_override_riscv_instr_stream=%0d", test_override_riscv_instr_stream)) begin
+      unique case(test_override_riscv_instr_stream)
+        1: begin 
+          uvm_factory::get().set_type_override_by_type(riscv_rand_instr_stream::get_type(), cv32e40p_rand_instr_stream::get_type()); 
+        end
+      endcase
+    end
   endfunction
 
   virtual function void apply_directed_instr();

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
@@ -29,6 +29,7 @@ package cv32e40p_instr_test_pkg;
   `include "instr_lib/cv32e40p_float_instr_lib.sv"
 
   // RISCV-DV class override definitions
+  `include "cv32e40p_rand_instr_stream.sv"
   `include "cv32e40p_compressed_instr.sv"
   `include "cv32e40p_illegal_instr.sv"
   `include "cv32e40p_privil_reg.sv"

--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Google LLC
+ * Copyright 2023 Dolphin Design
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +15,11 @@
  * limitations under the License.
  */
 
-// Base class for RISC-V instruction stream
-// A instruction stream here is a  queue of RISC-V basic instructions.
-// This class also provides some functions to manipulate the instruction stream, like insert a new
-// instruction, mix two instruction streams etc.
 
+// [Dolphin Design updates] 
+// Extended class from riscv_rand_instr_stream to override insert_instr_stream.
+// Prevent instructions from multiple streams from overlapping each others and 
+// to ensure the instructions order in one stream is preserved.
 class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
 
   // below properties are for insert_instr_stream function
@@ -29,7 +30,6 @@ class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
   `uvm_object_utils(cv32e40p_rand_instr_stream)
   `uvm_object_new
 
-  // overriding this function to modified the instructions placements so that directed streams should not overlap with each others
   virtual function void insert_instr_stream(riscv_instr new_instr[], int idx = -1, bit replace = 1'b0);
 
     int current_instr_cnt = instr_list.size();

--- a/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_rand_instr_stream.sv
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Base class for RISC-V instruction stream
+// A instruction stream here is a  queue of RISC-V basic instructions.
+// This class also provides some functions to manipulate the instruction stream, like insert a new
+// instruction, mix two instruction streams etc.
+
+class cv32e40p_rand_instr_stream extends riscv_rand_instr_stream;
+
+  // below properties are for insert_instr_stream function
+  protected int         idx_start[$];            
+  protected int         idx_end[$];            
+  protected int         idx_min = 0;            
+
+  `uvm_object_utils(cv32e40p_rand_instr_stream)
+  `uvm_object_new
+
+  // overriding this function to modified the instructions placements so that directed streams should not overlap with each others
+  virtual function void insert_instr_stream(riscv_instr new_instr[], int idx = -1, bit replace = 1'b0);
+
+    int current_instr_cnt = instr_list.size();
+    int new_instr_cnt = new_instr.size(); // e.g from directed stream
+
+    if (replace) begin
+      `uvm_fatal(`gfn, $sformatf("Function implementation is not ready for replace==1"))
+    end
+
+    if(current_instr_cnt == 0) begin
+      instr_list = new_instr;
+      return;
+    end
+    if(idx == -1) begin
+
+      bit idx_search_done = 0;
+      int rand_cnt = 0;
+
+      idx = $urandom_range(0, current_instr_cnt-1);
+      while (!instr_list[idx].atomic && !idx_search_done) begin
+        int idx_e = 0;
+        idx = $urandom_range(0, current_instr_cnt-1);
+        idx_e = (idx + new_instr_cnt-1);
+
+        if (idx_start.size() == 0) begin : SEARCH_IDX_FOR_NEW_INSTR
+          idx_min = idx;
+          idx_search_done = 1;
+        end // SEARCH_IDX_FOR_NEW_INSTR
+        else begin
+          foreach (idx_start[i]) begin
+            if (
+              (idx          >= idx_start[i]   &&  idx           <= idx_end[i])  ||
+              (idx_e        >= idx_start[i]   &&  idx_e         <= idx_end[i])  ||
+              (idx_start[i] >= idx            &&  idx_start[i]  <= idx_e)       ||
+              (idx_end[i]   >= idx            &&  idx_end[i]    <= idx_e)
+            ) begin : DETECT_OVERLAP_IDX_FOR_NEW_INSTR
+              break;
+            end // DETECT_OVERLAP_IDX_FOR_NEW_INSTR
+            else begin : NON_OVERLAP_IDX_FOR_NEW_INSTR
+              if (i == (idx_start.size()-1)) begin
+                idx_search_done = 1;
+                break;
+              end
+            end // NON_OVERLAP_IDX_FOR_NEW_INSTR
+          end // foreach
+        end // SEARCH_IDX_FOR_NEW_INSTR
+
+        if (idx_search_done) begin
+          int idx_placement[$];
+          if ((idx_start.size() == 0) || (idx_e < idx_min)) begin
+            idx_min = idx;
+            `uvm_info(`gfn, $sformatf("[DEBUG] - idx_min updated [%0d]", idx_min), UVM_DEBUG)
+          end
+          idx_start.push_back(idx);
+          idx_end.push_back(idx_e);
+          `uvm_info(`gfn, $sformatf("[DEBUG] - idx_start (before sort)       - %p", idx_start), UVM_DEBUG)
+          `uvm_info(`gfn, $sformatf("[DEBUG] - idx_end   (before sort)       - %p", idx_end), UVM_DEBUG)
+          idx_start.sort();
+          idx_end.sort();
+          `uvm_info(`gfn, $sformatf("[DEBUG] - idx_start (after sort)        - %p", idx_start), UVM_DEBUG)
+          `uvm_info(`gfn, $sformatf("[DEBUG] - idx_end   (after sort)        - %p", idx_end), UVM_DEBUG)
+          idx_placement = idx_start.find_first_index(x) with (x == idx);
+          for (int i=idx_placement[0]+1; i<idx_start.size(); i++) begin
+            idx_start[i] = idx_start[i]+new_instr_cnt;
+            idx_end[i]   = idx_end[i]+new_instr_cnt;
+            `uvm_info(`gfn, $sformatf("[DEBUG] - idx_start (update placement)  - %p", idx_start), UVM_DEBUG)
+            `uvm_info(`gfn, $sformatf("[DEBUG] - idx_end   (update placement)  - %p", idx_end), UVM_DEBUG)
+          end
+        end // idx_search_done
+
+        rand_cnt++;
+        if (rand_cnt >= 100) begin
+          `uvm_fatal(`gfn, $sformatf("rand_cnt hit limit %0d and not able to find space for instr placement. Please revise the stream", rand_cnt))
+        end // rand_cnt
+
+      end // while
+
+      if (instr_list[idx].atomic) begin
+        foreach (instr_list[i]) begin
+          if (!instr_list[i].atomic) begin
+            idx = i;
+            break;
+          end
+        end
+        if (instr_list[idx].atomic) begin
+          `uvm_fatal(`gfn, $sformatf("Cannot inject the instruction"))
+        end
+      end // instr_list[idx].atomic
+
+    end else if((idx > current_instr_cnt) || (idx < 0)) begin
+      `uvm_error(`gfn, $sformatf("Cannot insert instr stream at idx %0d", idx))
+    end // idx
+
+    // When replace is 1, the original instruction at this index will be removed. The label of the
+    // original instruction will be copied to the head of inserted instruction stream.
+    if(replace) begin
+      new_instr[0].label = instr_list[idx].label;
+      new_instr[0].has_label = instr_list[idx].has_label;
+      if (idx == 0) begin
+        instr_list = {new_instr, instr_list[idx+1:current_instr_cnt-1]};
+      end else begin
+        instr_list = {instr_list[0:idx-1], new_instr, instr_list[idx+1:current_instr_cnt-1]};
+      end
+    end else begin
+      if (idx == 0) begin
+        instr_list = {new_instr, instr_list[idx:current_instr_cnt-1]};
+      end else begin
+        instr_list = {instr_list[0:idx-1], new_instr, instr_list[idx:current_instr_cnt-1]};
+      end
+    end
+  endfunction
+
+endclass
+

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_base_instr_lib.sv
@@ -64,7 +64,7 @@
 
   function void post_randomize();
     for (int i = 0; i < instr_list.size(); i++) begin
-      instr_list[i].comment = $sformatf(" Inserted %0s - idx[%0d]", get_name(), i);
+      instr_list[i].comment = {instr_list[i].comment, $sformatf(" Inserted %0s - idx[%0d]", get_name(), i)};
     end
     super.post_randomize();
   endfunction : post_randomize

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
@@ -16,43 +16,233 @@
  * limitations under the License.
  */
 
+// DEFINES used in this class - start
+  // constraint for special pattern operands
+  // fixme: update the weight again
+  // note: DONOT insert " solve enable_special_operand_patterns before operand_``IDX``_pattern;\" at below code, it will limit the constraints (havent root caused)
+  `define C_OPERAND_PATTERN(IDX) \
+    constraint c_operand_``IDX``_pattern {\
+      soft operand_``IDX``_pattern.size() == num_of_instr_per_stream;\
+      foreach (operand_``IDX``_pattern[i]) {\
+        if (enable_special_operand_patterns) {\
+          operand_``IDX``_pattern[i] dist { IS_RAND := 4, IS_Q_NAN  := 2, IS_S_NAN              := 2, \
+                                            IS_POSITIVE_ZERO        := 2, IS_NEGATIVE_ZERO      := 2, \
+                                            IS_POSITIVE_INFINITY    := 2, IS_NEGATIVE_INFINITY  := 2, \
+                                            IS_POSITIVE_SUBNORMAL   := 0, IS_NEGATIVE_SUBNORMAL := 0 };\
+        } else {\
+          soft operand_``IDX``_pattern[i] == IS_RAND;\
+        }\
+      }\
+    } 
+  // fixme: pending subnormal definition
+  `define C_OPERAND(IDX) \
+    constraint c_operand_``IDX {\
+      sign_``IDX``.size()     == num_of_instr_per_stream;\
+      exp_``IDX``.size()      == num_of_instr_per_stream;\
+      mantissa_``IDX``.size() == num_of_instr_per_stream;\
+      operand_``IDX``.size()  == num_of_instr_per_stream;\
+      foreach (operand_``IDX``[i]) {\
+        if (operand_``IDX``_pattern[i] == IS_POSITIVE_ZERO) {\
+          sign_``IDX``[i] == 1'b0; exp_``IDX``[i] == 8'h00; mantissa_``IDX``[i] == 23'h0;\
+        }\
+        if (operand_``IDX``_pattern[i] == IS_NEGATIVE_ZERO) {\
+          sign_``IDX``[i] == 1'b1; exp_``IDX``[i] == 8'h00; mantissa_``IDX``[i] == 23'h0;\
+        }\
+        if (operand_``IDX``_pattern[i] == IS_POSITIVE_INFINITY) {\
+          sign_``IDX``[i] == 1'b0; exp_``IDX``[i] == 8'hFF; mantissa_``IDX``[i] == 23'h0;\
+        }\
+        if (operand_``IDX``_pattern[i] == IS_NEGATIVE_INFINITY) {\
+          sign_``IDX``[i] == 1'b1; exp_``IDX``[i] == 8'hFF; mantissa_``IDX``[i] == 23'h0;\
+        }\
+        if (operand_``IDX``_pattern[i] == IS_Q_NAN) {\
+          sign_``IDX``[i] == 1'b1; exp_``IDX``[i] == 8'hFF; mantissa_``IDX``[i][22] == 1'b1;\
+        }\
+        if (operand_``IDX``_pattern[i] == IS_S_NAN) {\
+          sign_``IDX``[i] == 1'b1; exp_``IDX``[i] == 8'hFF; mantissa_``IDX``[i][22] == 1'b0; mantissa_``IDX``[i][21:12] != 0;\
+        }\
+        operand_``IDX[i] == {sign_``IDX``[i], exp_``IDX``[i], mantissa_``IDX``[i]};\
+        solve operand_``IDX``_pattern[i] before sign_``IDX``[i];\
+        solve sign_``IDX``[i] before operand_``IDX[i];\
+        solve exp_``IDX``[i] before operand_``IDX[i];\
+        solve mantissa_``IDX``[i] before operand_``IDX[i];\
+      }\
+    }
+
+    // Add overhead instructions to override fp instr operands with specific operand pattern
+    // LUI->SW->FLW
+    `define MANIPULATE_F_INSTR_OPERANDS(FPR,OPERAND) \
+      if (instr.has_``FPR && ``OPERAND``_pattern != IS_RAND) begin\
+        riscv_instr                 m_instr;\
+        riscv_floating_point_instr  f_instr;\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({LUI}));\
+        override_instr(\
+          .instr  (m_instr),\
+          .rd     (imm_rd),\
+          .imm    ({12'h0, ``OPERAND``[31:12]})\
+        );\
+        instr_list.push_back(m_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_f_instr_``OPERAND``][LUI] `")};\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({SW}));\
+        override_instr(\
+          .instr  (m_instr),\
+          .rs2    (imm_rd),\
+          .rs1    (mem_rd),\
+          .imm    (32'h0)\
+        );\
+        instr_list.push_back(m_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_f_instr_``OPERAND``][SW] `")};\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({FLW}));\
+        `DV_CHECK_FATAL($cast(f_instr, m_instr), "Cast to instr_f failed!");\
+        override_instr(\
+          .f_instr  (f_instr),\
+          .fd       (instr.``FPR``),\
+          .rs1      (mem_rd),\
+          .imm      (32'h0)\
+        );\
+        instr_list.push_back(f_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_f_instr_``OPERAND``][FLW] `")};\
+      end
+
+    // Add overhead instructions to override zfinx fp instr operands with specific operand pattern
+    // LUI->SW->LW
+    `define MANIPULATE_ZFINX_INSTR_OPERANDS(GPR,OPERAND) \
+      if (instr.has_``GPR && ``OPERAND``_pattern != IS_RAND) begin\
+        riscv_instr                 m_instr;\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({LUI}));\
+        override_instr(\
+          .instr  (m_instr),\
+          .rd     (imm_rd),\
+          .imm    ({12'h0, ``OPERAND``[31:12]})\
+        );\
+        instr_list.push_back(m_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_zfinx_instr_``OPERAND``][LUI] `")};\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({SW}));\
+        override_instr(\
+          .instr  (m_instr),\
+          .rs2    (imm_rd),\
+          .rs1    (mem_rd),\
+          .imm    (32'h0)\
+        );\
+        instr_list.push_back(m_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_zfinx_instr_``OPERAND``][SW] `")};\
+        m_instr = new riscv_instr::get_rand_instr(.include_instr({LW}));\
+        override_instr(\
+          .instr  (m_instr),\
+          .rd     (instr.``GPR``),\
+          .rs1    (mem_rd),\
+          .imm    (32'h0)\
+        );\
+        instr_list.push_back(m_instr);\
+        instr_list[$].comment = {instr_list[$].comment, $sformatf(`" [manipulate_zfinx_instr_``OPERAND``][LW] `")};\
+      end
+
+
+// DEFINES - end
+
+
+// others fixme:
+// 1) fcvt.s.w - understand this and update for above
+
+// ALL FP STREAM CLASSESS - start
+  // base class for fp instruction stream generation
 class cv32e40p_float_zfinx_base_instr_stream extends cv32e40p_base_instr_stream;
 
-  string _header;
-  bit    is_zfinx; // only used as a shorthand for RV32ZFINX inside {riscv_instr_pkg::supported_isa}, and initialized in "new" method
+  localparam TOTAL_FPR = 32;
 
+  // typedef - start
+  typedef enum bit [3:0] {
+    IS_RAND = 0,
+    IS_POSITIVE_ZERO,       /* 'd0  */
+    IS_NEGATIVE_ZERO,       /* 'd524288 */
+    IS_POSITIVE_INFINITY,   /* 'd522240 */
+    IS_NEGATIVE_INFINITY,   /* 'd1046528  */
+    IS_POSITIVE_SUBNORMAL,
+    IS_NEGATIVE_SUBNORMAL,
+    IS_Q_NAN,               /* => 'd1047552  */
+    IS_S_NAN                /* => 'd1046528 and < 'dd1047552 */
+  } operand_pattens_t;
+  // typedef - end
+  
+  // properties - start
+  string              _header;
+  bit                 is_zfinx;
+  riscv_instr_name_t  include_instr[];
+  riscv_instr_name_t  exclude_instr[];
+  bit                 use_diff_instr_per_stream; // fixme: pending implementation
+  bit                 use_same_regs_for_operands_per_stream; // fixme: pending implementation
 
-  rand int unsigned num_of_avail_regs;
-  rand int unsigned num_of_instr_per_stream;
-  rand riscv_fpr_t  avail_fp_regs[];
-  rand riscv_fpr_t  reserved_fd[];   
+    // fixme: add constraints for multicycle instr 
+    // some instr will become multicycle if below properties are not-0
+  `ifdef FPU_ADDMUL_LAT
+    int unsigned fpu_addmul_lat = `FPU_ADDMUL_LAT;
+  `else
+    int unsigned fpu_addmul_lat = 0;
+  `endif
+  `ifdef FPU_OTHERS_LAT
+    int unsigned fpu_others_lat = `FPU_OTHERS_LAT;
+  `else
+    int unsigned fpu_others_lat = 0;
+  `endif
 
-  rand riscv_instr_name_t     exclude_instr[];
-  rand riscv_instr_category_t exclude_category[];
-  rand riscv_instr_group_t    exclude_group[];
+  rand int unsigned       num_of_instr_per_stream;
+  rand riscv_reg_t        avail_gp_regs[][];  // for zfinx and f
+  rand riscv_fpr_t        avail_fp_regs[][];  // for f only
+  rand bit [31:0]         imm;
+  rand f_rounding_mode_t  rm;
+  rand bit                use_rounding_mode_from_instr;
+
+  rand bit                enable_special_operand_patterns;
+  rand operand_pattens_t  operand_a_pattern[];
+  rand operand_pattens_t  operand_b_pattern[];
+  rand operand_pattens_t  operand_c_pattern[];
+  rand bit                sign_a[],     sign_b[],     sign_c[];
+  rand bit [7:0]          exp_a[],      exp_b[],      exp_c[];
+  rand bit [22:0]         mantissa_a[], mantissa_b[], mantissa_c[];
+  rand bit [31:0]         operand_a[],  operand_b[],  operand_c[];
+  // properties - end
 
   `uvm_object_utils(cv32e40p_float_zfinx_base_instr_stream)
 
+  // constraints - start
   constraint c_others {
-    soft num_of_avail_regs == 10; // todo: currently set to 10 for testing
+    soft num_of_instr_per_stream == 30; // fixed to 30
     num_of_instr_per_stream > 0;
-    soft num_of_instr_per_stream inside {[1:20]};
+    // soft num_of_instr_per_stream inside {[10:15]};
+    solve num_of_instr_per_stream before enable_special_operand_patterns;
   }
 
-  constraint c_x_regs {
-    soft avail_regs.size() == num_of_avail_regs;
-    unique{avail_regs};
-    avail_regs[0] inside {[S0:A5]};
-    foreach(avail_regs[i]) {
-      !(avail_regs[i] inside {cfg.reserved_regs, reserved_rd});
+  constraint c_avail_gp_regs {
+    soft avail_gp_regs.size() == num_of_instr_per_stream;
+    foreach (avail_gp_regs[i]) {
+      soft avail_gp_regs[i].size() == 10; // more buffer as some dedicated gpr should not been used
+      unique{avail_gp_regs[i]};
+      foreach (avail_gp_regs[i][j]) {
+        !(avail_gp_regs[i][j] inside {cfg.reserved_regs, reserved_rd});
+      }
     }
   }
 
-  constraint c_fp_regs {
-    soft avail_fp_regs.size() == num_of_avail_regs;
-    unique{avail_fp_regs};
-    avail_fp_regs[0] inside {[FT0:FT7]};
+  constraint c_avail_fp_regs {
+    soft avail_fp_regs.size() == num_of_instr_per_stream;
+    foreach (avail_fp_regs[i]) {
+      // avail_fp_regs[i].size() > 3; // minimum 4 - fs[1-3] + fd
+      avail_fp_regs[i].size() > TOTAL_FPR/2; // widen the range of selection
+      soft avail_fp_regs[i].size() < TOTAL_FPR + 1; // total of available fpr
+      unique{avail_fp_regs[i]};
+    }
   }
+
+  constraint c_enable_special_operand_patterns {
+    soft enable_special_operand_patterns == 0;
+  }
+
+  `C_OPERAND_PATTERN(a)
+  `C_OPERAND_PATTERN(b)
+  `C_OPERAND_PATTERN(c)
+  `C_OPERAND(a)
+  `C_OPERAND(b)
+  `C_OPERAND(c)
+  // constraints - end
 
   function new (string name="");
     super.new(name);
@@ -61,53 +251,119 @@ class cv32e40p_float_zfinx_base_instr_stream extends cv32e40p_base_instr_stream;
       `uvm_error(_header, $sformatf("RV32ZFINX and RV32F are not defined in RV_DV_ISA - refer cv32e40p_supported_isa.svh"));
     end
     is_zfinx = riscv_instr_pkg::RV32ZFINX inside {riscv_instr_pkg::supported_isa};
-  endfunction // new
+  endfunction: new
 
   function void pre_randomize();
     super.pre_randomize();
-  endfunction // pre_randomize
+  endfunction: pre_randomize
 
   function void post_randomize();
     riscv_instr                 instr;
     riscv_fp_in_x_regs_instr    instr_zfinx;
     riscv_floating_point_instr  instr_f;
+    riscv_instr_group_t         include_group[] = (is_zfinx)    ? {RV32ZFINX} : 
+                                                  ((XLEN >= 64) ? {RV32F, RV64F} : {RV32F});
 
-    `uvm_info(_header, $sformatf("supported_isa[%p] with num_of_instr_per_stream[%0d]", supported_isa, num_of_instr_per_stream), UVM_DEBUG);
-    for (int i = 0; i < num_of_instr_per_stream; i++) begin
-      if (is_zfinx) begin
-        instr = get_zfinx_instr();
-        `uvm_info(_header, $sformatf("instr[%s] and avail_regs[%p]", instr.instr_name.name(), avail_regs), UVM_DEBUG);
-        `DV_CHECK_FATAL($cast(instr_zfinx, instr), "Cast to instr_zfinx failed!");
-        randomize_gpr_zfinx(instr_zfinx);
-        instr_list.push_back(instr_zfinx);
+    `uvm_info(_header, $sformatf("%s - num_of_instr_per_stream[%0d] - enable_special_operand_patterns[%0b]", 
+      get_name(), num_of_instr_per_stream, enable_special_operand_patterns), UVM_NONE);
+    if (enable_special_operand_patterns) begin
+      foreach (operand_a[i]) begin
+        `uvm_info(_header, $sformatf(" imm20 for specific operand patterns \
+          \n>> instr[%0d] operand_a is %0d [%s]\
+          \n>> instr[%0d] operand_b is %0d [%s]\
+          \n>> instr[%0d] operand_c is %0d [%s]\
+          \n>>", 
+          i, operand_a[i][31:12], operand_a_pattern[i],
+          i, operand_b[i][31:12], operand_b_pattern[i],
+          i, operand_c[i][31:12], operand_c_pattern[i]), UVM_DEBUG);
       end
-      else begin
-        instr = get_float_instr();
-        `uvm_info(_header, $sformatf("instr[%s] and avail_fp_regs[%p]", instr.instr_name.name(), avail_fp_regs), UVM_DEBUG);
-        `DV_CHECK_FATAL($cast(instr_f, instr), "Cast to instr_f failed!");
-        randomize_fpr(instr_f);
-        instr_list.push_back(instr_f);
-      end 
-    end // num_of_instr_per_stream
+    end
 
+    for (int i = 0; i < num_of_instr_per_stream; i++) begin : GEN_N_MANIPULATE_INSTR
+
+      // gnerate instr per stream
+      update_get_directed_instr_arg_list();
+      instr = new riscv_instr::get_rand_instr(
+        .include_instr(include_instr),
+        .exclude_instr(exclude_instr),
+        .include_group(include_group)
+      );
+      rand_var_for_inline_constraint();
+
+      // differentiate based on extension
+      if (is_zfinx) begin : EXTENSION_ZFINX
+        `DV_CHECK_FATAL($cast(instr_zfinx, instr), "Cast to instr_zfinx failed!");
+        randomize_gpr_zfinx(instr_zfinx, i);
+        if (enable_special_operand_patterns) begin : OVERRIDE_OPERANDS_W_SPECIAL_PATTERNS
+          manipulate_zfinx_instr_operands(instr_zfinx, i);
+        end
+        instr_list.push_back(instr_zfinx);
+        `uvm_info(_header, $sformatf("\n>>>> instr_zfinx[%s] >>>> \
+          \n>> has_rs1 | has_rs2 | has_rs3 | has_rd  | has_imm    -> %0b , %0b , %0b , %0b , %0b \
+          \n>> rs1     | rs2     | rs3     | rd      | imm        -> %s  , %s  , %s  , %s  , 8'h%8h \
+          \n>>>>\n",
+          instr_zfinx.instr_name.name(), 
+          instr_zfinx.has_rs1,    instr_zfinx.has_rs2,    instr_zfinx.has_rs3,    instr_zfinx.has_rd,    instr_zfinx.has_imm,
+          instr_zfinx.rs1.name(), instr_zfinx.rs2.name(), instr_zfinx.rs3.name(), instr_zfinx.rd.name(), instr_zfinx.imm), UVM_DEBUG);
+      end
+      else begin : EXTENSION_F
+        `DV_CHECK_FATAL($cast(instr_f, instr), "Cast to instr_f failed!");
+        randomize_fpr(instr_f, i);
+        if (instr_f.instr_name == FSW) begin: SPECIAL_HANDLING_FOR_FLW
+          wa_prevent_store_on_code_space(instr_f);
+        end
+        if (enable_special_operand_patterns) begin : OVERRIDE_OPERANDS_W_SPECIAL_PATTERNS
+          if (!(instr_f.instr_name inside {FLW, FSW, FMV_X_W, FMV_W_X})) begin
+            manipulate_f_instr_operands(instr_f, i);
+          end
+        end
+        instr_list.push_back(instr_f);
+        `uvm_info(_header, $sformatf("\n>>>> instr_f[%s] >>>> \
+          \n>> has_rs1 | has_rs2 | has_rd  | has_imm    -> %0b , %0b , %0b , %0b \
+          \n>> rs1     | rs2     | rd      | imm        -> %s  , %s  , %s  , 8'h%8h \
+          \n>> has_fs1 | has_fs2 | has_fs3 | has_fd     -> %0b , %0b , %0b , %0b \
+          \n>> fs1     | fs2     | fs3     | fd         -> %s  , %s  , %s  , %s \
+          \n>>>>\n",
+          instr_f.instr_name.name(), 
+          instr_f.has_rs1,    instr_f.has_rs2,    instr_f.has_rd,     instr_f.has_imm,
+          instr_f.rs1.name(), instr_f.rs2.name(), instr_f.rd.name(),  instr_f.imm,
+          instr_f.has_fs1,    instr_f.has_fs2,    instr_f.has_fs3,    instr_f.has_fd,
+          instr_f.fs1.name(), instr_f.fs2.name(), instr_f.fs3.name(), instr_f.fd.name()), UVM_DEBUG);
+      end 
+
+    end // GEN_N_MANIPULATE_INSTR
     super.post_randomize();
-  endfunction // post_randomize
+  endfunction: post_randomize
+
+  // to update the arguments that use in get_rand_instr 
+  // note: include_group is not allow to be used here, it is fixed in the base class
+  virtual function void update_get_directed_instr_arg_list();
+    include_instr.delete();
+    exclude_instr.delete();
+    // fixme: for testing, TBD
+    // include_instr = new[1];
+    // include_instr[0] = FMADD_S;
+    // include_instr[1] = FLW;
+    // include_instr = {FSW, FLW};
+    // include_instr = {FMADD_S, FMSUB_S};
+  endfunction: update_get_directed_instr_arg_list
 
   // randomize registers to be used in this instr
-  function void randomize_gpr_zfinx(riscv_fp_in_x_regs_instr instr);
+  function void randomize_gpr_zfinx(riscv_fp_in_x_regs_instr instr, int idx=0);
+    instr.set_rand_mode();
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
-      if (local::avail_regs.size() > 0) {
+      if (local::avail_gp_regs[local::idx].size() > 0) {
         if (has_rs1) {
-          rs1 inside {avail_regs};
+          rs1 inside {avail_gp_regs[local::idx]};
         }
         if (has_rs2) {
-          rs2 inside {avail_regs};
+          rs2 inside {avail_gp_regs[local::idx]};
         }
         if (has_rs3) {
-          rs3 inside {avail_regs};
+          rs3 inside {avail_gp_regs[local::idx]};
         }
         if (has_rd) {
-          rd  inside {avail_regs};
+          rd  inside {avail_gp_regs[local::idx]};
         }
       }
       foreach (reserved_rd[i]) {
@@ -126,45 +382,216 @@ class cv32e40p_float_zfinx_base_instr_stream extends cv32e40p_base_instr_stream;
           rs1 != cfg.reserved_regs[i];
         }
       }
+      rm == local::rm;
+      use_rounding_mode_from_instr == local::use_rounding_mode_from_instr;
     )
-  endfunction // randomize_gpr_zfinx
+  endfunction: randomize_gpr_zfinx
 
-  function void randomize_fpr(riscv_floating_point_instr instr);
+  function void randomize_fpr(riscv_floating_point_instr instr, int idx=0);
+    instr.set_rand_mode();
     `DV_CHECK_RANDOMIZE_WITH_FATAL(instr,
-        if (local::avail_fp_regs.size() >0) {
+        if (local::avail_fp_regs[local::idx].size() >0 ) {
           if (has_fs1) {
-            fs1 inside {avail_fp_regs};
+            fs1 inside {avail_fp_regs[local::idx]};
           }
           if (has_fs2) {
-            fs2 inside {avail_fp_regs};
+            fs2 inside {avail_fp_regs[local::idx]};
           }
           if (has_fs3) {
-            fs3 inside {avail_fp_regs};
+            fs3 inside {avail_fp_regs[local::idx]};
           }
           if (has_fd) {
-            fd inside {avail_fp_regs};
+            fd inside {avail_fp_regs[local::idx]};
           }
         }
+        if (local::avail_gp_regs[local::idx].size() > 0) {
+          if (has_rs1) {
+            rs1 inside {avail_gp_regs[local::idx]};
+            !(rs1 inside {reserved_rd, cfg.reserved_regs, ZERO});
+          }
+          if (has_rs2) {
+            rs2 inside {avail_gp_regs[local::idx]};
+          }
+          if (has_rd) {
+            rd  inside {avail_gp_regs[local::idx]};
+            !(rd inside {reserved_rd, cfg.reserved_regs, ZERO});
+          }
+        }
+        if (instr_name inside {FLW, FSW}) {
+          imm == local::imm;
+        }
+        rm == local::rm;
+        use_rounding_mode_from_instr == local::use_rounding_mode_from_instr;
     )
-  endfunction // randomize_fpr
+  endfunction: randomize_fpr
 
-  virtual function riscv_instr get_zfinx_instr();
-      return riscv_instr::get_rand_instr(
-        .include_group({RV32ZFINX})
-      );
-  endfunction // get_zfinx_instr
+  function void rand_var_for_inline_constraint();
+    // use different <var> for every instr under same stream
+    void'(std::randomize(imm));
+    void'(std::randomize(rm));
+    void'(std::randomize(use_rounding_mode_from_instr));
+  endfunction: rand_var_for_inline_constraint
 
-  virtual function riscv_instr get_float_instr();
-    if (XLEN >= 64) begin
-      return riscv_instr::get_rand_instr(
-        .include_group({RV32F, RV64F})
-      );
-    end else begin
-      return riscv_instr::get_rand_instr(
-        .include_group({RV32F})
-      );
+  function void override_instr(
+    riscv_instr                instr=null,
+    riscv_floating_point_instr f_instr=null,
+    riscv_fpr_t fs1=FT0,  riscv_fpr_t fs2=FT0,  riscv_fpr_t fs3=FT0,  riscv_fpr_t fd=FT0,
+    riscv_reg_t rs1=ZERO, riscv_reg_t rs2=ZERO, riscv_reg_t rd=ZERO,  bit[31:0] imm=0);
+
+    // user to expend the list when necessary
+    if (instr != null) begin
+    unique case(instr.instr_name)
+      LUI : begin // LUI rd imm20
+              `DV_CHECK_RANDOMIZE_WITH_FATAL(instr, 
+                rd == local::rd; imm == local::imm;
+              )
+            end
+      SW :  begin // SW rs2 imm12(rs1)
+              `DV_CHECK_RANDOMIZE_WITH_FATAL(instr, 
+                rs2 == local::rs2; rs1 == local::rs1; imm == local::imm;
+              )
+            end
+      LW :  begin // LW rd imm12(rs1)
+              `DV_CHECK_RANDOMIZE_WITH_FATAL(instr, 
+                rd == local::rd; rs1 == local::rs1; imm == local::imm;
+              )
+            end
+    endcase
     end
-  endfunction // get_float_instr
+    // user to expend the list when needed
+    if (f_instr != null) begin
+    unique case(f_instr.instr_name)
+      FLW:  begin // FLW rd, imm12(rs1)
+              `DV_CHECK_RANDOMIZE_WITH_FATAL(f_instr, 
+                fd == local::fd; rs1 == local::rs1; imm == local::imm;
+              )
+            end
+    endcase
+    end
 
-endclass // cv32e40p_float_zfinx_base_instr_stream
+  endfunction: override_instr
 
+
+  function void manipulate_zfinx_instr_operands(riscv_fp_in_x_regs_instr instr, int idx=0);
+
+    bit [31:0]        m_operand_a, m_operand_b, m_operand_c;
+    operand_pattens_t m_operand_a_pattern, m_operand_b_pattern, m_operand_c_pattern;
+    riscv_reg_t       mem_rd, imm_rd;
+
+    void'(std::randomize(mem_rd) with {!(mem_rd inside {cfg.reserved_regs, reserved_rd, instr.rs1, instr.rs2, instr.rs3, instr.rd});          });
+    void'(std::randomize(imm_rd) with {!(imm_rd inside {cfg.reserved_regs, reserved_rd, instr.rs1, instr.rs2, instr.rs3, instr.rd, mem_rd});  });
+
+    if (
+      instr.has_rs1 && operand_a_pattern[idx] != IS_RAND ||
+      instr.has_rs2 && operand_b_pattern[idx] != IS_RAND ||
+      instr.has_rs3 && operand_c_pattern[idx] != IS_RAND
+    ) begin : DEFINE_MEM_ADDR
+      riscv_instr m_instr;
+      m_instr = new riscv_instr::get_rand_instr(.include_instr({LUI}));
+      override_instr(
+        .instr  (m_instr),
+        .rd     (mem_rd),
+        .imm    ({12'h0, 8'b1100_0000, 12'h0}) // use higher memory as mailbox
+      );
+      instr_list.push_back(m_instr);
+      instr_list[$].comment = {instr_list[$].comment, $sformatf(" [manipulate_zfinx_instr_operands][mem_addr] ")};
+    end // DEFINE_MEM_ADDR
+
+    m_operand_a = operand_a[idx]; m_operand_a_pattern = operand_a_pattern[idx];
+    m_operand_b = operand_b[idx]; m_operand_b_pattern = operand_b_pattern[idx];
+    m_operand_c = operand_c[idx]; m_operand_c_pattern = operand_c_pattern[idx];
+    `MANIPULATE_ZFINX_INSTR_OPERANDS(rs1,m_operand_a)
+    `MANIPULATE_ZFINX_INSTR_OPERANDS(rs2,m_operand_b)
+    `MANIPULATE_ZFINX_INSTR_OPERANDS(rs3,m_operand_c)
+    
+  endfunction: manipulate_zfinx_instr_operands
+ 
+
+  function void manipulate_f_instr_operands(riscv_floating_point_instr instr, int idx=0);
+
+    bit [31:0]        m_operand_a, m_operand_b, m_operand_c;
+    operand_pattens_t m_operand_a_pattern, m_operand_b_pattern, m_operand_c_pattern;
+    riscv_reg_t       mem_rd = A2;
+    riscv_reg_t       imm_rd = A3;
+    
+    if (idx == 0 && (
+      instr.has_fs1 && operand_a_pattern[idx] != IS_RAND ||
+      instr.has_fs2 && operand_b_pattern[idx] != IS_RAND ||
+      instr.has_fs3 && operand_c_pattern[idx] != IS_RAND
+    )) begin : DEFINE_MEM_ADDR
+      riscv_instr m_instr;
+      m_instr = new riscv_instr::get_rand_instr(.include_instr({LUI}));
+      override_instr(
+        .instr  (m_instr),
+        .rd     (mem_rd),
+        .imm    ({12'h0, 8'b1100_0000, 12'h0}) // use higher memory as mailbox
+      );
+      instr_list.push_back(m_instr);
+      instr_list[$].comment = {instr_list[$].comment, $sformatf(" [manipulate_f_instr_operands][mem_addr] ")};
+    end // DEFINE_MEM_ADDR
+
+    m_operand_a = operand_a[idx]; m_operand_a_pattern = operand_a_pattern[idx];
+    m_operand_b = operand_b[idx]; m_operand_b_pattern = operand_b_pattern[idx];
+    m_operand_c = operand_c[idx]; m_operand_c_pattern = operand_c_pattern[idx];
+    `MANIPULATE_F_INSTR_OPERANDS(fs1,m_operand_a)
+    `MANIPULATE_F_INSTR_OPERANDS(fs2,m_operand_b)
+    `MANIPULATE_F_INSTR_OPERANDS(fs3,m_operand_c)
+    
+  endfunction: manipulate_f_instr_operands
+
+
+  // workaround to prevent FSW from overriding onto the code space
+  function void wa_prevent_store_on_code_space(riscv_floating_point_instr instr, int idx=0);
+
+    bit [7:0] wa_rand_imm = $urandom_range(1,255);
+    riscv_instr wa_instr;
+    wa_instr = new riscv_instr::get_rand_instr(.include_instr({LUI}));
+    override_instr(
+      .instr  (wa_instr),
+      .rd     (instr.rs1),
+      .imm    ({12'h0, wa_rand_imm, 12'h0}) // yyy_ww_xxx
+    );
+    instr_list.push_back(wa_instr);
+    instr_list[$].comment = {instr_list[$].comment, $sformatf(" [wa_prevent_store_on_code_space] ")};
+
+  endfunction: wa_prevent_store_on_code_space
+
+endclass: cv32e40p_float_zfinx_base_instr_stream
+
+
+  // extended class that use to override instr operands with specific patterns
+class cv32e40p_fp_w_special_operands_instr_stream extends cv32e40p_float_zfinx_base_instr_stream;
+
+  `uvm_object_utils(cv32e40p_fp_w_special_operands_instr_stream)
+
+  constraint ovr_c_others {
+    num_of_instr_per_stream == 10; // fixed to 10
+    // num_of_instr_per_stream inside {[5:10]};
+    solve num_of_instr_per_stream before enable_special_operand_patterns;
+  }
+
+  constraint ovr_c_enable_special_operand_patterns {
+    enable_special_operand_patterns == 1;
+  }
+
+  function new (string name="");
+    super.new(name);
+  endfunction: new
+
+  function void post_randomize();
+    super.post_randomize();
+  endfunction: post_randomize
+
+  virtual function void update_get_directed_instr_arg_list();
+    // fixme: for testing, TBD
+    // include_instr = new[1];
+    // include_instr[0] = FMSUB_S;
+
+    // following list is created by referring to the testplan CV32E40P_F-Zfinx-instructions.xls
+    exclude_instr = new[15];
+    exclude_instr = {FLW, FSW, FADD_S, FSUB_S, FMIN_S, FMAX_S, FSGNJ_S, FSGNJN_S, FSGNJX_S, FMV_X_W, FMV_W_X, FEQ_S, FLT_S, FLE_S, FCLASS_S};
+  endfunction: update_get_directed_instr_arg_list
+
+endclass: cv32e40p_fp_w_special_operands_instr_stream
+
+// ALL FP STREAM CLASSESS - end

--- a/cv32e40p/tests/programs/corev-dv/corev_sanity_fp_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_sanity_fp_instr_test/corev-dv.yaml
@@ -9,11 +9,20 @@ compile_flags: >
 plusargs: >
     +instr_cnt=1000
     +num_of_sub_program=0
-    +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,100
-    +enable_floating_point=1;
-
+    +enable_floating_point=1
+    +test_override_riscv_instr_stream=1
+    +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,10
+    +directed_instr_1=cv32e40p_fp_w_special_operands_instr_stream,5
 
 # note:
-  # 1) example test for fp instruction with extended 'f'
+  # 1) example yaml template for fp test with f_extension
   # 2) above setting running 100 streams with [single/multiple b2b] fp instr; insert 100 streams per 1000 instr_cnt
   # 3) runcmd: make gen_corev-dv test TEST=corev_sanity_fp_instr_test USE_ISS=no CFG=pulp_fpu CFG_PLUSARGS="+UVM_VERBOSITY=UVM_DEBUG"
+  # 4) [Must have plusarg]  enable_floating_point for extension f
+  # 5) [Must have plusarg]  test_override_riscv_instr_stream=1
+  #   - <value>==1: is to tune the streams not to overlap with other streams during streams placement
+  # 6) [recomendation_1] for single directed_instr_<num==0>, try not to use apply too many streams else it might lead to placement issue
+  #   - e.g +directed_instr_0=cv32e40p_fp_w_special_operands_instr_stream,10
+  # 7) [recomendation_2] for single directed_instr_<num==0 and 1 and 2>, try limit the streams espcially for ext stream from base
+  #   - e.g +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,10
+  #   - e.g +directed_instr_1=cv32e40p_fp_w_special_operands_instr_stream,5

--- a/cv32e40p/tests/programs/corev-dv/corev_sanity_fp_zfinx_instr_test/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_sanity_fp_zfinx_instr_test/corev-dv.yaml
@@ -10,11 +10,20 @@ compile_flags: >
 plusargs: >
     +instr_cnt=1000
     +num_of_sub_program=0
-    +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,100
-    +enable_fp_in_x_regs=1
-
+    +enable_fp_in_x_regs=1=1
+    +test_override_riscv_instr_stream=1
+    +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,10
+    +directed_instr_1=cv32e40p_fp_w_special_operands_instr_stream,5
 
 # note:
-  # 1) example test for fp instruction with extended 'zfinx'
+  # 1) example yaml template for fp test with zfinx_extension
   # 2) above setting running 100 streams with [single/multiple b2b] fp instr; insert 100 streams per 1000 instr_cnt
   # 3) runcmd: make gen_corev-dv test TEST=corev_sanity_fp_zfinx_instr_test USE_ISS=no CFG=pulp_fpu_zfinx CFG_PLUSARGS="+UVM_VERBOSITY=UVM_DEBUG"
+  # 4) [Must have plusarg]  enable_floating_point for extension f
+  # 5) [Must have plusarg]  test_override_riscv_instr_stream=1
+  #   - <value>==1: is to tune the streams not to overlap with other streams during streams placement
+  # 6) [recomendation_1] for single directed_instr_<num==0>, try not to use apply too many streams else it might lead to placement issue
+  #   - e.g +directed_instr_0=cv32e40p_fp_w_special_operands_instr_stream,10
+  # 7) [recomendation_2] for single directed_instr_<num==0 and 1 and 2>, try limit the streams espcially for ext stream from base
+  #   - e.g +directed_instr_0=cv32e40p_float_zfinx_base_instr_stream,10
+  #   - e.g +directed_instr_1=cv32e40p_fp_w_special_operands_instr_stream,5


### PR DESCRIPTION
Updated fp stream tests based on the requirements from verif plan CV32E40P_F-Zfinx-instructions.xlsx
This is stage1 check-in and the development is still on-going. The updates are:-
1) Updated fp base stream to accommodate more specific test scenario
2) Updated test yaml to include more information on how to exercise f/zfinx tests
3) Added new simulation plusargs to prevent overlap of directed streams during instruction placement

note: prerequisite for this PR is PR#1922 (label: cv32e40p)