### PR TITLE
Removed b_ext_abs cfg from b-ext test in full regression 

### DIFF
--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -29,11 +29,6 @@ builds:
     cfg: clic_default
     dir: cv32e40s/sim/uvmt
 
-  uvmt_cv32e40s_b_ext_abs:
-    cmd: make comp_corev-dv comp
-    cfg: b_ext_abs
-    dir: cv32e40s/sim/uvmt
-
   uvmt_cv32e40s_b_ext_all:
     cmd: make comp_corev-dv comp
     cfg: b_ext_all
@@ -478,7 +473,7 @@ tests:
 
   b_ext_test:
     description: Directed Zb extension test
-    builds: [ uvmt_cv32e40s_b_ext_abs, uvmt_cv32e40s_b_ext_all]
+    builds: [ uvmt_cv32e40s_b_ext_all]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=b_ext_test
 


### PR DESCRIPTION
With the addition of zbc-instructions, the b_ext_test is incompatible with the b_ext_abs-cfg, and this configuration has been deprecated from full regression runs