### PR TITLE
ISACOV : Filter hazard cross

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -1459,10 +1459,23 @@ covergroup cg_sequential(string name,
   cross_seq_group_x3: cross cp_group, cp_group_pipe_x2, cp_group_pipe_x3;
   cross_seq_group_x4: cross cp_group, cp_group_pipe_x2, cp_group_pipe_x3, cp_group_pipe_x4;
 
-  // FIXME: This will need more filtering
   cross_seq_gpr_raw_hazard: cross cp_group, cp_group_pipe_x2, cp_gpr_raw_hazard {
     // Ignore non-hazard bins
     ignore_bins IGN_HAZ = binsof(cp_gpr_raw_hazard) intersect {0};
+    ignore_bins IGN_GROUP = binsof(cp_group) intersect {UNKNOWN_GROUP,
+                                                        FENCE_GROUP,
+                                                        FENCE_I_GROUP,
+                                                        RET_GROUP,
+                                                        WFI_GROUP,
+                                                        ENV_GROUP};
+    ignore_bins IGN_PREV_GROUP = binsof(cp_group_pipe_x2) intersect {UNKNOWN_GROUP,
+                                                                     FENCE_GROUP,
+                                                                     FENCE_I_GROUP,
+                                                                     RET_GROUP,
+                                                                     WFI_GROUP,
+                                                                     ENV_GROUP,
+                                                                     STORE_GROUP,
+                                                                     BRANCH_GROUP};
   }
 
   cross_seq_csr_hazard_x2: cross cp_csr, cp_instr, cp_csr_hazard {


### PR DESCRIPTION
Hello @MikeOpenHWGroup @silabs-robin ,
This PR related to filter hazard cross (RAW : Read After Write -> instr_prev.rd == instr.rs1 || instr.rs2) so all instruction do not have rd or one of the register source should not appear (**UNKNOWN_GROUP, FENCE_GROUP, FENCE_I_GROUP, RET_GROUP, ENV_GROUP**) in, the cross also :  
for current group of instruction should not have : **JUMP_GROUP** -> jump instruction do not have source register (only have rd)
for Previous group of instruction should not have : **STORE_GROUP & BRANCH_GROUP** -> Store & branch instruction do not have destination register (only have rs)