### PR TITLE
ci: report environment failures in dashboard

### DIFF
--- a/.gitlab-ci/cva6.yml
+++ b/.gitlab-ci/cva6.yml
@@ -71,6 +71,7 @@ stages:
   - smoke tests
   - verif tests
   - backend tests
+  - find failures
   - report
 
 .verif_test:
@@ -602,6 +603,24 @@ code_coverage-report:
     - when: on_success
   artifacts:
     expire_in: 3 week
+
+check gitlab jobs status:
+  stage: find failures
+  tags: [$TAGS_RUNNER]
+  rules:
+    - if: '$DASHBOARD_URL'
+      when: on_failure
+    - when: never
+  variables:
+    DASHBOARD_JOB_TITLE: "Environment check"
+    DASHBOARD_JOB_DESCRIPTION: "Detect environment issues"
+    DASHBOARD_SORT_INDEX: 0
+    DASHBOARD_JOB_CATEGORY: "Environment"
+  script:
+    - rm -rf artifacts/
+    - mkdir -p artifacts/reports
+    - python3 .gitlab-ci/scripts/report_envfail.py
+  artifacts: *artifacts
 
 merge reports:
   stage: report

--- a/.gitlab-ci/scripts/report_envfail.py
+++ b/.gitlab-ci/scripts/report_envfail.py
@@ -1,0 +1,17 @@
+# Copyright 2023 Thales Silicon Security
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+# You may obtain a copy of the License at https://solderpad.org/licenses/
+#
+# Original Author: Côme ALLART - Thales
+
+import report_builder as rb
+
+metric = rb.TableStatusMetric('')
+metric.add_fail('Environment failure detected. Some reports might be missing')
+
+report = rb.Report()
+report.add_metric(metric)
+report.dump()


### PR DESCRIPTION
Infrastructure issues sometimes occur, preventing some jobs requiring specific things from starting. So these jobs do not produce reports at all. As a result, jobs in the dashboard are "successful", which is misleading.

To fix that, this PR adds a job which is run only if one of the previous jobs failed in GitLab words (including the case when the job did not start). There are no specific requirements for this new job so there is no reason it doesn’t start.