### PR TITLE
cv32e40s: Testbench updates

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 8366c8b264eab5132c27ad1128102d337d2e0ded
+CV_CORE_HASH   ?= 8e560bf57d39800a15bdd1be6a19b25ec3f57b36
 CV_CORE_TAG    ?= none
 
 #RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
@@ -37,7 +37,7 @@
     assign rvvi.csr[0][0][``CSR_ADDR]    = csr_``CSR_NAME``_w | csr_``CSR_NAME``_r; \
     assign rvvi.csr_wb[0][0][``CSR_ADDR] = csr_``CSR_NAME``_wb; \
     always @(rvvi.csr[0][0][``CSR_ADDR]) begin \
-      if (`DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_rmask || `DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_wmask && `RVFI_IF.rvfi_valid) begin \
+      if ((`DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_rmask || `DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_wmask) && `RVFI_IF.rvfi_valid) begin \
         csr_``CSR_NAME``_wb = 1; \
       end \
     end \

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
@@ -37,7 +37,7 @@
     assign rvvi.csr[0][0][``CSR_ADDR]    = csr_``CSR_NAME``_w | csr_``CSR_NAME``_r; \
     assign rvvi.csr_wb[0][0][``CSR_ADDR] = csr_``CSR_NAME``_wb; \
     always @(rvvi.csr[0][0][``CSR_ADDR]) begin \
-      if (`DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_rmask || `DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_wmask ) begin \
+      if (`DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_rmask || `DUT_PATH.rvfi_csr_``CSR_NAME``_if.rvfi_csr_wmask && `RVFI_IF.rvfi_valid) begin \
         csr_``CSR_NAME``_wb = 1; \
       end \
     end \

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -2057,6 +2057,12 @@ module uvmt_cv32e40s_tb;
             $display("    --------------------------------------------------------");
          end
       end
+      // If there are any liveness assertions still pending at this time,
+      // kill all of them to prevent false failures after end of test.
+      // Actual failures _should_ have been caught and logged at this time
+      // This is needed as the core is not necessarily terminated by software,
+      // and there may be outstanding transactions.
+      $assertkill();
    end
    `endif
 

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -103,7 +103,10 @@ endif
 # ADV_DEBUG=YES will enable Indago, default is to use SimVision
 ifeq ($(call IS_YES,$(GUI)),YES)
 XRUN_GUI += -gui
-XRUN_USER_COMPILE_ARGS += -linedebug
+ifeq ($(call IS_YES,$(SRC_DEBUG)),YES)
+XRUN_USER_COMPILE_ARGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
+XRUN_USER_RUN_FLAGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
+endif
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
 XRUN_GUI += -indago
 endif


### PR DESCRIPTION
- Updated cv32e40s hash to latest
- Added $assertkill() to avoid liveness assertion errors upon test termination
- Added advanced debugging option flags to xrun makefile (SRC_DEBUG)
- Qualified CSR logic in imperas_dv_wrap with rvfi_valid