### PR TITLE
remove CLIC_INTTHRESHBITS

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -59,7 +59,6 @@ module uvmt_cv32e40s_dut_wrap
     parameter int                    PMP_GRANULARITY                     = 0,
     parameter logic                  CLIC                                = 0,
     parameter int                    CLIC_ID_WIDTH                       = 5,
-    parameter int                    CLIC_INTTHRESHBITS                  = 8,
     parameter int                    DBG_NUM_TRIGGERS                    = 1,
     parameter rv32_e                 RV32                                = RV32I,
 
@@ -179,8 +178,7 @@ module uvmt_cv32e40s_dut_wrap
                       .PMP_PMPNCFG_RV       (PMP_PMPNCFG_RV),
                       .RV32                 (RV32),
                       .CLIC                 (CLIC),
-                      .CLIC_ID_WIDTH        (CLIC_ID_WIDTH),
-                      .CLIC_INTTHRESHBITS   (CLIC_INTTHRESHBITS)
+                      .CLIC_ID_WIDTH        (CLIC_ID_WIDTH)
                       )
     cv32e40s_wrapper_i
         (

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -117,7 +117,6 @@ module uvmt_cv32e40s_tb;
                              .RV32                 (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_RV32),
                              .CLIC                 (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC),
                              .CLIC_ID_WIDTH        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC_ID_WIDTH),
-                             .CLIC_INTTHRESHBITS   (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC_INTTHRESHBITS),
                              .INSTR_ADDR_WIDTH     (ENV_PARAM_INSTR_ADDR_WIDTH),
                              .INSTR_RDATA_WIDTH    (ENV_PARAM_INSTR_DATA_WIDTH),
                              .RAM_ADDR_WIDTH       (ENV_PARAM_RAM_ADDR_WIDTH)

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
@@ -127,7 +127,6 @@ parameter logic CLIC = CORE_PARAM_CLIC;
 `elsif PARAM_SET_1
    // Sat from the include file
 `else
-   parameter int  CORE_PARAM_CLIC_INTTHRESHBITS = 8;
    parameter int  CORE_PARAM_CLIC_ID_WIDTH = 5;
 `endif
 


### PR DESCRIPTION
Same as this https://github.com/openhwgroup/cv32e40x-dv/pull/7, but for the s core: 

formal compiles, ci_check passes