### PR TITLE
Temporary fix to get ISS regression runs going

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_imperas_dv_wrap.sv
@@ -942,10 +942,12 @@ interface uvmt_imperas_dv_if_t;
     rvviRefCsrCompareEnable(hart_id, `CSR_MIP_ADDR, RVVI_FALSE);
     void'(rvviRefCsrSetVolatileMask(hart_id, `CSR_DCSR_ADDR, 'h8));
 
+    // TODO: Set these as volatiles as a temporary fix until
+    // we have a proper fix implemented in the ISS
     if (CORE_PARAM_CLIC == 1) begin
-      rvviRefCsrCompareEnable(hart_id, `CSR_MNXTI_ADDR, RVVI_FALSE);
-      rvviRefCsrCompareEnable(hart_id, `CSR_MSCRATCHCSW_ADDR, RVVI_FALSE);
-      rvviRefCsrCompareEnable(hart_id, `CSR_MSCRATCHCSWL_ADDR, RVVI_FALSE);
+      void'(rvviRefCsrSetVolatile(hart_id, `CSR_MNXTI_ADDR));
+      void'(rvviRefCsrSetVolatile(hart_id, `CSR_MSCRATCHCSW_ADDR));
+      void'(rvviRefCsrSetVolatile(hart_id, `CSR_MSCRATCHCSWL_ADDR));
     end
 
     // define asynchronous grouping


### PR DESCRIPTION
Temporary fix: Set comparison of the mnxti/mscratchcsw/mscratchcswl registers as volatile until we  have a proper iss fix - this will make the reference model mirror the state of these registers from the RTL, and their value are thus not properly checked.