### PR TITLE
Update cv32e20_dut_wrap to instantiate cv32e20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ waves.shm/
 *.log
 stdout.txt
 .vscode
-tools/
 cva6/tests/riscv-compliance/
 cva6/tests/riscv-arch-test/
 cva6/tests/riscv-tests/

--- a/cv32e20/regress/cv32e20_ci_check.yaml
+++ b/cv32e20/regress/cv32e20_ci_check.yaml
@@ -19,17 +19,17 @@ tests:
     cmd: make hello-world
     cmd: make test COREV=YES TEST=hello-world
     
-#  interrupt_test:
-#    build: uvmt_cv32e20
-#    description: Interrupt directed test  
-#    dir: cv32e20/sim/uvmt
-#    cmd: make test COREV=YES TEST=interrupt_test
+  interrupt_test:
+    build: uvmt_cv32e20
+    description: Interrupt directed test  
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=interrupt_test
     
-#  corev_rand_interrupt:
-#    build: uvmt_cv32e20
-#    description: Interrupt random test
-#    dir: cv32e20/sim/uvmt
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+  corev_rand_interrupt:
+    build: uvmt_cv32e20
+    description: Interrupt random test
+    dir: cv32e20/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
 #    num: 2
 
   illegal:
@@ -37,16 +37,16 @@ tests:
     dir: cv32e20/sim/uvmt
     cmd: make test COREV=YES TEST=illegal
 
-#  debug_test:
-#    build: uvmt_cv32e20
-#    dir: cv32e20/sim/uvmt
-#    cmd: make test COREV=YES TEST=debug_test
+  debug_test:
+    build: uvmt_cv32e20
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test
 
-#  csr_instructions:
-#    build: uvmt_cv32e20
-#    description: CSR Instruction Test
-#    dir: cv32e20/sim/uvmt
-#    cmd: make test COREV=YES TEST=csr_instructions
+  csr_instructions:
+    build: uvmt_cv32e20
+    description: CSR Instruction Test
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=csr_instructions
 
   riscv_arithmetic_basic_test_0:
     build: uvmt_cv32e20
@@ -54,24 +54,24 @@ tests:
     dir: cv32e20/sim/uvmt
     cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_0
 
-#  corev_rand_arithmetic_base_test:
-#    build: uvmt_cv32e20
-#    description: Generated corev-dv random arithmetic test
-#    dir: cv32e20/sim/uvmt
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_arithmetic_base_test
+  corev_rand_arithmetic_base_test:
+    build: uvmt_cv32e20
+    description: Generated corev-dv random arithmetic test
+    dir: cv32e20/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_arithmetic_base_test
 #    num: 2
 
-#  corev_rand_instr_test:
-#    build: uvmt_cv32e20  
-#    description: Generated corev-dv random instruction test
-#    dir: cv32e20/sim/uvmt
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_test
+  corev_rand_instr_test:
+    build: uvmt_cv32e20  
+    description: Generated corev-dv random instruction test
+    dir: cv32e20/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_test
 #    num: 2
 
-#  corev_rand_jump_stress_test:
-#    build: uvmt_cv32e20  
-#    description: Generated corev-dv jump stress test
-#    dir: cv32e20/sim/uvmt
-#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
+  corev_rand_jump_stress_test:
+    build: uvmt_cv32e20  
+    description: Generated corev-dv jump stress test
+    dir: cv32e20/sim/uvmt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
 #    num: 2
 

--- a/cv32e20/sim/ExternalRepos.mk
+++ b/cv32e20/sim/ExternalRepos.mk
@@ -12,7 +12,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cve2
 CV_CORE_BRANCH ?= main
-CV_CORE_HASH   ?= 520888b
+CV_CORE_HASH   ?= b8c94a3
 CV_CORE_TAG    ?= none
 
 RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e20/sim/tools/vsim/vsim.tcl
+++ b/cv32e20/sim/tools/vsim/vsim.tcl
@@ -1,0 +1,7 @@
+# Copyright 2023 OpenHW Group
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+#
+# Generic control script for Questasim
+
+run -all
+exit

--- a/cv32e20/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
+++ b/cv32e20/tb/uvmt/uvmt_cv32e20_dut_wrap.sv
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
-// Copyright 2020,2022 OpenHW Group
+// Copyright 2020,2023 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
 // Copyright 2020 Silicon Labs, Inc.
 //
@@ -22,7 +22,8 @@
 `ifndef __UVMT_CV32E20_DUT_WRAP_SV__
 `define __UVMT_CV32E20_DUT_WRAP_SV__
 
-import cve2_pkg::*;
+import uvm_pkg::*;  // needed for the UVM messaging service (`uvm_info(), etc.)
+import cve2_pkg::*; // definitions of enumerated types used by cve2
 
 /**
  * Wrapper for the CV32E20 RTL DUT.
@@ -54,8 +55,6 @@ module uvmt_cv32e20_dut_wrap #(
                             uvma_obi_memory_if           obi_memory_data_if
                            );
 
-    import uvm_pkg::*; // needed for the UVM messaging service (`uvm_info(), etc.)
-    import cve2_pkg::*;
 
     // signals connecting core to memory
     logic                         instr_req;

--- a/cv32e20/tb/uvmt/uvmt_cv32e20_tb.sv
+++ b/cv32e20/tb/uvmt/uvmt_cv32e20_tb.sv
@@ -34,24 +34,6 @@ module uvmt_cv32e20_tb;
    import uvmt_cv32e20_pkg::*;
    import uvme_cv32e20_pkg::*;
 
-   // DUT (core) parameters: refer to the CV2E40P User Manual.
-`ifdef NO_PULP
-   parameter int CORE_PARAM_PULP_XPULP       = 0;
-   parameter int CORE_PARAM_PULP_CLUSTER     = 0;
-   parameter int CORE_PARAM_PULP_ZFINX       = 0;
-`else
-   `ifdef PULP
-      parameter int CORE_PARAM_PULP_XPULP       = 1;
-      parameter int CORE_PARAM_PULP_CLUSTER     = 0;
-      parameter int CORE_PARAM_PULP_ZFINX       = 0;
-   `else
-      // If you don't explicitly specify either NO_PULP or PULP, you get NO_PULP
-      parameter int CORE_PARAM_PULP_XPULP       = 0;
-      parameter int CORE_PARAM_PULP_CLUSTER     = 0;
-      parameter int CORE_PARAM_PULP_ZFINX       = 0;
-   `endif
-`endif
-
 `ifdef SET_NUM_MHPMCOUNTERS
    parameter int CORE_PARAM_NUM_MHPMCOUNTERS = `SET_NUM_MHPMCOUNTERS;
 `else
@@ -110,14 +92,7 @@ module uvmt_cv32e20_tb;
    * a few mods to bring unused ports from the CORE to this level using SV interfaces.
    */
    uvmt_cv32e20_dut_wrap  #(
-                             .PULP_XPULP        (CORE_PARAM_PULP_XPULP),
-                             .PULP_CLUSTER      (CORE_PARAM_PULP_CLUSTER),
-                             .PULP_ZFINX        (CORE_PARAM_PULP_ZFINX),
-                             .NUM_MHPMCOUNTERS  (CORE_PARAM_NUM_MHPMCOUNTERS),
-                             .INSTR_ADDR_WIDTH  (ENV_PARAM_INSTR_ADDR_WIDTH),
-                             .INSTR_RDATA_WIDTH (ENV_PARAM_INSTR_DATA_WIDTH),
-                             .RAM_ADDR_WIDTH    (ENV_PARAM_RAM_ADDR_WIDTH)
-                            )
+                           )
                             dut_wrap (.*);
 
   bind uvmt_cv32e20_dut_wrap
@@ -466,12 +441,6 @@ module uvmt_cv32e20_tb;
     */
    initial begin : test_bench_entry_point
 
-     `ifdef PULP
-       `ifdef NO_PULP
-         `uvm_fatal("CV32E20 TB", "PULP and NO_PULP macros are mutually exclusive.")
-       `endif
-     `endif
-
      // Specify time format for simulation (units_number, precision_number, suffix_string, minimum_field_width)
      $timeformat(-9, 3, " ns", 8);
 
@@ -501,13 +470,8 @@ module uvmt_cv32e20_tb;
      uvm_config_db#(bit[31:0])::set(.cntxt(null), .inst_name("*"), .field_name("evalue"), .value(32'h00000000));
 
      // DUT and ENV parameters
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("CORE_PARAM_PULP_XPULP"),       .value(CORE_PARAM_PULP_XPULP)      );
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("CORE_PARAM_PULP_CLUSTER"),     .value(CORE_PARAM_PULP_CLUSTER)    );
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("CORE_PARAM_PULP_ZFINX"),       .value(CORE_PARAM_PULP_ZFINX)      );
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("CORE_PARAM_NUM_MHPMCOUNTERS"), .value(CORE_PARAM_NUM_MHPMCOUNTERS));
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("ENV_PARAM_INSTR_ADDR_WIDTH"),  .value(ENV_PARAM_INSTR_ADDR_WIDTH) );
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("ENV_PARAM_INSTR_DATA_WIDTH"),  .value(ENV_PARAM_INSTR_DATA_WIDTH) );
-     uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("ENV_PARAM_RAM_ADDR_WIDTH"),    .value(ENV_PARAM_RAM_ADDR_WIDTH)   );
+     // TODO: the E40P env uses this, but it is not clear that the E20 ever will.
+     //uvm_config_db#(int)::set(.cntxt(null), .inst_name("*"), .field_name("CORE_PARAM_PULP_XPULP"),       .value(CORE_PARAM_PULP_XPULP)      );
 
      // Run test
      uvm_top.enable_print_topology = 0; // ENV coders enable this as a debug aid

--- a/cv32e20/tests/programs/custom/debug_test/debug_test.c
+++ b/cv32e20/tests/programs/custom/debug_test/debug_test.c
@@ -20,8 +20,10 @@
 *******************************************************************************
 */
 
-#include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
+
 
 volatile int glb_hart_status  = 0; // Written by main code only, read by debug code
 volatile int glb_debug_status = 0; // Written by debug code only, read by main code
@@ -247,12 +249,19 @@ int main(int argc, char *argv[])
     printf(" Test2.2: check access to Trigger registers\n");
     // Writes are ignored
     temp = 0xFFFFFFFF;
+    printf("        - Trigger TSELECT check\n");
     __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
+    printf("        - Trigger TDATA1 check\n");
     __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
+    printf("        - Trigger TDATA2 check\n");
     __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
+    printf("        - Trigger TDATA3 check\n");
     __asm__ volatile("csrw  0x7a3, %0"     : "=r"(temp)); // Trigger TDATA3
+    printf("        - Trigger TINFO check\n");
     __asm__ volatile("csrw  0x7a4, %0"     : "=r"(temp)); // Trigger TINFO
+    printf("        - Trigger MCONTEXT check\n");
     __asm__ volatile("csrw  0x7a8, %0"     : "=r"(temp)); // Trigger MCONTEXT
+    printf("        - Trigger SCONTEXT check\n");
     __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
 
     // Read default value

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -75,18 +75,19 @@ VSIM_PMA_INC += +incdir+$(TBSRC_HOME)/uvmt \
                 +incdir+$(abspath $(MAKE_PATH)/../../../lib/mem_region_gen)
 
 VLOG_LDGEN_FLAGS ?= \
-				    -suppress 2577 \
-				    -suppress 2583 \
-				    -suppress 13185 \
-				    -suppress 13314 \
-				    -suppress 13288 \
-        		    -suppress 2181 \
-				    -suppress 13262 \
-				    -timescale "1ns/1ps" \
-				    -sv \
-        		    -mfcu \
-        		    +acc=rb \
-				    $(QUIET)
+                    -suppress 2577 \
+                    -suppress 2720 \
+                    -suppress 2583 \
+                    -suppress 13185 \
+                    -suppress 13314 \
+                    -suppress 13288 \
+                    -suppress 2181 \
+                    -suppress 13262 \
+                    -timescale "1ns/1ps" \
+                    -sv \
+                    -mfcu \
+                    +acc=rb \
+                    $(QUIET)
 
 VOPT_LDGEN_FLAGS ?= \
                     -debugdb \
@@ -102,19 +103,21 @@ VSIM_LDGEN_FLAGS ?= \
 ###############################################################################
 # VLOG (Compilation)
 VLOG_FLAGS    ?= \
-				-suppress 2577 \
-				-suppress 2583 \
-				-suppress 13185 \
-				-suppress 13314 \
-				-suppress 13288 \
-        		-suppress 2181 \
-				-suppress 13262 \
-				-timescale "1ns/1ps" \
-				-sv \
-        		-mfcu \
-        		+acc=rb \
-				$(QUIET) \
-        		-writetoplevels  uvmt_$(CV_CORE_LC)_tb
+                 -suppress 2577 \
+                 -suppress 2720 \
+                 -suppress 2583 \
+                 -suppress 13185 \
+                 -suppress 13314 \
+                 -suppress 13288 \
+                 -suppress 2181 \
+                 -suppress 13262 \
+                 -timescale "1ns/1ps" \
+                 -sv \
+                 -mfcu \
+                 +acc=rb \
+                 $(QUIET) \
+                 -writetoplevels  uvmt_$(CV_CORE_LC)_tb
+
 VLOG_FILE_LIST = -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 
 VLOG_FLAGS += $(DPILIB_VLOG_OPT)


### PR DESCRIPTION
The primary purpose of this PR is to instantiate the `b8c94a3` hash of [cv32e20](https://github.com/openhwgroup/cve2).  Note that this was done using Siemens EDA Questasim (vsim) - it _should_ work without issue using other simulators, but I have not yet tried that.