### PR TITLE
Add two arguments in cva6.py to controlle systemverilog seed

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -171,7 +171,7 @@ ALL_UVM_FLAGS           = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt \
 	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon))
 
-ALL_SIMV_UVM_FLAGS      = -licwait 20 +ntb_random_seed=1 \
+ALL_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) \
 		-sv_lib $(CORE_V_VERIF)/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
 		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
 


### PR DESCRIPTION
The first argument --gen_sv_seed run a test X times with a random seed and generates X logs. (0<X)

The second argument --sv_seed executes a test with a specific seed.

We cannot use both options at the same time.
