### PR TITLE
[cv32e40p] adding new v2 debug tests with xpulp and random xpulp stream

### DIFF
--- a/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
@@ -70,6 +70,9 @@ class cv32e40p_instr extends riscv_instr;
         .exclude_instr    ( disallowed_instr ) ,
         .exclude_category ( exclude_category )
       );
+
+      $cast(cv32_instr,instr);
+      return cv32_instr;
     end
 
     // if a specific instruction category is wanted, return it along with exclusions
@@ -84,6 +87,9 @@ class cv32e40p_instr extends riscv_instr;
         .exclude_instr    ( disallowed_instr ) ,
         .exclude_category ( exclude_category )
       );
+
+      $cast(cv32_instr,instr);
+      return cv32_instr;
     end
 
     instr = riscv_instr::get_rand_instr (

--- a/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
+++ b/cv32e40p/env/corev-dv/custom/isa/custom/riscv_custom_instr.sv
@@ -666,7 +666,7 @@ class cv32e40p_instr extends riscv_instr;
         imm_str = $sformatf("%0d, %0d", $unsigned(imm[9:5]), $unsigned(imm[4:0]));
     end else if (category == HWLOOP) begin
       if (instr_name == CV_SETUPI) begin
-        imm_str = $sformatf("%0d, %0d", $unsigned(imm[11:0]), $unsigned(imm[16:12] << 2));
+        imm_str = $sformatf("%0d, %0d", $unsigned(imm[11:0]), $unsigned(imm[16:12]));
       end else begin
         imm_str = $sformatf("%0d", $unsigned(imm[11:0] << 2));
       end

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_sequence.sv
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 Google LLC
+ * Copyright 2023 Dolphin Design
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------------------
+// CV32E40P RISC-V instruction sequence
+//
+// This class extends class riscv_instr_sequence of RISCV-DV Instruction generator
+// The class intends to override parent class methods wherever needed for cv32e40p
+// specific implementation.
+// Overriden Methods - 
+//   -- post_process_instr()
+//-----------------------------------------------------------------------------------------
+
+class cv32e40p_instr_sequence extends riscv_instr_sequence;
+
+  bit label_is_pulp_hwloop_body_label = 0; // variable to indicate if given instr's Label is for HWLOOP
+
+  `uvm_object_utils(cv32e40p_instr_sequence)
+
+  function new (string name = "");
+    super.new(name);
+  endfunction
+
+  //Function: cv32e40p_instr_sequence::post_process_instr()
+  //Override parent class post_process_instr() inside cv32e40p_instr_sequence
+  //Keeping same code as parent class post_process_intr() with additions -
+  //--logic to check for hwloop stream related labels
+  virtual function void post_process_instr();
+    int             i;
+    int             label_idx;
+    int             branch_cnt;
+    int unsigned    branch_idx[];
+    int             branch_target[int] = '{default: 0};
+    string          hwloop_label, temp_label;
+    int             len1, len2;
+    
+
+    // Insert directed instructions, it's randomly mixed with the random instruction stream.
+    foreach (directed_instr[i]) begin
+      instr_stream.insert_instr_stream(directed_instr[i].instr_list);
+    end
+    // Assign an index for all instructions, these indexes won't change even a new instruction
+    // is injected in the post process.
+    foreach (instr_stream.instr_list[i]) begin
+      instr_stream.instr_list[i].idx = label_idx;
+
+      //Determine if the label is for HWLOOP body.
+      //If label is HWLOOP label then keep label for the given instruction
+      //in post_process_instr(). Using label_is_pulp_hwloop_body_label.
+      label_is_pulp_hwloop_body_label = 0;
+      if(instr_stream.instr_list[i].has_label) begin
+        hwloop_label = "hwloop"; //Using this string for hwloop specific labels in random hwloop stream tests
+        temp_label=instr_stream.instr_list[i].label;
+        len1=hwloop_label.len();
+        len2=temp_label.len();
+
+        if(len1 < len2) begin
+            for(int j = 0;j < len2-len1+1; j++) begin
+                if(temp_label.substr(j,j+len1 -1) == hwloop_label) begin
+                  label_is_pulp_hwloop_body_label = 1; // This var set indicates that this instr's label is for HWLOOP and must be kept
+                  `uvm_info("cv32e40p_inst_sequence", $sformatf("Print HWLOOP label instr - instr_stream.instr_list[%0d] %0s =  %0s ",i,instr_stream.instr_list[i].convert2asm(),instr_stream.instr_list[i].label), UVM_DEBUG);
+                  break;
+                end
+            end
+        end
+      end
+
+      if (instr_stream.instr_list[i].has_label && !instr_stream.instr_list[i].atomic && !label_is_pulp_hwloop_body_label) begin
+        if ((illegal_instr_pct > 0) && (instr_stream.instr_list[i].is_illegal_instr == 0)) begin
+          // The illegal instruction generator always increase PC by 4 when resume execution, need
+          // to make sure PC + 4 is at the correct instruction boundary.
+          if (instr_stream.instr_list[i].is_compressed) begin
+            if (i < instr_stream.instr_list.size()-1) begin
+              if (instr_stream.instr_list[i+1].is_compressed) begin
+                instr_stream.instr_list[i].is_illegal_instr =
+                                       ($urandom_range(0, 100) < illegal_instr_pct);
+              end
+            end
+          end else begin
+            instr_stream.instr_list[i].is_illegal_instr =
+                                       ($urandom_range(0, 100) < illegal_instr_pct);
+          end
+        end
+        if ((hint_instr_pct > 0) && (instr_stream.instr_list[i].is_illegal_instr == 0)) begin
+          if (instr_stream.instr_list[i].is_compressed) begin
+            instr_stream.instr_list[i].is_hint_instr =
+                                       ($urandom_range(0, 100) < hint_instr_pct);
+          end
+        end
+        instr_stream.instr_list[i].label = $sformatf("%0d", label_idx);
+        instr_stream.instr_list[i].is_local_numeric_label = 1'b1;
+        label_idx++;
+      end
+    end
+    // Generate branch target
+    branch_idx = new[30];
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(branch_idx,
+                                       foreach(branch_idx[i]) {
+                                         branch_idx[i] inside {[1:cfg.max_branch_step]};
+                                       })
+    while(i < instr_stream.instr_list.size()) begin
+      if((instr_stream.instr_list[i].category == BRANCH) &&
+        (!instr_stream.instr_list[i].branch_assigned) &&
+        (!instr_stream.instr_list[i].is_illegal_instr)) begin
+        // Post process the branch instructions to give a valid local label
+        // Here we only allow forward branch to avoid unexpected infinite loop
+        // The loop structure will be inserted with a separate routine using
+        // reserved loop registers
+        int branch_target_label;
+        int branch_byte_offset;
+        branch_target_label = instr_stream.instr_list[i].idx + branch_idx[branch_cnt];
+        if (branch_target_label >= label_idx) begin
+          branch_target_label = label_idx-1;
+        end
+        branch_cnt++;
+        if (branch_cnt == branch_idx.size()) begin
+          branch_cnt = 0;
+          branch_idx.shuffle();
+        end
+        `uvm_info(get_full_name(),
+                  $sformatf("Processing branch instruction[%0d]:%0s # %0d -> %0d",
+                  i, instr_stream.instr_list[i].convert2asm(),
+                  instr_stream.instr_list[i].idx, branch_target_label), UVM_HIGH)
+        instr_stream.instr_list[i].imm_str = $sformatf("%0df", branch_target_label);
+        // Below calculation is only needed for generating the instruction stream in binary format
+        for (int j = i + 1; j < instr_stream.instr_list.size(); j++) begin
+          branch_byte_offset = (instr_stream.instr_list[j-1].is_compressed) ?
+                               branch_byte_offset + 2 : branch_byte_offset + 4;
+          if (instr_stream.instr_list[j].label == $sformatf("%0d", branch_target_label)) begin
+            instr_stream.instr_list[i].imm = branch_byte_offset;
+            break;
+          end else if (j == instr_stream.instr_list.size() - 1) begin
+            `uvm_fatal(`gfn, $sformatf("Cannot find target label : %0d", branch_target_label))
+          end
+        end
+        instr_stream.instr_list[i].branch_assigned = 1'b1;
+        branch_target[branch_target_label] = 1;
+      end
+      // Remove the local label which is not used as branch target
+      if(instr_stream.instr_list[i].has_label &&
+         instr_stream.instr_list[i].is_local_numeric_label) begin
+        int idx = instr_stream.instr_list[i].label.atoi();
+        if(!branch_target[idx]) begin
+          instr_stream.instr_list[i].has_label = 1'b0;
+        end
+      end
+      i++;
+    end
+    `uvm_info(get_full_name(), "Finished post-processing instructions", UVM_HIGH)
+  endfunction
+
+
+endclass

--- a/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_instr_test_pkg.sv
@@ -30,6 +30,7 @@ package cv32e40p_instr_test_pkg;
 
   // RISCV-DV class override definitions
   `include "cv32e40p_rand_instr_stream.sv"
+  `include "cv32e40p_instr_sequence.sv"
   `include "cv32e40p_compressed_instr.sv"
   `include "cv32e40p_illegal_instr.sv"
   `include "cv32e40p_privil_reg.sv"

--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_pulp_instr_lib.sv
@@ -34,11 +34,21 @@ class cv32e40p_base_pulp_instr_stream extends cv32e40p_base_instr_stream;
   endfunction
 
   virtual function void gen_xpulp_instr(riscv_instr_name_t base_instr_list[$] = {});
-    riscv_instr instr;
+    riscv_instr     instr;
+    cv32e40p_instr  cv32_instr;
+
+    avail_regs = new[num_of_avail_regs];
     randomize_avail_regs();
-    instr = cv32e40p_instr::get_xpulp_instr(.include_instr(base_instr_list));
-    randomize_gpr(instr);
-    instr_list.push_back(instr);
+    cv32_instr = cv32e40p_instr::get_xpulp_instr(.include_instr(base_instr_list));
+
+    //randomize GPRs for each instruction
+    randomize_cv32e40p_gpr(cv32_instr, avail_regs);
+
+    //randomize immediates for each instruction
+    randomize_cv32e40p_instr_imm(cv32_instr);
+
+    instr_list.push_back(cv32_instr);
+
   endfunction
 
 endclass

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
@@ -54,4 +54,45 @@ task uvme_cv32e40p_random_debug_c::body();
         end
     join
 endtask : body
+
+//Class : uvme_cv32e40p_reduced_rand_debug_req_c
+//Random debug with option for plusargs control for number of debug req
+//used for v2 tests for running random debug tests with limited number of
+//debug request. Default num of debug request is kept upto 3 per test
+class uvme_cv32e40p_reduced_rand_debug_req_c extends uvme_cv32e40p_random_debug_c;
+
+    rand int unsigned num_of_debug_req;
+
+    `uvm_object_utils_begin(uvme_cv32e40p_reduced_rand_debug_req_c)
+        `uvm_field_int(num_of_debug_req, UVM_DEFAULT)
+    `uvm_object_utils_end
+
+    constraint default_dly_c {
+        if (num_of_debug_req == 1) dly inside {[200:2000]};
+        else dly inside {[500:10000]};
+    }
+
+    constraint num_dgb_req_c {
+        num_of_debug_req inside {[1:3]};
+    }
+
+    extern function new(string name="uvme_cv32e40p_reduced_rand_debug_req");
+    extern virtual task body();
+endclass : uvme_cv32e40p_reduced_rand_debug_req_c
+
+function uvme_cv32e40p_reduced_rand_debug_req_c::new(string name="uvme_cv32e40p_reduced_rand_debug_req");
+    super.new(name);
+    if ($value$plusargs("num_debug_req=%0d",num_of_debug_req)) begin
+        num_of_debug_req.rand_mode(0);
+    end
+endfunction : new
+
+task uvme_cv32e40p_reduced_rand_debug_req_c::body();
+    for (int i = 1; i <= num_of_debug_req; i++) begin
+        uvma_debug_seq_item_c debug_req;
+        rand_delay();
+        `uvm_info("uvme_cv32e40p_reduced_rand_debug_req", $sformatf("Start Debug Req Sequence, debug_req number : %0d  of total %0d", i, num_of_debug_req), UVM_NONE);
+        `uvm_do_on_with(debug_req, p_sequencer.debug_sequencer, {});
+    end
+endtask : body
 `endif // __UVME_CV32E40P_RANDOM_DEBUG__

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/corev-dv.yaml
@@ -1,0 +1,24 @@
+name: corev_rand_debug_ebreak_xpulp
+uvm_test: $(CV_CORE_LC)_instr_base_test
+description: >
+    RISCV-DV use random ebreak for debug test for xpulp stream
+plusargs: >
+    +instr_cnt=2000
+    +num_of_sub_program=0
+    +directed_instr_0=riscv_load_store_rand_instr_stream,1
+    +directed_instr_1=cv32e40p_xpulp_rand_stream,2
+    +no_fence=0
+    +no_data_page=0
+    +randomize_csr=1
+    +no_branch_jump=1
+    +boot_mode=m
+    +no_csr_instr=0
+    +no_wfi=1
+    +no_ebreak=0
+    +no_dret=1
+    +enable_misaligned_instr=1
+    +enable_ebreak_in_debug_rom=1
+    +set_dcsr_ebreak=1
+    +enable_debug_single_step=0
+    +gen_debug_section=1
+    +test_override_riscv_instr_stream=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/test.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_ebreak_xpulp/test.yaml
@@ -1,0 +1,10 @@
+# Test definition YAML for random debug test
+
+# corev-dv generator test
+name: corev_rand_debug_ebreak_xpulp
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Random debug with ebreak for xpulp stream
+plusargs: >
+    +gen_reduced_rand_dbg_req
+    +num_debug_req=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/corev-dv.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/corev-dv.yaml
@@ -1,0 +1,24 @@
+name: corev_rand_debug_single_step_xpulp
+uvm_test: $(CV_CORE_LC)_instr_base_test
+description: >
+    RISCV-DV generated random debug test with single-stepping for xpulp stream
+plusargs: >
+    +instr_cnt=1000
+    +num_of_sub_program=0
+    +directed_instr_0=riscv_load_store_rand_instr_stream,1
+    +directed_instr_1=cv32e40p_xpulp_rand_stream,2
+    +no_fence=0
+    +no_data_page=0
+    +randomize_csr=1
+    +no_branch_jump=1
+    +boot_mode=m
+    +no_csr_instr=0
+    +no_wfi=1
+    +no_ebreak=1
+    +no_dret=1
+    +enable_misaligned_instr=0
+    +enable_ebreak_in_debug_rom=0
+    +set_dcsr_ebreak=0
+    +enable_debug_single_step=1
+    +gen_debug_section=1
+    +test_override_riscv_instr_stream=1

--- a/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/test.yaml
+++ b/cv32e40p/tests/programs/corev-dv/corev_rand_debug_single_step_xpulp/test.yaml
@@ -1,0 +1,10 @@
+# Test definition YAML for random debug test
+
+# corev-dv generator test
+name: corev_rand_debug_single_step_xpulp
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Random debug with xpulp stream
+plusargs: >
+    +gen_reduced_rand_dbg_req
+    +num_debug_req=1

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -85,6 +85,9 @@ endclass : uvmt_cv32e40p_firmware_test_c
 function uvmt_cv32e40p_firmware_test_c::new(string name="uvmt_cv32e40p_firmware_test", uvm_component parent=null);
 
    super.new(name, parent);
+   if ($test$plusargs("gen_reduced_rand_dbg_req")) begin
+        uvme_cv32e40p_random_debug_c::type_id::set_type_override(uvme_cv32e40p_reduced_rand_debug_req_c::get_type());
+   end
    `uvm_info("TEST", "This is the FIRMWARE TEST", UVM_NONE)
 
 endfunction : new
@@ -128,6 +131,12 @@ task uvmt_cv32e40p_firmware_test_c::run_phase(uvm_phase phase);
    if ($test$plusargs("debug_boot_set")) begin
     fork
       bootset_debug();
+    join_none
+   end
+
+   if ($test$plusargs("gen_reduced_rand_dbg_req")) begin
+    fork
+      random_debug();
     join_none
    end
 


### PR DESCRIPTION
This PR is for work for part of v2 debug random tests and xpulp streams needed for random tests including debug.
- Adding new debug vseq uvme_cv32e40p_reduced_rand_debug_req_c to target shorter random tests and mechanism to override controls from test yaml through pluargs
- Add way to include random xpulp instructions as part of random stream generated for debug_rom
- Create cv32e40p_xpulp_rand_stream for random xpulp instruction stream and updated related functions and other cv32e40_* extended classes from corev-dv to work with xpulp_rand_stream. 
No overwriting of riscv-dv files done here, all new updates are within cv32e40p/env/corev-dv files in extended classes for cv32e40p.
- added 2 new debug tests with xpulp using new xpulp stream.