### PR TITLE
ISACOV : switch beq instruction register

### DIFF
--- a/cva6/tests/custom/isacov/branch_to_zero.S
+++ b/cva6/tests/custom/isacov/branch_to_zero.S
@@ -39,7 +39,7 @@ branch2:
 branch3:
   bltu       a1, a1, branch3
 branch4:
-  beq        a1, zero, branch4
+  beq        zero, a1, branch4
 branch5:
   bne        t5, t5, branch5
   addi       a0, a0, 22


### PR DESCRIPTION
I switch register for beq instruction , because beq a1, zero, branch4 -> it's a compressed instruction c.bnez a1, branch4, that means I'll get coverage on c.bnez and not beq instruction