### PR TITLE
Adapting spike to implement the cvxif agent spec

### DIFF
--- a/cva6/tests/custom/cv_xif/cvxif_macros.h
+++ b/cva6/tests/custom/cv_xif/cvxif_macros.h
@@ -16,6 +16,6 @@
 #define CUS_ISS_EXC(rs1,rs2,rs3,rd) .word 0b##1100000##00000####00000##010##00000##1111011
 #define CUS_ADD_RS3(rs1,rs2,rs3,rd) .word 0b##rs3##01##rs2####rs1##000##rd##1111011
 #define CUS_ADD_MULTI(rs1,rs2,rs3,rd) .word 0b##0001000##rs2####rs1##000##rd##1111011
-#define CUS_EXC(rs1,rs2,rs3,rd) .word 0b####1000000##00000####rs1##000##00000##1111011
+#define CUS_EXC(rs1,rs2,rs3,rd) .word 0b####1100000##rs2####rs1##010##00000##1111011
 #define CUS_M_ADD(rs1,rs2,rs3,rd) .word 0b####0000010##rs2####rs1##011##rd##1111011
 #define CUS_S_ADD(rs1,rs2,rs3,rd) .word 0b####0000110##rs2####rs1##001##rd##1111011

--- a/cva6/tests/custom/cv_xif/cvxif_macros.h
+++ b/cva6/tests/custom/cv_xif/cvxif_macros.h
@@ -10,10 +10,10 @@
 
 #define LOAD_RS(rs,value) li rs, value
 #define COMP_RS(rs1,rs2,rd) xor rd, rs1, rs2
-#define CUS_ADD(rs1,rs2,rs3,rd) .word 0b##0000000##rs2####rs1##000##rd##1111011
+#define CUS_ADD(rs1,rs2,rs3,rd) .word 0b##0000000##rs2####rs1##001##rd##1111011
 #define CUS_NOP(rs1,rs2,rs3,rd) .word 0b##0000000##00000####00000##000##00000##1111011
 #define CUS_NOP_EXC(rs1,rs2,rs3,rd) .word 0b##0100000##00000####00000##000##00000##1111011
-#define CUS_ISS_EXC(rs1,rs2,rs3,rd) .word 0b##1100000##00000####00000##000##00000##1111011
+#define CUS_ISS_EXC(rs1,rs2,rs3,rd) .word 0b##1100000##00000####00000##010##00000##1111011
 #define CUS_ADD_RS3(rs1,rs2,rs3,rd) .word 0b##rs3##01##rs2####rs1##000##rd##1111011
 #define CUS_ADD_MULTI(rs1,rs2,rs3,rd) .word 0b##0001000##rs2####rs1##000##rd##1111011
 #define CUS_EXC(rs1,rs2,rs3,rd) .word 0b####1000000##00000####rs1##000##00000##1111011

--- a/cva6/tests/custom/cv_xif/cvxif_macros.h
+++ b/cva6/tests/custom/cv_xif/cvxif_macros.h
@@ -16,6 +16,6 @@
 #define CUS_ISS_EXC(rs1,rs2,rs3,rd) .word 0b##1100000##00000####00000##010##00000##1111011
 #define CUS_ADD_RS3(rs1,rs2,rs3,rd) .word 0b##rs3##01##rs2####rs1##000##rd##1111011
 #define CUS_ADD_MULTI(rs1,rs2,rs3,rd) .word 0b##0001000##rs2####rs1##000##rd##1111011
-#define CUS_EXC(rs1,rs2,rs3,rd) .word 0b####1100000##rs2####rs1##010##00000##1111011
+#define CUS_EXC(rs1,rs2,rs3,rd) .word 0b####1100000##rs2####rs1##010##rd##1111011
 #define CUS_M_ADD(rs1,rs2,rs3,rd) .word 0b####0000010##rs2####rs1##011##rd##1111011
 #define CUS_S_ADD(rs1,rs2,rs3,rd) .word 0b####0000110##rs2####rs1##001##rd##1111011

--- a/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
+++ b/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
@@ -139,8 +139,13 @@ class cvxif_t : public cvxif_extn_t
       
       case FUNC3_2:
         //Actually only CUS_EXC using func3 equal to one, we don't need to add another switch case
-        p -> put_csr(CSR_MCAUSE, (reg_t) ((insn.bits() >> 7) & 0x1f));
-        raise_exception(insn, (reg_t) ((insn.bits() >> 7) & 0x1f));
+        if (r_insn.rs2 != 0 || r_insn.rd != 0){
+          illegal_instruction();
+        } else {
+          p -> put_csr(CSR_MCAUSE, (reg_t) ((insn.bits() >> 7) & 0x1f));
+          raise_exception(insn, (reg_t) ((insn.bits() >> 7) & 0x1f));
+        }
+        
 
       default:
         illegal_instruction();

--- a/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
+++ b/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
@@ -142,11 +142,10 @@ class cvxif_t : public cvxif_extn_t
         if (r_insn.rs2 != 0 || r_insn.rd != 0){
           illegal_instruction();
         } else {
-          p -> put_csr(CSR_MCAUSE, (reg_t) ((insn.bits() >> 7) & 0x1f));
-          raise_exception(insn, (reg_t) ((insn.bits() >> 7) & 0x1f));
+          p -> put_csr(CSR_MCAUSE, r_insn.rs1);
+          raise_exception(insn, (reg_t) (r_insn.rs1));
         }
-        
-
+        break;
       default:
         illegal_instruction();
     }

--- a/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
+++ b/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
@@ -142,7 +142,6 @@ class cvxif_t : public cvxif_extn_t
         if (r_insn.rs2 != 0 || r_insn.rd != 0){
           illegal_instruction();
         } else {
-          p -> put_csr(CSR_MCAUSE, r_insn.rs1);
           raise_exception(insn, (reg_t) (r_insn.rs1));
         }
         break;
@@ -161,6 +160,12 @@ class cvxif_t : public cvxif_extn_t
   void raise_exception(insn_t insn, reg_t exc_index)
   {
     switch (exc_index) {
+      case CAUSE_MISALIGNED_FETCH:
+        throw trap_instruction_address_misaligned((p ? p->get_state()->v : false), 1, 0, 0);
+      case CAUSE_FETCH_ACCESS:
+        throw trap_instruction_access_fault((p ? p->get_state()->v : false), 1, 0, 0);
+      case CAUSE_BREAKPOINT:
+        throw trap_breakpoint((p ? p->get_state()->v : false), 1);
       case CAUSE_MISALIGNED_LOAD:
         // Use 0x1 as perfectly unaligned address;-)
         throw trap_load_address_misaligned((p ? p->get_state()->v : false), 1, 0, 0);
@@ -173,12 +178,30 @@ class cvxif_t : public cvxif_extn_t
       case CAUSE_STORE_ACCESS:
         // Use 0x1 as invalid address.
         throw trap_store_access_fault((p ? p->get_state()->v : false), 1, 0, 0);
+      case CAUSE_USER_ECALL:
+        throw trap_user_ecall();
+      case CAUSE_SUPERVISOR_ECALL:
+        throw trap_supervisor_ecall();
+      case CAUSE_VIRTUAL_SUPERVISOR_ECALL:
+        throw trap_virtual_supervisor_ecall();
+      case CAUSE_MACHINE_ECALL:
+        throw trap_machine_ecall();
+      case CAUSE_FETCH_PAGE_FAULT:
+        throw trap_instruction_page_fault((p ? p->get_state()->v : false), 1, 0, 0);
       case CAUSE_LOAD_PAGE_FAULT:
         // Use 0x1 as always-faulting address.
         throw trap_load_page_fault((p ? p->get_state()->v : false), 1, 0, 0);
       case CAUSE_STORE_PAGE_FAULT:
         // Use 0x1 as always-faulting address.
         throw trap_store_page_fault((p ? p->get_state()->v : false), 1, 0, 0);
+      case CAUSE_FETCH_GUEST_PAGE_FAULT:
+        throw trap_instruction_guest_page_fault(1, 0, 0);
+      case CAUSE_LOAD_GUEST_PAGE_FAULT:
+        throw trap_load_guest_page_fault( 1, 0, 0);
+      case CAUSE_VIRTUAL_INSTRUCTION:
+        throw trap_virtual_instruction(1);
+      case CAUSE_STORE_GUEST_PAGE_FAULT:
+        throw trap_store_guest_page_fault(1, 0, 0);
       default:
         illegal_instruction();
     }

--- a/vendor/riscv/riscv-isa-sim/riscv/cvxif.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/cvxif.h
@@ -62,6 +62,10 @@ union cvxif_insn_t
   insn_t i;
 };
 
+enum Func3 {FUNC3_0, FUNC3_1, FUNC3_2};
+enum Need_rs3 {NO_RS3, RS3_IN};
+enum Cus {CUS_NOP = 0, CUS_U_ADD = 2, CUS_S_ADD = 6, CUS_ADD_MULTI = 8};
+
 class cvxif_extn_t : public extension_t
 {
  public:

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.h
@@ -296,8 +296,11 @@ public:
 
   void clear_waiting_for_interrupt() { in_wfi = false; };
   bool is_waiting_for_interrupt() { return in_wfi; };
+  void set_nb_register_source(uint8_t new_number) {nb_register_src = new_number;}
+  uint8_t get_nb_register_source() {return nb_register_src;}
 
 private:
+  uint8_t nb_register_src = 2;
   const isa_parser_t * const isa;
   const cfg_t * const cfg;
 

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -88,6 +88,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --blocksz=<size>      Cache block size (B) for CMO operations(powers of 2) [default 64]\n");
   fprintf(stderr, "  --steps=<n>           Stop simulation after reaching specified number of steps "
           "(default: unlimited)\n");
+  fprintf(stderr, "  --nb_register_source=<n>     Set the number of register source usable(2 or 3)\n");
 
   exit(exit_code);
 }
@@ -329,6 +330,7 @@ static std::vector<size_t> parse_hartids(const char *s)
 
 int main(int argc, char** argv)
 {
+  uint8_t number_register_source = 2;
   bool debug = false;
   bool halted = false;
   bool histogram = false;
@@ -510,6 +512,9 @@ int main(int argc, char** argv)
       exit(-1);
     }
   });
+  parser.option(0, "nb_register_source", 1, [&](const char* s){
+    number_register_source = (uint8_t)atoi(s);
+  });
 
   auto argv1 = parser.parse(argv);
   std::vector<std::string> htif_args(argv1, (const char*const*)argv + argc);
@@ -590,6 +595,7 @@ int main(int argc, char** argv)
   if (dc) dc->set_log(log_cache);
   for (size_t i = 0; i < cfg.nprocs(); i++)
   {
+    s.get_core(i)->set_nb_register_source(number_register_source);
     if (ic) s.get_core(i)->get_mmu()->register_memtracer(&*ic);
     if (dc) s.get_core(i)->get_mmu()->register_memtracer(&*dc);
     for (auto e : extensions)


### PR DESCRIPTION
* Updates bit templateswith the new spec.
* Adds enums to cvxif.h for switch/case in cvxif.cc when instructions are decoded.
* Adds the number of source registers accepted (2 or 3) as a parameter to the `processor_t` class (processor.h).
* Adds an option in spike.cc to specify the number of source registers.

Signed-off-by: Jules FAUCHON <jules.fauchon@thalesgroup.com>