### PR TITLE
Add support for Spike tandem co-simulations

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -22,7 +22,9 @@ endif
 
 .DEFAULT_GOAL := help
 
-FLIST_TB   := $(CVA6_TB_DIR)/Flist.cva6_tb
+FLIST_TB    := $(CVA6_TB_DIR)/Flist.cva6_tb
+FLIST_COSIM := $(CVA6_TB_DIR)/Flist.cva6_tandem_cosim
+
 # target takes one of the following cva6 hardware configuration:
 # cv64a6_imafdc_sv39, cv32a6_imac_sv0, cv32a6_imac_sv32, cv32a6_imafc_sv32
 target     ?= cv64a6_imafdc_sv39
@@ -39,8 +41,8 @@ isspostrun_opts ?=
 log             ?=
 variant         ?=
 
-# Do NOT enable spike-tandem by default
-spike-tandem    ?=
+# Spike tandem mode: default to environment setting (DISABLED if envariable SPIKE_TANDEM is not set).
+export spike-tandem ?= $(SPIKE_TANDEM)
 
 # Set Spike step count limit if the caller provided a step count value in variable 'steps'.
 ifneq ($(steps),)
@@ -184,9 +186,10 @@ ALL_UVM_FLAGS           = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  -assert svaext -race=all -ignore unique_checks -full64 -q +incdir+$(VCS_HOME)/etc/uvm/src \
 	  +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt \
 	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon)) \
-	  $(if $(spike-tandem), +SPIKE_TANDEM=1)
+	  $(if $(spike-tandem), +define+SPIKE_TANDEM=1)
 
-ALL_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) \
+ALL_SIMV_UVM_FLAGS      = $(if $(spike-tandem), +permissive) -licwait 20 $(issrun_opts) \
+		$(if $(spike-tandem),-sv_lib $(CORE_V_VERIF)/tools/spike/lib/libdisasm) \
 		-sv_lib $(CORE_V_VERIF)/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
 		+UVM_TESTNAME=uvmt_cva6_firmware_test_c
 
@@ -210,13 +213,14 @@ endif
 
 dpi-library = $(CVA6_REPO_DIR)/work-dpi
 dpi_build:
-	$(MAKE) -C $(CVA6_REPO_DIR) spike-tandem=$(spike-tandem) $@
+	$(MAKE) -C $(CVA6_REPO_DIR) $@
 
 vcs_uvm_comp: dpi_build
 	@echo "[VCS] Building Model"
 	mkdir -p $(VCS_WORK_DIR)
 	cd $(VCS_WORK_DIR) && vcs $(ALL_UVM_FLAGS) \
 	  -f $(FLIST_CORE) -f $(FLIST_TB) \
+	  $(if $(spike-tandem), -f $(FLIST_COSIM)) \
 	  -f $(CVA6_UVMT_DIR)/uvmt_cva6.flist \
 	  $(cov-comp-opt) +define+UNSUPPORTED_WITH+ $(isscomp_opts)\
 	  -top uvmt_cva6_tb

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -118,7 +118,7 @@ spike:
 # testharness specific commands, variables
 ###############################################################################
 vcs-testharness:
-	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))
+	make -C $(path_var) vcs_build target=$(target) defines=$(subst +define+,,$(isscomp_opts))$(if $(spike-tandem),SPIKE_TANDEM=1)
 	$(path_var)/work-vcs/simv $(if $(VERDI), -verdi -do $(path_var)/init_testharness.do,) +permissive -sv_lib $(path_var)/work-dpi/ariane_dpi \
 	  +tohost_addr=$(shell $$RISCV/bin/${CV_SW_PREFIX}nm -B $(elf) | grep -w tohost | cut -d' ' -f1) \
 	  +PRELOAD=$(elf) +permissive-off ++$(elf) $(issrun_opts)

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -38,6 +38,10 @@ issrun_opts     ?=
 isspostrun_opts ?=
 log             ?=
 variant         ?=
+
+# Do NOT enable spike-tandem by default
+spike-tandem    ?=
+
 # Set Spike step count limit if the caller provided a step count value in variable 'steps'.
 ifneq ($(steps),)
   spike_stepout = --steps=$(steps)
@@ -179,7 +183,8 @@ ALL_UVM_FLAGS           = -lca -sverilog +incdir+$(VCS_HOME)/etc/uvm/src \
 	  $(VCS_HOME)/etc/uvm/src/uvm_pkg.sv +UVM_VERBOSITY=UVM_MEDIUM -ntb_opts uvm-1.2 -timescale=1ns/1ps \
 	  -assert svaext -race=all -ignore unique_checks -full64 -q +incdir+$(VCS_HOME)/etc/uvm/src \
 	  +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/env/uvme +incdir+$(CORE_V_VERIF)/$(CV_CORE_LC)/tb/uvmt \
-	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon))
+	  $(if $(DEBUG), -debug_access+all $(if $(VERDI), -kdb) $(if $(TRACE_COMPACT),+vcs+fsdbon)) \
+	  $(if $(spike-tandem), +SPIKE_TANDEM=1)
 
 ALL_SIMV_UVM_FLAGS      = -licwait 20 $(issrun_opts) \
 		-sv_lib $(CORE_V_VERIF)/lib/dpi_dasm/lib/Linux64/libdpi_dasm +signature=I-ADD-01.signature_output \
@@ -203,13 +208,9 @@ ifneq ($(DEBUG),)               # If RTL DEBUG support requested
   endif
 endif
 
-dpi-library = $(VCS_WORK_DIR)/work-dpi
+dpi-library = $(CVA6_REPO_DIR)/work-dpi
 dpi_build:
-	mkdir -p $(dpi-library)
-	g++ -shared -fPIC -std=c++17 -Bsymbolic -I../corev_apu/tb/dpi -O3 -I$(SPIKE_ROOT)/include \
-	-I$(VCS_HOME)/include -I$(RISCV)/include -c $(CVA6_REPO_DIR)/corev_apu/tb/dpi/elfloader.cc \
-	-o $(dpi-library)/elfloader.o
-	g++ -shared -m64 -o $(dpi-library)/ariane_dpi.so $(dpi-library)/elfloader.o -L$(RISCV)/lib -Wl,-rpath,$(RISCV)/lib
+	$(MAKE) -C $(CVA6_REPO_DIR) spike-tandem=$(spike-tandem) $@
 
 vcs_uvm_comp: dpi_build
 	@echo "[VCS] Building Model"

--- a/cva6/tb/core/Flist.cva6_tandem_cosim
+++ b/cva6/tb/core/Flist.cva6_tandem_cosim
@@ -1,0 +1,28 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2023 OpenHW Group
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+///////////////////////////////////////////////////////////////////////////////
+//
+// Manifest for the CVA6 TB.
+//   - This is a CORE-ONLY testbench.
+//   - Relevent simulation scripts/Makefiles must set the shell ENV variable
+//     CVA6_TB_DIR as required.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+${CVA6_REPO_DIR}/corev_apu/tb/common/spike.sv

--- a/cva6/tb/uvmt/cva6_tb_wrapper.sv
+++ b/cva6/tb/uvmt/cva6_tb_wrapper.sv
@@ -97,6 +97,21 @@ module cva6_tb_wrapper
     .end_of_test_o(tb_exit_o)
   ) ;
 
+`ifdef SPIKE_TANDEM
+    spike #(
+        .Size ( NUM_WORDS * 8 )
+    ) i_spike (
+        .clk_i,
+        .rst_ni,
+        .clint_tick_i ( 1'b0 ),  // FORNOW No RTC interrupts
+        .rvfi_i       ( rvfi )
+    );
+    initial begin
+        $display("Running binary in tandem mode");
+    end
+`endif
+
+
   //----------------------------------------------------------------------------
   // Memory
   //----------------------------------------------------------------------------

--- a/vendor/patches/riscv/riscv-isa-sim/0005-install-shared-disasm-lib.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0005-install-shared-disasm-lib.patch
@@ -1,0 +1,9 @@
+diff --git a/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in b/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
+index 9eafb12f9..89c7b04a6 100644
+--- a/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
++++ b/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
+@@ -3,3 +3,4 @@ disasm_srcs = \
+   regnames.cc \
+ 
+ disasm_install_lib = yes
++disasm_install_shared_lib = yes

--- a/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
+++ b/vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
@@ -3,3 +3,4 @@ disasm_srcs = \
   regnames.cc \
 
 disasm_install_lib = yes
+disasm_install_shared_lib = yes

--- a/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
@@ -278,6 +278,7 @@ void processor_t::step(size_t n)
 
           in_wfi = false;
           insn_fetch_t fetch = mmu->load_insn(pc);
+          state.last_inst_fetched = fetch.insn.bits();
           if (debug && !state.serialized)
             disasm(fetch.insn);
           pc = execute_insn_logged(this, pc, fetch);
@@ -289,6 +290,7 @@ void processor_t::step(size_t n)
         // Main simulation loop, fast path.
         for (auto ic_entry = _mmu->access_icache(pc); ; ) {
           auto fetch = ic_entry->data;
+          state.last_inst_fetched = fetch.insn.bits();
           pc = execute_insn_fast(this, pc, fetch);
           ic_entry = ic_entry->next;
           if (unlikely(ic_entry->tag != pc))

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.h
@@ -175,6 +175,7 @@ struct state_t
   reg_t last_inst_priv;
   int last_inst_xlen;
   int last_inst_flen;
+  uint64_t last_inst_fetched;
 };
 
 // this class represents one processor in a RISC-V machine.


### PR DESCRIPTION
## Purpose

This PR introduces the necessary changes to `core-v-verif` (including the vendorized Spike) required to run Spike tandem co-simulations using the latest Spike API.  The tandem (or "lock-step") operation is controlled by the environment variable `SPIKE_TANDEM`.  If set to a non-empty value, it will trigger the elaboration of a "tandem" simulation environment which compares RTL state against Spike state at every RTL commit.

## List of changes

[Spike tandem] Add support in Makefile.  Add insn bytes to Spike state.
* cva6/sim/Makefile (vcs-testharness): Add SPIKE_TANDEM=1 to RTL defines
      when in tandem mode.
* vendor/riscv/riscv-isa-sim/riscv/execute.cc (processor_t::step): Save the
      bit pattern of most recently fetched instruction in processor state.
* vendor/riscv/riscv-isa-sim/riscv/processor.h (struct state_t): Add the
     bit pattern of the most recently fetched instruction to processor state.

Add settings needed to build and run VCS-UVM in tandem out of the box.
    
* cva6/sim/Makefile (FLIST_COSIM): New.
      (spike-tandem): Export.  Control default setting from environment.
      (ALL_UVM_FLAGS): Define SPIKE_TANDEM macro iso. setting a plusarg.
      (ALL_SIMV_UVM_FLAGS): Add +permissive to let Spike's FESVR parse the
      arg list.  Use libdisasm from vendorized Spike when in Spike tandem mode.
      (dpi_build): Rely on export of spike-tandem.
      (vcs_uvm_comp): Add co-simulation Flist when in Spike tandem mode.
* cva6/tb/uvmt/cva6_tb_wrapper.sv (spike): Add Spike co-simulator instance
      when in Spike tandem mode.

[Spike] Build shared version of the disassembler lib.  Add matching patch.  The shared version of the disasm library is needed for tandem co-simulation with RTL simulators.
    
* vendor/patches/riscv/riscv-isa-sim/0005-install-shared-disasm-lib.patch:
      New.
* vendor/riscv/riscv-isa-sim/disasm/disasm.mk.in
      (disasm_install_shared_lib): Ditto.

Introduce support for Spike tandem.  Streamline CVA6 DPI build requests.
    
* cva6/sim/Makefile (spike-tandem): New.
      (ALL_UVM_FLAGS): Add Spike tandem define if tandem mode is enabled.
      (dpi-library): Use a tool-agnostic path.
      (dpi_build): Relay task to the CVA6 Makefile.  Pass Spike tandem setting.