### PR TITLE
Set Spike execution limit to 2M steps across all verification runs.

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -38,6 +38,10 @@ issrun_opts     ?=
 isspostrun_opts ?=
 log             ?=
 variant         ?=
+# Set Spike step count limit if the caller provided a step count value in variable 'steps'.
+ifneq ($(steps),)
+  spike_stepout = --steps=$(steps)
+endif
 
 # TRACE_FAST, TRACE_COMPACT and VERDI are mutually exclusive and imply non-empty DEBUG.
 ifneq ($(TRACE_FAST),)
@@ -101,7 +105,7 @@ endif
 # Spike specific commands, variables
 ###############################################################################
 spike:
-	$(tool_path)/spike --log-commits --isa=$(variant) -l $(elf)
+	$(tool_path)/spike $(spike_stepout) --log-commits --isa=$(variant) -l $(elf)
 	cp $(log).iss $(log)
 
 ###############################################################################

--- a/cva6/sim/cva6.yaml
+++ b/cva6/sim/cva6.yaml
@@ -14,8 +14,11 @@
   path_var: RTL_PATH
   tool_path: SPIKE_PATH
   tb_path: TB_PATH
+  # Set a limit of 2M steps for Spike to match the RVFI 2M cycles RTL timeout.
+  # Always keep this value in sync with the settings of RTL simulators (cf.
+  # <issrun_opts> values below).
   cmd: >
-    make spike variant=<variant> elf=<elf> tool_path=<tool_path> log=<log>
+    make spike steps=2000000 variant=<variant> elf=<elf> tool_path=<tool_path> log=<log>
 
 ###############################################################################
 # Verilator


### PR DESCRIPTION
In order to prevent runaway executions of Spike, this PR sets an execution limit of 2 million cycles on all Spike executions triggered by the CVA6 DV scripts.  The mechanism used is the new Spike cmdline option introduced in PR #1949.

Sullary of file changes:

* cva/sim/Makefile (spike_stepout): Set up Spike stepout option if caller supplied a step count limit.
  (spike): Invoke Spike with a 'stepout' limit option (possibly empty).
* cva6/sim/cva6.yaml (iss: spike): Set step limit of Spike runs to 2M.  Add explanatory comments.