### PR TITLE
add atomic to rvfi_instr_if, expand/divide the support pkg

### DIFF
--- a/lib/support/isa_constants.sv
+++ b/lib/support/isa_constants.sv
@@ -11,21 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-`ifndef __SUPPORT_PKG_SV__
-`define __SUPPORT_PKG_SV__
-
-
-package support_pkg;
-  `include "isa_constants.sv"
-  `include "isa_constants_csr.sv"
-  `include "isa_tdefs.sv"
-  `include "isa_tdefs_csr.sv"
-  `include "isa_support.sv" //TODO: krdosvik, change name to isa_disassembler when no outstanding PR
-  `include "isa_functions.sv"
-endpackage
-
-`endif // __SUPPORT_PKG_SV__
-
+// -------------------------------------------------------------------
+// This file holds constants related to the ISA
+// -------------------------------------------------------------------

--- a/lib/support/isa_constants_csr.sv
+++ b/lib/support/isa_constants_csr.sv
@@ -11,21 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-`ifndef __SUPPORT_PKG_SV__
-`define __SUPPORT_PKG_SV__
-
-
-package support_pkg;
-  `include "isa_constants.sv"
-  `include "isa_constants_csr.sv"
-  `include "isa_tdefs.sv"
-  `include "isa_tdefs_csr.sv"
-  `include "isa_support.sv" //TODO: krdosvik, change name to isa_disassembler when no outstanding PR
-  `include "isa_functions.sv"
-endpackage
-
-`endif // __SUPPORT_PKG_SV__
-
+// -------------------------------------------------------------------
+// This file holds constants related to the CSRs in the ISA.
+// -------------------------------------------------------------------

--- a/lib/support/isa_functions.sv
+++ b/lib/support/isa_functions.sv
@@ -11,21 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-`ifndef __SUPPORT_PKG_SV__
-`define __SUPPORT_PKG_SV__
+// -------------------------------------------------------------------
+// This file holds functions related to the ISA
+// -------------------------------------------------------------------
 
-
-package support_pkg;
   `include "isa_constants.sv"
   `include "isa_constants_csr.sv"
   `include "isa_tdefs.sv"
   `include "isa_tdefs_csr.sv"
   `include "isa_support.sv" //TODO: krdosvik, change name to isa_disassembler when no outstanding PR
-  `include "isa_functions.sv"
-endpackage
 
-`endif // __SUPPORT_PKG_SV__
 
+  //TODO: krdosvik, add function when A disassembler PR is in.

--- a/lib/support/isa_tdefs.sv
+++ b/lib/support/isa_tdefs.sv
@@ -11,21 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-`ifndef __SUPPORT_PKG_SV__
-`define __SUPPORT_PKG_SV__
-
-
-package support_pkg;
-  `include "isa_constants.sv"
-  `include "isa_constants_csr.sv"
-  `include "isa_tdefs.sv"
-  `include "isa_tdefs_csr.sv"
-  `include "isa_support.sv" //TODO: krdosvik, change name to isa_disassembler when no outstanding PR
-  `include "isa_functions.sv"
-endpackage
-
-`endif // __SUPPORT_PKG_SV__
-
+// -------------------------------------------------------------------
+// This file holds typedefs related to the ISA
+// -------------------------------------------------------------------

--- a/lib/support/isa_tdefs_csr.sv
+++ b/lib/support/isa_tdefs_csr.sv
@@ -11,21 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
 
-`ifndef __SUPPORT_PKG_SV__
-`define __SUPPORT_PKG_SV__
-
-
-package support_pkg;
-  `include "isa_constants.sv"
-  `include "isa_constants_csr.sv"
-  `include "isa_tdefs.sv"
-  `include "isa_tdefs_csr.sv"
-  `include "isa_support.sv" //TODO: krdosvik, change name to isa_disassembler when no outstanding PR
-  `include "isa_functions.sv"
-endpackage
-
-`endif // __SUPPORT_PKG_SV__
-
+// -------------------------------------------------------------------
+// This file holds typedefs related to the CSRs in the ISA.
+// -------------------------------------------------------------------

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -87,6 +87,7 @@ interface uvma_rvfi_instr_if_t
   localparam INSTR_MASK_DIV_REM     = 32'h FE00_607F;
   localparam INSTR_MASK_FULL          = 32'h FFFF_FFFF;
   localparam INSTR_MASK_R_TYPE        = 32'h FE00_707F;
+  localparam INSTR_MASK_AMO_TYPE      = 32'h F800_707F;
   localparam INSTR_MASK_I_S_B_TYPE    = 32'h 0000_707F;
   localparam INSTR_MASK_U_J_TYPE      = 32'h 0000_007F;
   localparam INSTR_MASK_CSRADDR       = 32'h FFF0_0000;
@@ -167,6 +168,18 @@ interface uvma_rvfi_instr_if_t
   localparam INSTR_OPCODE_CMPOPRET   = 32'b 00000000_00000000_101_11110_0000_00_10;
   localparam INSTR_OPCODE_CMPOPRETZ  = 32'b 00000000_00000000_101_11100_0000_00_10;
 
+  localparam INSTR_OPCODE_LRW       = 32'b 00010_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_SCW       = 32'b 00011_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOSWAPW  = 32'b 00001_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOADDW   = 32'b 00000_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOXORW   = 32'b 00100_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOANDW   = 32'b 01100_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOORW    = 32'b 01000_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOMINW   = 32'b 10000_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOMAXW   = 32'b 10100_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOMINUW  = 32'b 11000_0_0_00000_00000_010_00000_0101111;
+  localparam INSTR_OPCODE_AMOMAXUW  = 32'b 11100_0_0_00000_00000_010_00000_0101111;
+
   //positions
   localparam int INSTR_CSRADDR_POS  = 20;
   localparam int INSTR_CSRUIMM_POS  = 15;
@@ -237,6 +250,8 @@ interface uvma_rvfi_instr_if_t
   logic                             is_nmi_triggered;
   logic                             is_load_instr;
   logic                             is_store_instr;
+  logic                             is_amo_instr;
+  logic                             is_atomic_instr;
   logic                             is_loadstore_instr;
   logic                             is_exception;
   logic                             is_load_acc_fault;
@@ -344,6 +359,25 @@ interface uvma_rvfi_instr_if_t
 
   always_comb begin
     is_store_instr = rvfi_valid && |rvfi_mem_wmask_intended;
+  end
+
+  always_comb begin
+    is_amo_instr = rvfi_valid && (
+      match_instr(INSTR_OPCODE_AMOSWAPW,  INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOADDW,   INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOXORW,   INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOANDW,   INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOORW,    INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOMINW,   INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOMAXW,   INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOMINUW,  INSTR_MASK_AMO_TYPE)    ||
+      match_instr(INSTR_OPCODE_AMOMAXUW,  INSTR_MASK_AMO_TYPE));
+  end
+
+  always_comb begin
+    is_atomic_instr = rvfi_valid && (is_amo_instr ||
+      match_instr(INSTR_OPCODE_SCW,  INSTR_MASK_AMO_TYPE) ||
+      match_instr(INSTR_OPCODE_LRW,  INSTR_MASK_AMO_TYPE));
   end
 
   always_comb begin
@@ -840,7 +874,17 @@ function automatic logic [4*NMEM-1:0] rvfi_mem_rmask_intended_f();
     match_instr(INSTR_OPCODE_CLWSP,     INSTR_MASK_CMPR)        ||
     match_instr(INSTR_OPCODE_CMPOP,     INSTR_MASK_ZC_PUSHPOP)  ||
     match_instr(INSTR_OPCODE_CMPOPRET,  INSTR_MASK_ZC_PUSHPOP)  ||
-    match_instr(INSTR_OPCODE_CMPOPRETZ, INSTR_MASK_ZC_PUSHPOP);
+    match_instr(INSTR_OPCODE_CMPOPRETZ, INSTR_MASK_ZC_PUSHPOP)  ||
+    match_instr(INSTR_OPCODE_LRW,       INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOSWAPW,  INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOADDW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOXORW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOANDW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOORW,    INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMINW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMAXW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMINUW,  INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMAXUW,  INSTR_MASK_AMO_TYPE);
 
   rmask[0][2] = rmask[0][3];
 
@@ -918,10 +962,21 @@ function automatic logic [4*NMEM-1:0] rvfi_mem_wmask_intended_f();
   rlist = rvfi_insn[7:4];
 
   wmask[0][3] =
-    match_instr(INSTR_OPCODE_SW,      INSTR_MASK_I_S_B_TYPE) ||
-    match_instr(INSTR_OPCODE_CSW,     INSTR_MASK_CMPR)       ||
-    match_instr(INSTR_OPCODE_CSWSP,   INSTR_MASK_CMPR)       ||
-    match_instr(INSTR_OPCODE_PUSH,    INSTR_MASK_ZC_PUSHPOP);
+    match_instr(INSTR_OPCODE_SW,        INSTR_MASK_I_S_B_TYPE)  ||
+    match_instr(INSTR_OPCODE_CSW,       INSTR_MASK_CMPR)        ||
+    match_instr(INSTR_OPCODE_CSWSP,     INSTR_MASK_CMPR)        ||
+    match_instr(INSTR_OPCODE_PUSH,      INSTR_MASK_ZC_PUSHPOP)  ||
+    match_instr(INSTR_OPCODE_SCW,       INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOSWAPW,  INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOADDW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOXORW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOANDW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOORW,    INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMINW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMAXW,   INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMINUW,  INSTR_MASK_AMO_TYPE)    ||
+    match_instr(INSTR_OPCODE_AMOMAXUW,  INSTR_MASK_AMO_TYPE);
+
 
   wmask[0][2] = wmask[0][3];
 


### PR DESCRIPTION
Added is_amo and is_atomic instr to rvfi_instr_if. Also restructured the isa_support. Will continue working on isa_support files when the merges from cv32e40s/dev to cv32e40x/dev, and cv32e40s to cv32e40x-dv is done.

Must wait to merge this PR untill https://github.com/openhwgroup/cv32e40x-dv/pull/13 is merged, and we can update the clonetb hash.

Same status as https://github.com/openhwgroup/cv32e40x-dv/pull/13 (ci check passes partially and formal compiles) 