### PR TITLE
cva6.py : Fix config_pkg_generator.py path

### DIFF
--- a/cva6/sim/cva6.py
+++ b/cva6/sim/cva6.py
@@ -1219,7 +1219,7 @@ def main():
     sys.exit(130)
 
 if __name__ == "__main__":
-  sys.path.append(os.getcwd()+"/../../core-v-cores/cva6")
+  sys.path.append(os.getcwd()+"/../../core-v-cores/cva6/util")
   from config_pkg_generator import *
   main()
 


### PR DESCRIPTION
Hello,
This a HOTFIX  to fix the **config_pkg_generator.py** path in **cva6.py**, the problem appears with the last [cva6 commit](https://github.com/openhwgroup/cva6/commit/dc103cd49fa1a1d9cf353e2c29e64a1f94398d85) 