### PR TITLE
Use CVA6Cfg as cva6 parameter

### DIFF
--- a/cva6/tb/uvmt/cva6_tb_wrapper.sv
+++ b/cva6/tb/uvmt/cva6_tb_wrapper.sv
@@ -35,9 +35,8 @@ import "DPI-C" function byte get_section(output longint address, output longint 
 import "DPI-C" context function void read_section(input longint address, inout byte buffer[]);
 
 module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
-  // RVFI
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
-  parameter int unsigned NrCommitPorts = 0,
   //
   parameter int unsigned AXI_USER_WIDTH    = 1,
   parameter int unsigned AXI_USER_EN       = 0,
@@ -49,7 +48,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   input  logic                         rst_ni,
   input  logic [XLEN-1:0]              boot_addr_i,
   output logic [31:0]                  tb_exit_o,
-  output rvfi_instr_t [NrCommitPorts-1:0] rvfi_o,
+  output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
   input  cvxif_pkg::cvxif_resp_t       cvxif_resp,
   output cvxif_pkg::cvxif_req_t        cvxif_req,
   uvma_axi_intf                        axi_slave,
@@ -62,13 +61,11 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   static uvm_cmdline_processor uvcl = uvm_cmdline_processor::get_inst();
   string binary = "";
 
-  rvfi_instr_t [NrCommitPorts-1:0]  rvfi;
+  rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0]  rvfi;
   assign rvfi_o = rvfi;
 
   cva6 #(
-     // RVFI
-     .rvfi_instr_t ( rvfi_instr_t ),
-     .NrCommitPorts ( NrCommitPorts ),
+     .CVA6Cfg ( CVA6Cfg ),
      //
     .ArianeCfg  ( ariane_soc::ArianeSocCfg )
   ) i_cva6 (
@@ -92,7 +89,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   //----------------------------------------------------------------------------
 
   rvfi_tracer  #(
-    .NrCommitPorts(NrCommitPorts),
+    .CVA6Cfg(CVA6Cfg),
     .rvfi_instr_t(rvfi_instr_t),
     //
     .HART_ID(8'h0),

--- a/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -15,9 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
 module uvmt_cva6_dut_wrap # (
-  // RVFI
+  parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
-  parameter int unsigned NrCommitPorts = 0,
   //
   parameter int unsigned AXI_USER_WIDTH    = 1,
   parameter int unsigned AXI_USER_EN       = 0,
@@ -33,15 +32,14 @@ module uvmt_cva6_dut_wrap # (
                             uvmt_axi_switch_intf                axi_switch_vif,
                             uvme_cva6_core_cntrl_if             core_cntrl_if,
                             output logic[31:0]                  tb_exit_o,
-                            output rvfi_instr_t [NrCommitPorts-1:0] rvfi_o
+                            output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o
                            );
 
 
 
     cva6_tb_wrapper #(
-     // RVFI
+     .CVA6Cfg ( CVA6Cfg ),
      .rvfi_instr_t ( rvfi_instr_t ),
-     .NrCommitPorts ( NrCommitPorts ),
      //
      .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -30,35 +30,36 @@ module uvmt_cva6_tb;
    import uvmt_cva6_pkg::*;
    import uvme_cva6_pkg::*;
 
-   // cva6 Configuration
-   // RVFI
-   localparam int unsigned ILEN = 32;
-   localparam int unsigned NRET = 1;
-   typedef struct packed {
-     logic [NRET-1:0]                 valid;
-     logic [NRET*64-1:0]              order;
-     logic [NRET*ILEN-1:0]            insn;
-     logic [NRET-1:0]                 trap;
-     logic [NRET*riscv::XLEN-1:0]     cause;
-     logic [NRET-1:0]                 halt;
-     logic [NRET-1:0]                 intr;
-     logic [NRET*2-1:0]               mode;
-     logic [NRET*2-1:0]               ixl;
-     logic [NRET*5-1:0]               rs1_addr;
-     logic [NRET*5-1:0]               rs2_addr;
-     logic [NRET*riscv::XLEN-1:0]     rs1_rdata;
-     logic [NRET*riscv::XLEN-1:0]     rs2_rdata;
-     logic [NRET*5-1:0]               rd_addr;
-     logic [NRET*riscv::XLEN-1:0]     rd_wdata;
-     logic [NRET*riscv::XLEN-1:0]     pc_rdata;
-     logic [NRET*riscv::XLEN-1:0]     pc_wdata;
-     logic [NRET*riscv::VLEN-1:0]     mem_addr;
-     logic [NRET*riscv::PLEN-1:0]     mem_paddr;
-     logic [NRET*(riscv::XLEN/8)-1:0] mem_rmask;
-     logic [NRET*(riscv::XLEN/8)-1:0] mem_wmask;
-     logic [NRET*riscv::XLEN-1:0]     mem_rdata;
-     logic [NRET*riscv::XLEN-1:0]     mem_wdata; } rvfi_instr_t;
-   localparam int unsigned NrCommitPorts = cva6_config_pkg::CVA6ConfigNrCommitPorts;
+   // cva6 configuration
+   localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
+     int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
+     int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+   };
+   localparam type rvfi_instr_t = struct packed {
+     logic [ariane_pkg::NRET-1:0]                  valid;
+     logic [ariane_pkg::NRET*64-1:0]               order;
+     logic [ariane_pkg::NRET*ariane_pkg::ILEN-1:0] insn;
+     logic [ariane_pkg::NRET-1:0]                  trap;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      cause;
+     logic [ariane_pkg::NRET-1:0]                  halt;
+     logic [ariane_pkg::NRET-1:0]                  intr;
+     logic [ariane_pkg::NRET*2-1:0]                mode;
+     logic [ariane_pkg::NRET*2-1:0]                ixl;
+     logic [ariane_pkg::NRET*5-1:0]                rs1_addr;
+     logic [ariane_pkg::NRET*5-1:0]                rs2_addr;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rs1_rdata;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rs2_rdata;
+     logic [ariane_pkg::NRET*5-1:0]                rd_addr;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      rd_wdata;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      pc_rdata;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      pc_wdata;
+     logic [ariane_pkg::NRET*riscv::VLEN-1:0]      mem_addr;
+     logic [ariane_pkg::NRET*riscv::PLEN-1:0]      mem_paddr;
+     logic [ariane_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_rmask;
+     logic [ariane_pkg::NRET*(riscv::XLEN/8)-1:0]  mem_wmask;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      mem_rdata;
+     logic [ariane_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
+   };
 
    localparam AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH;
    localparam AXI_USER_EN       = ariane_pkg::AXI_USER_EN;
@@ -106,7 +107,7 @@ module uvmt_cva6_tb;
    uvmt_rvfi_if #(
      // RVFI
      .rvfi_instr_t      ( rvfi_instr_t ),
-     .NrCommitPorts     ( NrCommitPorts )
+     .CVA6Cfg           ( CVA6Cfg      )
    ) rvfi_if(
                                                  .rvfi_o(),
                                                  .tb_exit_o()
@@ -117,9 +118,8 @@ module uvmt_cva6_tb;
    */
 
    uvmt_cva6_dut_wrap #(
-     // RVFI
-     .rvfi_instr_t      ( rvfi_instr_t ),
-     .NrCommitPorts     ( NrCommitPorts ),
+     .CVA6Cfg           ( CVA6Cfg       ),
+     .rvfi_instr_t      ( rvfi_instr_t  ),
      //
      .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),

--- a/cva6/tb/uvmt/uvmt_cva6_tb_ifs.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb_ifs.sv
@@ -22,11 +22,10 @@
 
 
 interface uvmt_rvfi_if #(
-                    // RVFI
-                    parameter type rvfi_instr_t = logic,
-                    parameter int unsigned NrCommitPorts = 0
+                    parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
+                    parameter type rvfi_instr_t = logic
 ) (
-                    output rvfi_instr_t [NrCommitPorts-1:0] rvfi_o,
+                    output rvfi_instr_t [CVA6Cfg.NrCommitPorts-1:0] rvfi_o,
                     output logic[31:0] tb_exit_o
                                  );
 


### PR DESCRIPTION
CVA6Cfg is now a input parameter of CVA6 to gather all the different configuration variables in the same structure.

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>