### PR TITLE
Made it possible to use the Risc-v disassembler with isacov

### DIFF
--- a/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
@@ -243,6 +243,8 @@ class uvme_cv32e40s_cfg_c extends uvma_core_cntrl_cfg_c;
       isacov_cfg.seq_instr_x2_enabled       == 1;
       isacov_cfg.reg_crosses_enabled        == 0;
       isacov_cfg.reg_hazards_enabled        == 1;
+      isacov_cfg.decoder                    == RISCV_DISASSEMBLER;
+
 
       rvfi_cfg.nret                    == RVFI_NRET;
       rvfi_cfg.nmi_load_fault_enabled  == 1;
@@ -417,6 +419,7 @@ function uvme_cv32e40s_cfg_c::new(string name="uvme_cv32e40s_cfg");
      clic_irq_clear_on_ack_plusarg_valid = 1;
      clic_irq_clear_on_ack.rand_mode(0);
    end
+
 
    isacov_cfg           = uvma_isacov_cfg_c::type_id::create("isacov_cfg");
    clknrst_cfg          = uvma_clknrst_cfg_c::type_id::create("clknrst_cfg");

--- a/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
+++ b/cv32e40s/env/uvme/uvme_cv32e40s_cfg.sv
@@ -243,7 +243,7 @@ class uvme_cv32e40s_cfg_c extends uvma_core_cntrl_cfg_c;
       isacov_cfg.seq_instr_x2_enabled       == 1;
       isacov_cfg.reg_crosses_enabled        == 0;
       isacov_cfg.reg_hazards_enabled        == 1;
-      isacov_cfg.decoder                    == RISCV_DISASSEMBLER;
+      isacov_cfg.decoder                    == ISA_SUPPORT;
 
 
       rvfi_cfg.nret                    == RVFI_NRET;

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
@@ -54,6 +54,9 @@ class uvma_isacov_cfg_c extends uvm_object;
     `uvm_field_enum(decoder_e, decoder, UVM_DEFAULT);
   `uvm_object_utils_end;
 
+   constraint defaults_cons {
+      soft decoder  == SPIKE;
+   }
   extern function new(string name = "uvma_isacov_cfg");
 
 endclass : uvma_isacov_cfg_c

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
@@ -33,7 +33,7 @@ class uvma_isacov_cfg_c extends uvm_object;
   rand bit                     reg_crosses_enabled;
   rand bit                     reg_hazards_enabled;
 
-  rand decoder_e            decoder;
+  rand decoder_e               decoder;
 
   // Core configuration object to filter extensions, csrs, modes, supported
   uvma_core_cntrl_cfg_c        core_cfg;

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_cfg.sv
@@ -33,6 +33,8 @@ class uvma_isacov_cfg_c extends uvm_object;
   rand bit                     reg_crosses_enabled;
   rand bit                     reg_hazards_enabled;
 
+  rand decoder_e            decoder;
+
   // Core configuration object to filter extensions, csrs, modes, supported
   uvma_core_cntrl_cfg_c        core_cfg;
 
@@ -48,6 +50,8 @@ class uvma_isacov_cfg_c extends uvm_object;
     `uvm_field_int(seq_instr_x2_enabled, UVM_DEFAULT);
     `uvm_field_int(reg_crosses_enabled, UVM_DEFAULT);
     `uvm_field_int(reg_hazards_enabled, UVM_DEFAULT);
+
+    `uvm_field_enum(decoder_e, decoder, UVM_DEFAULT);
   `uvm_object_utils_end;
 
   extern function new(string name = "uvma_isacov_cfg");

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -26,11 +26,13 @@ class uvma_isacov_mon_c#(int ILEN=DEFAULT_ILEN,
   uvma_isacov_cfg_c                          cfg;
   uvm_analysis_port#(uvma_isacov_mon_trn_c)  ap;
   instr_name_t                               instr_name_lookup[string];
+  asm_t                                      instr_asm; 
 
   // Analysis export to receive instructions from RVFI
   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_isacov_mon_c) rvfi_instr_imp;
 
   extern function new(string name = "uvma_isacov_mon", uvm_component parent = null);
+
   extern virtual function void build_phase(uvm_phase phase);
 
   /**
@@ -42,6 +44,8 @@ class uvma_isacov_mon_c#(int ILEN=DEFAULT_ILEN,
    * Analysis port write from RVFI instruction retirement monitor
    */
   extern virtual function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) rvfi_instr);
+
+
 
 endclass : uvma_isacov_mon_c
 
@@ -75,13 +79,16 @@ function void uvma_isacov_mon_c::build_phase(uvm_phase phase);
   dasm_set_config(32, "rv32imc", 0);
 
   // Use the enumerations in <instr_name_t> to setup the instr_name_lookup
-  // convert the enums to lower-case and substitute underscore with . to match
-  // Spike disassembler
   in = in.first;
   repeat(in.num) begin
-    string instr_name_key = convert_instr_to_spike_name(in.name());
+    string instr_name_key = in.name();
+    if(cfg.decoder == SPIKE) begin
+      // convert the enums to lower-case and substitute underscore with . to match
+      // Spike disassembler
+      instr_name_key = convert_instr_to_spike_name(in.name());
+      `uvm_info("ISACOV", $sformatf("Converting: %s to %s", in.name(), instr_name_key), UVM_HIGH);
+    end
 
-    `uvm_info("ISACOV", $sformatf("Converting: %s to %s", in.name(), instr_name_key), UVM_HIGH);
     instr_name_lookup[instr_name_key] = in;
     in = in.next;
   end
@@ -138,62 +145,117 @@ function void uvma_isacov_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(IL
   mon_trn = uvma_isacov_mon_trn_c#(.ILEN(ILEN), .XLEN(XLEN))::type_id::create("mon_trn");
   mon_trn.instr = uvma_isacov_instr_c#(ILEN,XLEN)::type_id::create("mon_instr");
   mon_trn.instr.rvfi = rvfi_instr;
-
   // Mark trapped instructions from RVFI
   mon_trn.instr.trap = rvfi_instr.trap;
 
-  // Attempt to decode instruction with Spike DASM
-  instr_name = dasm_name(rvfi_instr.insn);
-  if (instr_name_lookup.exists(instr_name)) begin
-    mon_trn.instr.name = instr_name_lookup[instr_name];
-  end else begin
-    // Undecodable instruction
-    // Note that Spike can decode "everything" so if it doesn't map above, then it is an undecodable instruction
-    // from OpenHW core-v-verif perspective so set to UNKNOWN
-    mon_trn.instr.name = UNKNOWN;
-  end
+  // Get the config
+  void'(uvm_config_db#(uvma_isacov_cfg_c)::get(this, "", "cfg", cfg));
 
-  `uvm_info("ISACOVMON", $sformatf("rvfi = 0x%08x %s", rvfi_instr.insn, instr_name), UVM_HIGH);
+  if (cfg.decoder == SPIKE) begin
+    // Attempt to decode instruction with Spike DASM
+    instr_name = dasm_name(rvfi_instr.insn);
+    if (instr_name_lookup.exists(instr_name)) begin
+      mon_trn.instr.name = instr_name_lookup[instr_name];
+    end else begin
+      // Undecodable instruction
+      // Note that Spike can decode "everything" so if it doesn't map above, then it is an undecodable instruction
+      // from OpenHW core-v-verif perspective so set to UNKNOWN
+      mon_trn.instr.name = UNKNOWN;
+    end
 
-  mon_trn.instr.itype = get_instr_type(mon_trn.instr.name);
-  mon_trn.instr.ext   = get_instr_ext(mon_trn.instr.name);
-  mon_trn.instr.group = get_instr_group(mon_trn.instr.name, rvfi_instr.mem_addr);
+    `uvm_info("ISACOVMON", $sformatf("rvfi = 0x%08x %s", rvfi_instr.insn, instr_name), UVM_HIGH);
 
-  instr = $signed(rvfi_instr.insn);
+    mon_trn.instr.itype = get_instr_type(mon_trn.instr.name);
+    mon_trn.instr.ext   = get_instr_ext(mon_trn.instr.name);
+    mon_trn.instr.group = get_instr_group(mon_trn.instr.name, rvfi_instr.mem_addr);
 
-  // Disassemble the instruction using Spike (via DPI)
-  if (mon_trn.instr.ext == C_EXT) begin
-    mon_trn.instr.rs1     = dasm_rvc_rs1(instr);
-    mon_trn.instr.rs2     = dasm_rvc_rs2(instr);
-    mon_trn.instr.rd      = dasm_rvc_rd(instr);
-    mon_trn.instr.c_rdrs1 = dasm_rvc_rd(instr);
-    mon_trn.instr.c_rdp  = dasm_rvc_rs1s(instr);
-    mon_trn.instr.c_rs1s  = dasm_rvc_rs1s(instr);
-    mon_trn.instr.c_rs2s  = dasm_rvc_rs2s(instr);
-  end
-  else begin
-    mon_trn.instr.rs1  = dasm_rs1(instr);
-    mon_trn.instr.rs2  = dasm_rs2(instr);
-    mon_trn.instr.rd   = dasm_rd(instr);
-    mon_trn.instr.immi = dasm_i_imm(instr);
-    mon_trn.instr.imms = dasm_s_imm(instr);
-    mon_trn.instr.immb = dasm_sb_imm(instr) >> 1;  // Because dasm gives [12:0], not [12: 1]
-    mon_trn.instr.immu = dasm_u_imm(instr) >> 12;  // Because dasm gives [31:0], not [31:12]
-    mon_trn.instr.immj = dasm_uj_imm(instr) >> 1;  // Because dasm gives [20:0], not [20: 1]
-  end
+    instr = $signed(rvfi_instr.insn);
 
-  // Make instructions as illegal,
-  // 1. If UNKNOWN (undecodable)
-  if (mon_trn.instr.name == UNKNOWN)
-    mon_trn.instr.illegal = 1;
-  // 2. If a CSR instruction is not targeted to a valid CSR
-  if (mon_trn.instr.group == CSR_GROUP) begin
-    mon_trn.instr.csr_val = dasm_csr(instr);
-    if (!$cast(mon_trn.instr.csr, mon_trn.instr.csr_val) ||
-         cfg.core_cfg.unsupported_csr_mask[mon_trn.instr.csr_val]) begin
+    //Disassemble the instruction using Spike (via DPI)
+    if (mon_trn.instr.ext == C_EXT) begin
+      mon_trn.instr.rs1     = dasm_rvc_rs1(instr);
+      mon_trn.instr.rs2     = dasm_rvc_rs2(instr);
+      mon_trn.instr.rd      = dasm_rvc_rd(instr);
+      mon_trn.instr.c_rdrs1 = dasm_rvc_rd(instr);
+      mon_trn.instr.c_rdp   = dasm_rvc_rs1s(instr);
+      mon_trn.instr.c_rs1s  = dasm_rvc_rs1s(instr);
+      mon_trn.instr.c_rs2s  = dasm_rvc_rs2s(instr);
+    end
+    else begin
+      mon_trn.instr.rs1  = dasm_rs1(instr);
+      mon_trn.instr.rs2  = dasm_rs2(instr);
+      mon_trn.instr.rd   = dasm_rd(instr);
+      mon_trn.instr.immi = dasm_i_imm(instr);
+      mon_trn.instr.imms = dasm_s_imm(instr);
+      mon_trn.instr.immb = dasm_sb_imm(instr) >> 1;  // Because dasm gives [12:0], not [12: 1]
+      mon_trn.instr.immu = dasm_u_imm(instr) >> 12;  // Because dasm gives [31:0], not [31:12]
+      mon_trn.instr.immj = dasm_uj_imm(instr) >> 1;  // Because dasm gives [20:0], not [20: 1]
+    end
+
+    // Make instructions as illegal,
+    // 1. If UNKNOWN (undecodable)
+    if (mon_trn.instr.name == UNKNOWN)
+      mon_trn.instr.illegal = 1;
+    // 2. If a CSR instruction is not targeted to a valid CSR
+    if (mon_trn.instr.group == CSR_GROUP) begin
+      mon_trn.instr.csr_val = dasm_csr(instr);
+      if (!$cast(mon_trn.instr.csr, mon_trn.instr.csr_val) ||
+           cfg.core_cfg.unsupported_csr_mask[mon_trn.instr.csr_val]) begin
+        mon_trn.instr.illegal = 1;
+      end
+    end
+
+  end else if (cfg.decoder == RISCV_DISASSEMBLER) begin
+    // Attempt to decode instruction with the RISC-V disassembler
+    instr_asm = decode_instr(rvfi_instr.insn);
+
+    instr_name = instr_asm.instr.name();
+    if (instr_name_lookup.exists(instr_name)) begin
+      mon_trn.instr.name = instr_name_lookup[instr_name];
+    end else begin
+      // Undecodable instruction
+      mon_trn.instr.name = UNKNOWN;
+    end
+
+    mon_trn.instr.itype = get_instr_type(mon_trn.instr.name);
+    mon_trn.instr.ext   = get_instr_ext(mon_trn.instr.name);
+    mon_trn.instr.group = get_instr_group(mon_trn.instr.name, rvfi_instr.mem_addr);
+
+    if (mon_trn.instr.ext == C_EXT) begin
+      mon_trn.instr.rs1     = instr_asm.rs1.gpr;
+      mon_trn.instr.rs2     = instr_asm.rs2.gpr;
+      mon_trn.instr.rd      = instr_asm.rd.gpr;
+      mon_trn.instr.c_rdrs1 = instr_asm.rd.gpr;
+      mon_trn.instr.c_rdp   = instr_asm.rd.gpr;
+      mon_trn.instr.c_rs1s  = instr_asm.rs1.gpr;
+      mon_trn.instr.c_rs2s  = instr_asm.rs2.gpr;
+    end
+    else begin
+      mon_trn.instr.rs1     = instr_asm.rs1.gpr;
+      mon_trn.instr.rs2     = instr_asm.rs2.gpr;
+      mon_trn.instr.rd      = instr_asm.rd.gpr;
+      mon_trn.instr.immi    = instr_asm.imm.imm_raw_sorted;
+      mon_trn.instr.imms    = instr_asm.imm.imm_raw_sorted;
+      mon_trn.instr.immb    = instr_asm.imm.imm_raw_sorted;
+      mon_trn.instr.immu    = instr_asm.imm.imm_raw_sorted;
+      mon_trn.instr.immj    = instr_asm.imm.imm_raw_sorted;
+    end
+
+    // Make instructions as illegal,
+    // 1. If UNKNOWN (undecodable)
+    if (mon_trn.instr.name == UNKNOWN) begin
       mon_trn.instr.illegal = 1;
     end
+    // 2. If a CSR instruction is not targeted to a valid CSR
+    if (mon_trn.instr.group == CSR_GROUP) begin
+      mon_trn.instr.csr_val = instr_asm.csr.address;
+      if (!$cast(mon_trn.instr.csr, mon_trn.instr.csr_val) ||
+           cfg.core_cfg.unsupported_csr_mask[mon_trn.instr.csr_val]) begin
+        mon_trn.instr.illegal = 1;
+      end
+    end
   end
+
   // 3. Instruction is in unsupported extension
   if ((mon_trn.instr.ext == A_EXT && !cfg.core_cfg.ext_a_supported) ||
       (mon_trn.instr.ext == C_EXT && !cfg.core_cfg.ext_c_supported) ||
@@ -302,5 +364,4 @@ function void uvma_isacov_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(IL
   ap.write(mon_trn);
 
 endfunction : write_rvfi_instr
-
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_pkg.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_pkg.sv
@@ -26,10 +26,12 @@ package uvma_isacov_pkg;
   import uvma_core_cntrl_pkg::*;
   import uvma_rvfi_pkg::*;
 
+  import support_pkg::*;
+
   // DPI imports
   `include "dpi_dasm_imports.svh"
 
-  // Constants / Structs / Enums  
+  // Constants / Structs / Enums
   `include "uvma_isacov_constants.sv"
   `include "uvma_isacov_tdefs.sv"
 

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -19,6 +19,11 @@
 `define __UVMA_ISACOV_TDEFS_SV__
 
 typedef enum {
+  SPIKE,
+  RISCV_DISASSEMBLER
+} decoder_e;
+
+typedef enum {
   A_EXT,
   B_EXT,
   C_EXT,

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -20,7 +20,7 @@
 
 typedef enum {
   SPIKE,
-  RISCV_DISASSEMBLER
+  ISA_SUPPORT
 } decoder_e;
 
 typedef enum {


### PR DESCRIPTION
To verify the implementation, the test hello-world was ran to see if the coverage when using the SPIKE decoder is close to the coverage when using isa_support. 

The results showed that the two decoders had approximately the same coverage, indicating that the implementation works. 

Screenshot of coverage when using Spike:
![image](https://github.com/openhwgroup/core-v-verif/assets/136354327/fb4eac28-ec3e-401c-90b9-b48cf605543b)

Screenshot of coverage when using isa_support:
![image](https://github.com/openhwgroup/core-v-verif/assets/136354327/cf893bda-ff70-4d19-b8cb-8bbb9ff3f4fb)

