### PR TITLE
HOTFIX : Fix a cross in cvxif agent coverage model

### DIFF
--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
@@ -163,7 +163,7 @@ covergroup cg_result(
     bins EXCCODE [] = {[0:9],[11:13],15,24}; //Supported Exception code
    }
 
-   cross_result : cross cp_rd, cp_id, cp_we, cp_exc, cp_exccode {
+   cross_result : cross cp_id, cp_we, cp_exc, cp_exccode {
    illegal_bins ILLEGAL_BINS = binsof(cp_we) intersect{1} &&
                                binsof(cp_exc) intersect{1};
    }


### PR DESCRIPTION
Hello, So that fix for the cvxif agent coverage model specifically in a cross (removing a rd), it's like a copy-past bug on coverage model of the cvxif agent