### PR TITLE
Reinstate VCS support for CV32E40Pv2 on cv32e40p/dev branch

### DIFF
--- a/bin/ci_check
+++ b/bin/ci_check
@@ -47,7 +47,7 @@ import subprocess
 import pprint
 import yaml
 import re
-import distutils.spawn
+import shutil
 
 if (sys.version_info < (3,0,0)):
     print ('Requires python 3')
@@ -243,7 +243,7 @@ if (args.verilator):
 elif (args.simulator == None):
     print ('Must specify a simulator.  Type `ci_check -h` to see how')
     exit(0)
-elif (not(distutils.spawn.find_executable(args.simulator))):
+elif (not(shutil.which(args.simulator))):
     print ('ERROR: simulator='+args.simulator+' but executable not found')
     exit(0)
 else:
@@ -263,7 +263,7 @@ if not (prcmd):
         print ('This will delete your previously cloned RTL repo plus all previously generated files')
         ask_user()
         os.chdir(os.path.abspath(os.path.join(topdir, args.core.lower(), 'sim/uvmt')))
-        os.system('make clean_all')
+        os.system('make clean_all SIMULATOR={}'.format(args.simulator))
         os.chdir(os.path.join(topdir, '{}/sim/core'.format(args.core.lower())))
         os.system('make clean_all')
         os.chdir(os.path.join(topdir, 'bin'))

--- a/cv32e40p/tests/programs/custom/debug_test/debug_test.c
+++ b/cv32e40p/tests/programs/custom/debug_test/debug_test.c
@@ -248,12 +248,19 @@ int main(int argc, char *argv[])
     printf(" Test2.2: check access to Trigger registers\n");
     // Writes are ignored
     temp = 0xFFFFFFFF;
+    printf("        - Trigger TSELECT check\n");
     __asm__ volatile("csrw  0x7a0, %0"     : "=r"(temp)); // Trigger TSELECT
+    printf("        - Trigger TDATA1 check\n");
     __asm__ volatile("csrw  0x7a1, %0"     : "=r"(temp)); // Trigger TDATA1
+    printf("        - Trigger TDATA2 check\n");
     __asm__ volatile("csrw  0x7a2, %0"     : "=r"(temp)); // Trigger TDATA2
+    printf("        - Trigger TDATA3 check\n");
     __asm__ volatile("csrw  0x7a3, %0"     : "=r"(temp)); // Trigger TDATA3
+    printf("        - Trigger TINFO check\n");
     __asm__ volatile("csrw  0x7a4, %0"     : "=r"(temp)); // Trigger TINFO
+    printf("        - Trigger MCONTEXT check\n");
     __asm__ volatile("csrw  0x7a8, %0"     : "=r"(temp)); // Trigger MCONTEXT
+    printf("        - Trigger SCONTEXT check\n");
     __asm__ volatile("csrw  0x7aa, %0"     : "=r"(temp)); // Trigger SCONTEXT
 
     // Read default value

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
@@ -49,23 +49,23 @@ covergroup cg_obi(string name,
    option.name         = name;
 
    we: coverpoint (trn.access_type) {
-      ignore_bins IGN_WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE} with (!write_enabled);
-      ignore_bins IGN_READ =  {UVMA_OBI_MEMORY_ACCESS_READ} with (!read_enabled);
+      ignore_bins IGN_WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE} with ((item>1) && (!write_enabled));
+      ignore_bins IGN_READ =  {UVMA_OBI_MEMORY_ACCESS_READ}  with ((item>1) && (!read_enabled));
       bins WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE};
       bins READ = {UVMA_OBI_MEMORY_ACCESS_READ};
    }
 
    memtype: coverpoint (trn.memtype) {
-      ignore_bins IGN_MEMTYPE = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_MEMTYPE = {[0:$]} with ((item>1) && (!is_1p2));
    }
 
    prot: coverpoint (trn.prot) {
-      ignore_bins IGN_MEMTYPE = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_MEMTYPE = {[0:$]} with ((item>1) && (!is_1p2));
       ignore_bins IGN_RSVD_PRIV = {3'b100, 3'b101};
    }
 
    err: coverpoint (trn.err) {
-      ignore_bins IGN_ERR = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_ERR = {[0:$]} with ((item>1) && (!is_1p2));
    }
 
 endgroup : cg_obi

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -29,8 +29,9 @@ ifeq ($(OS_IS_UBUNTU),Ubuntu)
 endif
 
 # Executables
-VCS              = $(CV_SIM_PREFIX) vcs -full64
-SIMV             = $(CV_TOOL_PREFIX)simv -licwait 20
+VCS              = $(CV_SIM_PREFIX) vcs
+#SIMV             = $(CV_TOOL_PREFIX) simv -licwait 20
+SIMV             = simv -licwait 20
 DVE              = $(CV_TOOL_PREFIX) dve
 #VERDI            = $(CV_TOOL_PREFIX)verdi
 URG               = $(CV_SIM_PREFIX) urg
@@ -39,18 +40,25 @@ URG               = $(CV_SIM_PREFIX) urg
 VCS_DIR         ?= $(SIM_CFG_RESULTS)/vcs.d
 VCS_ELAB_COV     = -cm line+cond+tgl+fsm+branch+assert  -cm_dir $(MAKECMDGOALS)/$(MAKECMDGOALS).vdb
 
-# modifications to already defined variables to take into account VCS
-VCS_OVP_MODEL_DPI = $(OVP_MODEL_DPI:.so=)                    # remove extension as VCS adds it
+# Modifications to already defined variables to take into account that VCS
+# does not require the ".so" extension for shared objects.
+VCS_OVP_MODEL_DPI = $(OVP_MODEL_DPI:.so=)
+VCS_DPI_DASM_LIB  = $(DPI_DASM_LIB:.so=)
+VCS_SVLIB_LIB     = $(SVLIB_LIB:.so=)
+
 VCS_TIMESCALE = $(shell echo "$(TIMESCALE)" | tr ' ' '=')    # -timescale=1ns/1ps
 
 VCS_UVM_VERBOSITY ?= UVM_MEDIUM
 
 # Flags
-#VCS_UVMHOME_ARG ?= /opt/uvm/1800.2-2017-0.9/
-VCS_UVMHOME_ARG ?= /opt/synopsys/vcs-mx/O-2018.09-SP2-3/etc/uvm-1.2
-VCS_UVM_ARGS          ?= +incdir+$(VCS_UVMHOME_ARG)/src $(VCS_UVMHOME_ARG)/src/uvm_pkg.sv -ntb_opts uvm-1.2
+VCS_VERSION     ?= S-2021.09-SP1
+VCS_UVMHOME_ARG ?= /synopsys/vcs/$(VCS_VERSION)/etc/uvm-1.2
+VCS_UVM_ARGS    ?= +incdir+$(VCS_UVMHOME_ARG)/src $(VCS_UVMHOME_ARG)/src/uvm_pkg.sv +UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) -ntb_opts uvm-1.2
 
-VCS_COMP_FLAGS  ?= -lca -sverilog $(SV_CMP_FLAGS) $(VCS_UVM_ARGS) $(VCS_TIMESCALE) -assert svaext -race=all -ignore unique_checks
+VCS_COMP_FLAGS  ?= -lca -sverilog \
+                   $(SV_CMP_FLAGS) $(VCS_UVM_ARGS) $(VCS_TIMESCALE) \
+                   +define+CV32E40P_RVFI \
+                   -assert svaext -race=all -ignore unique_checks -full64
 VCS_GUI         ?=
 VCS_RUN_COV      = -cm line+cond+tgl+fsm+branch+assert -cm_dir $(MAKECMDGOALS).vdb
 
@@ -84,18 +92,12 @@ endif
 # Waveform generation
 # WAVES=YES enables waveform generation for entire testbench
 # ADV_DEBUG=YES currently not supported
-# FSDB=YES enables FSDB waveform file generation for entire testbench
 ifeq ($(call IS_YES,$(WAVES)),YES)
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
 $(error ADV_DEBUG not yet supported by VCS )
-VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
+VCS_USER_COMPILE_ARGS = +vcs+vcdpluson
 else
-ifeq ($(call IS_YES,$(FSDB)),YES)
-VCS_USER_COMPILE_ARGS += -debug_access+all +vcs+fsdbon -kdb
-VCS_RUN_WAVES_FLAGS  ?= -ucli -i $(abspath $(MAKE_PATH)/../tools/vcs/vcs_wave.tcl)
-else
-VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
-endif
+VCS_USER_COMPILE_ARGS = +vcs+vcdpluson
 endif
 endif
 
@@ -136,38 +138,37 @@ COV_ARGS = -dir $(TEST_NAME).vdb
 endif
 
 
-ifeq ($(call IS_YES,$(CHECK_SIM_RESULT)),YES)
-CHECK_SIM_LOG ?= $(abspath $(SIM_RUN_RESULTS))/vcs-$(TEST_NAME).log
-POST_TEST = \
-	@if grep -q "SIMULATION FAILED" $(CHECK_SIM_LOG); then \
-		exit 1; \
-	fi
-endif
-
 ################################################################################
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 #VCS_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
 VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
-VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
     VCS_PLUSARGS += +USE_ISS
 else
 	VCS_PLUSARGS += +DISABLE_OVPSIM
 endif
 
+# TODO: determine impact of removing VCS_OVP_MODEL_DPI with USE_ISS=YES
+#                        -sv_lib $(VCS_OVP_MODEL_DPI) \
+# TODO: removing VCS_DPIDASM_LIB effectively disables ISACOV
+#                        -sv_lib $(VCS_DPI_DASM_LIB) \
+
 VCS_RUN_BASE_FLAGS   ?= $(VCS_GUI) \
-                        $(VCS_PLUSARGS) +ntb_random_seed=$(RNDSEED) \
-						-sv_lib $(VCS_OVP_MODEL_DPI) \
-						-sv_lib $(DPI_DASM_LIB:.so=) \
-						-sv_lib $(abspath $(SVLIB_LIB:.so=))
+                        $(VCS_PLUSARGS) \
+                        +ntb_random_seed=$(RNDSEED) \
+                        -assert nopostproc \
+                        -sv_lib $(abspath $(VCS_SVLIB_LIB))
 
 # Simulate using latest elab
-VCS_RUN_FLAGS        ?=
+VCS_RUN_FLAGS        ?= 
 VCS_RUN_FLAGS        += $(VCS_RUN_BASE_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_WAVES_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_COV_FLAGS)
-VCS_RUN_FLAGS        += $(USER_RUN_FLAGS)
+
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
+DPI_INCLUDE          ?= $(shell dirname $(shell which vcs))/../lib
 
 ###############################################################################
 # Targets
@@ -190,6 +191,7 @@ hello-world:
 
 VCS_COMP = $(VCS_COMP_FLAGS) \
 		$(QUIET) \
+		$(VCS_UVM_ARGS) \
 		$(VCS_USER_COMPILE_ARGS) \
 		+incdir+$(DV_UVME_PATH) \
 		+incdir+$(DV_UVMT_PATH) \
@@ -197,12 +199,12 @@ VCS_COMP = $(VCS_COMP_FLAGS) \
 		$(VCS_FILE_LIST) \
 		$(UVM_PLUSARGS)
 
-comp: mk_vcs_dir $(CV_CORE_PKG) $(SVLIB_PKG) $(OVP_MODEL_DPI)
+comp: mk_vcs_dir $(CV_CORE_PKG) $(SVLIB_PKG)
+	cd $(VCS_DIR) && $(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
 	@echo "$(BANNER)"
 	@echo "* $(SIMULATOR) compile complete"
 	@echo "* Log: $(SIM_CFG_RESULTS)/vcs.log"
 	@echo "$(BANNER)"
-	cd $(SIM_CFG_RESULTS) && $(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
 
 ifneq ($(call IS_NO,$(COMP)),NO)
 VCS_SIM_PREREQ = comp
@@ -223,25 +225,28 @@ gen_ovpsim_ic:
 	@if [ ! -z "$(CFG_OVPSIM)" ]; then \
 		echo "$(CFG_OVPSIM)" > $(SIM_RUN_RESULTS)/ovpsim.ic; \
 	fi
+export IMPERAS_TOOLS=$(SIM_RUN_RESULTS)/ovpsim.ic
 
 ################################################################################
 # The new general test target
 
 test: $(VCS_SIM_PREREQ) hex gen_ovpsim_ic
+	@echo "$(BANNER)"
+	@echo "* Running simulation"
+	@echo "* with VCS_RUN_FLAGS = $(VCS_RUN_FLAGS)"
+	@echo "$(BANNER)"
 	mkdir -p $(SIM_RUN_RESULTS)
 	cd $(SIM_RUN_RESULTS) && \
-	export IMPERAS_TOOLS=$(SIM_RUN_RESULTS)/ovpsim.ic && \
-		$(SIM_RESULTS)/$(CFG)/$(SIMV) \
-			-l vcs-$(TEST_NAME).log \
-			-cm_name $(TEST_NAME) $(VCS_RUN_FLAGS) \
-			$(CFG_PLUSARGS) \
-			$(TEST_PLUSARGS) \
-			+UVM_TESTNAME=$(TEST_UVM_TEST) \
-			+UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) \
+		$(VCS_DIR)/$(SIMV) \
+		-l vcs-$(TEST_NAME).log \
+		-cm_name $(TEST_NAME) \
+		$(VCS_RUN_FLAGS) \
+		$(CFG_PLUSARGS) \
+		$(TEST_PLUSARGS) \
+		+UVM_TESTNAME=$(TEST_UVM_TEST) \
     		+elf_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
-			+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
-			+itb_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
-	$(POST_TEST)
+		+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
+		+itb_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
 
 ###############################################################################
 # Run a single test-program from the RISC-V Compliance Test-suite. The parent
@@ -276,48 +281,6 @@ compliance: $(VCS_COMPLIANCE_PREREQ)
 		+firmware=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).hex \
 		+elf_file=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).elf
 
-################################################################################
-# RISCOF RISCV-ARCH-TEST DUT simulation targets
-VCS_RISCOF_SIM_PREREQ = $(RISCOF_TEST_RUN_DIR)/dut_test.elf
-
-comp_dut_riscof_sim:
-	@echo "$(BANNER)"
-	@echo "* Compiling vcs in $(SIM_RISCOF_ARCH_TESTS_RESULTS)"
-	@echo "* Log: $(SIM_RISCOF_ARCH_TESTS_RESULTS)/vcs.log"
-	@echo "$(BANNER)"
-	mkdir -p $(SIM_RISCOF_ARCH_TESTS_RESULTS) && \
-	cd $(SIM_RISCOF_ARCH_TESTS_RESULTS) && \
-		$(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
-
-comp_dut_rtl_riscof_sim: $(CV_CORE_PKG) $(SVLIB_PKG) $(OVP_MODEL_DPI) comp_dut_riscof_sim
-
-setup_riscof_sim: clean_riscof_arch_test_suite clone_riscof_arch_test_suite comp_dut_rtl_riscof_sim
-
-gen_riscof_ovpsim_ic:
-	@touch $(RISCOF_TEST_RUN_DIR)/ovpsim.ic
-	@if [ ! -z "$(CFG_OVPSIM)" ]; then \
-		echo "$(CFG_OVPSIM)" > $(RISCOF_TEST_RUN_DIR)/ovpsim.ic; \
-	fi
-
-# Target to run RISCOF DUT sim with VCS
-riscof_sim_run: $(VCS_RISCOF_SIM_PREREQ) comp_dut_rtl_riscof_sim gen_riscof_ovpsim_ic
-	@echo "$(BANNER)"
-	@echo "* Running vcs in $(PWD)"
-	@echo "$(BANNER)"
-	cd $(RISCOF_TEST_RUN_DIR) && \
-	export IMPERAS_TOOLS=$(RISCOF_TEST_RUN_DIR)/ovpsim.ic && \
-		$(RISCOF_TEST_RUN_DIR)/$(SIMV) \
-			-l vcs-dut_test.log \
-			-cm_name dut_test $(VCS_RUN_FLAGS) \
-			$(CFG_PLUSARGS) \
-			$(RISCOF_TEST_PLUSARGS) \
-			+UVM_TESTNAME=uvmt_cv32e40p_riscof_firmware_test_c \
-			+UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) \
-			+firmware=dut_test.hex \
-			+elf_file=dut_test.elf \
-			+itb_file=dut_test.itb
-
-
 ###############################################################################
 # Use Google instruction stream generator (RISCV-DV) to create new test-programs
 comp_corev-dv: $(RISCVDV_PKG) $(CV_CORE_PKG)
@@ -332,13 +295,16 @@ comp_corev-dv: $(RISCVDV_PKG) $(CV_CORE_PKG)
 		+incdir+$(CV_CORE_COREVDV_PKG) \
 		-f $(CV_CORE_MANIFEST) \
 		$(CFG_COMPILE_FLAGS) \
-		$(GEN_COMPILE_FLAGS) \
 		-f $(COREVDV_PKG)/manifest.f \
 		-l vcs.log
 
 corev-dv: clean_riscv-dv clone_riscv-dv comp_corev-dv
 
 gen_corev-dv:
+	@echo "$(BANNER)"
+	@echo "* Generating $(TEST) with corev-dv..."
+	@echo "* with VCS_RUN_FLAGS = $(VCS_RUN_FLAGS) "
+	@echo "$(BANNER)"
 	mkdir -p $(SIM_COREVDV_RESULTS)/$(TEST)
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
 		mkdir -p $(SIM_TEST_RESULTS)/$$idx/test_program; \
@@ -355,7 +321,7 @@ gen_corev-dv:
 			$(GEN_PLUSARGS)
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
 		cp -f ${BSP}/link_corev-dv.ld ${SIM_TEST_RESULTS}/$$idx/test_program/link.ld; \
-		cp ${VCS_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${SIM_TEST_RESULTS}/$$idx/test_program; \
+		cp ${SIM_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${SIM_TEST_RESULTS}/$$idx/test_program; \
 	done
 
 ################################################################################
@@ -396,7 +362,7 @@ endif
 
 clean:
 	@echo "$(MAKEFILE_LIST)"
-	rm -rf $(SIM_RUN_RESULTS)
+	rm -rf $(SIM_RESULTS)
 
 # Files created by Eclipse when using the Imperas ISS + debugger
 clean_eclipse:
@@ -405,8 +371,6 @@ clean_eclipse:
 	rm  -f stdout.txt
 	rm  -rf workspace
 
-clean_rtl:
-	rm -rf $(CV_CORE_PKG)
-
 # All generated files plus the clone of the RTL
-clean_all: clean clean_rtl clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench clean_dpi_dasm_spike clean_svlib
+clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean_bsp clean_compliance clean_embench clean_dpi_dasm_spike clean_svlib
+	rm -rf $(CV_CORE_PKG)

--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -682,7 +682,7 @@ cov: $(COV_MERGE_TARGET)
 # Clean up your mess!
 
 clean:
-	rm -rf $(SIM_RUN_RESULTS)
+	rm -rf $(SIM_RESULTS)
 
 clean_rtl:
 	rm -rf $(CV_CORE_PKG)


### PR DESCRIPTION
For longer than I can remember, no active member has been using VCS to run simulations of CV32E40P in CORE-V-VERIF.  This pull-request restores the ability to use VCS (and also fixes a latent bug in `ci_check` that I did not realise was there).

Note that this PR does (almost) the same thing as #2006 on the master branch.