### PR TITLE
Define AXI as cva6 input parameters

### DIFF
--- a/cva6/tb/core/Flist.cva6_tb
+++ b/cva6/tb/core/Flist.cva6_tb
@@ -29,6 +29,7 @@
 ${CVA6_REPO_DIR}/corev_apu/riscv-dbg/src/dm_pkg.sv
 ${CVA6_REPO_DIR}/corev_apu/axi_mem_if/src/axi2mem.sv
 ${CVA6_REPO_DIR}/corev_apu/tb/ariane_soc_pkg.sv
+${CVA6_REPO_DIR}/corev_apu/tb/axi_intf.sv
 
 // RVFI tracer
 ${CVA6_REPO_DIR}/corev_apu/tb/rvfi_tracer.sv

--- a/cva6/tb/core/Flist.cva6_tb
+++ b/cva6/tb/core/Flist.cva6_tb
@@ -30,6 +30,7 @@ ${CVA6_REPO_DIR}/corev_apu/riscv-dbg/src/dm_pkg.sv
 ${CVA6_REPO_DIR}/corev_apu/axi_mem_if/src/axi2mem.sv
 ${CVA6_REPO_DIR}/corev_apu/tb/ariane_soc_pkg.sv
 ${CVA6_REPO_DIR}/corev_apu/tb/axi_intf.sv
+${CVA6_REPO_DIR}/corev_apu/tb/ariane_axi_pkg.sv
 
 // RVFI tracer
 ${CVA6_REPO_DIR}/corev_apu/tb/rvfi_tracer.sv

--- a/cva6/tb/uvmt/cva6_tb_wrapper.sv
+++ b/cva6/tb/uvmt/cva6_tb_wrapper.sv
@@ -38,10 +38,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
   //
-  parameter int unsigned AXI_USER_WIDTH    = 1,
   parameter int unsigned AXI_USER_EN       = 0,
-  parameter int unsigned AXI_ADDRESS_WIDTH = 64,
-  parameter int unsigned AXI_DATA_WIDTH    = 64,
   parameter int unsigned NUM_WORDS         = 2**25
 ) (
   input  logic                         clk_i,
@@ -108,12 +105,12 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
 
   logic                         req;
   logic                         we;
-  logic [AXI_ADDRESS_WIDTH-1:0] addr;
-  logic [AXI_DATA_WIDTH/8-1:0]  be;
-  logic [AXI_DATA_WIDTH-1:0]    wdata;
-  logic [AXI_USER_WIDTH-1:0]    wuser;
-  logic [AXI_DATA_WIDTH-1:0]    rdata;
-  logic [AXI_USER_WIDTH-1:0]    ruser;
+  logic [CVA6Cfg.AxiAddrWidth-1:0] addr;
+  logic [CVA6Cfg.AxiDataWidth/8-1:0]  be;
+  logic [CVA6Cfg.AxiDataWidth-1:0]    wdata;
+  logic [CVA6Cfg.AxiUserWidth-1:0]    wuser;
+  logic [CVA6Cfg.AxiDataWidth-1:0]    rdata;
+  logic [CVA6Cfg.AxiUserWidth-1:0]    ruser;
 
   //Response structs
    assign axi_ariane_resp.aw_ready = (axi_switch_vif.active) ? axi_slave.aw_ready : cva6_axi_bus.aw_ready;
@@ -186,10 +183,10 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
 
 
   AXI_BUS #(
-    .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH        ),
-    .AXI_DATA_WIDTH ( AXI_DATA_WIDTH           ),
+    .AXI_ADDR_WIDTH ( CVA6Cfg.AxiAddrWidth     ),
+    .AXI_DATA_WIDTH ( CVA6Cfg.AxiDataWidth     ),
     .AXI_ID_WIDTH   ( ariane_soc::IdWidthSlave ),
-    .AXI_USER_WIDTH ( AXI_USER_WIDTH           )
+    .AXI_USER_WIDTH ( CVA6Cfg.AxiUserWidth     )
   ) cva6_axi_bus();
 
   axi_master_connect #(
@@ -201,9 +198,9 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
 
   axi2mem #(
     .AXI_ID_WIDTH   ( ariane_soc::IdWidthSlave ),
-    .AXI_ADDR_WIDTH ( AXI_ADDRESS_WIDTH        ),
-    .AXI_DATA_WIDTH ( AXI_DATA_WIDTH           ),
-    .AXI_USER_WIDTH ( AXI_USER_WIDTH           )
+    .AXI_ADDR_WIDTH ( CVA6Cfg.AxiAddrWidth     ),
+    .AXI_DATA_WIDTH ( CVA6Cfg.AxiDataWidth     ),
+    .AXI_USER_WIDTH ( CVA6Cfg.AxiUserWidth     )
   ) i_cva6_axi2mem (
     .clk_i  ( clk_i       ),
     .rst_ni ( rst_ni      ),
@@ -219,8 +216,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
   );
 
   sram #(
-    .USER_WIDTH ( AXI_USER_WIDTH ),
-    .DATA_WIDTH ( AXI_DATA_WIDTH ),
+    .USER_WIDTH ( CVA6Cfg.AxiUserWidth ),
+    .DATA_WIDTH ( CVA6Cfg.AxiDataWidth ),
     .USER_EN    ( AXI_USER_EN    ),
     .SIM_INIT   ( "zeros"        ),
     .NUM_WORDS  ( NUM_WORDS      )
@@ -229,7 +226,7 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     .rst_ni     ( rst_ni                                                                      ),
     .req_i      ( req                                                                         ),
     .we_i       ( we                                                                          ),
-    .addr_i     ( addr[$clog2(NUM_WORDS)-1+$clog2(AXI_DATA_WIDTH/8):$clog2(AXI_DATA_WIDTH/8)] ),
+    .addr_i     ( addr[$clog2(NUM_WORDS)-1+$clog2(CVA6Cfg.AxiDataWidth/8):$clog2(CVA6Cfg.AxiDataWidth/8)] ),
     .wuser_i    ( wuser                                                                       ),
     .wdata_i    ( wdata                                                                       ),
     .be_i       ( be                                                                          ),

--- a/cva6/tb/uvmt/cva6_tb_wrapper.sv
+++ b/cva6/tb/uvmt/cva6_tb_wrapper.sv
@@ -77,8 +77,8 @@ module cva6_tb_wrapper import uvmt_cva6_pkg::*; #(
     .rvfi_o               ( rvfi                      ),
     .cvxif_req_o          ( cvxif_req                 ),
     .cvxif_resp_i         ( cvxif_resp                ),
-    .axi_req_o            ( axi_ariane_req            ),
-    .axi_resp_i           ( axi_ariane_resp           )
+    .noc_req_o            ( axi_ariane_req            ),
+    .noc_resp_i           ( axi_ariane_resp           )
   );
 
   //----------------------------------------------------------------------------

--- a/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_dut_wrap.sv
@@ -18,10 +18,7 @@ module uvmt_cva6_dut_wrap # (
   parameter ariane_pkg::cva6_cfg_t CVA6Cfg = ariane_pkg::cva6_cfg_empty,
   parameter type rvfi_instr_t = logic,
   //
-  parameter int unsigned AXI_USER_WIDTH    = 1,
   parameter int unsigned AXI_USER_EN       = 0,
-  parameter int unsigned AXI_ADDRESS_WIDTH = 64,
-  parameter int unsigned AXI_DATA_WIDTH    = 64,
   parameter int unsigned NUM_WORDS         = 2**25
 )
 
@@ -41,10 +38,7 @@ module uvmt_cva6_dut_wrap # (
      .CVA6Cfg ( CVA6Cfg ),
      .rvfi_instr_t ( rvfi_instr_t ),
      //
-     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),
-     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
-     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
      .NUM_WORDS         (NUM_WORDS)
 )
     cva6_tb_wrapper_i        (

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -32,12 +32,12 @@ module uvmt_cva6_tb;
 
    // cva6 configuration
    localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
-     int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
-     int'(cva6_config_pkg::CVA6ConfigRvfiTrace),      // IsRVFI
-     int'(cva6_config_pkg::CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
-     int'(cva6_config_pkg::CVA6ConfigAxiDataWidth),   // AxiDataWidth
-     int'(cva6_config_pkg::CVA6ConfigAxiIdWidth),     // AxiIdWidth
-     int'(cva6_config_pkg::CVA6ConfigDataUserWidth)   // AxiUserWidth
+     unsigned'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+     unsigned'(cva6_config_pkg::CVA6ConfigRvfiTrace),      // IsRVFI
+     unsigned'(cva6_config_pkg::CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
+     unsigned'(cva6_config_pkg::CVA6ConfigAxiDataWidth),   // AxiDataWidth
+     unsigned'(cva6_config_pkg::CVA6ConfigAxiIdWidth),     // AxiIdWidth
+     unsigned'(cva6_config_pkg::CVA6ConfigDataUserWidth)   // AxiUserWidth
    };
    localparam type rvfi_instr_t = struct packed {
      logic [ariane_pkg::NRET-1:0]                  valid;

--- a/cva6/tb/uvmt/uvmt_cva6_tb.sv
+++ b/cva6/tb/uvmt/uvmt_cva6_tb.sv
@@ -32,8 +32,12 @@ module uvmt_cva6_tb;
 
    // cva6 configuration
    localparam ariane_pkg::cva6_cfg_t CVA6Cfg = {
-     int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),
-     int'(cva6_config_pkg::CVA6ConfigRvfiTrace)
+     int'(cva6_config_pkg::CVA6ConfigNrCommitPorts),  // NrCommitPorts
+     int'(cva6_config_pkg::CVA6ConfigRvfiTrace),      // IsRVFI
+     int'(cva6_config_pkg::CVA6ConfigAxiAddrWidth),   // AxiAddrWidth
+     int'(cva6_config_pkg::CVA6ConfigAxiDataWidth),   // AxiDataWidth
+     int'(cva6_config_pkg::CVA6ConfigAxiIdWidth),     // AxiIdWidth
+     int'(cva6_config_pkg::CVA6ConfigDataUserWidth)   // AxiUserWidth
    };
    localparam type rvfi_instr_t = struct packed {
      logic [ariane_pkg::NRET-1:0]                  valid;
@@ -61,10 +65,7 @@ module uvmt_cva6_tb;
      logic [ariane_pkg::NRET*riscv::XLEN-1:0]      mem_wdata;
    };
 
-   localparam AXI_USER_WIDTH    = ariane_pkg::AXI_USER_WIDTH;
    localparam AXI_USER_EN       = ariane_pkg::AXI_USER_EN;
-   localparam AXI_ADDRESS_WIDTH = 64;
-   localparam AXI_DATA_WIDTH    = 64;
    localparam NUM_WORDS         = 2**24;
 
    // ENV (testbench) parameters
@@ -121,10 +122,7 @@ module uvmt_cva6_tb;
      .CVA6Cfg           ( CVA6Cfg       ),
      .rvfi_instr_t      ( rvfi_instr_t  ),
      //
-     .AXI_USER_WIDTH    (AXI_USER_WIDTH),
      .AXI_USER_EN       (AXI_USER_EN),
-     .AXI_ADDRESS_WIDTH (AXI_ADDRESS_WIDTH),
-     .AXI_DATA_WIDTH    (AXI_DATA_WIDTH),
      .NUM_WORDS         (NUM_WORDS)
    ) cva6_dut_wrap (
                     .clknrst_if(clknrst_if),


### PR DESCRIPTION
Previously a part of AXI was defined in packages, now it is defined as cva6 input parameters

Signed-off-by: Jean-Roch Coulon <jean-roch.coulon@thalesgroup.com>