### PR TITLE
Fixed marchid in cv32e40s_readonly_csr_access_test

### DIFF
--- a/cv32e40s/tests/programs/custom/cv32e40s_readonly_csr_access_test/cv32e40s_readonly_csr_access_test.S
+++ b/cv32e40s/tests/programs/custom/cv32e40s_readonly_csr_access_test/cv32e40s_readonly_csr_access_test.S
@@ -122,7 +122,7 @@ main:
 	csrrwi x0,  3858, 0x0a   # illegal instruction: attempt to write RO CSR
 
 	csrrc  x5,  3858, x0     # not illegal
-	li     x30, 0x00000014
+	li     x30, 0x00000015
 	bne    x5,  x30, fail
 
 	# mipmid


### PR DESCRIPTION
- Fixed: marchid 0x14->0x15 for cv32e40s in cv32e40s_readonly_csr_access_test