### PR TITLE
change where integrity signal is fetched from

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1369,11 +1369,10 @@ module uvmt_cv32e40s_tb;
         .lrfodi_bus_req (core_i.load_store_unit_i.buffer_trans_valid),
         .lrfodi_bus_gnt (core_i.load_store_unit_i.buffer_trans_ready),
 
-        .req_is_store (core_i.load_store_unit_i.bus_trans.we),
-        .req_instr_integrity (core_i.if_stage_i.mpu_i.bus_trans_integrity),
-        .req_data_integrity (core_i.load_store_unit_i.mpu_i.bus_trans_integrity),
+        .req_is_store (core_i.m_c_obi_data_if.req_payload.we),
+        .req_instr_integrity (core_i.m_c_obi_instr_if.req_payload.integrity),
+        .req_data_integrity (core_i.m_c_obi_data_if.req_payload.integrity),
         .instr_req_pc ({core_i.m_c_obi_instr_if.req_payload.addr[31:2], 2'b0})
-
     );
 
     bind cv32e40s_wrapper

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_csrs_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_csrs_interrupt_assert.sv
@@ -31,11 +31,11 @@ module uvmt_cv32e40s_xsecure_hardened_csrs_interrupt_assert
 
     //CSRs:
     input mcause_t mcause,
-    input logic [$bits(mcause_t)-1:0] mcause_shadow,
     input logic [31:0] mie,
     input mtvec_t mtvec,
 
     //Shadows:
+    input logic [$bits(mcause_t)-1:0] mcause_shadow,
     input logic [31:0] mie_shadow,
     input logic [$bits(mtvec_t)-1:0] mtvec_shadow
 


### PR DESCRIPTION
Make sure we fetch a valid obi req integrity signal.
(And place the mcause_shadow signal with the other shadow signals)