### PR TITLE
first proposal of CV32E40Pv2 ci_check script

### DIFF
--- a/cv32e40p/regress/cv32e40pv2_ci_check.yaml
+++ b/cv32e40p/regress/cv32e40pv2_ci_check.yaml
@@ -49,12 +49,7 @@ builds:
     cfg: pulp_fpu_3cyclat
     dir: cv32e40p/sim/uvmt
 
-  uvmt_cv32e40p_pulp_fpu_4cyclat:
-    cmd: make comp
-    cfg: pulp_fpu_4cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_fpu_zfinx:
+    uvmt_cv32e40p_pulp_fpu_zfinx:
     cmd: make comp
     cfg: pulp_fpu_zfinx
     dir: cv32e40p/sim/uvmt
@@ -74,12 +69,7 @@ builds:
     cfg: pulp_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
 
-  uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat:
-    cmd: make comp
-    cfg: pulp_fpu_zfinx_4cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster:
+    uvmt_cv32e40p_pulp_cluster:
     cmd: make comp
     cfg: pulp_cluster
     dir: cv32e40p/sim/uvmt
@@ -104,12 +94,7 @@ builds:
     cfg: pulp_cluster_fpu_3cyclat
     dir: cv32e40p/sim/uvmt
 
-  uvmt_cv32e40p_pulp_cluster_fpu_4cyclat:
-    cmd: make comp
-    cfg: pulp_cluster_fpu_4cyclat
-    dir: cv32e40p/sim/uvmt
-
-  uvmt_cv32e40p_pulp_cluster_fpu_zfinx:
+    uvmt_cv32e40p_pulp_cluster_fpu_zfinx:
     cmd: make comp
     cfg: pulp_cluster_fpu_zfinx
     dir: cv32e40p/sim/uvmt
@@ -129,11 +114,6 @@ builds:
     cfg: pulp_cluster_fpu_zfinx_3cyclat
     dir: cv32e40p/sim/uvmt
 
-  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat:
-    cmd: make comp
-    cfg: pulp_cluster_fpu_zfinx_4cyclat
-    dir: cv32e40p/sim/uvmt
-
 
 # make sure that everything is compiling and running, with iss
 tests:
@@ -146,23 +126,19 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
       - uvmt_cv32e40p_pulp_fpu_3cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
       - uvmt_cv32e40p_pulp_cluster
       - uvmt_cv32e40p_pulp_cluster_fpu
       - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_2cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_3cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_3cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
     description: UVM Hello World Test
     dir: cv32e40p/sim/uvmt
     iss: 1
@@ -176,17 +152,13 @@ tests:
       - uvmt_cv32e40p_pulp
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
       - uvmt_cv32e40p_pulp_cluster
       - uvmt_cv32e40p_pulp_cluster_fpu
       - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
     description: Interrupt directed test on the 5 configurations + FPU latencies and default
     dir: cv32e40p/sim/uvmt
     iss: 1
@@ -200,17 +172,13 @@ tests:
       - uvmt_cv32e40p_pulp
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
       - uvmt_cv32e40p_pulp_cluster
       - uvmt_cv32e40p_pulp_cluster_fpu
       - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
     dir: cv32e40p/sim/uvmt
     iss: 1
     cov: 0
@@ -222,7 +190,6 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_1cyclat
       - uvmt_cv32e40p_pulp_fpu_2cyclat
       - uvmt_cv32e40p_pulp_fpu_3cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
     dir: cv32e40p/sim/uvmt
     iss: 1
     cov: 0
@@ -234,7 +201,6 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
     dir: cv32e40p/sim/uvmt
     iss: 1
     cov: 0
@@ -246,7 +212,6 @@ tests:
   #     - uvmt_cv32e40p_pulp_fpu_1cyclat
   #     - uvmt_cv32e40p_pulp_fpu_2cyclat
   #     - uvmt_cv32e40p_pulp_fpu_3cyclat
-  #     - uvmt_cv32e40p_pulp_fpu_4cyclat
   #   dir: cv32e40p/sim/uvmt
   #   iss: 1
   #   cov: 0
@@ -258,7 +223,6 @@ tests:
   #     - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
   #     - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
   #     - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
-  #     - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
   #   dir: cv32e40p/sim/uvmt
   #   iss: 1
   #   cov: 0
@@ -296,17 +260,13 @@ tests:
       - uvmt_cv32e40p_pulp
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
       - uvmt_cv32e40p_pulp_cluster
       - uvmt_cv32e40p_pulp_cluster_fpu
       - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
     dir: cv32e40p/sim/uvmt
     iss: 1
     cov: 0
@@ -317,17 +277,13 @@ tests:
       - uvmt_cv32e40p_pulp
       - uvmt_cv32e40p_pulp_fpu
       - uvmt_cv32e40p_pulp_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_4cyclat
       - uvmt_cv32e40p_pulp_fpu_zfinx
       - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
       - uvmt_cv32e40p_pulp_cluster
       - uvmt_cv32e40p_pulp_cluster_fpu
       - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
       - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
-      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
     dir: cv32e40p/sim/uvmt
     iss: 1
     cov: 0

--- a/cv32e40p/regress/cv32e40pv2_ci_check.yaml
+++ b/cv32e40p/regress/cv32e40pv2_ci_check.yaml
@@ -1,0 +1,334 @@
+# YAML file to specify the ci_check regression testlist.
+name: cv32e40pv2_ci_check
+description: Commit sanity for the cv32e40pv2
+
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+
+  # Only one compilation of corev-dv is enough
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+
+  # One tb per configuration
+  uvmt_cv32e40p_default:
+    cmd: make comp
+    cfg: default
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_no_pulp:
+    cmd: make comp
+    cfg: no_pulp
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp:
+    cmd: make comp
+    cfg: pulp
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu:
+    cmd: make comp
+    cfg: pulp_fpu
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_1cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_1cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_2cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_2cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_3cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_3cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_4cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_4cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_zfinx:
+    cmd: make comp
+    cfg: pulp_fpu_zfinx
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_zfinx_1cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_zfinx_2cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_zfinx_3cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat:
+    cmd: make comp
+    cfg: pulp_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster:
+    cmd: make comp
+    cfg: pulp_cluster
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu:
+    cmd: make comp
+    cfg: pulp_cluster_fpu
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_1cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_1cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_2cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_2cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_3cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_3cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_4cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_4cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_zfinx:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_zfinx
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_zfinx_1cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_zfinx_2cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_3cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_zfinx_3cyclat
+    dir: cv32e40p/sim/uvmt
+
+  uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat:
+    cmd: make comp
+    cfg: pulp_cluster_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+
+
+# make sure that everything is compiling and running, with iss
+tests:
+  hello-world:
+    builds:
+      - uvmt_cv32e40p_default
+      - uvmt_cv32e40p_no_pulp
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+      - uvmt_cv32e40p_pulp_cluster
+      - uvmt_cv32e40p_pulp_cluster_fpu
+      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_3cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
+    description: UVM Hello World Test
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make test COREV=YES TEST=hello-world
+
+  interrupt_test:
+    builds:
+      - uvmt_cv32e40p_default
+      - uvmt_cv32e40p_no_pulp
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+      - uvmt_cv32e40p_pulp_cluster
+      - uvmt_cv32e40p_pulp_cluster_fpu
+      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
+    description: Interrupt directed test on the 5 configurations + FPU latencies and default
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make test COREV=YES TEST=interrupt_test
+
+  debug_test:
+    builds:
+      - uvmt_cv32e40p_default
+      - uvmt_cv32e40p_no_pulp
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+      - uvmt_cv32e40p_pulp_cluster
+      - uvmt_cv32e40p_pulp_cluster_fpu
+      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make test COREV=YES TEST=debug_test
+
+  corev_fp_instr_test_for_regr:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test_for_regr
+
+  corev_fp_zfinx_instr_test_for_regr:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_zfinx_instr_test_for_regr
+
+  # corev_multicycle_fp_instr_test:
+  #   builds:
+  #     - uvmt_cv32e40p_pulp_fpu
+  #     - uvmt_cv32e40p_pulp_fpu_1cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_2cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_3cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_4cyclat
+  #   dir: cv32e40p/sim/uvmt
+  #   iss: 1
+  #   cov: 0
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
+
+  # corev_multicycle_fp_zfinx_instr_test:
+  #   builds:
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+  #   dir: cv32e40p/sim/uvmt
+  #   iss: 1
+  #   cov: 0
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_zfinx_instr_test
+
+  # corev_rand_pulp_mac_simd_test:
+  #   builds:
+  #     - uvmt_cv32e40p_pulp
+  #     - uvmt_cv32e40p_pulp_fpu
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx
+  #     - uvmt_cv32e40p_pulp_cluster
+  #     - uvmt_cv32e40p_pulp_cluster_fpu
+  #     - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+  #   dir: cv32e40p/sim/uvmt
+  #   iss: 1
+  #   cov: 0
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_mac_simd_test
+
+  # corev_sanity_pulp_instr_test:
+  #   builds:
+  #     - uvmt_cv32e40p_pulp
+  #     - uvmt_cv32e40p_pulp_fpu
+  #     - uvmt_cv32e40p_pulp_fpu_zfinx
+  #     - uvmt_cv32e40p_pulp_cluster
+  #     - uvmt_cv32e40p_pulp_cluster_fpu
+  #     - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+  #   dir: cv32e40p/sim/uvmt
+  #   iss: 1
+  #   cov: 0
+  #   cmd: make gen_corev-dv test COREV=YES TEST=corev_sanity_pulp_instr_test
+
+
+  corev_rand_pulp_hwloop_debug:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+      - uvmt_cv32e40p_pulp_cluster
+      - uvmt_cv32e40p_pulp_cluster_fpu
+      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_debug
+
+  corev_rand_pulp_hwloop_test:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_4cyclat
+      - uvmt_cv32e40p_pulp_cluster
+      - uvmt_cv32e40p_pulp_cluster_fpu
+      - uvmt_cv32e40p_pulp_cluster_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_4cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_cluster_fpu_zfinx_4cyclat
+    dir: cv32e40p/sim/uvmt
+    iss: 1
+    cov: 0
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_hwloop_test


### PR DESCRIPTION
Here is a first proposal for a ci_check script. 

I added all configurations from `cv32e40p/tests/cfg`, and mixed them a bit depending on what it seems to be relevant for me. 

Don't hesitate to tell me if anything's missing/wrong

Some tests are commented because they are not already merged in our working branch (`cv32e40p/dev`) and it will cause the cv_regress to issue a critical error. 

The commands to generate & run the ci_check script will be, for running with vsim and Questa Verification Run Manager with 4 jobs in parallel : 
```shell
./cv_regress --rmdb --file=cv32e40pv2_ci_check.yaml --simulator=vsim --outfile=cv32e40pv2_ci_check.rmdb --lsf "bsub -K -q 'vanilla'" --check_sim_results
vrun -rmdb cv32e40pv2_ci_check.rmdb -run cv32e40p -j 4 -mintimeout 0:300 -nolocalrerun
```

To generate a shell script, the command is : 
```shell
./cv_regress --sh --file=cv32e40pv2_ci_check.yaml --simulator=vsim --outfile=cv32e40pv2_ci_check.sh
```

