### PR TITLE
Refactored testbench code

### DIFF
--- a/bin/cv_regress
+++ b/bin/cv_regress
@@ -151,6 +151,8 @@ def read_file(args, file):
             test.sub_make(args.make)
         if args.iss != None:
             test.iss = args.iss
+        else:
+            args.iss = 'YES'
         if args.cfg:
             test.cfg = args.cfg
         if not test.builds and test.build:
@@ -270,7 +272,7 @@ if args.metrics:
                                  cfg=args.cfg,
                                  toolchain=args.toolchain,
                                  makeargs=' '.join(args.makearg) if args.makearg else '',
-                                 iss=' '.join(args.iss) if args.iss else '',
+                                 iss=''.join(args.iss) if args.iss else '',
                                  unique_builds=unique_builds))
     out_fh.close()
     os.chmod(args.outfile, 0o775)
@@ -294,7 +296,7 @@ if args.vsif:
                                  simulator=args.simulator,
                                  filter_dir=get_filter_dir(),
                                  unique_builds=unique_builds,
-                                 iss=' '.join(args.iss) if args.iss else ''))
+                                 iss=''.join(args.iss) if args.iss else ''))
     out_fh.close()
 
     # Generate a Vmanager-compatible SVE

--- a/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_fencei_tamper_seq.sv
+++ b/cv32e40s/env/uvme/vseq/uvme_cv32e40s_vp_fencei_tamper_seq.sv
@@ -18,6 +18,7 @@
 `ifndef __UVME_CV32E40S_VP_FENCEI_TAMPER_SEQ_SV__
 `define __UVME_CV32E40S_VP_FENCEI_TAMPER_SEQ_SV__
 
+import rvviApiPkg::*;
 
 class uvme_cv32e40s_vp_fencei_tamper_seq_c#(
    parameter AUSER_WIDTH = `UVMA_OBI_MEMORY_AUSER_DEFAULT_WIDTH, ///< Width of the auser signal. RI5CY, Ibex, CV32E40* do not have the auser signal.
@@ -139,25 +140,11 @@ function void uvme_cv32e40s_vp_fencei_tamper_seq_c::write_rtl_mem();
 
 endfunction : write_rtl_mem
 
-`ifdef USE_ISS
-import "DPI-C" context function void rvviRefMemoryWrite(
-    input int hartId,
-    input longint address,
-    input longint data,
-    input int size);
-`endif
-
 function void uvme_cv32e40s_vp_fencei_tamper_seq_c::write_iss_mem();
 
-//  `ifdef USE_ISS
-//    rvviRefMemoryWrite(0, addr, data, 4);
-//  `endif
-
-`ifdef USE_ISS
   if ($test$plusargs("USE_ISS")) begin
     rvviRefMemoryWrite(0, addr, data, 4);
   end
-`endif
 
 endfunction : write_iss_mem
 

--- a/cv32e40s/tb/uvmt/imperas_dummy_pkg.flist
+++ b/cv32e40s/tb/uvmt/imperas_dummy_pkg.flist
@@ -1,0 +1,1 @@
+${DV_UVMT_PATH}/uvmt_cv32e40s_imperas_dummy_pkg.sv

--- a/cv32e40s/tb/uvmt/imperas_dv_deps.flist
+++ b/cv32e40s/tb/uvmt/imperas_dv_deps.flist
@@ -21,6 +21,7 @@
 //   that is external to this repo.
 //
 
-// ImperasDV test bench wrapper
-${TBSRC_HOME}/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
++incdir+${IMPERAS_HOME}/ImpProprietary/include/host
+-f ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/rvvi.f
+-f ${IMPERAS_HOME}/ImpProprietary/source/host/idv/idv.f
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s.flist
@@ -26,7 +26,8 @@
 -f ${DV_SVLIB_PATH}/svlib_pkg.flist
 -f ${DV_SUPPORT_PATH}/support_pkg.flist
 
-${DV_UVM_TESTCASE_PATH}/base-tests/uvmt_cv32e40s_base_test_pkg.sv
+// Imperas dv dependencies (rvvi, idv) or dummy package goes here (later packages depend on this)
+${FILE_LIST_IDV_DEPS}
 
 // Agents
 -f ${DV_UVMA_CORE_CNTRL_PATH}/uvma_core_cntrl_pkg.flist
@@ -48,6 +49,8 @@ ${DV_UVM_TESTCASE_PATH}/base-tests/uvmt_cv32e40s_base_test_pkg.sv
 +incdir+${DV_UVM_TESTCASE_PATH}/compliance-tests
 +incdir+${DV_UVM_TESTCASE_PATH}/vseq
 
+${DV_UVM_TESTCASE_PATH}/base-tests/uvmt_cv32e40s_base_test_pkg.sv
+
 // CV32E40S tests (includes constants/macros/types meant for test bench)
 +incdir+${TBSRC_HOME}
 
@@ -55,7 +58,8 @@ ${DV_UVM_TESTCASE_PATH}/base-tests/uvmt_cv32e40s_base_test_pkg.sv
 -f ${DV_UVME_PATH}/uvme_cv32e40s_pkg.flist
 ${DV_UVMT_PATH}/uvmt_cv32e40s_pkg.sv
 
-// ImperasDV  (this env var is not set if not using idv)
+// ImperasDV wrapper files (this env var is not set if not using idv)
+// Depends on env
 ${FILE_LIST_IDV}
 
 // CV32E40S test bench files

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dummy_pkg.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dummy_pkg.sv
@@ -1,0 +1,60 @@
+// Copyright 2023 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+//
+
+`ifndef __UVMT_CV32E40S_IMPERAS_DUMMY_PKG_SV__
+`define __UVMT_CV32E40S_IMPERAS_DUMMY_PKG_SV__
+import uvm_pkg::*;
+
+package rvviApiPkg;
+  function int rvviRefShutdown();
+    `uvm_error("ISS_DUMMY", "USE_ISS=1 set but no ISS installation is available");
+    return 0;
+  endfunction : rvviRefShutdown
+
+  function void rvviRefMemoryWrite(
+    int hartId,
+    longint address,
+    longint data,
+    int size
+  );
+    `uvm_error("ISS_DUMMY", "USE_ISS=1 set but not ISS installation is available");
+  endfunction : rvviRefMemoryWrite
+endpackage : rvviApiPkg
+
+interface rvviTrace
+  #(
+    parameter int NHART  = 1,
+    parameter int RETIRE = 1
+  );
+endinterface : rvviTrace
+
+module uvmt_cv32e40s_imperas_dv_wrap
+  import uvm_pkg::*;
+  #()
+  (
+    rvviTrace rvvi
+  );
+
+endmodule : uvmt_cv32e40s_imperas_dv_wrap
+
+interface uvmt_imperas_dv_if_t;
+  task ref_init;
+    `uvm_info("ISS_DUMMY", "ref_init called from uvmt_cv32e40s_imperas_dummy_pkg.sv", UVM_LOW);
+  endtask : ref_init
+endinterface : uvmt_imperas_dv_if_t
+
+`endif // __UVMT_CV32E40S_IMPERAS_DUMMY_PKG_SV__

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
@@ -311,7 +311,7 @@ module uvmt_cv32e40s_imperas_dv_wrap
    )
 
    (
-           rvviTrace  rvvi // RVVI SystemVerilog Interface
+           rvviTrace rvvi // RVVI SystemVerilog Interface
    );
 
    trace2api       #(.CMP_PC      (1),
@@ -793,12 +793,20 @@ module uvmt_cv32e40s_imperas_dv_wrap
        end
    end: Monitor_RVFI
 
-  /////////////////////////////////////////////////////////////////////////////
-  // REF control
-  /////////////////////////////////////////////////////////////////////////////
+endmodule : uvmt_cv32e40s_imperas_dv_wrap
+
+interface uvmt_imperas_dv_if_t;
+  import uvm_pkg::*;
+  import cv32e40s_pkg::*;
+  import uvmt_cv32e40s_base_test_pkg::*;
+  import uvme_cv32e40s_pkg::*;
+  import rvviApiPkg::*;
+
+  string info_tag = "ImperasDV_if";
+
   task ref_init;
     string test_program_elf;
-    reg [31:0] hart_id;
+    logic [31:0] hart_id;
 
     // Select processor name
     void'(rvviRefConfigSetString(IDV_CONFIG_MODEL_NAME, "CVE4S"));
@@ -985,25 +993,7 @@ module uvmt_cv32e40s_imperas_dv_wrap
 
     `uvm_info(info_tag, "ref_init() complete", UVM_LOW)
   endtask // ref_init
-
-endmodule : uvmt_cv32e40s_imperas_dv_wrap
-
-`else // ! USE_IMPERASDV
-
-    module uvmt_cv32e40s_imperas_dv_wrap
-      import uvm_pkg::*;
-      import uvmt_cv32e40s_base_test_pkg::*;
-      import uvme_cv32e40s_pkg::*;
-      #(
-       )
-
-       (
-               rvviTrace  rvvi // RVVI SystemVerilog Interface
-       );
-
-       task ref_init;
-       endtask
-endmodule : uvmt_cv32e40s_imperas_dv_wrap
+endinterface : uvmt_imperas_dv_if_t
 
 `endif  // USE_IMPERASDV
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -33,10 +33,8 @@ module uvmt_cv32e40s_tb;
    import cv32e40s_pkg::*;
    import uvmt_cv32e40s_base_test_pkg::*;
    import uvmt_cv32e40s_pkg::*;
-   `ifdef USE_ISS
    `ifndef FORMAL
    import rvviApiPkg::*;
-   `endif
    `endif
 
    // Capture regs for test status from Virtual Peripheral in dut_wrap.mem_i
@@ -87,10 +85,9 @@ module uvmt_cv32e40s_tb;
                                                    .sec_lvl());     // Core status outputs
 
    // RVVI SystemVerilog Interface
-   `ifdef USE_ISS
    `ifndef FORMAL
       rvviTrace #( .NHART(1), .RETIRE(1)) rvvi_if();
-   `endif
+      uvmt_imperas_dv_if_t imperas_dv_if();
    `endif
 
   /**
@@ -1648,10 +1645,8 @@ module uvmt_cv32e40s_tb;
     //uvmt_cv32e40s_rvvi_handcar u_rvvi_handcar();
 
     // IMPERAS DV
-    `ifdef USE_ISS
     `ifndef FORMAL
       uvmt_cv32e40s_imperas_dv_wrap imperas_dv (rvvi_if);
-    `endif
     `endif
 
    /**
@@ -1663,6 +1658,7 @@ module uvmt_cv32e40s_tb;
      // Specify time format for simulation (units_number, precision_number, suffix_string, minimum_field_width)
      $timeformat(-9, 3, " ns", 8);
 
+     uvm_config_db#(virtual uvmt_imperas_dv_if_t)::set(.cntxt(null), .inst_name("uvm_test_top"), .field_name("idv_support_vif"), .value(imperas_dv_if));
      // Add interfaces handles to uvm_config_db
      uvm_config_db#(virtual uvma_debug_if_t             )::set(.cntxt(null), .inst_name("*.env.debug_agent"),            .field_name("vif"),           .value(debug_if));
      uvm_config_db#(virtual uvma_clknrst_if_t           )::set(.cntxt(null), .inst_name("*.env.clknrst_agent"),          .field_name("vif"),           .value(clknrst_if));
@@ -1933,9 +1929,9 @@ module uvmt_cv32e40s_tb;
      `endif
 
      // IMPERAS_DV interface
-     `ifdef USE_ISS
-     uvm_config_db#(virtual rvviTrace)::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("rvvi_vif"), .value(rvvi_if));
-     `endif
+     if ($test$plusargs("USE_ISS")) begin
+       uvm_config_db#(virtual rvviTrace)::set(.cntxt(null), .inst_name("*.env.rvvi_agent"), .field_name("rvvi_vif"), .value(rvvi_if));
+     end
 
      // Virtual Peripheral Status interface
      uvm_config_db#(virtual uvmt_cv32e40s_vp_status_if_t              )::set(.cntxt(null), .inst_name("*"), .field_name("vp_status_vif"),       .value(vp_status_if)      );
@@ -1963,20 +1959,6 @@ module uvmt_cv32e40s_tb;
    `endif
 
    assign core_cntrl_if.clk = clknrst_if.clk;
-
-   // Informational print message on loading of OVPSIM ISS to benchmark some elf image loading times
-   // OVPSIM runs its initialization at the #1ns timestamp, and should dominate the initial startup time
-   `ifdef USE_ISS
-   `ifndef FORMAL // Formal ignores initial blocks, avoids unnecessary warning
-   // overcome race
-   initial begin
-     if ($test$plusargs("USE_ISS")) begin
-       #0.9ns;
-       imperas_dv.ref_init();
-     end
-   end
-   `endif
-   `endif
 
    // Capture the test status and exit pulse flags
    // TODO: put this logic in the vp_status_if (makes it easier to pass to ENV)
@@ -2031,15 +2013,11 @@ module uvmt_cv32e40s_tb;
       warning_count = rs.get_severity_count(UVM_WARNING);
       fatal_count   = rs.get_severity_count(UVM_FATAL);
 
-      void'(uvm_config_db#(bit)::get(null, "", "sim_finished", sim_finished));
-
-      // Shutdown the Reference Model
-      `ifdef USE_ISS
       if ($test$plusargs("USE_ISS")) begin
-         // Exit handler for ImperasDV
-         void'(rvviRefShutdown());
+         void'(rvviApiPkg::rvviRefShutdown());
       end
-      `endif
+
+      void'(uvm_config_db#(bit)::get(null, "", "sim_finished", sim_finished));
 
       `uvm_info("DV_WRAP", $sformatf("\n%m: *** Test Summary ***\n"), UVM_DEBUG);
 

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test.sv
@@ -199,7 +199,6 @@ class uvmt_cv32e40s_base_test_c extends uvm_test;
 
 endclass : uvmt_cv32e40s_base_test_c
 
-
 function uvmt_cv32e40s_base_test_c::new(string name="uvmt_cv32e40s_base_test", uvm_component parent=null);
 
    super.new(name, parent);
@@ -246,7 +245,6 @@ function void uvmt_cv32e40s_base_test_c::connect_phase(uvm_phase phase);
 endfunction : connect_phase
 
 function void uvmt_cv32e40s_base_test_c::end_of_elaboration_phase(uvm_phase phase);
-
    super.end_of_elaboration_phase(phase);
 
    `uvm_info("BASE TEST", $sformatf("Top-level environment configuration:\n%s", env_cfg.sprint()), UVM_NONE)
@@ -254,18 +252,16 @@ function void uvmt_cv32e40s_base_test_c::end_of_elaboration_phase(uvm_phase phas
 
 endfunction : end_of_elaboration_phase
 
-
 task uvmt_cv32e40s_base_test_c::run_phase(uvm_phase phase);
-
    super.run_phase(phase);
 
    watchdog_timer();
 
 endtask : run_phase
 
-
 task uvmt_cv32e40s_base_test_c::reset_phase(uvm_phase phase);
 
+   virtual uvmt_imperas_dv_if_t imperas_dv_if;
    super.reset_phase(phase);
 
    phase.raise_objection(this);
@@ -275,6 +271,13 @@ task uvmt_cv32e40s_base_test_c::reset_phase(uvm_phase phase);
    `uvm_info("BASE TEST", $sformatf("Starting reset virtual sequence:\n%s", reset_vseq.sprint()), UVM_NONE)
    reset_vseq.start(vsequencer);
    `uvm_info("BASE TEST", $sformatf("Finished reset virtual sequence:\n%s", reset_vseq.sprint()), UVM_NONE)
+
+   if(!(uvm_config_db#(virtual uvmt_imperas_dv_if_t)::get(.cntxt(null), .inst_name("uvm_test_top"), .field_name("idv_support_vif"), .value(imperas_dv_if)))) begin
+     `uvm_error("BASE TEST", "imperas_dv_if instance not found in uvm_config_db");
+   end
+   if ($test$plusargs("USE_ISS")) begin
+     imperas_dv_if.ref_init();
+   end
 
    phase.drop_objection(this);
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -192,7 +192,6 @@ OVP_MODEL_DPI   = $(DV_OVPM_MODEL)/bin/Linux64/imperas_CV32.dpi.so
 
 ###############################################################################
 # Imperas OVPsim Instruction Set Simulator
-#IMPERAS_DV_MODEL = $(CORE_V_VERIF)/vendor_lib/ImperasDV/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model.so
 IMPERAS_DV_MODEL = $(IMPERAS_HOME)/lib/$(IMPERAS_ARCH)/ImperasLib/imperas.com/verification/riscv/1.0/model.so
 
 ###############################################################################

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -28,7 +28,7 @@
 #
 OS_IS_UBUNTU = $(findstring Ubuntu,$(shell lsb_release -d))
 ifeq ($(OS_IS_UBUNTU),Ubuntu)
-    .IGNORE: hello-world comp test compliance comp_corev-dv corev-dv gen_corev-dv
+  .IGNORE: hello-world comp test compliance comp_corev-dv corev-dv gen_corev-dv
 endif
 
 # Executables
@@ -70,15 +70,14 @@ XRUN_GUI         ?=
 XRUN_SINGLE_STEP ?=
 XRUN_ELAB_COV     = -covdut uvmt_$(CV_CORE_LC)_tb -coverage b:e:f:u
 XRUN_ELAB_COVFILE = -covfile $(abspath $(MAKE_PATH)/../tools/xrun/covfile.tcl)
-XRUN_RUN_COV      = -covscope uvmt_$(CV_CORE_LC)_tb \
-					-nowarn CGDEFN
+XRUN_RUN_COV      = -covscope uvmt_$(CV_CORE_LC)_tb -nowarn CGDEFN
 XRUN_RUN_BASE_FLAGS += -sv_lib $(DPI_DASM_LIB)
 
 # Only append the IMPERAS_DV_MODEL sv_lib flag if the file actually exists)
 ifneq (,$(wildcard $(IMPERAS_DV_MODEL)))
-ifeq ($(call IS_YES,$(USE_ISS)),YES)
-XRUN_RUN_BASE_FLAGS += -sv_lib $(IMPERAS_DV_MODEL)
-endif
+  ifeq ($(call IS_YES,$(USE_ISS)),YES)
+    XRUN_RUN_BASE_FLAGS += -sv_lib $(IMPERAS_DV_MODEL)
+  endif
 endif
 
 XRUN_RUN_BASE_FLAGS += -sv_lib $(abspath $(SVLIB_LIB))
@@ -99,9 +98,9 @@ XRUN_PMA_INC += +incdir+$(DV_UVM_TESTCASE_PATH)/base-tests \
 ###############################################################################
 # Common QUIET flag defaults to -quiet unless VERBOSE is set
 ifeq ($(call IS_YES,$(VERBOSE)),YES)
-QUIET=
+  QUIET=
 else
-QUIET=-quiet
+  QUIET=-quiet
 endif
 
 ################################################################################
@@ -109,14 +108,14 @@ endif
 # GUI=YES enables interactive mode
 # ADV_DEBUG=YES will enable Indago, default is to use SimVision
 ifeq ($(call IS_YES,$(GUI)),YES)
-XRUN_GUI += -gui
-ifeq ($(call IS_YES,$(SRC_DEBUG)),YES)
-XRUN_USER_COMPILE_ARGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
-XRUN_USER_RUN_FLAGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
-endif
-ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
-XRUN_GUI += -indago
-endif
+  XRUN_GUI += -gui
+  ifeq ($(call IS_YES,$(SRC_DEBUG)),YES)
+    XRUN_USER_COMPILE_ARGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
+    XRUN_USER_RUN_FLAGS += -linedebug -uvmlinedebug -enable_tpe -classlinedebug
+  endif
+  ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
+    XRUN_GUI += -indago
+  endif
 endif
 
 ################################################################################
@@ -143,9 +142,9 @@ endif
 ################################################################################
 # Waveform (post-process) command line
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
-WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(INDAGO) -db ida.db
+  WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(INDAGO) -db ida.db
 else
-WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(SIMVISION) waves.shm
+  WAVES_CMD = cd $(SIM_RUN_RESULTS) && $(SIMVISION) waves.shm
 endif
 
 XRUN_USER_COMPILE_ARGS += $(USER_COMPILE_FLAGS)
@@ -158,31 +157,31 @@ IMC_REPORT_ARGS = -exec $(CORE_V_VERIF)/$(CV_CORE)/sim/tools/xrun/cov_report.tcl
 MERGED_COV_DIR ?= merged_cov
 
 ifeq ($(call IS_YES,$(COV)),YES)
-XRUN_ELAB_COV_FLAGS += $(XRUN_ELAB_COV)
-XRUN_ELAB_COV_FLAGS += $(XRUN_ELAB_COVFILE)
-XRUN_RUN_COV_FLAGS += $(XRUN_RUN_COV)
+  XRUN_ELAB_COV_FLAGS += $(XRUN_ELAB_COV)
+  XRUN_ELAB_COV_FLAGS += $(XRUN_ELAB_COVFILE)
+  XRUN_RUN_COV_FLAGS += $(XRUN_RUN_COV)
 endif
 
 # Find command to gather ucd files
 COV_MERGE_FIND = find "$(SIM_CFG_RESULTS)" -type f -name "*.ucd" | grep -v d_cov | xargs dirname
 
 ifeq ($(call IS_YES,$(MERGE)),YES)
-COV_MERGE = cov_merge
-TEST = $(MERGED_COV_DIR)
+  COV_MERGE = cov_merge
+  TEST = $(MERGED_COV_DIR)
 else
-COV_MERGE =
+  COV_MERGE =
 endif
 
 ifeq ($(call IS_YES,$(MERGE)),YES)
-COV_DIR ?= $(XRUN_RESULTS)/$(CFG)/$(MERGED_COV_DIR)/cov_work/scope/merged
+  COV_DIR ?= $(XRUN_RESULTS)/$(CFG)/$(MERGED_COV_DIR)/cov_work/scope/merged
 else
-COV_DIR ?= cov_work/uvmt_$(CV_CORE_LC)_tb/$(TEST_NAME)
+  COV_DIR ?= cov_work/uvmt_$(CV_CORE_LC)_tb/$(TEST_NAME)
 endif
 
 ifeq ($(call IS_YES,$(GUI)),YES)
-COV_ARGS += -gui
+  COV_ARGS += -gui
 else
-COV_ARGS += $(IMC_REPORT_ARGS)
+  COV_ARGS += $(IMC_REPORT_ARGS)
 endif
 
 ################################################################################
@@ -197,26 +196,26 @@ XRUN_USER_COMPILE_ARGS += +define+UVM
 
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
   ifeq (,$(wildcard $(IMPERAS_HOME)/IMPERAS_LICENSE.pdf))
-	  export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
+    export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
   else
-	  export FILE_LIST_IDV      ?= -f $(DV_UVMT_PATH)/imperas_dv.flist
-		export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dv_deps.flist
+    export FILE_LIST_IDV      ?= -f $(DV_UVMT_PATH)/imperas_dv.flist
+    export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dv_deps.flist
   endif
-	XRUN_PLUSARGS          += +USE_ISS
-	XRUN_USER_COMPILE_ARGS += +define+USE_IMPERASDV
-	XRUN_USER_COMPILE_ARGS += +define+USE_ISS
+  XRUN_PLUSARGS          += +USE_ISS
+  XRUN_USER_COMPILE_ARGS += +define+USE_IMPERASDV
+  XRUN_USER_COMPILE_ARGS += +define+USE_ISS
 else
-	XRUN_PLUSARGS          += +DISABLE_OVPSIM
-	export FILE_LIST_IDV_DEPS   ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
+  XRUN_PLUSARGS          += +DISABLE_OVPSIM
+  export FILE_LIST_IDV_DEPS   ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
 endif
 ifeq ($(call IS_YES,$(USE_RVVI)),YES)
-    XRUN_PLUSARGS +="+USE_RVVI"
+  XRUN_PLUSARGS +="+USE_RVVI"
 endif
 ifeq ($(call IS_YES,$(TEST_DISABLE_ALL_CSR_CHECKS)),YES)
-    XRUN_PLUSARGS +="+DISABLE_ALL_CSR_CHECKS"
+  XRUN_PLUSARGS +="+DISABLE_ALL_CSR_CHECKS"
 endif
 ifneq ($(TEST_DISABLE_CSR_CHECK),)
-	XRUN_PLUSARGS += +DISABLE_CSR_CHECK=$(TEST_DISABLE_CSR_CHECK)
+  XRUN_PLUSARGS += +DISABLE_CSR_CHECK=$(TEST_DISABLE_CSR_CHECK)
 endif
 
 # Simulate using latest elab
@@ -347,7 +346,7 @@ comp: mk_xrun_dir $(CV_CORE_PKG) $(SVLIB_PKG)
 		-elaborate
 
 ifneq ($(call IS_NO,$(COMP)),NO)
-XRUN_SIM_PREREQ = comp
+  XRUN_SIM_PREREQ = comp
 endif
 
 XRUN_COMP_RUN = $(XRUN_RUN_FLAGS)
@@ -449,7 +448,7 @@ test: $(XRUN_SIM_PREREQ) hex gen_ovpsim_ic
 #                make compliance RISCV_DEVICE=C COMPLIANCE_PROG=add-01
 #
 RISCV_ISA       ?= rv32i_m
-RISCV_DEVICE		?= I
+RISCV_DEVICE    ?= I
 COMPLIANCE_PROG ?= add-01
 
 SIG_ROOT      ?= $(SIM_CFG_RESULTS)/$(RISCV_ISA)
@@ -458,7 +457,7 @@ REF           ?= $(COMPLIANCE_PKG)/riscv-test-suite/$(RISCV_ISA)/$(RISCV_DEVICE)
 TEST_PLUSARGS ?= +signature=$(COMPLIANCE_PROG).signature_output
 
 ifneq ($(call IS_NO,$(COMP)),NO)
-XRUN_COMPLIANCE_PREREQ = comp build_compliance
+  XRUN_COMPLIANCE_PREREQ = comp build_compliance
 endif
 
 # 40p workaround for ISS configuration

--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -73,7 +73,14 @@ XRUN_ELAB_COVFILE = -covfile $(abspath $(MAKE_PATH)/../tools/xrun/covfile.tcl)
 XRUN_RUN_COV      = -covscope uvmt_$(CV_CORE_LC)_tb \
 					-nowarn CGDEFN
 XRUN_RUN_BASE_FLAGS += -sv_lib $(DPI_DASM_LIB)
+
+# Only append the IMPERAS_DV_MODEL sv_lib flag if the file actually exists)
+ifneq (,$(wildcard $(IMPERAS_DV_MODEL)))
+ifeq ($(call IS_YES,$(USE_ISS)),YES)
 XRUN_RUN_BASE_FLAGS += -sv_lib $(IMPERAS_DV_MODEL)
+endif
+endif
+
 XRUN_RUN_BASE_FLAGS += -sv_lib $(abspath $(SVLIB_LIB))
 
 XRUN_UVM_VERBOSITY ?= UVM_MEDIUM
@@ -187,13 +194,20 @@ XRUN_UVM_MACROS_INC_FILE = $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC)_uvm_macros_inc.sv
 XRUN_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 XRUN_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
 XRUN_USER_COMPILE_ARGS += +define+UVM
+
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
+  ifeq (,$(wildcard $(IMPERAS_HOME)/IMPERAS_LICENSE.pdf))
+	  export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
+  else
+	  export FILE_LIST_IDV      ?= -f $(DV_UVMT_PATH)/imperas_dv.flist
+		export FILE_LIST_IDV_DEPS ?= -f $(DV_UVMT_PATH)/imperas_dv_deps.flist
+  endif
 	XRUN_PLUSARGS          += +USE_ISS
 	XRUN_USER_COMPILE_ARGS += +define+USE_IMPERASDV
 	XRUN_USER_COMPILE_ARGS += +define+USE_ISS
-	export FILE_LIST_IDV ?= -f $(DV_UVMT_PATH)/imperas_dv.flist
 else
 	XRUN_PLUSARGS          += +DISABLE_OVPSIM
+	export FILE_LIST_IDV_DEPS   ?= -f $(DV_UVMT_PATH)/imperas_dummy_pkg.flist
 endif
 ifeq ($(call IS_YES,$(USE_RVVI)),YES)
     XRUN_PLUSARGS +="+USE_RVVI"


### PR DESCRIPTION
* Moved iss-initalization to uvm_reset phase
* Moved ref_init to an interface instead of inside imperas_dv wrapper module to easily access function with uvm
* Fixed issue with ISS in regressions
* Added iss dummy package to support building with and without iss installed and remove all compile time `ifdef USE_ISS` 
* Split imperas manifest file in two, to resolve dependencies with initialization in uvm-code

Future work: change $test$plusarg("USE_ISS") to depend on uvm configuration setting.