### PR TITLE
convert array, since the corresponding array is convertes in the rtl

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
@@ -72,8 +72,8 @@ module uvmt_cv32e40s_xsecure_interface_integrity_assert
 
     //Alignment buffer:
     input inst_resp_t alb_resp_i,
-    input inst_resp_t [0:ALBUF_DEPTH-1] alb_resp_q,
-    input logic [0:ALBUF_DEPTH-1] alb_valid,
+    input inst_resp_t [ALBUF_DEPTH-1:0] alb_resp_q,
+    input logic [ALBUF_DEPTH-1:0] alb_valid,
     input logic [ALBUF_CNT_WIDTH-1:0] alb_wptr,
     input logic [ALBUF_CNT_WIDTH-1:0] alb_rptr1,
     input logic [ALBUF_CNT_WIDTH-1:0] alb_rptr2,
@@ -583,20 +583,20 @@ module uvmt_cv32e40s_xsecure_interface_integrity_assert
     && alb_resp_q[wptr_position].bus_resp.integrity == $past(support_if.instr_req_had_integrity);
   endproperty
 
- // FIXME: needs 0.9.0 update
- // generate
- //   for (genvar wptr = 0; wptr < ALBUF_DEPTH; wptr++) begin
 
- //     a_xsecure_integrity_instr_to_alignment_buffer: assert property (
- //       p_instr_to_alignment_buffer(wptr)
- //     ) else `uvm_error(info_tag, "The integrity error bit and/or the checksum bits from a response packet is not forwarded into the alignment buffer\n");
+  generate
+    for (genvar wptr = 0; wptr < ALBUF_DEPTH; wptr++) begin
 
- //     a_glitch_xsecure_integrity_instr_to_alignment_buffer: assert property (
- //       p_instr_to_alignment_buffer(wptr)
- //     ) else `uvm_error(info_tag_glitch, "The integrity error bit and/or the checksum bits from a response packet is not forwarded into the alignment buffer\n");
+      a_xsecure_integrity_instr_to_alignment_buffer: assert property (
+        p_instr_to_alignment_buffer(wptr)
+      ) else `uvm_error(info_tag, "The integrity error bit and/or the checksum bits from a response packet is not forwarded into the alignment buffer\n");
 
- //   end
- // endgenerate
+      a_glitch_xsecure_integrity_instr_to_alignment_buffer: assert property (
+        p_instr_to_alignment_buffer(wptr)
+      ) else `uvm_error(info_tag_glitch, "The integrity error bit and/or the checksum bits from a response packet is not forwarded into the alignment buffer\n");
+
+    end
+  endgenerate
 
 
   //Verify that the instruction propegated to the id stage have an integrity error if any of its related instruction fetches have integrity errors or alignment buffer based checksum errors.


### PR DESCRIPTION
1) Fixed todo, by inverting the alb_resp_q array (which is connected to the resp_q array in the alignment buffer), since the corresponding array is inverted in the rtl:
![image](https://github.com/openhwgroup/core-v-verif/assets/110398284/9c4803a4-aa2c-46c1-9485-f2d08909e52c)
