### PR TITLE
Updated regression scripts to fix issues with --iss 0

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -255,7 +255,8 @@ if args.sh:
                                  results=args.results,
                                  makeargs=' '.join(args.makearg) if args.makearg else '',
                                  session=os.path.splitext(os.path.basename(args.outfile))[0],
-                                 unique_builds=unique_builds))
+                                 unique_builds=unique_builds,
+                                 iss=''.join(args.iss) if args.iss else ''))
     out_fh.close()
     os.chmod(args.outfile, 0o775)
 
@@ -269,6 +270,7 @@ if args.metrics:
                                  cfg=args.cfg,
                                  toolchain=args.toolchain,
                                  makeargs=' '.join(args.makearg) if args.makearg else '',
+                                 iss=' '.join(args.iss) if args.iss else '',
                                  unique_builds=unique_builds))
     out_fh.close()
     os.chmod(args.outfile, 0o775)
@@ -291,7 +293,8 @@ if args.vsif:
                                  toolchain=args.toolchain,
                                  simulator=args.simulator,
                                  filter_dir=get_filter_dir(),
-                                 unique_builds=unique_builds))
+                                 unique_builds=unique_builds,
+                                 iss=' '.join(args.iss) if args.iss else ''))
     out_fh.close()
 
     # Generate a Vmanager-compatible SVE

--- a/bin/templates/regress_sh.j2
+++ b/bin/templates/regress_sh.j2
@@ -62,7 +62,7 @@ incr_test_counts () {
 
 {% for b in unique_builds.values() %}
 # Build:{{b.name}} {{b.description}}
-{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + b.cfg + ' SIMULATOR=' + b.simulator + ' COV=' + regress_macros.yesorno(b.cov) + ' ' + regress_macros.cv_results(results) + ' ' + makeargs %}
+{% set cmd = b.cmd + ' CV_CORE=' + project + ' CFG=' + b.cfg + ' SIMULATOR=' + b.simulator + ' USE_ISS=' + regress_macros.yesorno(iss) + ' COV=' + regress_macros.yesorno(b.cov) + ' ' + regress_macros.cv_results(results) + ' ' + makeargs %}
 echo "{{session}}: Running build: [cd {{b.abs_dir}} && {{cmd}}]"
 pushd {{b.abs_dir}} > /dev/null
 {{cmd}}
@@ -80,7 +80,7 @@ popd > /dev/null
 # --> Test: {{t.name}} : Build: {{build}} : {{t.description}}
 {% if t.precmd %}
 #  Test (Precommand): {{t.name}} {{t.description}}
-{% set cmd = t.precmd + ' CV_CORE=' + project + 'CFG=' + r.builds[build].cfg + ' ' + toolchain|upper + '=1' + ' SIMULATOR=' + t.simulator + ' SEED=random GEN_NUM_TESTS=' + t.num + ' ' + regress_macros.cv_results(results) + ' ' + makeargs + ' ' + t.makearg %}
+{% set cmd = t.precmd + ' CV_CORE=' + project + 'CFG=' + r.builds[build].cfg + ' ' + toolchain|upper + '=1' + ' SIMULATOR=' + t.simulator + ' USE_ISS=' + regress_macros.yesorno(t.iss) + ' SEED=random GEN_NUM_TESTS=' + t.num + ' ' + regress_macros.cv_results(results) + ' ' + makeargs + ' ' + t.makearg %}
 echo "{{session}}: Running precmd: [cd {{t.abs_dir}} && {{cmd}}]
 pushd {{t.abs_dir}} > /dev/null
 {{cmd}} >& /dev/null;

--- a/bin/templates/regress_vsif.j2
+++ b/bin/templates/regress_vsif.j2
@@ -53,7 +53,7 @@ group {{project}} {
     group {{build.name}} {
 
         // Build:{{build.name}} {{build.description}}
-        pre_group_script: 'cd {{build.abs_dir}} && {{build.cmd}} CV_CORE={{project}} CFG={{build.cfg}} CV_SIM_PREFIX= {{toolchain|upper}}=1 SIMULATOR={{build.simulator}} COV={{regress_macros.yesorno(build.cov)}} {{regress_macros.cv_results(results)}} {{makeargs}}';
+        pre_group_script: 'cd {{build.abs_dir}} && {{build.cmd}} CV_CORE={{project}} CFG={{build.cfg}} CV_SIM_PREFIX= {{toolchain|upper}}=1 SIMULATOR={{build.simulator}} USE_ISS={{regress_macros.yesorno(iss)}} COV={{regress_macros.yesorno(build.cov)}} {{regress_macros.cv_results(results)}} {{makeargs}}';
 
 {% for t in r.get_tests_of_build(build.name) %}
 {% set indent = '    '%}
@@ -64,7 +64,7 @@ group {{project}} {
         test precmd {
             sv_seed: gen_random;
             count: 1;
-            run_script: 'cd {{t.abs_dir}} && {{t.precmd}} CV_SIM_PREFIX= CV_CORE={{project}} CFG={{build.cfg}} {{toolchain|upper}}=1 SIMULATOR={{t.simulator}} RNDSEED=$RUN_ENV(BRUN_SV_SEED) NUM_TESTS={{t.num}} {{regress_macros.cv_results(results)}} {{makeargs}}';
+            run_script: 'cd {{t.abs_dir}} && {{t.precmd}} CV_SIM_PREFIX= CV_CORE={{project}} CFG={{build.cfg}} {{toolchain|upper}}=1 SIMULATOR={{t.simulator}} USE_ISS={{regress_macros.yesorno(t.iss)}} RNDSEED=$RUN_ENV(BRUN_SV_SEED) NUM_TESTS={{t.num}} {{regress_macros.cv_results(results)}} {{makeargs}}';
         };
 {% else %}
 {% endif %}


### PR DESCRIPTION
Fixed: makefile builds env with ISS defined, but runs without if using the flag --iss 0, causing test failure