### PR TITLE
Formal warning fixes/directed test fixes

### DIFF
--- a/cv32e40s/env/uvme/cov/uvme_debug_covg.sv
+++ b/cv32e40s/env/uvme/cov/uvme_debug_covg.sv
@@ -294,19 +294,20 @@ class uvme_debug_covg extends uvm_component;
     covergroup cg_debug_regs_d_mode;
         `per_instance_fcov
         mode : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
-            bins M = {1};
+            bins M         = {1};
         }
         access : coverpoint (cntxt.debug_cov_vif.mon_cb.csr_access && cntxt.debug_cov_vif.mon_cb.wb_valid) {
-            bins hit = {1};
+            bins hit       = {1};
         }
         op : coverpoint cntxt.debug_cov_vif.mon_cb.csr_op {
-            bins read = {'h0};
-            bins write = {'h1};
-            // TODO:ropeders also SET and CLEAR?
+            bins read      = {cv32e40s_pkg::CSR_OP_READ};
+            bins write     = {cv32e40s_pkg::CSR_OP_WRITE};
+            bins set       = {cv32e40s_pkg::CSR_OP_SET};
+            bins clear     = {cv32e40s_pkg::CSR_OP_CLEAR};
         }
         addr : coverpoint cntxt.debug_cov_vif.mon_cb.wb_stage_instr_rdata_i[31:20] { // csr addr not updated if illegal access
-            bins dcsr = {'h7B0};
-            bins dpc = {'h7B1};
+            bins dcsr      = {'h7B0};
+            bins dpc       = {'h7B1};
             bins dscratch0 = {'h7B2};
             bins dscratch1 = {'h7B3};
         }
@@ -317,19 +318,20 @@ class uvme_debug_covg extends uvm_component;
     covergroup cg_debug_regs_m_mode;
         `per_instance_fcov
         mode : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q {
-            bins M = {0};
+            bins M         = {0};
         }
         access : coverpoint (cntxt.debug_cov_vif.mon_cb.csr_access && cntxt.debug_cov_vif.mon_cb.wb_valid) {
-            bins hit = {1};
+            bins hit       = {1};
         }
         op : coverpoint cntxt.debug_cov_vif.mon_cb.csr_op {
-            bins read = {1'h0};
-            bins write = {1'h1};
-            // TODO:ropeders also SET and CLEAR?
+            bins read      = {cv32e40s_pkg::CSR_OP_READ};
+            bins write     = {cv32e40s_pkg::CSR_OP_WRITE};
+            bins set       = {cv32e40s_pkg::CSR_OP_SET};
+            bins clear     = {cv32e40s_pkg::CSR_OP_CLEAR};
         }
         addr : coverpoint cntxt.debug_cov_vif.mon_cb.wb_stage_instr_rdata_i[31:20] { // csr addr not updated if illegal access
-            bins dcsr = {'h7B0};
-            bins dpc = {'h7B1};
+            bins dcsr      = {'h7B0};
+            bins dpc       = {'h7B1};
             bins dscratch0 = {'h7B2};
             bins dscratch1 = {'h7B3};
         }
@@ -342,17 +344,18 @@ class uvme_debug_covg extends uvm_component;
         `per_instance_fcov
         mode : coverpoint cntxt.debug_cov_vif.mon_cb.debug_mode_q; // Only M and D supported
         access : coverpoint (cntxt.debug_cov_vif.mon_cb.csr_access && cntxt.debug_cov_vif.mon_cb.wb_valid) {
-            bins hit = {1};
+            bins hit    = {1};
         }
         op : coverpoint cntxt.debug_cov_vif.mon_cb.csr_op {
-            bins read = {'h0};
-            bins write = {'h1};
+            bins read   = {cv32e40s_pkg::CSR_OP_READ};
+            bins write  = {cv32e40s_pkg::CSR_OP_WRITE};
+            bins set    = {cv32e40s_pkg::CSR_OP_SET};
+            bins clear  = {cv32e40s_pkg::CSR_OP_CLEAR};
         }
         addr : coverpoint cntxt.debug_cov_vif.mon_cb.wb_stage_instr_rdata_i[31:20] { // csr addr not updated if illegal access
-            bins tsel = {'h7A0};
+            bins tsel   = {'h7A0};
             bins tdata1 = {'h7A1};
             bins tdata2 = {'h7A2};
-            bins tdata3 = {'h7A3};
             bins tinfo  = {'h7A4};
         }
         tregs_access : cross mode, access, op, addr;

--- a/cv32e40s/env/uvme/uvma_cv32e40s_core_cntrl_agent.sv
+++ b/cv32e40s/env/uvme/uvma_cv32e40s_core_cntrl_agent.sv
@@ -223,7 +223,11 @@ function void uvma_cv32e40s_core_cntrl_agent_c::configure_iss();
    case(cfg.debug_spec_version)
      DEBUG_VERSION_0_13_2: $fwrite(fh, $sformatf("--override %s/debug_version=0.13.2-DRAFT\n", refpath));
      DEBUG_VERSION_0_14_0: $fwrite(fh, $sformatf("--override %s/debug_version=0.14.0-DRAFT\n", refpath));
-     DEBUG_VERSION_1_0_0: $fwrite(fh, $sformatf("--override %s/debug_version=1.0.0-STABLE\n", refpath));
+     DEBUG_VERSION_1_0_0: begin
+       $fwrite(fh, $sformatf("--override %s/debug_version=1.0.0-STABLE\n", refpath));
+       // TODO silabs-hfegran: Update this if/when ISS changes the default setting
+       $fwrite(fh, $sformatf("--override %s/no_hit=F\n",refpath));
+     end
    endcase
 
    case(cfg.priv_spec_version)

--- a/cv32e40s/env/uvme/uvme_cv32e40s_core_cntrl_if.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_core_cntrl_if.sv
@@ -19,7 +19,11 @@ interface uvme_cv32e40s_core_cntrl_if_t
     logic [3:0]  mimpid_patch;
 
     logic [31:0] num_mhpmcounters;
+    `ifndef FORMAL
     pma_cfg_t pma_cfg[];
+    `else
+    pma_cfg_t pma_cfg[16];
+    `endif
     cv32e40s_pkg::b_ext_e b_ext;
 
     // Testcase asserts this to load memory (not really a core control signal)

--- a/cv32e40s/fv/dummy_pkg.sv
+++ b/cv32e40s/fv/dummy_pkg.sv
@@ -21,19 +21,6 @@
 
 // Defines
 
-`define RVFI_CSR_BIND(csr_name)                             \
-  bind cv32e40s_wrapper                                     \
-    uvma_rvfi_csr_if_t #(                                   \
-      uvmt_cv32e40s_base_test_pkg::XLEN                     \
-    ) rvfi_csr_``csr_name``_if (                            \
-      .clk(clk_i),                                          \
-      .reset_n(rst_ni),                                     \
-      .rvfi_csr_rmask(rvfi_i.rvfi_csr_``csr_name``_rmask),  \
-      .rvfi_csr_wmask(rvfi_i.rvfi_csr_``csr_name``_wmask),  \
-      .rvfi_csr_rdata(rvfi_i.rvfi_csr_``csr_name``_rdata),  \
-      .rvfi_csr_wdata(rvfi_i.rvfi_csr_``csr_name``_wdata)   \
-    );
-
 `define  RVFI_CSR_IDX_BIND(csr_name,csr_suffix,idx)
 `define  RVFI_CSR_UVM_CONFIG_DB_SET(csr_name)
 
@@ -64,7 +51,7 @@ endpackage
 
 // Interfaces
 
-interface uvma_clknrst_if_t ();
+interface uvma_clknrst_if_t;
   logic  clk;
   logic  reset_n;
 endinterface : uvma_clknrst_if_t

--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_sl_req_attribute_fifo.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_sl_req_attribute_fifo.sv
@@ -80,16 +80,16 @@ module uvmt_cv32e40s_sl_req_attribute_fifo
   always @(posedge clk_i, negedge rst_ni) begin
     if(!rst_ni) begin
       fifo <= 3'b000;
-      pointer = 2;
+      pointer = 2'd2;
     end else begin
       //This logic is demonstrated in time t1, t2 and t3 in the figure above
       if ((gnt && req) && !rvalid) begin
         fifo[pointer] = req_attribute_i;
-        pointer <= pointer - 1;
+        pointer <= pointer - 2'd1;
 
       //This logic is demonstrated in time t4, t5 and t6 in the figure above
       end else if (!(gnt && req) && rvalid) begin
-        pointer <= pointer + 1;
+        pointer <= pointer + 2'd1;
         fifo <= {fifo[1:0], '0};
 
       //This logic is demonstrated in time t8 and t9 in the figure above (and uses t7 to generate a situation where this part of the logic can be used)

--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
@@ -195,8 +195,8 @@ module uvmt_cv32e40s_support_logic
       tdata2_array = '0;
 
     end else if (in_support_if.wb_valid) begin
-      tdata1_array[in_support_if.wb_tselect] = in_support_if.wb_tdata1;
-      tdata2_array[in_support_if.wb_tselect] = in_support_if.wb_tdata2;
+      tdata1_array[in_support_if.wb_tselect[$clog2(MAX_NUM_TRIGGERS)-1:0]] = in_support_if.wb_tdata1;
+      tdata2_array[in_support_if.wb_tselect[$clog2(MAX_NUM_TRIGGERS)-1:0]] = in_support_if.wb_tdata2;
     end
   end
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
@@ -1068,10 +1068,19 @@ module uvmt_cv32e40s_clic_interrupt_assert
     // Only one irq_ack per irq
     // ------------------------------------------------------------------------
 
+    //property p_only_one_ack_per_irq;
+    //    clic.irq
+    //  |->
+    //    irq_ack[=0:1] within $changed(clic)[->1];
+    //endproperty : p_only_one_ack_per_irq
+
     property p_only_one_ack_per_irq;
         clic.irq
-      |->
-        irq_ack[=0:1] within $changed(clic)[->1];
+        && $changed(clic)
+      |=>
+        irq_ack[=1] within ($changed(clic)[->1])
+      or
+        !irq_ack until ($changed(clic)[->1]);
     endproperty : p_only_one_ack_per_irq
 
     a_only_one_ack_per_irq: assert property (p_only_one_ack_per_irq)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
@@ -1068,12 +1068,6 @@ module uvmt_cv32e40s_clic_interrupt_assert
     // Only one irq_ack per irq
     // ------------------------------------------------------------------------
 
-    //property p_only_one_ack_per_irq;
-    //    clic.irq
-    //  |->
-    //    irq_ack[=0:1] within $changed(clic)[->1];
-    //endproperty : p_only_one_ack_per_irq
-
     property p_only_one_ack_per_irq;
         clic.irq
         && $changed(clic)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -117,7 +117,6 @@ module uvmt_cv32e40s_dut_wrap
     assign obi_instr_if.wuser     = 'b0;
     assign obi_instr_if.aid       = 'b0;
     assign obi_instr_if.wdata     = 'b0;
-    assign obi_instr_if.reqpar    = ~obi_instr_if.req;
     assign obi_instr_if.rready    = 1'b1;
     assign obi_instr_if.rreadypar = 1'b0;
 
@@ -126,7 +125,6 @@ module uvmt_cv32e40s_dut_wrap
     assign obi_data_if.auser      = 'b0;
     assign obi_data_if.wuser      = 'b0;
     assign obi_data_if.aid        = 'b0;
-    assign obi_data_if.reqpar     = ~obi_data_if.req;
     assign obi_data_if.rready     = 1'b1;
     assign obi_data_if.rreadypar  = 1'b0;
 
@@ -134,7 +132,7 @@ module uvmt_cv32e40s_dut_wrap
     // Connect to uvma_interrupt_if
     assign interrupt_if.clk         = clknrst_if.clk;
     assign interrupt_if.reset_n     = clknrst_if.reset_n;
-    assign interrupt_if.irq_id      = cv32e40s_wrapper_i.core_i.irq_id;
+    assign interrupt_if.irq_id      = $bits(interrupt_if.irq_id)'(cv32e40s_wrapper_i.core_i.irq_id); // cast to avoid the warning with clic (TODO: tieoff with clic instead?)
     assign interrupt_if.irq_ack     = cv32e40s_wrapper_i.core_i.irq_ack;
 
     // --------------------------------------------

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
@@ -78,13 +78,15 @@ module  uvmt_cv32e40s_pma_cov
   assign  rvfi_pmamain_lowhigh[0] = pma_status_rvfidata_word0highbyte_i.main;
 
 
-  // Helper Logic - "Past" Values
+  // typedef to parameterize size of helper signals
+  typedef logic [$bits(rvfi_if.rvfi_mem_wmask)-1:0] rvfi_mem_wmask_t;
 
-  var logic  occured_rvfi_valid;
-  var logic  rvfi_pma_fault_q;
-  var logic  rvfi_mem_wmask_q;
-  var logic  rvfi_mem_act_q;
-  var logic  rvfi_pmamain_low_q;
+  // Helper Logic - "Past" Values
+  var logic             occured_rvfi_valid;
+  var logic             rvfi_pma_fault_q;
+  var logic             rvfi_mem_act_q;
+  var logic             rvfi_pmamain_low_q;
+  var rvfi_mem_wmask_t  rvfi_mem_wmask_q;
 
   always_ff @(posedge clk_ungated or negedge rst_n) begin
     if (rst_n == 0) begin
@@ -96,7 +98,7 @@ module  uvmt_cv32e40s_pma_cov
     end else if (rvfi_if.rvfi_valid) begin
       occured_rvfi_valid <= 1;
       rvfi_pma_fault_q   <= rvfi_if.is_pma_fault;
-      rvfi_mem_wmask_q   <= rvfi_if.rvfi_mem_wmask;
+      rvfi_mem_wmask_q   <= rvfi_mem_wmask_t'(rvfi_if.rvfi_mem_wmask);
       rvfi_mem_act_q     <= rvfi_if.is_mem_act;
       rvfi_pmamain_low_q <= rvfi_pmamain_lowhigh[1];
     end

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pma_cov.sv
@@ -129,10 +129,10 @@ module  uvmt_cv32e40s_pma_cov
     }
 
     cp_matchregion: coverpoint  match_idx  iff (is_mpu_activated) {
-      bins  regions[] = {[0:PMA_NUM_REGIONS-1]}
+      bins  regions[] = {[0:(PMA_NUM_REGIONS > 0) ? (PMA_NUM_REGIONS-1) : 0 ]}
         with (!SIMPLIFY_FV)
         iff (have_match == 1);
-      bins  nomatch   = {[0:PMA_NUM_REGIONS-1]}
+      bins  nomatch   = {[0:(PMA_NUM_REGIONS > 0) ? (PMA_NUM_REGIONS-1) : 0]}
         with (!SIMPLIFY_FV)
         iff (have_match == 0);
     }

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmprvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_pmprvfi_assert.sv
@@ -277,9 +277,9 @@ module uvmt_cv32e40s_pmprvfi_assert
   var [31:0]  clk_cnt;
   always @(posedge clk_i, negedge rst_ni) begin
     if (rst_ni == 0) begin
-      clk_cnt <= 64'd 1;
+      clk_cnt <= 32'd 1;
     end else if (clk_cnt != '1) begin
-      clk_cnt <= clk_cnt + 64'd 1;
+      clk_cnt <= clk_cnt + 32'd 1;
     end
   end
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_rvfi_assert.sv
@@ -129,7 +129,8 @@ module uvmt_cv32e40s_rvfi_assert
   // RVFI exception cause matches "mcause"
 
   wire logic [10:0]  rvfi_mcause_exccode;
-  assign rvfi_mcause_exccode = (rvfi_csr_mcause_wdata & rvfi_csr_mcause_wmask);
+  // Explicit truncation to avoid warning
+  assign rvfi_mcause_exccode = $bits(rvfi_mcause_exccode)'(rvfi_csr_mcause_wdata & rvfi_csr_mcause_wmask);
 
   a_exc_cause: assert property (
     rvfi_valid           &&

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -911,7 +911,7 @@ module uvmt_cv32e40s_tb;
 
 
 
-  if (CORE_PARAM_PMP_NUM_REGIONS > 0) begin
+  if (CORE_PARAM_PMP_NUM_REGIONS > 0) begin: gen_hardened_csrs_pmp_assert
     localparam PMP_ADDR_WIDTH = (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY > 0) ? 33 - uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY : 32;
 
     pmpncfg_t pmpncfg[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
@@ -928,9 +928,6 @@ module uvmt_cv32e40s_tb;
       assign pmp_addr_shadow[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.gen_hardened.shadow_q;
     end
 
-  end
-
-  if (CORE_PARAM_PMP_NUM_REGIONS > 0) begin: gen_hardened_csrs_pmp_assert
 
     bind cv32e40s_wrapper
       uvmt_cv32e40s_xsecure_hardened_csrs_pmp_assert #(
@@ -948,13 +945,13 @@ module uvmt_cv32e40s_tb;
 
         //CSRs:
         .pmp_mseccfg        (core_i.cs_registers_i.csr_pmp.pmp_mseccfg_csr_i.rdata_q),
-        .pmpncfg            (uvmt_cv32e40s_tb.pmpncfg),
-        .pmp_addr           (uvmt_cv32e40s_tb.pmp_addr),
+        .pmpncfg            (uvmt_cv32e40s_tb.gen_hardened_csrs_pmp_assert.pmpncfg),
+        .pmp_addr           (uvmt_cv32e40s_tb.gen_hardened_csrs_pmp_assert.pmp_addr),
 
         //Shadows:
         .pmp_mseccfg_shadow (core_i.cs_registers_i.csr_pmp.pmp_mseccfg_csr_i.gen_hardened.shadow_q),
-        .pmpncfg_shadow     (uvmt_cv32e40s_tb.pmpncfg_shadow),
-        .pmp_addr_shadow    (uvmt_cv32e40s_tb.pmp_addr_shadow)
+        .pmpncfg_shadow     (uvmt_cv32e40s_tb.gen_hardened_csrs_pmp_assert.pmpncfg_shadow),
+        .pmp_addr_shadow    (uvmt_cv32e40s_tb.gen_hardened_csrs_pmp_assert.pmp_addr_shadow)
       );
 
   end : gen_hardened_csrs_pmp_assert

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -911,21 +911,24 @@ module uvmt_cv32e40s_tb;
 
 
 
-  localparam PMP_ADDR_WIDTH = (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY > 0) ? 33 - uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY : 32;
+  if (CORE_PARAM_PMP_NUM_REGIONS > 0) begin
+    localparam PMP_ADDR_WIDTH = (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY > 0) ? 33 - uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY : 32;
 
-  pmpncfg_t pmpncfg[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
-  logic [PMP_ADDR_WIDTH-1:0] pmp_addr[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+    pmpncfg_t pmpncfg[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+    logic [PMP_ADDR_WIDTH-1:0] pmp_addr[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
 
-  logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
-  logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+    logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+    logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
 
-  generate for (genvar n = 0; n < uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS; n++) begin
-    assign pmpncfg[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.rdata_q;
-    assign pmp_addr[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.rdata_q;
+    for (genvar n = 0; n < uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS; n++) begin
+      assign pmpncfg[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.rdata_q;
+      assign pmp_addr[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.rdata_q;
 
-    assign pmpncfg_shadow[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.gen_hardened.shadow_q;
-    assign pmp_addr_shadow[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.gen_hardened.shadow_q;
-  end endgenerate
+      assign pmpncfg_shadow[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.gen_hardened.shadow_q;
+      assign pmp_addr_shadow[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmp_addr_csr_i.gen_hardened.shadow_q;
+    end
+
+  end
 
   if (CORE_PARAM_PMP_NUM_REGIONS > 0) begin: gen_hardened_csrs_pmp_assert
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -913,11 +913,11 @@ module uvmt_cv32e40s_tb;
 
   localparam PMP_ADDR_WIDTH = (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY > 0) ? 33 - uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY : 32;
 
-  pmpncfg_t pmpncfg[PMP_MAX_REGIONS];
-  logic [PMP_ADDR_WIDTH-1:0] pmp_addr[PMP_MAX_REGIONS];
+  pmpncfg_t pmpncfg[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+  logic [PMP_ADDR_WIDTH-1:0] pmp_addr[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
 
-  logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[PMP_MAX_REGIONS];
-  logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[PMP_MAX_REGIONS];
+  logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
+  logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS];
 
   generate for (genvar n = 0; n < uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS; n++) begin
     assign pmpncfg[n] = dut_wrap.cv32e40s_wrapper_i.core_i.cs_registers_i.csr_pmp.gen_pmp_csr[n].pmp_region.pmpncfg_csr_i.rdata_q;

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -182,7 +182,9 @@ module uvmt_cv32e40s_triggers_assert_cov
   endgenerate
 
   logic m6_hits_written;
-  assign m6_hits_written = (rvfi_if.is_csr_write(ADDR_TDATA1));
+  always_comb begin
+    m6_hits_written = (rvfi_if.is_csr_write(ADDR_TDATA1));
+  end
 
   //logic m6_hits_was_0;
   //always_latch begin
@@ -242,13 +244,15 @@ module uvmt_cv32e40s_triggers_assert_cov
   logic is_csrrci;
   logic [4:0] csri_uimm;
 
-  assign is_csrrw = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRW);
-  assign is_csrrs = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRS);
-  assign is_csrrc = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRC);
-  assign is_csrrwi = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRWI);
-  assign is_csrrsi = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRSI);
-  assign is_csrrci = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRCI);
-  assign csri_uimm = rvfi_if.rvfi_insn[19:15];
+  always_comb begin
+    is_csrrw = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRW);
+    is_csrrs = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRS);
+    is_csrrc = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRC);
+    is_csrrwi = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRWI);
+    is_csrrsi = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRSI);
+    is_csrrci = rvfi_if.match_instr_isb(rvfi_if.INSTR_OPCODE_CSRRCI);
+    csri_uimm = rvfi_if.rvfi_insn[19:15];
+  end
 
 
   /////////// Sequences ///////////

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -215,7 +215,7 @@ module uvmt_cv32e40s_triggers_assert_cov
   logic tdata1_pre_state_m6_hits;
   assign tdata1_pre_state_m6_hits = {tdata1_pre_state[M6_HIT1], tdata1_pre_state[M6_HIT0]};
 
-  logic tdata1_post_state_m6_hits;
+  logic [1:0] tdata1_post_state_m6_hits;
   assign tdata1_post_state_m6_hits = {tdata1_post_state[M6_HIT1], tdata1_post_state[M6_HIT0]};
 
   logic valid_instr_in_mmode;
@@ -1414,8 +1414,7 @@ module uvmt_cv32e40s_triggers_assert_cov
     a_dt_write_tdata2_random_in_dmode_type_2_6_15: assert property (
 
       (seq_csr_write_dmode(ADDR_TDATA2)
-      ##0 rvfi_if.rvfi_rs1_rdata == $random()
-      && (tdata1_pre_state[MSB_TYPE:LSB_TYPE] == 2
+      ##0 (tdata1_pre_state[MSB_TYPE:LSB_TYPE] == 2
       || tdata1_pre_state[MSB_TYPE:LSB_TYPE] == 6
       || tdata1_pre_state[MSB_TYPE:LSB_TYPE] == 15))
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_umode_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_umode_cov.sv
@@ -62,18 +62,18 @@ module  uvmt_cv32e40s_umode_cov
 
   // Helper Definitions
 
-  localparam int  MODE_U = 2'b 00;
-  localparam int  MODE_M = 2'b 11;
+  localparam bit [1:0]  MODE_U = 2'b 00;
+  localparam bit [1:0]  MODE_M = 2'b 11;
+
+  localparam bit [11:0]  CSRADDR_MISA       = 12'h 301;
+  localparam bit [11:0]  CSRADDR_MSCRATCH   = 12'h 340;
+  localparam bit [11:0]  CSRADDR_MSTATUS    = 12'h 300;
+  localparam bit [11:0]  CSRADDR_MEDELEG    = 12'h 302;
+  localparam bit [11:0]  CSRADDR_MIDELEG    = 12'h 303;
+  localparam bit [11:0]  CSRADDR_MCOUNTEREN = 12'h 306;
 
   localparam int  EXC_ACCESFAULT =  1;
   localparam int  EXC_BUSFAULT   = 24;
-
-  localparam int  CSRADDR_MISA       = 12'h 301;
-  localparam int  CSRADDR_MSCRATCH   = 12'h 340;
-  localparam int  CSRADDR_MSTATUS    = 12'h 300;
-  localparam int  CSRADDR_MEDELEG    = 12'h 302;
-  localparam int  CSRADDR_MIDELEG    = 12'h 303;
-  localparam int  CSRADDR_MCOUNTEREN = 12'h 306;
 
   typedef struct packed {
     logic [31:18]  dontcare2;

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_csrs_pmp_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_csrs_pmp_assert.sv
@@ -33,13 +33,13 @@ module uvmt_cv32e40s_xsecure_hardened_csrs_pmp_assert
 
     //CSRs:
     input mseccfg_t pmp_mseccfg,
-    input pmpncfg_t pmpncfg[PMP_MAX_REGIONS],
-    input logic [PMP_ADDR_WIDTH-1:0] pmp_addr[PMP_MAX_REGIONS],
+    input pmpncfg_t pmpncfg[PMP_NUM_REGIONS],
+    input logic [PMP_ADDR_WIDTH-1:0] pmp_addr[PMP_NUM_REGIONS],
 
     //Shadows:
     input logic [$bits(mseccfg_t)-1:0] pmp_mseccfg_shadow,
-    input logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[PMP_MAX_REGIONS],
-    input logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[PMP_MAX_REGIONS]
+    input logic [$bits(pmpncfg_t)-1:0] pmpncfg_shadow[PMP_NUM_REGIONS],
+    input logic [PMP_ADDR_WIDTH-1:0] pmp_addr_shadow[PMP_NUM_REGIONS]
 
   );
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_register_file_ecc_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_register_file_ecc_assert.sv
@@ -146,9 +146,9 @@ module uvmt_cv32e40s_xsecure_register_file_ecc_assert
   We detect bit flip in the GPRs by comparing them with the local memory
   ****************************************/
 
-  logic [31:0][31:0] gpr_mem_shadow = '0;
+  logic [31:0][31:0] gpr_mem_shadow;
 
-  always @(posedge clk_i) begin
+  always @(posedge clk_i or negedge rst_ni) begin
     if(!rst_ni) begin
       gpr_mem_shadow = '0;
     end else if (gpr_we && gpr_waddr != ZERO) begin
@@ -159,7 +159,7 @@ module uvmt_cv32e40s_xsecure_register_file_ecc_assert
   //Verify that support logic work as expected:
 
   a_xsecure_rf_ecc_reset_gpr_mem_shadow: assert property (
-
+    ##0
     $rose(rst_ni)
     |->
     gpr_mem_shadow == '0

--- a/cv32e40s/tests/programs/custom/debug_test_reset/debugger.S
+++ b/cv32e40s/tests/programs/custom/debug_test_reset/debugger.S
@@ -49,13 +49,8 @@ _debugger_trigger_regs_access:
     li t0, 0xff
     csrw 0x7a4, t0 # tinfo
     csrr t0, 0x7a4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
-
-    li t0, 0xff
-    csrw 0x7a3, t0 # tdata3
-    csrr t0, 0x7a3
-    bne t0, x0, _debugger_error
 
     li t0, 0xff
     csrw 0x7a0, t0 # tsel
@@ -158,56 +153,13 @@ _debugger_trigger_regs_access:
     li t1,  1<<2
     bne t0, t1, _debugger_error
 
-    # TDATA3, CSRRSI
-    csrw 0x7A3, x0 # clear before test
-    csrr t1, 0x7A3
-    csrrsi t0, 0x7A3, 0x4 # Set bit 2
-    bne t0, t1, _debugger_error
-    csrr t0, 0x7A3
-    li t1, 0
-    bne t0, t1, _debugger_error
-
-    # TDATA3, CSRRCI
-    csrr t1, 0x7A3
-    csrrci t0, 0x7A3, 0x4 # Clear bit 2
-    bne t0, t1, _debugger_error
-    csrr t0, 0x7A3
-    li t1, 0x0
-    bne t0, t1, _debugger_error
-
-    # TDATA3, CSRRS
-    csrr t1, 0x7A3
-    li t0, 0xa5a5a5a5
-    csrrs t0, 0x7A3, t0
-    bne t0, t1, _debugger_error
-    csrr t0, 0x7A3
-    li t1,  0x0
-    bne t0, t1, _debugger_error
-
-    # TDATA3, CSRRC
-    csrr t1, 0x7A3
-    li t0, 0xFFFFFFFF
-    csrrc t0, 0x7A3, t0
-    bne t0, t1, _debugger_error
-    csrr t0, 0x7A3
-    li t1,  0x0
-    bne t0, t1, _debugger_error
-
-    # TDATA3, CSRRWI
-    csrr t1, 0x7A3
-    csrrwi t0, 0x7A3, 0x4 # Set bit 2
-    bne t0, t1, _debugger_error
-    csrr t0, 0x7A3
-    li t1,  0x0
-    bne t0, t1, _debugger_error
-
     # TINFO, CSRRSI
     csrw 0x7A4, x0 # clear before test
     csrr t1, 0x7A4
     csrrsi t0, 0x7A4, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
 
     # TINFO, CSRRCI
@@ -215,7 +167,7 @@ _debugger_trigger_regs_access:
     csrrci t0, 0x7A4, 0x4 # Clear bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
 
     # TINFO, CSRRS
@@ -224,7 +176,7 @@ _debugger_trigger_regs_access:
     csrrs t0, 0x7A4, t0
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
 
     # TINFO, CSRRC
@@ -233,7 +185,7 @@ _debugger_trigger_regs_access:
     csrrc t0, 0x7A4, t0
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
 
     # TINFO, CSRRWI
@@ -241,7 +193,7 @@ _debugger_trigger_regs_access:
     csrrwi t0, 0x7A4, 0x4 # Set bit 2
     bne t0, t1, _debugger_error
     csrr t0, 0x7A4
-    li t1, 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
+    li t1, 1<<0x18 | 1<<0xF | 1<<6 | 1<<5 | 1<<2 # Supported trigger types
     bne t0, t1, _debugger_error
 
     # TSELECT, CSRRSI

--- a/cv32e40s/tests/programs/custom/misalign/misalign.c
+++ b/cv32e40s/tests/programs/custom/misalign/misalign.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <strings.h>
+#include <string.h>
 
 //#include "../../../core/custom/startup/support.h"
 #include "./support.h"
@@ -85,15 +85,15 @@ int main () {
         printf("\n");
         printf("Load Index=%d off=%d\n", i, i%4);
 
-        bzero(cpa, 32);
+        memset((void *)(cpa-i), 0, 32);
         *spa = *(u16 *)(pLoad + i);
         printf("  (u16 *) =             %04X\n", *spa);
 
-        bzero(cpa, 32);
+        memset((void *)(cpa-i), 0, 32);
         *ipa = *(u32 *)(pLoad + i);
         printf("  (u32 *) =         %08X\n",     *ipa);
 
-        bzero(cpa, 32);
+        memset((void *)(cpa-i), 0, 32);
         *lpa = *(u64 *)(pLoad + i);
         u64_32.u64v = *lpa;
         printf("  (u64 *) = %08X%08X\n",         u64_32.u32v[1], u64_32.u32v[0]);

--- a/cv32e40s/tests/programs/custom/requested_csr_por/requested_csr_por.c
+++ b/cv32e40s/tests/programs/custom/requested_csr_por/requested_csr_por.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   uint32_t mstatus_rval, misa_rval, mie_rval, mtvec_rval;
   uint32_t mcounteren_rval, mcountinhibit_rval, mphmevent_rval[32];
   uint32_t mscratch_rval, mepc_rval, mcause_rval, mtval_rval, mip_rval;
-  uint32_t tselect_rval, tdata1_rval, tdata2_rval, tdata3_rval, tinfo_rval;
+  uint32_t tselect_rval, tdata1_rval, tdata2_rval, tinfo_rval;
   uint32_t mcycle_rval, minstret_rval, mhpmcounter_rval[32], mcycleh_rval;
   uint32_t minstreth_rval, mhpmcounterh[32];
   uint32_t mvendorid_rval, marchid_rval, mimpid_rval, mhartid_rval;
@@ -115,7 +115,6 @@ int main(int argc, char *argv[])
   __asm__ volatile("csrr %0, 0x7A0" : "=r"(tselect_rval));
   __asm__ volatile("csrr %0, 0x7A1" : "=r"(tdata1_rval));
   __asm__ volatile("csrr %0, 0x7A2" : "=r"(tdata2_rval));
-  __asm__ volatile("csrr %0, 0x7A3" : "=r"(tdata3_rval));
   __asm__ volatile("csrr %0, 0x7A4" : "=r"(tinfo_rval));
 
   if (tselect_rval != 0x0) {
@@ -133,12 +132,7 @@ int main(int argc, char *argv[])
     ++err_cnt;
   }
 
-  if (tdata3_rval != 0x0) {
-    printf("ERROR: CSR TDATA3 not 0x0!\n\n");
-    ++err_cnt;
-  }
-
-  if (tinfo_rval != 0x8064) {
+  if (tinfo_rval != 0x01008064) {
     printf("ERROR: CSR TINFO not 0x8064!\n\n");
     ++err_cnt;
   }
@@ -342,7 +336,6 @@ int main(int argc, char *argv[])
   printf("\ttselect       = 0x%0lx\n", tselect_rval);
   printf("\ttdata1        = 0x%0lx\n", tdata1_rval);
   printf("\ttdata2        = 0x%0lx\n", tdata2_rval);
-  printf("\ttdata3        = 0x%0lx\n", tdata3_rval);
   printf("\ttinfo         = 0x%0lx\n", tinfo_rval);
   printf("\tmcycle        = 0x%0lx\n", mcycle_rval);
   printf("\tminstret      = 0x%0lx\n", minstret_rval);

--- a/cv32e40s/tests/programs/custom/requested_csr_por/requested_csr_por.c
+++ b/cv32e40s/tests/programs/custom/requested_csr_por/requested_csr_por.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
   }
 
   if (tinfo_rval != 0x01008064) {
-    printf("ERROR: CSR TINFO not 0x8064!\n\n");
+    printf("ERROR: CSR TINFO not 0x01008064!\n\n");
     ++err_cnt;
   }
 

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_pkg.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_pkg.sv
@@ -28,7 +28,7 @@ package uvmt_cv32e40s_base_test_pkg;
     `include "uvmt_cv32e40s_base_test_constants.sv"
     `include "uvmt_cv32e40s_base_test_tdefs.sv"
 
-endpackage : uvmt_cv32e40s_base_test_pkg;
+endpackage : uvmt_cv32e40s_base_test_pkg
 
 `endif // __UVMT_CV32E40S_BASE_TEST_PKG_SV__
 

--- a/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
+++ b/lib/uvm_agents/uvma_clic/uvma_clic_if.sv
@@ -23,7 +23,7 @@
  * Encapsulates all signals and clocking of Interrupt interface. Used by
  * monitor and driver.
  */
-interface uvma_clic_if_t#(CLIC_ID_WIDTH = 5)();
+interface uvma_clic_if_t#(CLIC_ID_WIDTH = 5);
 
     // ---------------------------------------------------------------------------
     // Interface wires
@@ -59,6 +59,11 @@ interface uvma_clic_if_t#(CLIC_ID_WIDTH = 5)();
     bit                       clic_irq_shv_drv;
 
     bit [1:0]                 clic_irq_priv_masked;
+
+    // typedef to be able to parameterize clic_irq_id_drv assignments
+    // without warnings
+    typedef bit [$bits(clic_irq_id_drv) - 1:0] clic_irq_id_t;
+
     // -------------------------------------------------------------------
     // Begin module code
     // -------------------------------------------------------------------
@@ -67,11 +72,11 @@ interface uvma_clic_if_t#(CLIC_ID_WIDTH = 5)();
     //always_comb begin
     //  clic_irq = is_active ? clic_irq_drv : 1'b0;
     //end
-    assign clic_irq       = is_active ? clic_irq_drv          : 'b0;
-    assign clic_irq_id    = is_active ? clic_irq_id_drv       : 'b0;
-    assign clic_irq_level = is_active ? clic_irq_level_drv    : 'b0;
-    assign clic_irq_priv  = is_active ? clic_irq_priv_masked  : 'b11;
-    assign clic_irq_shv   = is_active ? clic_irq_shv_drv      : 'b0;
+    assign clic_irq       = is_active ? clic_irq_drv          : 1'b0;
+    assign clic_irq_id    = is_active ? clic_irq_id_drv       : clic_irq_id_t'('b0);
+    assign clic_irq_level = is_active ? clic_irq_level_drv    : 2'b0;
+    assign clic_irq_priv  = is_active ? clic_irq_priv_masked  : 2'b11;
+    assign clic_irq_shv   = is_active ? clic_irq_shv_drv      : 1'b0;
 
     assign clic_irq_priv_masked = is_mmode_irq_only ? 2'b11 : clic_irq_priv_drv;
 

--- a/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
@@ -34,10 +34,13 @@ interface uvma_debug_if_t(
 
     assign debug_req = is_active ? debug_drv : 1'b0;
 
+    `ifndef FORMAL
     initial begin
         is_active = 1'b0;
         debug_drv = 1'b0;
     end
+    `endif // `ifndef FORMAL
+
    /**
     * Used by target DUT.
     */

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_if.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_if.sv
@@ -54,10 +54,12 @@ interface uvma_interrupt_if_t
     // Mux in driver to irq lines
     assign irq = is_active ? irq_drv : 1'b0;
 
+    `ifndef FORMAL
     initial begin
         is_active = 1'b0;
         irq_drv = '0;
     end
+    `endif // `ifndef FORMAL
 
 
     /**

--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_assert.sv
@@ -222,7 +222,7 @@ module uvma_obi_memory_assert
 
 
   // R-8 Data address LSBs must be consistent with byte enables on writes
-  function bit [1:0] get_addr_lsb(bit[3:0] be);
+  function automatic bit [1:0] get_addr_lsb(bit[3:0] be);
     casex (be)
       4'b???1: return 0;
       4'b??10: return 1;

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -262,6 +262,7 @@ interface uvma_rvfi_instr_if_t
       irq_cnt          <= 0;
       is_nmi_triggered <= 0;
     end else begin
+      cycle_cnt <= cycle_cnt + 1;
       // Detect taken nmi or pending nmi and start counting
       is_nmi_triggered <= is_nmi_triggered ? 1'b1 : (is_nmi || (rvfi_nmip && rvfi_valid));
       if (is_nmi_triggered && rvfi_valid) begin
@@ -270,7 +271,6 @@ interface uvma_rvfi_instr_if_t
       single_step_cnt <= (rvfi_dbg[2:0] == 3'h4 && rvfi_valid) ? single_step_cnt + 1 : single_step_cnt;
       irq_cnt <= ((rvfi_intr.intr == 1) && (rvfi_intr.interrupt == 1) && rvfi_valid) ? irq_cnt + 1 : irq_cnt;
     end
-    cycle_cnt <= cycle_cnt + 1;
   end
 
   // assigning signal aliases to helper functions
@@ -725,7 +725,7 @@ function automatic logic [31:0] rvfi_mem_addr_word0highbyte_f();
 endfunction : rvfi_mem_addr_word0highbyte_f
 
 function automatic logic is_split_datatrans_f();
-  logic [31:0]  low_addr  = rvfi_mem_addr;
+  logic [31:0]  low_addr  = rvfi_mem_addr[XLEN-1:0];
   logic [31:0]  high_addr = rvfi_mem_addr_word0highbyte;
   return  is_mem_act && (low_addr[31:2] != high_addr[31:2]);
 endfunction : is_split_datatrans_f


### PR DESCRIPTION
- Fixed some warnings with Jasper FV
- Fixed debug_test_reset test
- Fixed non-sensitive function assignment in assertion support logic 
- Fixed requested_csr_por test
- Fixed misalign test
- Fixed "only one ack per clic irq" assertion
- Fixed coverage bins definitions
- Fixed debug_trigger_test (0.9.0 changes)
- Enabled mcontrol6.hit in the ISS configuration