### PR TITLE
Added first draft for v2 regressions, with support of test_cfg option

### DIFF
--- a/cv32e40p/regress/cv32e40pv2_full_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_full_covg.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
 # YAML file to specify a regression testlist
 # Note that the COREV=YES is set for all tests in this regression.
 # This means you need to have a toolchain at COREV_SW_TOOLCHAIN (see Common.mk)

--- a/cv32e40p/regress/cv32e40pv2_full_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_full_covg.yaml
@@ -67,7 +67,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_instr_test
     iss: 1
     cov: 1
     num: 200
@@ -78,7 +78,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_simd_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_simd_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_simd_test
     iss: 1
     cov: 1
     num: 200
@@ -89,7 +89,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_mac_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_mac_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_mac_test
     iss: 1
     cov: 1
     num: 200
@@ -100,7 +100,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_hwloop_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_hwloop_instr_test
     iss: 1
     cov: 1
     num: 20
@@ -118,7 +118,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_hwloop_instr_test with FPU enabled
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_hwloop_instr_test
     iss: 1
     cov: 1
     num: 20
@@ -129,7 +129,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     iss: 1
     cov: 1
     num: 100
@@ -147,7 +147,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_debug_ebreak_xpulp with FPU enabled
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     iss: 1
     cov: 1
     num: 20
@@ -158,7 +158,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     iss: 1
     cov: 1
     num: 100
@@ -176,7 +176,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     iss: 1
     cov: 1
     num: 20
@@ -193,7 +193,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     iss: 1
     cov: 1
     num: 50
@@ -211,7 +211,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     iss: 1
     cov: 1
     num: 5
@@ -222,7 +222,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: legacy v1 corev_rand_interrupt with added instructions
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     iss: 1
     cov: 1
     num: 10
@@ -240,7 +240,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     iss: 1
     cov: 1
     num: 10
@@ -251,7 +251,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     iss: 1
     cov: 1
     num: 50
@@ -269,7 +269,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     iss: 1
     cov: 1
     num: 20
@@ -287,7 +287,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     iss: 1
     cov: 1
     num: 10
@@ -305,7 +305,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     iss: 1
     cov: 1
     num: 10
@@ -323,7 +323,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     iss: 1
     cov: 1
     num: 10
@@ -341,7 +341,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     iss: 1
     cov: 1
     num: 10
@@ -357,7 +357,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -371,7 +371,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_fp_zfinx_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_zfinx_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_zfinx_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -385,7 +385,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -399,7 +399,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_multicycle_fp_zfinx_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_zfinx_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_zfinx_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -726,7 +726,7 @@ pulp_bit_manipulation:
     build: uvmt_cv32e40p_pulp
     description: pulp_bit_manipulation legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_bit_manipulation
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_bit_manipulation
     iss: 1
     cov: 1
     num: 1
@@ -735,7 +735,7 @@ pulp_general_alu:
     build: uvmt_cv32e40p_pulp
     description: pulp_general_alu legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_general_alu
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_general_alu
     iss: 1
     cov: 1
     num: 1
@@ -744,7 +744,7 @@ pulp_immediate_branching:
     build: uvmt_cv32e40p_pulp
     description: pulp_immediate_branching legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_immediate_branching
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_immediate_branching
     iss: 1
     cov: 1
     num: 1
@@ -753,7 +753,7 @@ pulp_multiply_accumulate:
     build: uvmt_cv32e40p_pulp
     description: pulp_multiply_accumulate legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_multiply_accumulate
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_multiply_accumulate
     iss: 1
     cov: 1
     num: 1
@@ -762,7 +762,7 @@ pulp_post_increment_load_store:
     build: uvmt_cv32e40p_pulp
     description: pulp_post_increment_load_store legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_post_increment_load_store
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_post_increment_load_store
     iss: 1
     cov: 1
     num: 1
@@ -771,7 +771,7 @@ pulp_vectorial_add_sub:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_add_sub legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_add_sub
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_add_sub
     iss: 1
     cov: 1
     num: 1
@@ -780,7 +780,7 @@ pulp_vectorial_avg:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_avg legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_avg
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_avg
     iss: 1
     cov: 1
     num: 1
@@ -789,7 +789,7 @@ pulp_vectorial_bit_manip:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_bit_manip legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bit_manip
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_bit_manip
     iss: 1
     cov: 1
     num: 1
@@ -798,7 +798,7 @@ pulp_vectorial_bitwise:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_bitwise legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bitwise
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_bitwise
     iss: 1
     cov: 1
     num: 1
@@ -807,7 +807,7 @@ pulp_vectorial_comparison_1:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_1 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_1
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_1
     iss: 1
     cov: 1
     num: 1
@@ -816,7 +816,7 @@ pulp_vectorial_comparison_2:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_2 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_2
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_2
     iss: 1
     cov: 1
     num: 1
@@ -825,7 +825,7 @@ pulp_vectorial_comparison_3:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_3 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_3
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_3
     iss: 1
     cov: 1
     num: 1
@@ -834,7 +834,7 @@ pulp_vectorial_complex:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_complex legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_complex
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_complex
     iss: 1
     cov: 1
     num: 1
@@ -843,7 +843,7 @@ pulp_vectorial_dot_product_1:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_dot_product_1 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_1
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_dot_product_1
     iss: 1
     cov: 1
     num: 1
@@ -852,7 +852,7 @@ pulp_vectorial_dot_product_2:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_dot_product_2 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_2
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_dot_product_2
     iss: 1
     cov: 1
     num: 1
@@ -861,7 +861,7 @@ pulp_vectorial_max:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_max legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_max
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_max
     iss: 1
     cov: 1
     num: 1
@@ -870,7 +870,7 @@ pulp_vectorial_min:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_min legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_min
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_min
     iss: 1
     cov: 1
     num: 1
@@ -879,7 +879,7 @@ pulp_vectorial_shift:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_shift legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shift
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_shift
     iss: 1
     cov: 1
     num: 1
@@ -888,7 +888,7 @@ pulp_vectorial_shuffle_pack:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_shuffle_pack legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shuffle_pack
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_shuffle_pack
     iss: 1
     cov: 1
     num: 1

--- a/cv32e40p/regress/cv32e40pv2_full_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_full_covg.yaml
@@ -1,0 +1,894 @@
+# YAML file to specify a regression testlist
+# Note that the COREV=YES is set for all tests in this regression.
+# This means you need to have a toolchain at COREV_SW_TOOLCHAIN (see Common.mk)
+---
+# Header
+name: cv32_full_covg_no_pulp
+description: Full regression (all tests) for CV32E40P with step-and-compare against RM"
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp
+  uvmt_cv32e40p_pulp_fpu:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu
+  uvmt_cv32e40p_pulp_fpu_1cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_1cyclat
+  uvmt_cv32e40p_pulp_fpu_2cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_2cyclat
+  uvmt_cv32e40p_pulp_fpu_3cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_3cyclat
+  uvmt_cv32e40p_pulp_fpu_zfinx:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx
+  uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_1cyclat
+  uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_2cyclat
+  uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_3cyclat
+
+
+# ====================================================================================
+# List of tests
+tests:
+
+  # ====================================================================================
+  # V2 PULP tests
+  # ====================================================================================
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_pulp_instr_test
+  corev_rand_pulp_instr_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_instr_test
+    iss: 1
+    cov: 1
+    num: 200
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_pulp_simd_test
+  corev_rand_pulp_simd_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_simd_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_simd_test
+    iss: 1
+    cov: 1
+    num: 200
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_pulp_mac_test
+  corev_rand_pulp_mac_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_mac_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_mac_test
+    iss: 1
+    cov: 1
+    num: 200
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_hwloop_instr_test
+  corev_rand_hwloop_instr_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_hwloop_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    iss: 1
+    cov: 1
+    num: 20
+
+  corev_rand_hwloop_instr_test_floating_pt_instr_en:
+    testname: corev_rand_hwloop_instr_test
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_hwloop_instr_test with FPU enabled
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    iss: 1
+    cov: 1
+    num: 20
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_debug_ebreak_xpulp
+  corev_rand_debug_ebreak_xpulp:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_xpulp_floating_pt_instr_en:
+    testname: corev_rand_debug_ebreak_xpulp
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_debug_ebreak_xpulp with FPU enabled
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    iss: 1
+    cov: 1
+    num: 20
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_debug_ebreak_single_step_xpulp
+  corev_rand_debug_ebreak_single_step_xpulp:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_single_step_xpulp_floating_pt_instr_en:
+    testname: corev_rand_debug_ebreak_single_step_xpulp
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    iss: 1
+    cov: 1
+    num: 20
+
+
+
+  # ====================================================================================
+  # V1 rand tests re-used with v2 features
+  # ====================================================================================
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_instr_long_stall
+  corev_rand_instr_long_stall:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_instr_long_stall_floating_pt_instr_en:
+    testname: corev_rand_instr_long_stall
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    iss: 1
+    cov: 1
+    num: 5
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_interrupt
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p_pulp
+    description: legacy v1 corev_rand_interrupt with added instructions
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    iss: 1
+    cov: 1
+    num: 10
+
+  corev_rand_interrupt_floating_pt_instr_en:
+    testname: corev_rand_interrupt
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    iss: 1
+    cov: 1
+    num: 10
+
+  # -----------------------------------------------------------------------------------
+  # corev_rand_interrupt_debug
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_debug_floating_pt_instr_en:
+    testname: corev_rand_interrupt_debug
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    iss: 1
+    cov: 1
+    num: 20
+
+  corev_rand_interrupt_exception:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    iss: 1
+    cov: 1
+    num: 10
+
+  corev_rand_interrupt_nested:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    iss: 1
+    cov: 1
+    num: 10
+
+  corev_rand_interrupt_wfi_mem_stress:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    iss: 1
+    cov: 1
+    num: 10
+
+  corev_rand_jump_stress_test:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    iss: 1
+    cov: 1
+    num: 10
+
+# ------------------------------------------------------------------------------
+# V2 FPU test
+# ------------------------------------------------------------------------------
+  corev_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 30
+
+  corev_fp_zfinx_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_fp_zfinx_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_zfinx_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 30
+
+  corev_multicycle_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_multicycle_fp_zfinx_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_multicycle_fp_zfinx_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_zfinx_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+
+
+# ====================================================================================
+# V1 test re-used
+# ====================================================================================
+  hello-world:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: uvm_hello_world_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hello-world
+    iss: 1
+    cov: 1
+    num: 1
+
+  hpmcounter_basic_test:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Hardware performance counter basic test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hpmcounter_basic_test
+        iss: 1
+    cov: 1
+    num: 1
+
+  hpmcounter_hazard_test:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Hardware performance counter hazard test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=hpmcounter_hazard_test
+        iss: 1
+    cov: 1
+    num: 1
+
+  riscv_ebreak_test_0:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Static corev-dv ebreak
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_ebreak_test_0
+        iss: 1
+    cov: 1
+    num: 1
+
+  riscv_arithmetic_basic_test_0:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Static riscv-dv arithmetic test 0
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_0
+        iss: 1
+    cov: 1
+    num: 1
+    num: 1
+
+  riscv_arithmetic_basic_test_1:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Static riscv-dv arithmetic test 1
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=riscv_arithmetic_basic_test_1
+        iss: 1
+    cov: 1
+    num: 1
+    num: 1
+
+  illegal:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Illegal-riscv-tests
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=illegal
+        iss: 1
+    cov: 1
+    num: 1
+
+  fibonacci:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Fibonacci test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=fibonacci
+        iss: 1
+    cov: 1
+    num: 1
+
+  misalign:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Misalign test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=misalign
+        iss: 1
+    cov: 1
+    num: 1
+
+  dhrystone:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Dhrystone test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=dhrystone
+        iss: 1
+    cov: 1
+    num: 1
+
+  debug_test:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Debug Test 1
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test
+        iss: 1
+    cov: 1
+    num: 1
+
+  debug_test_reset:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Debug reset test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test_reset
+        iss: 1
+    cov: 1
+    num: 1
+
+  debug_test_trigger:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Debug trigger test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test_trigger
+        iss: 1
+    cov: 1
+    num: 1
+
+  debug_test_known_miscompares:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Debug test which contains known miscompares
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test_known_miscompares
+    iss: 0
+    cov: 1
+    num: 1
+
+  debug_test_boot_set:
+    builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Debug test target debug_req at BOOT_SET
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test_boot_set
+    iss: 1
+    cov: 1
+    num: 1
+
+  interrupt_bootstrap:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Interrupt bootstrap test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=interrupt_bootstrap
+    iss: 1
+    cov: 1
+    num: 1
+
+  interrupt_test:
+        builds:
+      - uvmt_cv32e40p_pulp
+      - uvmt_cv32e40p_pulp_fpu
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: Interrupt test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test COREV=YES TEST=interrupt_test
+    iss: 1
+    cov: 1
+    num: 1
+
+
+# ====================================================================================
+# V1 legacy pulp tests
+# ====================================================================================
+pulp_bit_manipulation:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_bit_manipulation legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_bit_manipulation
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_general_alu:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_general_alu legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_general_alu
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_immediate_branching:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_immediate_branching legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_immediate_branching
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_multiply_accumulate:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_multiply_accumulate legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_multiply_accumulate
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_post_increment_load_store:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_post_increment_load_store legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_post_increment_load_store
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_add_sub:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_add_sub legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_add_sub
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_avg:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_avg legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_avg
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_bit_manip:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_bit_manip legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bit_manip
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_bitwise:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_bitwise legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bitwise
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_1:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_1
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_2:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_2
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_3:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_3 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_3
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_complex:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_complex legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_complex
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_dot_product_1:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_dot_product_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_1
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_dot_product_2:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_dot_product_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_2
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_max:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_max legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_max
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_min:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_min legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_min
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_shift:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_shift legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shift
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_shuffle_pack:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_shuffle_pack legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shuffle_pack
+    iss: 1
+    cov: 1
+    num: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
@@ -30,7 +30,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_instr_test
     iss: 1
     cov: 1
     num: 100
@@ -39,7 +39,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_simd_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_simd_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_simd_test
     iss: 1
     cov: 1
     num: 100
@@ -48,7 +48,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_pulp_mac_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_mac_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_pulp_mac_test
     iss: 1
     cov: 1
     num: 100
@@ -57,7 +57,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_hwloop_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_hwloop_instr_test
     iss: 1
     cov: 1
     num: 100
@@ -66,7 +66,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     iss: 1
     cov: 1
     num: 100
@@ -75,7 +75,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     test_cfg: debug_single_step_en
     iss: 1
     cov: 1
@@ -89,7 +89,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     iss: 1
     cov: 1
     num: 100
@@ -98,7 +98,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     iss: 1
     cov: 1
     num: 100
@@ -107,7 +107,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     iss: 1
     cov: 1
     num: 100
@@ -116,7 +116,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     iss: 1
     cov: 1
     num: 100
@@ -125,7 +125,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     iss: 1
     cov: 1
     num: 100
@@ -134,7 +134,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     iss: 1
     cov: 1
     num: 100
@@ -143,7 +143,7 @@ tests:
     build: uvmt_cv32e40p_pulp
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     iss: 1
     cov: 1
     num: 100
@@ -157,7 +157,7 @@ pulp_bit_manipulation:
     build: uvmt_cv32e40p_pulp
     description: pulp_bit_manipulation legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_bit_manipulation
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_bit_manipulation
     iss: 1
     cov: 1
     num: 1
@@ -166,7 +166,7 @@ pulp_general_alu:
     build: uvmt_cv32e40p_pulp
     description: pulp_general_alu legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_general_alu
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_general_alu
     iss: 1
     cov: 1
     num: 1
@@ -175,7 +175,7 @@ pulp_immediate_branching:
     build: uvmt_cv32e40p_pulp
     description: pulp_immediate_branching legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_immediate_branching
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_immediate_branching
     iss: 1
     cov: 1
     num: 1
@@ -184,7 +184,7 @@ pulp_multiply_accumulate:
     build: uvmt_cv32e40p_pulp
     description: pulp_multiply_accumulate legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_multiply_accumulate
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_multiply_accumulate
     iss: 1
     cov: 1
     num: 1
@@ -193,7 +193,7 @@ pulp_post_increment_load_store:
     build: uvmt_cv32e40p_pulp
     description: pulp_post_increment_load_store legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_post_increment_load_store
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_post_increment_load_store
     iss: 1
     cov: 1
     num: 1
@@ -202,7 +202,7 @@ pulp_vectorial_add_sub:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_add_sub legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_add_sub
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_add_sub
     iss: 1
     cov: 1
     num: 1
@@ -211,7 +211,7 @@ pulp_vectorial_avg:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_avg legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_avg
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_avg
     iss: 1
     cov: 1
     num: 1
@@ -220,7 +220,7 @@ pulp_vectorial_bit_manip:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_bit_manip legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bit_manip
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_bit_manip
     iss: 1
     cov: 1
     num: 1
@@ -229,7 +229,7 @@ pulp_vectorial_bitwise:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_bitwise legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bitwise
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_bitwise
     iss: 1
     cov: 1
     num: 1
@@ -238,7 +238,7 @@ pulp_vectorial_comparison_1:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_1 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_1
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_1
     iss: 1
     cov: 1
     num: 1
@@ -247,7 +247,7 @@ pulp_vectorial_comparison_2:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_2 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_2
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_2
     iss: 1
     cov: 1
     num: 1
@@ -256,7 +256,7 @@ pulp_vectorial_comparison_3:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_comparison_3 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_3
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_comparison_3
     iss: 1
     cov: 1
     num: 1
@@ -265,7 +265,7 @@ pulp_vectorial_complex:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_complex legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_complex
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_complex
     iss: 1
     cov: 1
     num: 1
@@ -274,7 +274,7 @@ pulp_vectorial_dot_product_1:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_dot_product_1 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_1
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_dot_product_1
     iss: 1
     cov: 1
     num: 1
@@ -283,7 +283,7 @@ pulp_vectorial_dot_product_2:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_dot_product_2 legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_2
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_dot_product_2
     iss: 1
     cov: 1
     num: 1
@@ -292,7 +292,7 @@ pulp_vectorial_max:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_max legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_max
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_max
     iss: 1
     cov: 1
     num: 1
@@ -301,7 +301,7 @@ pulp_vectorial_min:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_min legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_min
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_min
     iss: 1
     cov: 1
     num: 1
@@ -310,7 +310,7 @@ pulp_vectorial_shift:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_shift legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shift
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_shift
     iss: 1
     cov: 1
     num: 1
@@ -319,7 +319,7 @@ pulp_vectorial_shuffle_pack:
     build: uvmt_cv32e40p_pulp
     description: pulp_vectorial_shuffle_pack legacy v1, kept as it stresses corner cases
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shuffle_pack
+    cmd: make gen_corev-dv test COREV=YES TEST=pulp_vectorial_shuffle_pack
     iss: 1
     cov: 1
     num: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
@@ -1,0 +1,325 @@
+
+
+# Header
+name: cv32e40pv2_pulp_fpu_no_lat_covg
+description: regression for CV32E40Pv2, pulp_fpu tests with no latency, step-and-compare against RM, cov enabled
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp
+
+
+# ====================================================================================
+# List of tests
+tests:
+
+  # ====================================================================================
+  # V2 PULP tests
+  # ====================================================================================
+  corev_rand_pulp_instr_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_instr_test
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_pulp_simd_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_simd_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_simd_test
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_pulp_mac_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_pulp_mac_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_pulp_mac_test
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_hwloop_instr_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_hwloop_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_xpulp:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_single_step_xpulp:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    test_cfg: debug_single_step_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  # ====================================================================================
+  # V1 rand tests re-used with v2 features
+  # ====================================================================================
+
+  corev_rand_instr_long_stall:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_nested:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_wfi_mem_stress:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_jump_stress_test:
+    build: uvmt_cv32e40p_pulp
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    iss: 1
+    cov: 1
+    num: 100
+
+
+# ====================================================================================
+# V1 legacy pulp tests
+# ====================================================================================
+
+pulp_bit_manipulation:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_bit_manipulation legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_bit_manipulation
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_general_alu:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_general_alu legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_general_alu
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_immediate_branching:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_immediate_branching legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_immediate_branching
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_multiply_accumulate:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_multiply_accumulate legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_multiply_accumulate
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_post_increment_load_store:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_post_increment_load_store legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_post_increment_load_store
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_add_sub:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_add_sub legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_add_sub
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_avg:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_avg legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_avg
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_bit_manip:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_bit_manip legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bit_manip
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_bitwise:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_bitwise legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_bitwise
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_1:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_1
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_2:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_2
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_comparison_3:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_comparison_3 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_comparison_3
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_complex:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_complex legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_complex
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_dot_product_1:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_dot_product_1 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_1
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_dot_product_2:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_dot_product_2 legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_dot_product_2
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_max:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_max legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_max
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_min:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_min legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_min
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_shift:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_shift legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shift
+    iss: 1
+    cov: 1
+    num: 1
+
+pulp_vectorial_shuffle_pack:
+    build: uvmt_cv32e40p_pulp
+    description: pulp_vectorial_shuffle_pack legacy v1, kept as it stresses corner cases
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=pulp_vectorial_shuffle_pack
+    iss: 1
+    cov: 1
+    num: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_covg.yaml
@@ -1,8 +1,9 @@
-
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # Header
-name: cv32e40pv2_pulp_fpu_no_lat_covg
-description: regression for CV32E40Pv2, pulp_fpu tests with no latency, step-and-compare against RM, cov enabled
+name: cv32e40pv2_pulp_covg
+description: regression for CV32E40Pv2, pulp step-and-compare against RM, cov enabled
 
 # List of builds
 builds:

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
@@ -1,0 +1,185 @@
+
+
+# Header
+name: cv32e40pv2_pulp_fpu_all_lat_covg
+description: regression for CV32E40Pv2, pulp_fpu tests with all three latencies configurations, step-and-compare against RM, cov enabled
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp_fpu_1cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_1cyclat
+  uvmt_cv32e40p_pulp_fpu_2cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_2cyclat
+  uvmt_cv32e40p_pulp_fpu_3cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_3cyclat
+
+# List of tests
+tests:
+  corev_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 20
+
+  corev_multicycle_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_hwloop_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_hwloop_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 10
+
+  corev_rand_debug_ebreak_xpulp:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_debug_ebreak_single_step_xpulp:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_instr_long_stall:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_debug:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_exception:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_nested:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_wfi_mem_stress:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_jump_stress_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_3cyclat
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
@@ -35,7 +35,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -48,7 +48,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -61,7 +61,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_hwloop_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_hwloop_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_hwloop_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -74,7 +74,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -87,7 +87,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -100,7 +100,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -113,7 +113,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -126,7 +126,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -139,7 +139,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -152,7 +152,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -165,7 +165,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -178,7 +178,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_3cyclat
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_all_lat_covg.yaml
@@ -1,4 +1,5 @@
-
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # Header
 name: cv32e40pv2_pulp_fpu_all_lat_covg

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
@@ -1,4 +1,5 @@
-
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # Header
 name: cv32e40pv2_pulp_fpu_no_lat_covg

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
@@ -24,7 +24,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -34,7 +34,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -44,7 +44,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -54,7 +54,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -64,7 +64,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -74,7 +74,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -84,7 +84,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -94,7 +94,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -104,7 +104,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -114,7 +114,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -124,7 +124,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_no_lat_covg.yaml
@@ -1,0 +1,131 @@
+
+
+# Header
+name: cv32e40pv2_pulp_fpu_no_lat_covg
+description: regression for CV32E40Pv2, pulp_fpu tests with no latency, step-and-compare against RM, cov enabled
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp_fpu:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu
+
+# List of tests
+tests:
+  corev_fp_instr_test:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_multicycle_fp_instr_test:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_xpulp:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_single_step_xpulp:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_instr_long_stall:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_nested:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_wfi_mem_stress:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_jump_stress_test:
+    build: uvmt_cv32e40p_pulp_fpu
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
@@ -1,4 +1,5 @@
-
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # Header
 name: cv32e40pv2_pulp_fpu_zfinx_all_lat_covg

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
@@ -1,0 +1,172 @@
+
+
+# Header
+name: cv32e40pv2_pulp_fpu_zfinx_all_lat_covg
+description: regression for CV32E40Pv2, pulp_fpu_zfinx tests with all three latencies configurations, step-and-compare against RM, cov enabled
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_1cyclat
+  uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_2cyclat
+  uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx_3cyclat
+
+# List of tests
+tests:
+  corev_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 20
+
+  corev_multicycle_fp_instr_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_debug_ebreak_xpulp:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_debug_ebreak_single_step_xpulp:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_instr_long_stall:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_debug:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_exception:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_nested:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_interrupt_wfi_mem_stress:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_rand_jump_stress_test:
+    builds:
+      - uvmt_cv32e40p_pulp_fpu_zfinx_1cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_2cyclat
+      - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_all_lat_covg.yaml
@@ -35,7 +35,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -48,7 +48,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -61,7 +61,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -74,7 +74,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -87,7 +87,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -100,7 +100,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -113,7 +113,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -126,7 +126,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -139,7 +139,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -152,7 +152,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -165,7 +165,7 @@ tests:
       - uvmt_cv32e40p_pulp_fpu_zfinx_3cyclat
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
@@ -1,4 +1,5 @@
-
+# Copyright 2023 Dolphin Design
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # Header
 name: cv32e40pv2_pulp_fpu_zfinx_no_lat_covg

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
@@ -24,7 +24,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -34,7 +34,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_multicycle_fp_instr_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_multicycle_fp_instr_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -44,7 +44,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_debug_ebreak_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -54,7 +54,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_debug_ebreak_single_step_xpulp
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -64,7 +64,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_instr_long_stall
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_instr_long_stall
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -74,7 +74,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_interrupt
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -84,7 +84,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_interrupt_debug
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_debug
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -94,7 +94,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_interrupt_exception
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_exception
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -104,7 +104,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_interrupt_nested
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_nested
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -114,7 +114,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_interrupt_wfi_mem_stress
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1
@@ -124,7 +124,7 @@ tests:
     build: uvmt_cv32e40p_pulp_fpu_zfinx
     description: corev_rand_jump_stress_test
     dir: cv32e40p/sim/uvmt
-    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_jump_stress_test
     test_cfg: floating_pt_instr_en
     iss: 1
     cov: 1

--- a/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
+++ b/cv32e40p/regress/cv32e40pv2_pulp_fpu_zfinx_no_lat_covg.yaml
@@ -1,0 +1,131 @@
+
+
+# Header
+name: cv32e40pv2_pulp_fpu_zfinx_no_lat_covg
+description: regression for CV32E40Pv2, pulp_fpu_zfinx tests with no latency, step-and-compare against RM, cov enabled
+
+# List of builds
+builds:
+  clean_fw:
+    cmd: make clean-bsp clean_test_programs
+    dir: cv32e40p/sim/uvmt
+  corev-dv:
+    cmd: make clean_riscv-dv comp_corev-dv
+    dir: cv32e40p/sim/uvmt
+    cov: 0
+  uvmt_cv32e40p_pulp_fpu_zfinx:
+    cmd: make comp
+    dir: cv32e40p/sim/uvmt
+    cfg: pulp_fpu_zfinx
+
+# List of tests
+tests:
+  corev_fp_instr_test:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 50
+
+  corev_multicycle_fp_instr_test:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_multicycle_fp_instr_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_multicycle_fp_instr_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_xpulp:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_debug_ebreak_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_debug_ebreak_single_step_xpulp:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_debug_ebreak_single_step_xpulp
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_debug_ebreak_single_step_xpulp
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_instr_long_stall:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_instr_long_stall
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_instr_long_stall
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_interrupt
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_debug:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_interrupt_debug
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_debug
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_exception:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_interrupt_exception
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_exception
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_nested:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_interrupt_nested
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_nested
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_interrupt_wfi_mem_stress:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_interrupt_wfi_mem_stress
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_interrupt_wfi_mem_stress
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100
+
+  corev_rand_jump_stress_test:
+    build: uvmt_cv32e40p_pulp_fpu_zfinx
+    description: corev_rand_jump_stress_test
+    dir: cv32e40p/sim/uvmt
+    cmd: make test gen_corev-dv COREV=YES TEST=corev_rand_jump_stress_test
+    test_cfg: floating_pt_instr_en
+    iss: 1
+    cov: 1
+    num: 100


### PR DESCRIPTION
This PR adds the first draft for CV32E40P v2 regressions.

These are preliminary and not complete yet, and are commited to allow first regressions to be run.

More will be added / they will be updated later when needed

To be merged after PR #2053 