### PR TITLE
[cv32e40p] adding rv32f/zfinx functional coverage based on v2 testplans

### DIFF
--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
@@ -32,6 +32,7 @@ class uvme_cv32e40p_cov_model_c extends uvm_component;
    uvme_rv32isa_covg   isa_covg;   
    uvme_interrupt_covg interrupt_covg;
    uvme_debug_covg debug_covg;
+   uvme_rv32f_zfinx_covg rv32f_zfinx_covg;
 
    `uvm_component_utils_begin(uvme_cv32e40p_cov_model_c)
       `uvm_field_object(cfg  , UVM_DEFAULT)
@@ -110,6 +111,9 @@ function void uvme_cv32e40p_cov_model_c::build_phase(uvm_phase phase);
    debug_covg = uvme_debug_covg::type_id::create("debug_covg", this);
    uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "debug_covg", "cntxt", cntxt);
    
+   rv32f_zfinx_covg = uvme_rv32f_zfinx_covg::type_id::create("rv32f_zfinx_covg", this);
+   uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "rv32f_zfinx_covg", "cntxt", cntxt);
+
 endfunction : build_phase
 
 function void uvme_cv32e40p_cov_model_c::connect_phase(uvm_phase phase);

--- a/cv32e40p/env/uvme/cov/uvme_rv32f_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_rv32f_covg.sv
@@ -1,0 +1,612 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright 2023 OpenHW Group
+// Copyright 2023 Dolphin Design
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+
+class uvme_rv32f_zfinx_covg extends uvm_component;
+    /*
+    * Class members
+    */
+    uvme_cv32e40p_cntxt_c  cntxt;
+    logic [5:0]     curr_fpu_apu_op;
+
+    `uvm_component_utils(uvme_rv32f_zfinx_covg);
+
+    extern function new(string name = "rv32f_zfinx_covg", uvm_component parent = null);
+    extern function void build_phase(uvm_phase phase);
+    extern task run_phase(uvm_phase phase);
+    extern task sample_clk_i();
+
+    /*
+    * Covergroups
+    */
+
+    covergroup cg_f_multicycle;
+        `per_instance_fcov
+        option.at_least = 10;
+
+        cp_if_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.if_stage_instr_rdata_i {
+            wildcard bins if_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
+            wildcard bins if_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
+            wildcard bins if_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
+            wildcard bins if_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
+            wildcard bins if_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
+            wildcard bins if_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
+            wildcard bins if_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
+            wildcard bins if_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
+            wildcard bins if_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
+            wildcard bins if_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
+            wildcard bins if_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
+            wildcard bins if_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
+            wildcard bins if_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
+            wildcard bins if_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
+            wildcard bins if_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
+            wildcard bins if_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
+            wildcard bins if_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
+            wildcard bins if_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
+            wildcard bins if_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
+            wildcard bins if_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
+            wildcard bins if_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
+            wildcard bins if_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
+            wildcard bins if_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
+            wildcard bins if_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            option.weight = 5;
+        }
+
+        cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i {
+            wildcard bins id_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
+            wildcard bins id_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
+            wildcard bins id_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
+            wildcard bins id_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
+            wildcard bins id_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
+            wildcard bins id_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
+            wildcard bins id_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
+            wildcard bins id_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
+            wildcard bins id_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
+            wildcard bins id_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
+            wildcard bins id_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
+            wildcard bins id_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
+            wildcard bins id_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
+            wildcard bins id_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
+            wildcard bins id_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
+            wildcard bins id_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
+            wildcard bins id_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
+            wildcard bins id_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
+            wildcard bins id_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
+            wildcard bins id_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
+            wildcard bins id_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
+            wildcard bins id_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
+            wildcard bins id_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
+            wildcard bins id_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            option.weight = 5;
+        }
+
+        cp_id_stage_apu_op_ex_o : coverpoint cntxt.cov_vif.mon_cb.id_stage_apu_op_ex_o {
+            bins next_apu_op_fmadd       =    {APU_OP_FMADD};
+            bins next_apu_op_fnmsub      =    {APU_OP_FNMSUB};
+            bins next_apu_op_fadd        =    {APU_OP_FADD};
+            bins next_apu_op_fmul        =    {APU_OP_FMUL};
+            bins next_apu_op_fdiv        =    {APU_OP_FDIV};
+            bins next_apu_op_fsqrt       =    {APU_OP_FSQRT};
+            bins next_apu_op_fsgnj       =    {APU_OP_FSGNJ};
+            bins next_apu_op_fminmax     =    {APU_OP_FMINMAX};
+            bins next_apu_op_fcmp        =    {APU_OP_FCMP};
+            bins next_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
+            bins next_apu_op_f2f         =    {APU_OP_F2F};
+            bins next_apu_op_f2i         =    {APU_OP_F2I};
+            bins next_apu_op_i2f         =    {APU_OP_I2F};
+            bins next_apu_op_fmsub       =    {APU_OP_FMSUB};
+            bins next_apu_op_fnmadd      =    {APU_OP_FNMADD};
+            bins next_apu_op_fsub        =    {APU_OP_FSUB};
+            bins next_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
+            bins next_apu_op_f2i_u       =    {APU_OP_F2I_U};
+            bins next_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+
+        cp_f_multicycle_clk_window : coverpoint cntxt.cov_vif.if_clk_cycle_window {
+            bins clk1 = {1};
+            bins clk2 = {2};
+            bins clk3 = {3};
+            bins clk4 = {4};
+            bins clk5 = {5};
+            bins clk6 = {6};
+            bins clk7 = {7};
+            bins clk8 = {8};
+            bins clk9 = {9};
+            bins clk10 = {10};
+            bins clk11 = {11};
+            bins clk12 = {12};
+            ignore_bins ignore_idle = {0};
+            illegal_bins clk_more_than_12 = {[13:31]};
+        }
+
+        cp_id_stage_inst_valid : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_if_stage_inst_valid : coverpoint cntxt.cov_vif.mon_cb.if_stage_instr_rvalid_i {
+            bins if_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_id_stage_apu_en_ex_o : coverpoint cntxt.cov_vif.mon_cb.id_stage_apu_en_ex_o {
+            bins id_stage_apu_en_ex_1 = {1};
+            bins id_stage_apu_en_ex_0_to_1 = (0 => 1);
+            option.weight = 1;
+        }
+
+        cp_apu_req_valid : coverpoint cntxt.cov_vif.mon_cb.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint cntxt.cov_vif.mon_cb.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint cntxt.cov_vif.mon_cb.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            bins curr_apu_op_fmadd       =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub      =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd        =    {APU_OP_FADD};
+            bins curr_apu_op_fmul        =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv        =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt       =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj       =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax     =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp        =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f         =    {APU_OP_F2F};
+            bins curr_apu_op_f2i         =    {APU_OP_F2I};
+            bins curr_apu_op_i2f         =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub       =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd      =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub        =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u       =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+
+        //cross coverage for F-inst in ID-stage with preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_fpu_multicycle_req : cross cp_id_stage_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_apu_op {option.weight = 50;}
+
+        //cross coverage for F-inst in ID-stage with preceeding F-multicycle - case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_id_stage_inp_while_fpu_busy : cross cp_id_stage_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            //For FPU config with Latency=0 , apu_busy is expected to be set only for FDIV and FSQRT case  
+            illegal_bins apu_busy_curr_apu_op_not_div_sqrt = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (binsof(cp_apu_busy) intersect{1});
+`endif
+        }
+        
+        //cross coverage for F-inst arriving at ID-stage input at various stages of APU latency clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_id_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_inst_valid, cp_id_stage_f_inst, cp_f_multicycle_clk_window, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            illegal_bins clk_2_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1});
+`elsif FPU_LAT_1_CYC
+            illegal_bins clk_3_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2});
+`elsif FPU_LAT_2_CYC
+            illegal_bins clk_4_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3});
+`elsif FPU_LAT_3_CYC
+            illegal_bins clk_5_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4});
+`elsif FPU_LAT_4_CYC
+            illegal_bins clk_6_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4, 5});
+`endif
+        }
+
+        //cross coverage for F-inst at ID-stage output with preceeding F-multicycle instr
+        //Note: Added 2 separate similar cross coverages ID stage because of different arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_fpu_multicycle_req : cross cp_id_stage_apu_en_ex_o, cp_id_stage_apu_op_ex_o, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_apu_op {option.weight = 50;}
+
+        //cross coverage for F-inst at ID-stage output with preceeding F-multicycle - case with apu_busy or APU needing more than 1 clock cycle 
+        //Note: Added 2 separate similar cross coverages ID stage because of different arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_while_fpu_busy : cross cp_id_stage_apu_en_ex_o, cp_id_stage_apu_op_ex_o, cp_apu_busy, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            illegal_bins apu_busy_curr_apu_op_not_div_sqrt = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (binsof(cp_apu_busy) intersect{1});
+`endif
+        }
+
+        //cross coverage for F-inst arriving at ID-stage output at various stages of APU latency clk-cycles of the ongoing/preceeding F-multicycle instr
+        //Note: Added 2 separate similar cross coverages ID stage because of different arrival times of next instruction w.r.t APU Req
+        cr_f_inst_at_id_stage_out_with_cyc_window_of_ongoing_fpu_calc : cross cp_id_stage_apu_en_ex_o, cp_id_stage_apu_op_ex_o, cp_f_multicycle_clk_window, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            illegal_bins clk_2_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1});
+`elsif FPU_LAT_1_CYC
+            illegal_bins clk_3_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2});
+`elsif FPU_LAT_2_CYC
+            illegal_bins clk_4_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3});
+`elsif FPU_LAT_3_CYC
+            illegal_bins clk_5_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4});
+`elsif FPU_LAT_4_CYC
+            illegal_bins clk_6_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4, 5});
+`endif
+        }
+
+        //cross coverage for F-inst at IF-stage with preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_fpu_multicycle_req : cross cp_if_stage_inst_valid, cp_if_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_apu_op {option.weight = 50;}
+
+        //cross coverage for F-inst at IF-stage with preceeding F-multicycle - case with apu_busy or APU needing more than 1 clock cycle 
+        cr_f_inst_at_if_stage_inp_while_fpu_busy : cross cp_if_stage_inst_valid, cp_if_stage_f_inst, cp_apu_busy, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            illegal_bins apu_busy_curr_apu_op_not_div_sqrt = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (binsof(cp_apu_busy) intersect{1});
+`endif
+        }
+
+        //cross coverage for F-inst arriving at IF-stage output at various stages of APU latency clk-cycles of the ongoing/preceeding F-multicycle instr
+        cr_f_inst_at_if_stage_inp_with_cyc_window_of_ongoing_fpu_calc : cross cp_if_stage_inst_valid, cp_if_stage_f_inst, cp_f_multicycle_clk_window, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            illegal_bins clk_2_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1});
+`elsif FPU_LAT_1_CYC
+            illegal_bins clk_3_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2});
+`elsif FPU_LAT_2_CYC
+            illegal_bins clk_4_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3});
+`elsif FPU_LAT_3_CYC
+            illegal_bins clk_5_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4});
+`elsif FPU_LAT_4_CYC
+            illegal_bins clk_6_12_group_NON_DIVSQRT  = (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1, 2, 3, 4, 5});
+`endif
+        }
+
+    endgroup : cg_f_multicycle
+
+    
+    covergroup cg_f_inst_reg;
+        `per_instance_fcov
+
+        cp_apu_req_valid : coverpoint cntxt.cov_vif.mon_cb.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint cntxt.cov_vif.mon_cb.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint cntxt.cov_vif.mon_cb.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_id_inst_valid : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            bins curr_apu_op_fmadd       =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub      =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd        =    {APU_OP_FADD};
+            bins curr_apu_op_fmul        =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv        =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt       =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj       =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax     =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp        =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f         =    {APU_OP_F2F};
+            bins curr_apu_op_f2i         =    {APU_OP_F2I};
+            bins curr_apu_op_i2f         =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub       =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd      =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub        =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u       =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+
+        cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i {
+            wildcard bins id_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
+            wildcard bins id_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
+            wildcard bins id_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
+            wildcard bins id_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
+            wildcard bins id_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
+            wildcard bins id_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
+            wildcard bins id_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
+            wildcard bins id_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
+            wildcard bins id_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
+            wildcard bins id_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
+            wildcard bins id_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
+            wildcard bins id_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
+            wildcard bins id_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
+            wildcard bins id_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
+            wildcard bins id_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
+            wildcard bins id_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
+            wildcard bins id_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
+            wildcard bins id_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
+            wildcard bins id_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
+            wildcard bins id_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
+            wildcard bins id_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
+            wildcard bins id_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
+            wildcard bins id_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
+            wildcard bins id_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            option.weight = 5;
+        }
+
+        cp_id_f_inst_fs1 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] {
+            bins fs1[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_f_inst_fs2 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] {
+            bins fs2[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
+            bins fd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_x_inst_rs1 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] {
+            bins rs1[] = {[0:31]};
+            option.weight = 1;
+        }
+
+        cp_fd_fs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs1_equal = {1};
+        }
+        cp_fd_fs2_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs2_equal = {1};
+        }
+        cp_rd_rs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs1_equal = {1};
+        }
+
+//*************************************************************************************************************************************************
+//      Cross Coverage description for various cases of reg-to-reg dependencies in instruction sequence with F-multicycle cases
+//*************************************************************************************************************************************************
+
+        //cross coverage for F-instructions with fd to fs1 dependency - case with APU latency greater than 1 
+        cr_fd_fs1_eq_nonzero_lat : cross cp_fd_fs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+        }
+
+        //cross coverage for F-instructions with fd to fs2 dependency - case with APU latency greater than 1 
+        cr_fd_fs2_eq_nonzero_lat : cross cp_fd_fs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+        }
+
+        //cross coverage for F-instructions with fd to fs1 dependency 
+        cr_fd_fs1_eq_no_lat  :  cross cp_fd_fs1_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        }
+
+        //cross coverage for F-instructions with fd to fs2 dependency 
+        cr_fd_fs2_eq_no_lat  :  cross cp_fd_fs2_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        }
+
+        //cross coverage for F-instructions with rd to rs1 dependency - case with APU latency greater than 1
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs_id_stage_f_inst = !binsof(cp_id_stage_f_inst) intersect {APU_OP_I2F, APU_OP_I2F_U};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+        }
+
+        //cross coverage for F-instructions with rd to rs1 dependency 
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs_id_stage_f_inst = !binsof(cp_id_stage_f_inst) intersect {APU_OP_I2F, APU_OP_I2F_U};
+        }
+        
+        //TODO : need for cross with non-fpu inst in pipeline with same reg dependency?
+        //cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+        //    option.weight = 50;
+        //    ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        //    ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+        //}
+        //cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+        //    option.weight = 50;
+        //    ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        //}
+
+
+
+    endgroup : cg_f_inst_reg
+
+    covergroup cg_zfinx_inst_reg;
+        `per_instance_fcov
+
+        cp_apu_req_valid : coverpoint cntxt.cov_vif.mon_cb.apu_req {
+            bins apu_req_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_grant_valid : coverpoint cntxt.cov_vif.mon_cb.apu_gnt {
+            bins apu_gnt_valid = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_busy : coverpoint cntxt.cov_vif.mon_cb.apu_busy {
+            bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_id_inst_valid : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_valid_i {
+            bins id_stage_instr_valid = {1};
+            option.weight = 1;
+        }
+
+        cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
+            bins curr_apu_op_fmadd       =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub      =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd        =    {APU_OP_FADD};
+            bins curr_apu_op_fmul        =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv        =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt       =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj       =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax     =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp        =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f         =    {APU_OP_F2F};
+            bins curr_apu_op_f2i         =    {APU_OP_F2I};
+            bins curr_apu_op_i2f         =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub       =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd      =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub        =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u       =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+
+        cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[7:0] {
+            bins f_inst_opcode_in_id_stage[] = {    
+                                        cv32e40p_pkg::OPCODE_OP_FP,
+                                        cv32e40p_pkg::OPCODE_OP_FMADD,
+                                        cv32e40p_pkg::OPCODE_OP_FMSUB,
+                                        cv32e40p_pkg::OPCODE_OP_FNMSUB,
+                                        cv32e40p_pkg::OPCODE_OP_FNMADD,
+                                        cv32e40p_pkg::OPCODE_STORE_FP,
+                                        cv32e40p_pkg::OPCODE_LOAD_FP
+            };
+            option.weight = 5;
+        }
+
+        cp_id_f_inst_fs1 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] {
+            bins fs1[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_f_inst_fs2 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] {
+            bins fs2[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_fd : coverpoint cntxt.cov_vif.curr_fpu_fd {
+            bins fd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_curr_fpu_inst_rd : coverpoint cntxt.cov_vif.curr_fpu_rd {
+            bins rd[] = {[0:31]};
+            option.weight = 1;
+        }
+        cp_id_x_inst_rs1 : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] {
+            bins rs1[] = {[0:31]};
+            option.weight = 1;
+        }
+
+        cp_rd_rs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs1_equal = {1};
+        }
+        cp_rd_rs2_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs2_equal = {1};
+        }
+ 
+//*************************************************************************************************************************************************
+//      Cross Coverage description for various cases of reg-to-reg dependencies in instruction sequence with F-multicycle cases
+//*************************************************************************************************************************************************
+
+        //cross coverage for F-instructions with rd to rs1 dependency - case with APU latency greater than 1 
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+        }
+
+        //cross coverage for F-instructions with rd to rs1 dependency
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+        }
+
+        //cross coverage for F-instructions with rd to rs2 dependency - case with APU latency greater than 1 
+        cr_rd_rs2_eq_nonzero_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+        }
+        
+        //cross coverage for F-instructions with rd to rs2 dependency
+        cr_rd_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+            option.weight = 50;
+        }
+        
+    endgroup : cg_zfinx_inst_reg
+
+endclass : uvme_rv32f_zfinx_covg
+
+function uvme_rv32f_zfinx_covg::new(string name = "rv32f_zfinx_covg", uvm_component parent = null);
+    super.new(name, parent);
+    cg_f_multicycle = new();
+`ifdef ZFINX
+    cg_zfinx_inst_reg = new();
+`else
+    cg_f_inst_reg = new();
+`endif
+
+endfunction : new
+
+function void uvme_rv32f_zfinx_covg::build_phase(uvm_phase phase);
+    super.build_phase(phase);
+
+    void'(uvm_config_db#(uvme_cv32e40p_cntxt_c)::get(this, "", "cntxt", cntxt));
+    if (cntxt == null) begin
+        `uvm_fatal("rv32f_zfinx_covg", "No cntxt object passed to model");
+    end
+endfunction : build_phase
+
+task uvme_rv32f_zfinx_covg::run_phase(uvm_phase phase);
+    super.run_phase(phase);
+    `uvm_info("rv32f_zfinx_covg", "The RV32_F_ZFINX coverage model is running", UVM_LOW);
+    fork
+        sample_clk_i();
+    join_none
+endtask : run_phase
+
+
+task uvme_rv32f_zfinx_covg::sample_clk_i();
+    while (1) begin
+        @(cntxt.cov_vif.mon_cb);
+        cg_f_multicycle.sample();
+`ifdef ZFINX
+        cg_zfinx_inst_reg.sample();
+`else
+        cg_f_inst_reg.sample();
+`endif
+    end
+endtask  : sample_clk_i

--- a/cv32e40p/env/uvme/cov/uvme_rv32f_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_rv32f_covg.sv
@@ -41,81 +41,89 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
         option.at_least = 10;
 
         cp_if_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.if_stage_instr_rdata_i {
-            wildcard bins if_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
-            wildcard bins if_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
-            wildcard bins if_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
-            wildcard bins if_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
-            wildcard bins if_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
-            wildcard bins if_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
-            wildcard bins if_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
-            wildcard bins if_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
-            wildcard bins if_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
-            wildcard bins if_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
-            wildcard bins if_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
-            wildcard bins if_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
-            wildcard bins if_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
-            wildcard bins if_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
-            wildcard bins if_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
-            wildcard bins if_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
-            wildcard bins if_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
-            wildcard bins if_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
-            wildcard bins if_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
-            wildcard bins if_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
-            wildcard bins if_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
-            wildcard bins if_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
-            wildcard bins if_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
-            wildcard bins if_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            wildcard bins if_fadd       =    {INSTR_FADD};
+            wildcard bins if_fsub       =    {INSTR_FSUB};
+            wildcard bins if_fmul       =    {INSTR_FMUL};
+            wildcard bins if_fdiv       =    {INSTR_FDIV};
+            wildcard bins if_fsqrt      =    {INSTR_FSQRT};
+            wildcard bins if_fsgnjs     =    {INSTR_FSGNJS};
+            wildcard bins if_fsgnjns    =    {INSTR_FSGNJNS};
+            wildcard bins if_fsgnjxs    =    {INSTR_FSGNJXS};
+            wildcard bins if_fmin       =    {INSTR_FMIN};
+            wildcard bins if_fmax       =    {INSTR_FMAX};
+            wildcard bins if_fcvtws     =    {INSTR_FCVTWS};
+            wildcard bins if_fcvtwus    =    {INSTR_FCVTWUS};
+            wildcard bins if_fmvxs      =    {INSTR_FMVXS};
+            wildcard bins if_feqs       =    {INSTR_FEQS};
+            wildcard bins if_flts       =    {INSTR_FLTS};
+            wildcard bins if_fles       =    {INSTR_FLES};
+            wildcard bins if_fclass     =    {INSTR_FCLASS};
+            wildcard bins if_fcvtsw     =    {INSTR_FCVTSW};
+            wildcard bins if_fcvtswu    =    {INSTR_FCVTSWU};
+            wildcard bins if_fmvsw      =    {INSTR_FMVSX};
+            wildcard bins if_fmadd      =    {INSTR_FMADD};
+            wildcard bins if_fmsub      =    {INSTR_FMSUB};
+            wildcard bins if_fnmsub     =    {INSTR_FNMSUB};
+            wildcard bins if_fnmadd     =    {INSTR_FNMADD};
+`ifndef ZFINX
+            wildcard bins if_flw        =    {INSTR_FLW};
+            wildcard bins if_fsw        =    {INSTR_FSW};
+`endif
             option.weight = 5;
         }
 
         cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i {
-            wildcard bins id_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
-            wildcard bins id_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
-            wildcard bins id_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
-            wildcard bins id_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
-            wildcard bins id_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
-            wildcard bins id_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
-            wildcard bins id_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
-            wildcard bins id_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
-            wildcard bins id_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
-            wildcard bins id_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
-            wildcard bins id_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
-            wildcard bins id_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
-            wildcard bins id_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
-            wildcard bins id_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
-            wildcard bins id_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
-            wildcard bins id_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
-            wildcard bins id_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
-            wildcard bins id_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
-            wildcard bins id_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
-            wildcard bins id_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
-            wildcard bins id_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
-            wildcard bins id_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
-            wildcard bins id_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
-            wildcard bins id_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            wildcard bins id_fadd       =    {INSTR_FADD};
+            wildcard bins id_fsub       =    {INSTR_FSUB};
+            wildcard bins id_fmul       =    {INSTR_FMUL};
+            wildcard bins id_fdiv       =    {INSTR_FDIV};
+            wildcard bins id_fsqrt      =    {INSTR_FSQRT};
+            wildcard bins id_fsgnjs     =    {INSTR_FSGNJS};
+            wildcard bins id_fsgnjns    =    {INSTR_FSGNJNS};
+            wildcard bins id_fsgnjxs    =    {INSTR_FSGNJXS};
+            wildcard bins id_fmin       =    {INSTR_FMIN};
+            wildcard bins id_fmax       =    {INSTR_FMAX};
+            wildcard bins id_fcvtws     =    {INSTR_FCVTWS};
+            wildcard bins id_fcvtwus    =    {INSTR_FCVTWUS};
+            wildcard bins id_fmvxs      =    {INSTR_FMVXS};
+            wildcard bins id_feqs       =    {INSTR_FEQS};
+            wildcard bins id_flts       =    {INSTR_FLTS};
+            wildcard bins id_fles       =    {INSTR_FLES};
+            wildcard bins id_fclass     =    {INSTR_FCLASS};
+            wildcard bins id_fcvtsw     =    {INSTR_FCVTSW};
+            wildcard bins id_fcvtswu    =    {INSTR_FCVTSWU};
+            wildcard bins id_fmvsw      =    {INSTR_FMVSX};
+            wildcard bins id_fmadd      =    {INSTR_FMADD};
+            wildcard bins id_fmsub      =    {INSTR_FMSUB};
+            wildcard bins id_fnmsub     =    {INSTR_FNMSUB};
+            wildcard bins id_fnmadd     =    {INSTR_FNMADD};
+`ifndef ZFINX
+            wildcard bins id_flw        =    {INSTR_FLW};
+            wildcard bins id_fsw        =    {INSTR_FSW};
+`endif
             option.weight = 5;
         }
 
         cp_id_stage_apu_op_ex_o : coverpoint cntxt.cov_vif.mon_cb.id_stage_apu_op_ex_o {
-            bins next_apu_op_fmadd       =    {APU_OP_FMADD};
-            bins next_apu_op_fnmsub      =    {APU_OP_FNMSUB};
-            bins next_apu_op_fadd        =    {APU_OP_FADD};
-            bins next_apu_op_fmul        =    {APU_OP_FMUL};
-            bins next_apu_op_fdiv        =    {APU_OP_FDIV};
-            bins next_apu_op_fsqrt       =    {APU_OP_FSQRT};
-            bins next_apu_op_fsgnj       =    {APU_OP_FSGNJ};
-            bins next_apu_op_fminmax     =    {APU_OP_FMINMAX};
-            bins next_apu_op_fcmp        =    {APU_OP_FCMP};
-            bins next_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
-            bins next_apu_op_f2f         =    {APU_OP_F2F};
-            bins next_apu_op_f2i         =    {APU_OP_F2I};
-            bins next_apu_op_i2f         =    {APU_OP_I2F};
-            bins next_apu_op_fmsub       =    {APU_OP_FMSUB};
-            bins next_apu_op_fnmadd      =    {APU_OP_FNMADD};
-            bins next_apu_op_fsub        =    {APU_OP_FSUB};
-            bins next_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
-            bins next_apu_op_f2i_u       =    {APU_OP_F2I_U};
-            bins next_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            bins next_apu_op_fmadd      =    {APU_OP_FMADD};
+            bins next_apu_op_fnmsub     =    {APU_OP_FNMSUB};
+            bins next_apu_op_fadd       =    {APU_OP_FADD};
+            bins next_apu_op_fmul       =    {APU_OP_FMUL};
+            bins next_apu_op_fdiv       =    {APU_OP_FDIV};
+            bins next_apu_op_fsqrt      =    {APU_OP_FSQRT};
+            bins next_apu_op_fsgnj      =    {APU_OP_FSGNJ};
+            bins next_apu_op_fminmax    =    {APU_OP_FMINMAX};
+            bins next_apu_op_fcmp       =    {APU_OP_FCMP};
+            bins next_apu_op_fclassify  =    {APU_OP_FCLASSIFY};
+            bins next_apu_op_f2f        =    {APU_OP_F2F};
+            bins next_apu_op_f2i        =    {APU_OP_F2I};
+            bins next_apu_op_i2f        =    {APU_OP_I2F};
+            bins next_apu_op_fmsub      =    {APU_OP_FMSUB};
+            bins next_apu_op_fnmadd     =    {APU_OP_FNMADD};
+            bins next_apu_op_fsub       =    {APU_OP_FSUB};
+            bins next_apu_op_fsgnj_se   =    {APU_OP_FSGNJ_SE};
+            bins next_apu_op_f2i_u      =    {APU_OP_F2I_U};
+            bins next_apu_op_i2f_u      =    {APU_OP_I2F_U};
             option.weight = 5;
         }
 
@@ -301,54 +309,123 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
             option.weight = 1;
         }
 
+        cp_apu_rvalid : coverpoint cntxt.cov_vif.mon_cb.apu_rvalid_i {
+            bins apu_rvalid = {1};
+            option.weight = 1;
+        }
+
+        cp_apu_contention : coverpoint cntxt.cov_vif.mon_cb.apu_perf_wb_o {
+            bins no_contention = {0};
+            bins has_contention = {1};
+            option.weight = 1;
+        }
+
         cp_curr_fpu_apu_op : coverpoint cntxt.cov_vif.o_curr_fpu_apu_op_if {
-            bins curr_apu_op_fmadd       =    {APU_OP_FMADD};
-            bins curr_apu_op_fnmsub      =    {APU_OP_FNMSUB};
-            bins curr_apu_op_fadd        =    {APU_OP_FADD};
-            bins curr_apu_op_fmul        =    {APU_OP_FMUL};
-            bins curr_apu_op_fdiv        =    {APU_OP_FDIV};
-            bins curr_apu_op_fsqrt       =    {APU_OP_FSQRT};
-            bins curr_apu_op_fsgnj       =    {APU_OP_FSGNJ};
-            bins curr_apu_op_fminmax     =    {APU_OP_FMINMAX};
-            bins curr_apu_op_fcmp        =    {APU_OP_FCMP};
-            bins curr_apu_op_fclassify   =    {APU_OP_FCLASSIFY};
-            bins curr_apu_op_f2f         =    {APU_OP_F2F};
-            bins curr_apu_op_f2i         =    {APU_OP_F2I};
-            bins curr_apu_op_i2f         =    {APU_OP_I2F};
-            bins curr_apu_op_fmsub       =    {APU_OP_FMSUB};
-            bins curr_apu_op_fnmadd      =    {APU_OP_FNMADD};
-            bins curr_apu_op_fsub        =    {APU_OP_FSUB};
-            bins curr_apu_op_fsgnj_se    =    {APU_OP_FSGNJ_SE};
-            bins curr_apu_op_f2i_u       =    {APU_OP_F2I_U};
-            bins curr_apu_op_i2f_u       =    {APU_OP_I2F_U};
+            bins curr_apu_op_fmadd      =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub     =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd       =    {APU_OP_FADD};
+            bins curr_apu_op_fmul       =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv       =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt      =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj      =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax    =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp       =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify  =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f        =    {APU_OP_F2F};
+            bins curr_apu_op_f2i        =    {APU_OP_F2I};
+            bins curr_apu_op_i2f        =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub      =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd     =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub       =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se   =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u      =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u      =    {APU_OP_I2F_U};
             option.weight = 5;
         }
 
+`ifdef FPU_LAT_1_CYC
+        cp_last_fpu_apu_op_at_contention : coverpoint cntxt.cov_vif.o_last_fpu_apu_op_if {
+            bins curr_apu_op_fmadd        =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd         =    {APU_OP_FADD};
+            bins curr_apu_op_fmul         =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv         =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp         =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f          =    {APU_OP_F2F};
+            bins curr_apu_op_f2i          =    {APU_OP_F2I};
+            bins curr_apu_op_i2f          =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub         =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+`endif
+
+        //TODO: need to add another cover point for F-inst at ID-EX boundary ?
         cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i {
-            wildcard bins id_fadd = {cv32e40p_tracer_pkg::INSTR_FADD};
-            wildcard bins id_fsub = {cv32e40p_tracer_pkg::INSTR_FSUB};
-            wildcard bins id_fmul = {cv32e40p_tracer_pkg::INSTR_FMUL};
-            wildcard bins id_fdiv = {cv32e40p_tracer_pkg::INSTR_FDIV};
-            wildcard bins id_fsqrt = {cv32e40p_tracer_pkg::INSTR_FSQRT};
-            wildcard bins id_fsgnjs = {cv32e40p_tracer_pkg::INSTR_FSGNJS};
-            wildcard bins id_fsgnjns = {cv32e40p_tracer_pkg::INSTR_FSGNJNS};
-            wildcard bins id_fsgnjxs = {cv32e40p_tracer_pkg::INSTR_FSGNJXS};
-            wildcard bins id_fmin = {cv32e40p_tracer_pkg::INSTR_FMIN};
-            wildcard bins id_fmax = {cv32e40p_tracer_pkg::INSTR_FMAX};
-            wildcard bins id_fcvtws = {cv32e40p_tracer_pkg::INSTR_FCVTWS};
-            wildcard bins id_fcvtwus = {cv32e40p_tracer_pkg::INSTR_FCVTWUS};
-            wildcard bins id_fmvxs = {cv32e40p_tracer_pkg::INSTR_FMVXS};
-            wildcard bins id_feqs = {cv32e40p_tracer_pkg::INSTR_FEQS};
-            wildcard bins id_flts = {cv32e40p_tracer_pkg::INSTR_FLTS};
-            wildcard bins id_fles = {cv32e40p_tracer_pkg::INSTR_FLES};
-            wildcard bins id_fclass = {cv32e40p_tracer_pkg::INSTR_FCLASS};
-            wildcard bins id_fcvtsw = {cv32e40p_tracer_pkg::INSTR_FCVTSW};
-            wildcard bins id_fcvtswu = {cv32e40p_tracer_pkg::INSTR_FCVTSWU};
-            wildcard bins id_fmvsw = {cv32e40p_tracer_pkg::INSTR_FMVSX};
-            wildcard bins id_fmadd = {cv32e40p_tracer_pkg::INSTR_FMADD};
-            wildcard bins id_fmsub = {cv32e40p_tracer_pkg::INSTR_FMSUB};
-            wildcard bins id_fnmsub = {cv32e40p_tracer_pkg::INSTR_FNMSUB};
-            wildcard bins id_fnmadd = {cv32e40p_tracer_pkg::INSTR_FNMADD};
+            wildcard bins id_fadd       =    {INSTR_FADD};
+            wildcard bins id_fsub       =    {INSTR_FSUB};
+            wildcard bins id_fmul       =    {INSTR_FMUL};
+            wildcard bins id_fdiv       =    {INSTR_FDIV};
+            wildcard bins id_fsqrt      =    {INSTR_FSQRT};
+            wildcard bins id_fsgnjs     =    {INSTR_FSGNJS};
+            wildcard bins id_fsgnjns    =    {INSTR_FSGNJNS};
+            wildcard bins id_fsgnjxs    =    {INSTR_FSGNJXS};
+            wildcard bins id_fmin       =    {INSTR_FMIN};
+            wildcard bins id_fmax       =    {INSTR_FMAX};
+            wildcard bins id_fcvtws     =    {INSTR_FCVTWS};
+            wildcard bins id_fcvtwus    =    {INSTR_FCVTWUS};
+            wildcard bins id_fmvxs      =    {INSTR_FMVXS};
+            wildcard bins id_feqs       =    {INSTR_FEQS};
+            wildcard bins id_flts       =    {INSTR_FLTS};
+            wildcard bins id_fles       =    {INSTR_FLES};
+            wildcard bins id_fclass     =    {INSTR_FCLASS};
+            wildcard bins id_fcvtsw     =    {INSTR_FCVTSW};
+            wildcard bins id_fcvtswu    =    {INSTR_FCVTSWU};
+            wildcard bins id_fmvsw      =    {INSTR_FMVSX};
+            wildcard bins id_fmadd      =    {INSTR_FMADD};
+            wildcard bins id_fmsub      =    {INSTR_FMSUB};
+            wildcard bins id_fnmsub     =    {INSTR_FNMSUB};
+            wildcard bins id_fnmadd     =    {INSTR_FNMADD};
+`ifndef ZFINX
+            wildcard bins id_flw        =    {INSTR_FLW};
+            wildcard bins id_fsw        =    {INSTR_FSW};
+`endif
+            option.weight = 5;
+        }
+
+        //TODO: to add rv32c coverage
+        cp_id_stage_non_rv32fc_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[6:0] {
+            bins system_opcode          =    {TB_OPCODE_SYSTEM};
+            bins fence_opcode           =    {TB_OPCODE_FENCE};
+            bins op_opcode              =    {TB_OPCODE_OP};
+            bins opimm_opcode           =    {TB_OPCODE_OPIMM};
+            bins store_opcode           =    {TB_OPCODE_STORE};
+            bins load_opcode            =    {TB_OPCODE_LOAD};
+            bins branch_opcode          =    {TB_OPCODE_BRANCH};
+            bins jalr_opcode            =    {TB_OPCODE_JALR};
+            bins jal_opcode             =    {TB_OPCODE_JAL};
+            bins auipc_opcode           =    {TB_OPCODE_AUIPC};
+            bins lui_opcode             =    {TB_OPCODE_LUI};
+            bins fpu_fp_opcode          =    {TB_OPCODE_OP_FP};
+            bins fpu_fmadd_opcode       =    {TB_OPCODE_OP_FMADD};
+            bins fpu_fnmadd_opcode      =    {TB_OPCODE_OP_FNMADD};
+            bins fpu_fmsub_opcode       =    {TB_OPCODE_OP_FMSUB};
+            bins fpu_fnmsub_opcode      =    {TB_OPCODE_OP_FNMSUB};
+            bins fpu_str_opcode         =    {TB_OPCODE_STORE_FP};
+            bins fpu_ld_opcode          =    {TB_OPCODE_LOAD_FP};
+            bins xpulp_custom_0         =    {OPCODE_CUSTOM_0};
+            bins xpulp_custom_1         =    {OPCODE_CUSTOM_1};
+            bins xpulp_custom_2         =    {OPCODE_CUSTOM_2};
+            bins xpulp_custom_3         =    {OPCODE_CUSTOM_3};
+
             option.weight = 5;
         }
 
@@ -372,6 +449,36 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
             bins rs1[] = {[0:31]};
             option.weight = 1;
         }
+`ifndef FPU_LAT_1_CYC
+        cp_apu_alu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+`else
+        cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+`endif
+        cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
+            bins rd[] = {[0:63]};
+            option.weight = 1;
+        }
+
+        cp_contention_state : coverpoint cntxt.cov_vif.contention_state {
+            bins no_contention = {0};
+            bins contention_1st_cyc_done = {1};
+            bins contention_2nd_cyc_done = {2};
+            ignore_bins state3 = {3};
+            option.weight = 1;
+        }
+
+        cp_b2b_contention : coverpoint cntxt.cov_vif.b2b_contention {
+            bins b2b_contention_true = {1};
+            option.weight = 5;
+        }
 
         cp_fd_fs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_fd) {
             bins fd_fs1_equal = {1};
@@ -379,72 +486,224 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
         cp_fd_fs2_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_fd) {
             bins fd_fs2_equal = {1};
         }
+        cp_fd_fs3_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_fd) {
+            bins fd_fs3_equal = {1};
+        }
         cp_rd_rs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs1_equal = {1};
+        }
+        cp_rd_rs2_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd) {
             bins rd_rs1_equal = {1};
         }
 
 //*************************************************************************************************************************************************
 //      Cross Coverage description for various cases of reg-to-reg dependencies in instruction sequence with F-multicycle cases
 //*************************************************************************************************************************************************
+//Description: This cross coverage captures the cases where latest APU execution's RD addr is same as rs1/rs2/rs3 of the next instruction in pipeline.
+//Design is expected to stall EX in such scenarios until the previous instruction retires. The test scenarios are captured for correct RTL behavior,
+//expecting EX stall in such cases. And for any conflicting design behaviour with EX proceeding without stalls, the tests rely on Reference model
+//to flag the resulting errors.
 
-        //cross coverage for F-instructions with fd to fs1 dependency - case with APU latency greater than 1 
-        cr_fd_fs1_eq_nonzero_lat : cross cp_fd_fs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+//*************************************************************************************************************************************************
+//CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU WRITE WILL WIN (APU LATENCY = 0,2,3,4)
+//*************************************************************************************************************************************************
+
+        //cross coverage for F-instr following F-instr with fd to fs1 dependency - case with APU latency > 0
+        cr_fd_fs1_eq_nonzero_lat : cross cp_fd_fs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
             ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
 `ifdef FPU_LAT_0_CYC
             ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
 `endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
 
-        //cross coverage for F-instructions with fd to fs2 dependency - case with APU latency greater than 1 
-        cr_fd_fs2_eq_nonzero_lat : cross cp_fd_fs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+        //cross coverage for F-instr following F-instr with fd to fs2 dependency - case with APU latency > 0
+        cr_fd_fs2_eq_nonzero_lat : cross cp_fd_fs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
             ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
 `ifdef FPU_LAT_0_CYC
             ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
 `endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
 
-        //cross coverage for F-instructions with fd to fs1 dependency 
-        cr_fd_fs1_eq_no_lat  :  cross cp_fd_fs1_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
+        //cross coverage for F-instr following F-instr with fd to fs3 dependency - case with APU latency > 0
+        cr_fd_fs3_eq_nonzero_lat : cross cp_fd_fs3_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
             ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_fs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {INSTR_FMADD,INSTR_FMSUB,INSTR_FNMSUB,INSTR_FNMADD};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
 
-        //cross coverage for F-instructions with fd to fs2 dependency 
-        cr_fd_fs2_eq_no_lat  :  cross cp_fd_fs2_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op {
-            option.weight = 50;
-            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
-        }
-
-        //cross coverage for F-instructions with rd to rs1 dependency - case with APU latency greater than 1
-        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
             ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
             ignore_bins non_rs_id_stage_f_inst = !binsof(cp_id_stage_f_inst) intersect {APU_OP_I2F, APU_OP_I2F_U};
 `ifdef FPU_LAT_0_CYC
             ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
 `endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
 
-        //cross coverage for F-instructions with rd to rs1 dependency 
-        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs1_eq_nonzero_lat : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs2_eq_nonzero_lat : cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
+        }
+
+`ifndef FPU_LAT_1_CYC
+        //cross coverage for contention case 2nd cycle with ALU regfile write
+        cr_waddr_rd_apu_alu_ex_contention : cross cp_apu_alu_contention_wr_rd, cp_contention_state, cp_apu_contention {
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
+        }
+`endif
+
+
+//*************************************************************************************************************************************************
+//CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU WRITE WILL WIN for APU LATENCY = 0
+//*************************************************************************************************************************************************
+
+`ifdef FPU_LAT_0_CYC
+        //cross coverage for F-instr following F-instr with fd to fs1 dependency - 0 Latency
+        cr_fd_fs1_eq_no_lat  :  cross cp_fd_fs1_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        }
+
+        //cross coverage for F-instr following F-instr with fd to fs2 dependency - 0 Latency
+        cr_fd_fs2_eq_no_lat  :  cross cp_fd_fs2_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+        }
+
+        //cross coverage for F-instr following F-instr with fd to fs3 dependency - 0 Latency
+        cr_fd_fs3_eq_no_lat  :  cross cp_fd_fs3_eq, cp_apu_req_valid, cp_id_stage_f_inst, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_fd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_fs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {INSTR_FMADD,INSTR_FMSUB,INSTR_FNMSUB,INSTR_FNMADD};
+        }
+
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
             ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
             ignore_bins non_rs_id_stage_f_inst = !binsof(cp_id_stage_f_inst) intersect {APU_OP_I2F, APU_OP_I2F_U};
         }
-        
-        //TODO : need for cross with non-fpu inst in pipeline with same reg dependency?
-        //cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
-        //    option.weight = 50;
-        //    ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
-        //    ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
-        //}
-        //cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
-        //    option.weight = 50;
-        //    ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
-        //}
 
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+        }
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+        }
+`endif
+
+//*************************************************************************************************************************************************
+//CASES WITH CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU RESULT WRITE TO REGFILE STALLS (APU LATENCY = 1)
+//*************************************************************************************************************************************************
+
+`ifdef FPU_LAT_1_CYC
+        //cp_apu_contention = 1 cases
+        //cp_contention_state = 1 indicates that there was contention in WB at LSU-APU regfile wr mux
+
+        //cross coverage for F-instr following F-instr with fd to fs1 dependency - case with APU latency = 1 and contention with LSU
+        cr_fd_fs1_eq_nonzero_lat_with_contention : cross cp_fd_fs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_fd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for F-instr following F-instr with fd to fs2 dependency - case with APU latency = 1 and contention with LSU
+        cr_fd_fs2_eq_nonzero_lat_with_contention : cross cp_fd_fs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_fd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for F-instr following F-instr with fd to fs3 dependency - case with APU latency = 1 and contention with LSU
+        cr_fd_fs3_eq_nonzero_lat_with_contention : cross cp_fd_fs3_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_fd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_fd_f_inst = binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_fs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {INSTR_FMADD,INSTR_FMSUB,INSTR_FNMSUB,INSTR_FNMADD};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - case with APU latency = 1 and contention with LSU
+        cr_rd_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rd_f_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FCMP, APU_OP_FCLASSIFY, APU_OP_F2I, APU_OP_F2I_U};
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //TODO: does it require checking rd to rs1/rs2 equal in this case?
+        //cross coverage for contention case 1st cycle with LSU regfile write win
+        cr_waddr_rd_lsu_apu_wb_contention : cross cp_apu_busy, cp_apu_rvalid, cp_lsu_apu_contention_wr_rd, cp_apu_contention {
+            ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
+        }
+
+`endif
 
 
     endgroup : cg_f_inst_reg
@@ -464,6 +723,17 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
 
         cp_apu_busy : coverpoint cntxt.cov_vif.mon_cb.apu_busy {
             bins apu_busy_high = {1'b1};
+            option.weight = 1;
+        }
+
+        cp_apu_rvalid : coverpoint cntxt.cov_vif.mon_cb.apu_rvalid_i {
+            bins apu_rvalid = {1};
+            option.weight = 1;
+        }
+
+        cp_apu_contention : coverpoint cntxt.cov_vif.mon_cb.apu_perf_wb_o {
+            bins no_contention = {0};
+            bins has_contention = {1};
             option.weight = 1;
         }
 
@@ -495,16 +765,85 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
             option.weight = 5;
         }
 
-        cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[7:0] {
-            bins f_inst_opcode_in_id_stage[] = {    
-                                        cv32e40p_pkg::OPCODE_OP_FP,
-                                        cv32e40p_pkg::OPCODE_OP_FMADD,
-                                        cv32e40p_pkg::OPCODE_OP_FMSUB,
-                                        cv32e40p_pkg::OPCODE_OP_FNMSUB,
-                                        cv32e40p_pkg::OPCODE_OP_FNMADD,
-                                        cv32e40p_pkg::OPCODE_STORE_FP,
-                                        cv32e40p_pkg::OPCODE_LOAD_FP
-            };
+`ifdef FPU_LAT_1_CYC
+        cp_last_fpu_apu_op_at_contention : coverpoint cntxt.cov_vif.o_last_fpu_apu_op_if {
+            bins curr_apu_op_fmadd        =    {APU_OP_FMADD};
+            bins curr_apu_op_fnmsub       =    {APU_OP_FNMSUB};
+            bins curr_apu_op_fadd         =    {APU_OP_FADD};
+            bins curr_apu_op_fmul         =    {APU_OP_FMUL};
+            bins curr_apu_op_fdiv         =    {APU_OP_FDIV};
+            bins curr_apu_op_fsqrt        =    {APU_OP_FSQRT};
+            bins curr_apu_op_fsgnj        =    {APU_OP_FSGNJ};
+            bins curr_apu_op_fminmax      =    {APU_OP_FMINMAX};
+            bins curr_apu_op_fcmp         =    {APU_OP_FCMP};
+            bins curr_apu_op_fclassify    =    {APU_OP_FCLASSIFY};
+            bins curr_apu_op_f2f          =    {APU_OP_F2F};
+            bins curr_apu_op_f2i          =    {APU_OP_F2I};
+            bins curr_apu_op_i2f          =    {APU_OP_I2F};
+            bins curr_apu_op_fmsub        =    {APU_OP_FMSUB};
+            bins curr_apu_op_fnmadd       =    {APU_OP_FNMADD};
+            bins curr_apu_op_fsub         =    {APU_OP_FSUB};
+            bins curr_apu_op_fsgnj_se     =    {APU_OP_FSGNJ_SE};
+            bins curr_apu_op_f2i_u        =    {APU_OP_F2I_U};
+            bins curr_apu_op_i2f_u        =    {APU_OP_I2F_U};
+            option.weight = 5;
+        }
+`endif
+
+        //TODO: need to add another cover point for F-inst at ID-EX boundary ?
+        cp_id_stage_f_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i {
+            wildcard bins id_fadd       =    {INSTR_FADD};
+            wildcard bins id_fsub       =    {INSTR_FSUB};
+            wildcard bins id_fmul       =    {INSTR_FMUL};
+            wildcard bins id_fdiv       =    {INSTR_FDIV};
+            wildcard bins id_fsqrt      =    {INSTR_FSQRT};
+            wildcard bins id_fsgnjs     =    {INSTR_FSGNJS};
+            wildcard bins id_fsgnjns    =    {INSTR_FSGNJNS};
+            wildcard bins id_fsgnjxs    =    {INSTR_FSGNJXS};
+            wildcard bins id_fmin       =    {INSTR_FMIN};
+            wildcard bins id_fmax       =    {INSTR_FMAX};
+            wildcard bins id_fcvtws     =    {INSTR_FCVTWS};
+            wildcard bins id_fcvtwus    =    {INSTR_FCVTWUS};
+            wildcard bins id_fmvxs      =    {INSTR_FMVXS};
+            wildcard bins id_feqs       =    {INSTR_FEQS};
+            wildcard bins id_flts       =    {INSTR_FLTS};
+            wildcard bins id_fles       =    {INSTR_FLES};
+            wildcard bins id_fclass     =    {INSTR_FCLASS};
+            wildcard bins id_fcvtsw     =    {INSTR_FCVTSW};
+            wildcard bins id_fcvtswu    =    {INSTR_FCVTSWU};
+            wildcard bins id_fmvsw      =    {INSTR_FMVSX};
+            wildcard bins id_fmadd      =    {INSTR_FMADD};
+            wildcard bins id_fmsub      =    {INSTR_FMSUB};
+            wildcard bins id_fnmsub     =    {INSTR_FNMSUB};
+            wildcard bins id_fnmadd     =    {INSTR_FNMADD};
+            option.weight = 5;
+        }
+
+        //TODO: to add rv32c coverage
+        cp_id_stage_non_rv32fc_inst : coverpoint cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[6:0] {
+            bins system_opcode          =    {TB_OPCODE_SYSTEM};
+            bins fence_opcode           =    {TB_OPCODE_FENCE};
+            bins op_opcode              =    {TB_OPCODE_OP};
+            bins opimm_opcode           =    {TB_OPCODE_OPIMM};
+            bins store_opcode           =    {TB_OPCODE_STORE};
+            bins load_opcode            =    {TB_OPCODE_LOAD};
+            bins branch_opcode          =    {TB_OPCODE_BRANCH};
+            bins jalr_opcode            =    {TB_OPCODE_JALR};
+            bins jal_opcode             =    {TB_OPCODE_JAL};
+            bins auipc_opcode           =    {TB_OPCODE_AUIPC};
+            bins lui_opcode             =    {TB_OPCODE_LUI};
+            bins fpu_fp_opcode          =    {TB_OPCODE_OP_FP};
+            bins fpu_fmadd_opcode       =    {TB_OPCODE_OP_FMADD};
+            bins fpu_fnmadd_opcode      =    {TB_OPCODE_OP_FNMADD};
+            bins fpu_fmsub_opcode       =    {TB_OPCODE_OP_FMSUB};
+            bins fpu_fnmsub_opcode      =    {TB_OPCODE_OP_FNMSUB};
+            bins fpu_str_opcode         =    {TB_OPCODE_STORE_FP};
+            bins fpu_ld_opcode          =    {TB_OPCODE_LOAD_FP};
+            bins xpulp_custom_0         =    {OPCODE_CUSTOM_0};
+            bins xpulp_custom_1         =    {OPCODE_CUSTOM_1};
+            bins xpulp_custom_2         =    {OPCODE_CUSTOM_2};
+            bins xpulp_custom_3         =    {OPCODE_CUSTOM_3};
+
             option.weight = 5;
         }
 
@@ -529,43 +868,219 @@ class uvme_rv32f_zfinx_covg extends uvm_component;
             option.weight = 1;
         }
 
+`ifndef FPU_LAT_1_CYC
+        cp_apu_alu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+`else
+        cp_lsu_apu_contention_wr_rd : coverpoint cntxt.cov_vif.curr_rd_at_wb_regfile_wr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};
+            option.weight = 1;
+        }
+`endif
+        cp_prev_rd_waddr_contention : coverpoint cntxt.cov_vif.prev_rd_waddr_contention {
+            bins rd[] = {[0:31]};
+            illegal_bins rd_addr_32_63 = {[32:63]};  //for zfinx only 32 gprs available
+            option.weight = 1;
+        }
+
+        cp_contention_state : coverpoint cntxt.cov_vif.contention_state {
+            bins no_contention = {0};
+            bins contention_1st_cyc_done = {1};
+            bins contention_2nd_cyc_done = {2};
+            ignore_bins state3 = {3};
+            option.weight = 1;
+        }
+
+        cp_b2b_contention : coverpoint cntxt.cov_vif.b2b_contention {
+            bins b2b_contention_true = {1};
+            option.weight = 5;
+        }
+
         cp_rd_rs1_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[19:15] == cntxt.cov_vif.curr_fpu_rd) {
             bins rd_rs1_equal = {1};
         }
         cp_rd_rs2_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[24:20] == cntxt.cov_vif.curr_fpu_rd) {
             bins rd_rs2_equal = {1};
         }
- 
+        cp_rd_rs3_eq : coverpoint (cntxt.cov_vif.mon_cb.id_stage_instr_rdata_i[31:27] == cntxt.cov_vif.curr_fpu_rd) {
+            bins rd_rs3_equal = {1};
+        }
+`ifndef FPU_LAT_1_CYC
+        cp_contention_rd_rd_eq : coverpoint (cntxt.cov_vif.curr_rd_at_ex_regfile_wr_contention == cntxt.cov_vif.prev_rd_waddr_contention) {
+            bins contention_rd_rd_equal = {1};
+        }
+`else
+        cp_contention_rd_rd_eq : coverpoint (cntxt.cov_vif.curr_fpu_rd == cntxt.cov_vif.prev_rd_waddr_contention) {
+            bins contention_rd_rd_equal = {1};
+        }
+`endif
+
 //*************************************************************************************************************************************************
 //      Cross Coverage description for various cases of reg-to-reg dependencies in instruction sequence with F-multicycle cases
 //*************************************************************************************************************************************************
 
-        //cross coverage for F-instructions with rd to rs1 dependency - case with APU latency greater than 1 
-        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+//*************************************************************************************************************************************************
+//CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU WRITE WILL WIN (APU LATENCY = 0,2,3,4)
+//*************************************************************************************************************************************************
+
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rd_rs1_eq_nonzero_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
 `ifdef FPU_LAT_0_CYC
             ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
 `endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
 
-        //cross coverage for F-instructions with rd to rs1 dependency
-        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
-            option.weight = 50;
-        }
-
-        //cross coverage for F-instructions with rd to rs2 dependency - case with APU latency greater than 1 
-        cr_rd_rs2_eq_nonzero_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+        //cross coverage for F-instr following F-instr with rd to rs2 dependency - case with APU latency > 0
+        cr_rd_rs2_eq_nonzero_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
 `ifdef FPU_LAT_0_CYC
             ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
 `endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
         }
-        
-        //cross coverage for F-instructions with rd to rs2 dependency
-        cr_rd_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op {
+
+        //cross coverage for F-instr following F-instr with rd to rs3 dependency - case with APU latency > 0
+        cr_rd_rs3_eq_nonzero_lat  :  cross cp_rd_rs3_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {INSTR_FMADD,INSTR_FMSUB,INSTR_FNMSUB,INSTR_FNMADD};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs1_eq_nonzero_lat : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - case with APU latency > 0
+        cr_rv32f_rd_non_rv32f_rs2_eq_nonzero_lat : cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_busy, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+`ifdef FPU_LAT_0_CYC
+            ignore_bins zero_lat_inst = !binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT};
+`endif
+`ifdef FPU_LAT_1_CYC
+            ignore_bins in_contention_lsu_wr = binsof(cp_apu_contention) intersect {1};
+`endif
+        }
+
+`ifndef FPU_LAT_1_CYC
+        //cross coverage for contention case 2nd cycle with ALU regfile write
+        cr_waddr_rd_apu_alu_ex_contention : cross cp_apu_alu_contention_wr_rd, cp_contention_state, cp_apu_contention {
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
+        }
+`endif
+
+        //cross coverage for RD-RD equal for both contention instructions
+        cr_contention_rd_rd_eq : cross cp_contention_rd_rd_eq, cp_contention_state, cp_apu_contention {
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins no_contention = binsof(cp_apu_contention) intersect {1};
+        }
+
+//*************************************************************************************************************************************************
+//CASES WITH/WITHOUT CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU WRITE WILL WIN for APU LATENCY = 0
+//*************************************************************************************************************************************************
+
+`ifdef FPU_LAT_0_CYC
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rd_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+        }
+
+        //cross coverage for F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rd_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
             option.weight = 50;
         }
         
+        //cross coverage for F-instr following F-instr with rd to rs3 dependency - 0 Latency
+        cr_rd_rs3_eq_no_lat  :  cross cp_rd_rs3_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs3_f_inst = !binsof(cp_id_stage_f_inst) intersect {INSTR_FMADD,INSTR_FMSUB,INSTR_FNMSUB,INSTR_FNMADD};
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs1_eq_no_lat  :  cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+        }
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - 0 Latency
+        cr_rv32f_rd_non_rv32fc_rs2_eq_no_lat  :  cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_apu_req_valid, cp_apu_grant_valid, cp_apu_rvalid, cp_curr_fpu_inst_rd, cp_curr_fpu_apu_op, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+        }
+`endif
+
+//*************************************************************************************************************************************************
+//CASES WITH CONTENTION AT THE TIME OF APU RESULT WRITE TO REGFILE WHERE APU RESULT WRITE TO REGFILE STALLS (APU LATENCY = 1)
+//*************************************************************************************************************************************************
+
+`ifdef FPU_LAT_1_CYC
+        //cross coverage for F-instr following F-instr with rd to rs1 dependency - case with APU latency = 1 and contention with LSU
+        cr_rd_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for F-instr following F-instr with rd to rs2 dependency - case with APU latency = 1 and contention with LSU
+        cr_rd_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for F-instr following F-instr with rd to rs3 dependency - case with APU latency = 1 and contention with LSU
+        cr_rd_rs3_eq_nonzero_lat_with_contention : cross cp_rd_rs3_eq, cp_id_inst_valid, cp_id_stage_f_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs1 dependency - case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs1_eq_nonzero_lat_with_contention : cross cp_rd_rs1_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs1_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //cross coverage for Non F-instr following F-instr with rd to rs2 dependency - case with APU latency = 1 and contention with LSU
+        cr_rv32f_rd_non_rv32fc_rs2_eq_nonzero_lat_with_contention : cross cp_rd_rs2_eq, cp_id_inst_valid, cp_id_stage_non_rv32fc_inst, cp_curr_fpu_inst_rd, cp_last_fpu_apu_op_at_contention, cp_contention_state, cp_apu_contention {
+            option.weight = 50;
+            ignore_bins non_rs2_rv32_instr = binsof(cp_id_stage_non_rv32fc_inst) intersect {TB_OPCODE_LUI,TB_OPCODE_AUIPC,TB_OPCODE_JAL,TB_OPCODE_JALR,TB_OPCODE_LOAD,TB_OPCODE_OPIMM,TB_OPCODE_FENCE,TB_OPCODE_SYSTEM};
+            ignore_bins non_stalled_contention_wr_state = binsof(cp_contention_state) intersect {0,1};
+            ignore_bins contention_at_lsu_wr = binsof(cp_apu_contention) intersect {1};
+        }
+
+        //TODO: does it require checking rd to rs1/rs2 equal in this case?
+        //cross coverage for contention case 1st cycle with LSU regfile write win
+        cr_waddr_rd_lsu_apu_wb_contention : cross cp_apu_busy, cp_apu_rvalid, cp_lsu_apu_contention_wr_rd, cp_apu_contention {
+            ignore_bins no_contention_lsu_wr = binsof(cp_apu_contention) intersect {0};
+
+`endif
     endgroup : cg_zfinx_inst_reg
 
 endclass : uvme_rv32f_zfinx_covg

--- a/cv32e40p/env/uvme/uvme_cv32e40p_cntxt.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_cntxt.sv
@@ -30,6 +30,7 @@ class uvme_cv32e40p_cntxt_c extends uvm_object;
    virtual uvmt_cv32e40p_vp_status_if         vp_status_vif; ///< Virtual interface for Virtual Peripherals
    virtual uvma_interrupt_if                  intr_vif     ; ///< Virtual interface for interrupts
    virtual uvma_debug_if                      debug_vif    ; ///< Virtual interface for debug
+   virtual uvmt_cv32e40p_cov_if               cov_vif      ; ///< Virtual interface to use for all other coverage classes
 
    // Agent context handles
    uvma_cv32e40p_core_cntrl_cntxt_c  core_cntrl_cntxt;

--- a/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
@@ -55,6 +55,55 @@ parameter CV_VP_OBI_SLV_RESP_BASE      = CV_VP_REGISTER_BASE + CV_VP_OBI_SLV_RES
 parameter CV_VP_SIG_WRITER_BASE        = CV_VP_REGISTER_BASE + CV_VP_SIG_WRITER_OFFSET;
 parameter CV_VP_FENCEI_TAMPER_BASE     = CV_VP_REGISTER_BASE + CV_VP_FENCEI_TAMPER_OFFSET;
 
+parameter TB_OPCODE_SYSTEM             =    7'h73;
+parameter TB_OPCODE_FENCE              =    7'h0f;
+parameter TB_OPCODE_OP                 =    7'h33;
+parameter TB_OPCODE_OPIMM              =    7'h13;
+parameter TB_OPCODE_STORE              =    7'h23;
+parameter TB_OPCODE_LOAD               =    7'h03;
+parameter TB_OPCODE_BRANCH             =    7'h63;
+parameter TB_OPCODE_JALR               =    7'h67;
+parameter TB_OPCODE_JAL                =    7'h6f;
+parameter TB_OPCODE_AUIPC              =    7'h17;
+parameter TB_OPCODE_LUI                =    7'h37;
+parameter TB_OPCODE_AMO                =    7'h2F;
+
+parameter TB_OPCODE_OP_FP              =    7'h53;
+parameter TB_OPCODE_OP_FMADD           =    7'h43;
+parameter TB_OPCODE_OP_FNMADD          =    7'h4f;
+parameter TB_OPCODE_OP_FMSUB           =    7'h47;
+parameter TB_OPCODE_OP_FNMSUB          =    7'h4b;
+parameter TB_OPCODE_STORE_FP           =    7'h27;
+parameter TB_OPCODE_LOAD_FP            =    7'h07;
+
+parameter INSTR_FMADD               =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FMADD};
+parameter INSTR_FMSUB               =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FMSUB};
+parameter INSTR_FNMSUB              =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FNMSUB};
+parameter INSTR_FNMADD              =    {5'b?, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FNMADD};
+parameter INSTR_FADD                =    {5'b00000, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FSUB                =    {5'b00001, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FMUL                =    {5'b00010, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FDIV                =    {5'b00011, 2'b00, 10'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FSQRT               =    {5'b01011, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FSGNJS              =    {5'b00100, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FSGNJNS             =    {5'b00100, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FSGNJXS             =    {5'b00100, 2'b00, 10'b?, 3'b010, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FMIN                =    {5'b00101, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FMAX                =    {5'b00101, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FCVTWS              =    {5'b11000, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FCVTWUS             =    {5'b11000, 2'b00, 5'b1, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FMVXS               =    {5'b11100, 2'b00, 5'b0, 5'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FEQS                =    {5'b10100, 2'b00, 10'b?, 3'b010, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FLTS                =    {5'b10100, 2'b00, 10'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FLES                =    {5'b10100, 2'b00, 10'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FCLASS              =    {5'b11100, 2'b00, 5'b0, 5'b?, 3'b001, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FCVTSW              =    {5'b11010, 2'b00, 5'b0, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FCVTSWU             =    {5'b11010, 2'b00, 5'b1, 5'b?, 3'b?, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FMVSX               =    {5'b11110, 2'b00, 5'b0, 5'b?, 3'b000, 5'b?, TB_OPCODE_OP_FP};
+parameter INSTR_FLW                 =    {12'b?,5'b?,3'b010,5'b?,TB_OPCODE_LOAD_FP};
+parameter INSTR_FSW                 =    {7'b?,5'b?,5'b?,3'b010,5'b?,TB_OPCODE_STORE_FP};
+
+
 //XPULP instructions custom opcodes
 parameter OPCODE_CUSTOM_0 = 7'h0b;
 parameter OPCODE_CUSTOM_1 = 7'h2b;

--- a/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_constants.sv
@@ -443,4 +443,31 @@ parameter INSTR_CV_SUB_DIV2         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b0
 parameter INSTR_CV_SUB_DIV4         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b100, 5'b?, OPCODE_CUSTOM_3};
 parameter INSTR_CV_SUB_DIV8         =    {5'b01110, 1'b1, 1'b0, 5'b?, 5'b?, 3'b110, 5'b?, OPCODE_CUSTOM_3};
 
+parameter APU_OP_FMADD              =    {6'h00};
+parameter APU_OP_FNMSUB             =    {6'h01};
+parameter APU_OP_FADD               =    {6'h02};
+parameter APU_OP_FMUL               =    {6'h03};
+parameter APU_OP_FDIV               =    {6'h04};
+parameter APU_OP_FSQRT              =    {6'h05};
+parameter APU_OP_FSGNJ              =    {6'h06};
+parameter APU_OP_FMINMAX            =    {6'h07};
+parameter APU_OP_FCMP               =    {6'h08};
+parameter APU_OP_FCLASSIFY          =    {6'h09};
+parameter APU_OP_F2F                =    {6'h0A};
+parameter APU_OP_F2I                =    {6'h0B};
+parameter APU_OP_I2F                =    {6'h0C};
+
+parameter APU_OP_FMSUB              =    {6'h10};
+parameter APU_OP_FNMADD             =    {6'h11};
+parameter APU_OP_FSUB               =    {6'h12};
+parameter APU_OP_FSGNJ_SE           =    {6'h16};
+parameter APU_OP_F2I_U              =    {6'h1B};
+parameter APU_OP_I2F_U              =    {6'h1C};
+
+`ifdef FPU_ADDMUL_LAT
+    `define FPU_LAT_``FPU_ADDMUL_LAT``_CYC
+`else
+    `define FPU_LAT_0_CYC
+`endif
+
 `endif // __UVME_CV32E40P_CONSTANTS_SV__

--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -377,6 +377,11 @@ function void uvme_cv32e40p_env_c::retrieve_vifs();
       `uvm_fatal("UVME_CV32E40P_ENV", $sformatf("No uvmt_cv32e40p_debug_cov_assert_if found in config database"))
    end
 
+   void'(uvm_config_db#(virtual uvmt_cv32e40p_cov_if)::get(this, "", "cov_vif", cntxt.cov_vif));
+   if (cntxt.cov_vif == null) begin
+      `uvm_fatal("UVME_CV32E40P_ENV", $sformatf("No uvmt_cv32e40p_cov_if found in config database"))
+   end
+
 endfunction: retrieve_vifs
 
 

--- a/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_pkg.sv
@@ -84,6 +84,7 @@ package uvme_cv32e40p_pkg;
    `include "uvme_interrupt_covg.sv"
    `include "uvme_debug_covg.sv"
    `include "uvme_rv32isa_covg.sv"
+   `include "uvme_rv32f_covg.sv"
    `include "uvme_cv32e40p_cov_model.sv"
    `include "uvme_cv32e40p_sb.sv"
    `include "uvme_cv32e40p_vsqr.sv"

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -498,6 +498,24 @@ module uvmt_cv32e40p_tb;
     .pending_enabled_irq()
   );
 
+  //Interface for coverage components
+  uvmt_cv32e40p_cov_if cov_if(
+    .clk_i(clknrst_if.clk),
+    .rst_ni(clknrst_if.reset_n),
+    .if_stage_instr_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rvalid_i),
+    .if_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.if_stage_i.instr_rdata_i),
+    .id_stage_instr_valid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_valid_i),
+    .id_stage_instr_rdata_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.instr_rdata_i),
+    .apu_req(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_req_o),
+    .apu_gnt(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_gnt_i),
+    .apu_busy(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_busy_i),
+    .apu_op(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_op_o),
+    .id_stage_apu_op_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_op_ex_o),
+    .id_stage_apu_en_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_en_ex_o),
+    .regfile_alu_waddr_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_waddr_fw_o),
+    .regfile_alu_we_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_fw_o)
+  );
+
   // Instantiate debug assertions
   uvmt_cv32e40p_debug_assert u_debug_assert(.cov_assert_if(debug_cov_assert_if));
 
@@ -562,6 +580,7 @@ module uvmt_cv32e40p_tb;
      uvm_config_db#(virtual uvmt_cv32e40p_debug_cov_assert_if)::set(.cntxt(null), .inst_name("*.env"),                        .field_name("debug_cov_vif"),    .value(debug_cov_assert_if)                             );
      uvm_config_db#(virtual uvmt_cv32e40p_isa_covg_if        )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("isa_covg_vif"),     .value(isa_covg_if)                                     );
      uvm_config_db#(virtual uvma_debug_if                    )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("debug_vif"),        .value(debug_if)                                        );
+     uvm_config_db#(virtual uvmt_cv32e40p_cov_if             )::set(.cntxt(null), .inst_name("*.env"),                        .field_name("cov_vif"),          .value(cov_if)                                          );
 
      `RVFI_CSR_UVM_CONFIG_DB_SET(fflags)
      `RVFI_CSR_UVM_CONFIG_DB_SET(frm)

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb.sv
@@ -510,8 +510,12 @@ module uvmt_cv32e40p_tb;
     .apu_gnt(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_gnt_i),
     .apu_busy(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_busy_i),
     .apu_op(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_op_o),
+    .apu_rvalid_i(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.apu_rvalid_i),
+    .apu_perf_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.apu_perf_wb_o),
     .id_stage_apu_op_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_op_ex_o),
     .id_stage_apu_en_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.id_stage_i.apu_en_ex_o),
+    .regfile_waddr_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_waddr_wb_o),
+    .regfile_we_wb_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_we_wb_o),
     .regfile_alu_waddr_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_waddr_fw_o),
     .regfile_alu_we_ex_o(dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i.ex_stage_i.regfile_alu_we_fw_o)
   );

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_tb_ifs.sv
@@ -342,37 +342,61 @@ interface uvmt_cv32e40p_cov_if
   import uvm_pkg::*;
   import uvme_cv32e40p_pkg::*;
   (
-    input           clk_i,
-    input           rst_ni,
-    input           if_stage_instr_rvalid_i,
-    input  [31:0]   if_stage_instr_rdata_i,
-    input           id_stage_instr_valid_i,
-    input  [31:0]   id_stage_instr_rdata_i,
-    input           apu_req,
-    input           apu_gnt,
-    input           apu_busy,
-    input  [5:0]    apu_op,
-    input  [5:0]    id_stage_apu_op_ex_o,
-    input           id_stage_apu_en_ex_o,
-    input  [5:0]    regfile_alu_waddr_ex_o,
-    input           regfile_alu_we_ex_o,
+    input               clk_i,
+    input               rst_ni,
+    input               if_stage_instr_rvalid_i,
+    input  [31:0]       if_stage_instr_rdata_i,
+    input               id_stage_instr_valid_i,
+    input  [31:0]       id_stage_instr_rdata_i,
+    input               apu_req,
+    input               apu_gnt,
+    input               apu_busy,
+    input  [5:0]        apu_op,
+    input               apu_rvalid_i,
+    input               apu_perf_wb_o,
+    input  [5:0]        id_stage_apu_op_ex_o,
+    input               id_stage_apu_en_ex_o,
+    input  [5:0]        regfile_waddr_wb_o,  // regfile write port A addr from WB stage
+    input               regfile_we_wb_o,
+    input  [5:0]        regfile_alu_waddr_ex_o, // regfile write port B addr from EX stage
+    input               regfile_alu_we_ex_o,
 
-    output logic[5:0] o_curr_fpu_apu_op_if,
-    output logic[4:0] if_clk_cycle_window,
-    output [5:0]    curr_fpu_fd,
-    output [5:0]    curr_fpu_rd
+    output logic[5:0]   o_curr_fpu_apu_op_if,
+    output logic[5:0]   o_last_fpu_apu_op_if,
+    output logic[4:0]   if_clk_cycle_window,
+    output [4:0]        curr_fpu_fd,
+    output [4:0]        curr_fpu_rd,
+    output [5:0]        curr_rd_at_ex_regfile_wr_contention,
+    output [5:0]        curr_rd_at_wb_regfile_wr_contention,
+    output [5:0]        prev_rd_waddr_contention,
+    output logic[1:0]   contention_state,
+    output              b2b_contention
   );
 
   logic [4:0]       clk_cycle_window;
   logic [5:0]       curr_fpu_apu_op_if;
-  logic [4:0]       regfile_alu_waddr_fd;
-  logic [4:0]       regfile_alu_waddr_rd;
+  logic [5:0]       last_fpu_contention_op_if;
+  logic [5:0]       prev_regfile_waddr_contention;
+  logic [4:0]       regfile_waddr_wb_fd;
+  logic [4:0]       regfile_alu_waddr_ex_fd;
+  logic [4:0]       regfile_waddr_wb_rd;
+  logic [4:0]       regfile_alu_waddr_ex_rd;
+  logic [5:0]       regfile_waddr_ex_contention;
+  logic [5:0]       regfile_waddr_wb_contention;
+  logic [1:0]       contention_valid;
+  logic             b2b_contention_valid;
 
   initial begin
       clk_cycle_window = 0;
       curr_fpu_apu_op_if = 0;
-      regfile_alu_waddr_fd = 0;
-      regfile_alu_waddr_rd = 0;
+      regfile_waddr_wb_fd = 0;
+      regfile_alu_waddr_ex_fd = 0;
+      regfile_waddr_wb_rd = 0;
+      regfile_alu_waddr_ex_rd = 0;
+      regfile_waddr_ex_contention = 0;
+      regfile_waddr_wb_contention = 0;
+      contention_valid = 0;
+      b2b_contention_valid = 0;
   end
 
   clocking mon_cb @(posedge clk_i);
@@ -385,6 +409,8 @@ interface uvmt_cv32e40p_cov_if
       input apu_gnt;
       input apu_busy;
       input apu_op;
+      input apu_rvalid_i;
+      input apu_perf_wb_o;
       input id_stage_apu_op_ex_o;
       input id_stage_apu_en_ex_o;
   endclocking : mon_cb
@@ -413,22 +439,117 @@ interface uvmt_cv32e40p_cov_if
       end
   end
 
-  //sample each APU operation's destination register address for functional coverage
-  always @(posedge clk_i) begin
-      if ((apu_req == 1) && (regfile_alu_we_ex_o == 1)) begin
-          regfile_alu_waddr_fd <= (regfile_alu_waddr_ex_o - 32);
-          regfile_alu_waddr_rd <= (regfile_alu_waddr_ex_o < 32) ? regfile_alu_waddr_ex_o : 0;
+  //Model APU contention state in EX/WB for functional coverage
+  always @(posedge clk_i or negedge rst_ni) begin
+      if(!rst_ni) begin
+          contention_valid <= 0;
+          b2b_contention_valid <= 0;
+          last_fpu_contention_op_if <= 0;
+          prev_regfile_waddr_contention <= 0;
       end
-      else if ((apu_busy == 1) && (regfile_alu_we_ex_o == 1)) begin
-          regfile_alu_waddr_fd <= (regfile_alu_waddr_ex_o - 32);
-          regfile_alu_waddr_rd <= (regfile_alu_waddr_ex_o < 32) ? regfile_alu_waddr_ex_o : 0;
+      else begin
+          if (((contention_valid == 0) || (contention_valid == 2)) && (apu_perf_wb_o)) begin
+              contention_valid <= 1; //set contention_valid
+              b2b_contention_valid <= 0;
+ `ifndef FPU_LAT_1_CYC
+              prev_regfile_waddr_contention <= regfile_alu_waddr_ex_o;
+ `else
+              prev_regfile_waddr_contention <= regfile_waddr_wb_o;
+              last_fpu_contention_op_if <= curr_fpu_apu_op_if;
+ `endif
+          end
+          else if((contention_valid == 1) && (apu_perf_wb_o)) begin
+              contention_valid <= 1; //reset contention_valid
+              b2b_contention_valid <= 1;
+              //if no APU execution during contention then nothing to do
+              //else TODO: check if during contention another APU transaction
+              //can go through?
+ `ifndef FPU_LAT_1_CYC
+              prev_regfile_waddr_contention <= regfile_alu_waddr_ex_o;
+ `else
+              prev_regfile_waddr_contention <= regfile_waddr_wb_o;
+ `endif
+          end
+          else if((contention_valid == 1) && (!apu_perf_wb_o)) begin
+              contention_valid <= 2; //stalled write complete after contention
+              b2b_contention_valid <= 0;
+          end
+          else begin
+              contention_valid <= 0;
+              b2b_contention_valid <= 0;
+          end
       end
   end
 
-  assign curr_fpu_fd = regfile_alu_waddr_fd;
-  assign curr_fpu_rd = regfile_alu_waddr_rd;
+
+  //sample each APU operation's destination register address for functional coverage
+  always @(posedge clk_i or negedge rst_ni) begin
+      if(!rst_ni) begin
+          regfile_alu_waddr_ex_fd <= 0;
+          regfile_alu_waddr_ex_rd <= 0;
+          regfile_waddr_wb_fd <= 0;
+          regfile_waddr_wb_rd <= 0;
+          regfile_waddr_wb_contention <= 0;
+          regfile_waddr_ex_contention <= 0;
+      end
+      else begin
+`ifndef FPU_LAT_1_CYC //Case for FPU Latency {0,2,3,4}, with regfile write from EX stage with highest priority of APU
+          if (((apu_req == 1) || (apu_busy == 1)) && (regfile_alu_we_ex_o == 1) && (apu_rvalid_i == 1)) begin
+              regfile_alu_waddr_ex_fd <= (regfile_alu_waddr_ex_o - 32);
+              regfile_alu_waddr_ex_rd <= (regfile_alu_waddr_ex_o < 32) ? regfile_alu_waddr_ex_o : 0;
+              regfile_waddr_ex_contention <= 0;
+              regfile_waddr_wb_contention <= 0;
+          end
+          else if ((contention_valid == 1) && (regfile_alu_we_ex_o == 1) && !apu_perf_wb_o) begin // write for stalled regfile wr at contention
+              regfile_alu_waddr_ex_fd <= 0;
+              regfile_alu_waddr_ex_rd <= 0;
+              regfile_waddr_ex_contention <= regfile_alu_waddr_ex_o; //should not be >31, check for illegal in coverage
+              regfile_waddr_wb_contention <= 0;
+          end
+ `else
+          //Case FPU Latency = 1; regfile wr from WB;LSU > priority;no LSU contention, F-inst regfile wr succeed
+          if ((apu_busy == 1) && (regfile_we_wb_o == 1) && (apu_rvalid_i == 1) && (!apu_perf_wb_o)) begin
+              regfile_waddr_wb_fd <= (regfile_waddr_wb_o - 32);
+              regfile_waddr_wb_rd <= (regfile_waddr_wb_o < 32) ? regfile_waddr_wb_o : 0;
+              regfile_waddr_ex_contention <= 0;
+              regfile_waddr_wb_contention <= 0;
+          end
+          //Case FPU Latency = 1; regfile wr from WB;LSU > priority;LSU contention,F-inst regfile wr stall
+          else if((apu_busy == 1) && (regfile_we_wb_o == 1) && (apu_rvalid_i == 1) && (apu_perf_wb_o)) begin
+              regfile_waddr_wb_fd <= 0
+              regfile_waddr_wb_rd <= 0;
+              regfile_waddr_ex_contention <= 0;
+              regfile_waddr_wb_contention = regfile_waddr_wb_o; //should not be >31, check for illegal in coverage
+          end
+          //Case FPU Latency = 1;regfile wr from WB;LSU > priority;LSU contention - FPU reg write cycle after contention
+          else if((contention_valid == 1) && (regfile_we_wb_o == 1) && !apu_perf_wb_o) begin
+              regfile_waddr_wb_fd <= (regfile_waddr_wb_o - 32);
+              regfile_waddr_wb_rd <= (regfile_waddr_wb_o < 32) ? regfile_waddr_wb_o : 0;
+              regfile_waddr_ex_contention <= 0;
+              regfile_waddr_wb_contention <= 0;
+          end
+ `endif
+          else begin
+              regfile_alu_waddr_ex_fd <= 0;
+              regfile_alu_waddr_ex_rd <= 0;
+              regfile_waddr_wb_fd <= 0;
+              regfile_waddr_wb_rd <= 0;
+              regfile_waddr_ex_contention <= 0;
+              regfile_waddr_wb_contention <= 0;
+          end
+      end
+  end
+
+  assign curr_fpu_fd = regfile_alu_waddr_ex_fd | regfile_waddr_wb_fd;
+  assign curr_fpu_rd = regfile_alu_waddr_ex_rd | regfile_waddr_wb_rd;
   assign if_clk_cycle_window = clk_cycle_window;
   assign o_curr_fpu_apu_op_if = curr_fpu_apu_op_if;
+  assign o_last_fpu_apu_op_if = last_fpu_contention_op_if;
+  assign curr_rd_at_ex_regfile_wr_contention = regfile_waddr_ex_contention;
+  assign curr_rd_at_wb_regfile_wr_contention = regfile_waddr_wb_contention;
+  assign contention_state = contention_valid;
+  assign b2b_contention = b2b_contention_valid;
+  assign prev_rd_waddr_contention = prev_regfile_waddr_contention;
 
 endinterface : uvmt_cv32e40p_cov_if
 


### PR DESCRIPTION
Adding new functional coverage for RV32F and Zfinx extensions for cv32e40p. This is based on testplans for cv32e40p v2.
We have testplan reviews ongoing and this first version of the functional coverage and can be modified based on review outcomes and coverage analysis.
Functional coverage is for F-multicycle scenarios, operand register corner cases and different cases for various cv32e40p FPU configurations.