### PR TITLE
Add A extension to STEP1 configuration

### DIFF
--- a/cva6/env/corev-dv/target/rv32imac/riscv_core_setting.sv
+++ b/cva6/env/corev-dv/target/rv32imac/riscv_core_setting.sv
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//-----------------------------------------------------------------------------
+// Processor feature configuration
+//-----------------------------------------------------------------------------
+// XLEN
+parameter int XLEN = 32;
+
+// Parameter for SATP mode, set to BARE if address translation is not supported
+parameter satp_mode_t SATP_MODE = BARE;
+
+// Supported Privileged mode
+privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
+
+// Unsupported instructions
+riscv_instr_name_t unsupported_instr[];
+
+// ISA supported by the processor
+riscv_instr_group_t supported_isa[$] = {RV32I, RV32M, RV32C, RV32A};
+
+// Interrupt mode support
+mtvec_mode_t supported_interrupt_mode[$] = {DIRECT, VECTORED};
+
+// The number of interrupt vectors to be generated, only used if VECTORED interrupt mode is
+// supported
+int max_interrupt_vector_num = 16;
+
+// Physical memory protection support
+bit support_pmp = 0;
+
+// Debug mode support
+bit support_debug_mode = 0;
+
+// Support delegate trap to user mode
+bit support_umode_trap = 0;
+
+// Support sfence.vma instruction
+bit support_sfence = 0;
+
+// Support unaligned load/store
+bit support_unaligned_load_store = 1'b1;
+
+// Parameter for vector extension
+parameter int VECTOR_EXTENSION_ENABLE = 0;
+parameter int VLEN = 512;
+parameter int ELEN = 64;
+parameter int SLEN = 64;
+
+// Number of harts
+parameter int NUM_HARTS = 1;
+
+// ----------------------------------------------------------------------------
+// Previleged CSR implementation
+// ----------------------------------------------------------------------------
+
+// Implemented previlieged CSR list
+`ifdef DSIM
+privileged_reg_t implemented_csr[] = {
+`else
+const privileged_reg_t implemented_csr[] = {
+`endif
+    // Machine mode mode CSR
+    MVENDORID,  // Vendor ID
+    MARCHID,    // Architecture ID
+    MIMPID,     // Implementation ID
+    MHARTID,    // Hardware thread ID
+    MSTATUS,    // Machine status
+    MISA,       // ISA and extensions
+    MIE,        // Machine interrupt-enable register
+    MTVEC,      // Machine trap-handler base address
+    MCOUNTEREN, // Machine counter enable
+    MSCRATCH,   // Scratch register for machine trap handlers
+    MEPC,       // Machine exception program counter
+    MCAUSE,     // Machine trap cause
+    MTVAL,      // Machine bad address or instruction
+    MIP         // Machine interrupt pending
+};
+
+// ----------------------------------------------------------------------------
+// Supported interrupt/exception setting, used for functional coverage
+// ----------------------------------------------------------------------------
+
+`ifdef DSIM
+interrupt_cause_t implemented_interrupt[] = {
+`else
+const interrupt_cause_t implemented_interrupt[] = {
+`endif
+    M_SOFTWARE_INTR,
+    M_TIMER_INTR,
+    M_EXTERNAL_INTR
+};
+
+`ifdef DSIM
+exception_cause_t implemented_exception[] = {
+`else
+const exception_cause_t implemented_exception[] = {
+`endif
+    INSTRUCTION_ACCESS_FAULT,
+    ILLEGAL_INSTRUCTION,
+    BREAKPOINT,
+    LOAD_ADDRESS_MISALIGNED,
+    LOAD_ACCESS_FAULT,
+    ECALL_MMODE
+};

--- a/cva6/regress/dv-generated-tests.sh
+++ b/cva6/regress/dv-generated-tests.sh
@@ -104,7 +104,7 @@ printf "+=======================================================================
 j=0
 while [[ $j -lt ${#TEST_NAME[@]} ]];do
   cp ../env/corev-dv/custom/riscv_custom_instr_enum.sv ./dv/src/isa/custom/
-  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
+  python3 cva6.py --testlist=$TESTLIST_FILE --test ${TEST_NAME[j]} --iss_yaml cva6.yaml --target $DV_TARGET -cs ../env/corev-dv/target/rv32imac/ --mabi ilp32 --isa rv32imac --simulator_yaml ../env/corev-dv/simulator.yaml --iss=vcs-uvm,spike -i ${I[j]} -bz 1 --iss_timeout 300
   n=0
   echo "Generate the test : ${TEST_NAME[j]}"
 #this while loop detects the failed tests from the log file and remove them


### PR DESCRIPTION
Hi,
As you all know the STEP1 configuration is **rv32imac**, this configuration does not exist in the RISCV-DV, so I add it in the core-dv (cva6); to use it when generating tests.