### PR TITLE
CVA6-DV : Update CVA6-DV

### DIFF
--- a/cva6/env/corev-dv/custom/cvxif_custom_instr.sv
+++ b/cva6/env/corev-dv/custom/cvxif_custom_instr.sv
@@ -17,12 +17,20 @@
  */
 class cvxif_custom_instr extends riscv_custom_instr;
 
+   riscv_instr_name_t            instr_name;
+
    rand riscv_reg_t rs1;
    rand riscv_reg_t rs2;
    rand riscv_reg_t rs3;
 
    `uvm_object_utils(cvxif_custom_instr)
    `uvm_object_new
+
+  static function bit register(riscv_instr_name_t instr_name);
+    `uvm_info("custom_cva6_instr", $sformatf("Registering %0s", instr_name.name()), UVM_LOW)
+    instr_registry[instr_name] = 1;
+    return 1;
+  endfunction : register
 
    virtual function string get_instr_name();
       get_instr_name = instr_name.name();

--- a/cva6/env/corev-dv/cva6_defines.svh
+++ b/cva6/env/corev-dv/cva6_defines.svh
@@ -10,6 +10,21 @@
 // -------------------------------------------------------------------------------------------
 
 // Custom extension instruction for CVXIF
+`define INSTR_BODY(instr_n, instr_format, instr_category, instr_group, imm_tp = IMM) \
+    static bit valid = cvxif_custom_instr::register(instr_n);  \
+    `uvm_object_utils(riscv_``instr_n``_instr)  \
+    function new(string name = "");  \
+      super.new(name);  \
+      this.instr_name = ``instr_n; \
+      this.format = ``instr_format;  \
+      this.group = ``instr_group;  \
+      this.category = ``instr_category;  \
+      this.imm_type = ``imm_tp;  \
+      set_imm_len(); \
+      set_rand_mode(); \
+    endfunction \
+  endclass
+
 `define DEFINE_CVXIF_CUSTOM_INSTR(instr_n, instr_format, instr_category, instr_group, imm_tp = IMM)  \
    class riscv_``instr_n``_instr extends cvxif_custom_instr;  \
       `INSTR_BODY(instr_n, instr_format, instr_category, instr_group, imm_tp)

--- a/cva6/env/corev-dv/cva6_instr_pkg.sv
+++ b/cva6/env/corev-dv/cva6_instr_pkg.sv
@@ -11,6 +11,19 @@
 
 package cva6_instr_pkg;
 
+  typedef enum {
+    // Add custom instruction name enum
+    CUS_ADD,
+    CUS_ADD_MULTI,
+    CUS_NOP,
+    CUS_ADD_RS3
+    // CUS_EXC,
+    // CUS_M_ADD,
+    // CUS_S_ADD,
+    // CUS_NOP_EXC,
+    // CUS_ISS_EXC,
+  } riscv_instr_name_t;
+
    import uvm_pkg::*;
    `include "cva6_defines.svh"
    import riscv_instr_pkg::*;


### PR DESCRIPTION
Hello,
So this update of the CVA6-DV is about the custom instruction use in cvxif, so we add the cutom instruction definition in the cva6_instr_pkg, instead of copy them to the riscv_instr_pkg then use it.
it's just an update to be more independent from the RISCV-DV 