### PR TITLE
PMA Coverage - Fix Missing Declaration

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
@@ -23,24 +23,26 @@
 module  uvmt_cv32e40s_pma_cov
   import uvmt_cv32e40s_base_test_pkg::*;
 #(
+  parameter bit  IS_INSTR_SIDE,
   parameter int  PMA_NUM_REGIONS,
-  parameter bit  IS_INSTR_SIDE
+  parameter type CORE_REQ_TYPE
 )(
   input wire  clk,
   input wire  clk_ungated,
   input wire  rst_n,
 
   // MPU Signals
-  input wire  core_trans_ready_o,
-  input wire  core_trans_valid_i,
-  input wire  misaligned_access_i,
-  input wire  load_access,
-  input wire  core_trans_pushpop_i,
+  input CORE_REQ_TYPE  core_trans_i,
+  input wire           core_trans_pushpop_i,
+  input wire           core_trans_ready_o,
+  input wire           core_trans_valid_i,
+  input wire           load_access,
+  input wire           misaligned_access_i,
 
   // Helper Logic
   input wire pma_status_t  pma_status_i,
-  input wire pma_status_t  pma_status_rvfidata_word0lowbyte_i,
   input wire pma_status_t  pma_status_rvfidata_word0highbyte_i,
+  input wire pma_status_t  pma_status_rvfidata_word0lowbyte_i,
   uvma_rvfi_instr_if_t     rvfi_if
 );
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1540,8 +1540,9 @@ module uvmt_cv32e40s_tb;
 
     bind  dut_wrap.cv32e40s_wrapper_i.core_i.if_stage_i.mpu_i
       uvmt_cv32e40s_pma_cov #(
-        .PMA_NUM_REGIONS (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .IS_INSTR_SIDE   (1'b 1)
+        .CORE_REQ_TYPE   (cv32e40s_pkg::obi_inst_req_t),
+        .IS_INSTR_SIDE   (1'b 1),
+        .PMA_NUM_REGIONS (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS)
       ) pma_cov_instr_i (
         .clk_ungated                         (clknrst_if.clk),
         .pma_status_i                        (uvmt_cv32e40s_tb.pma_status_instr),
@@ -1553,8 +1554,9 @@ module uvmt_cv32e40s_tb;
 
     bind  dut_wrap.cv32e40s_wrapper_i.core_i.load_store_unit_i.mpu_i
       uvmt_cv32e40s_pma_cov #(
-        .PMA_NUM_REGIONS (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-        .IS_INSTR_SIDE   (1'b 0)
+        .CORE_REQ_TYPE   (cv32e40s_pkg::obi_data_req_t),
+        .IS_INSTR_SIDE   (1'b 0),
+        .PMA_NUM_REGIONS (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS)
       ) pma_cov_data_i (
         .clk_ungated                         (clknrst_if.clk),
         .pma_status_i                        (uvmt_cv32e40s_tb.pma_status_data),


### PR DESCRIPTION
This PR adds a missing signal declaration that gave warnings.

Test status:
* Formal - Still works.
* Hello world - Passes.