### PR TITLE
CVXIF : Filter cross coverage for commit interface

### DIFF
--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
@@ -59,7 +59,9 @@ covergroup cg_request(
 
    cross_req : cross cp_id, cp_rs_valid, cp_mode;
    cross_valid_ready : cross cp_valid, cp_ready;
-   cross_commit : cross cp_commit_valid, cp_commit_kill, cp_commit_id;
+   cross_commit : cross cp_commit_valid, cp_commit_kill, cp_commit_id {
+   ignore_bins IGN_BINS = binsof(cp_commit_valid) intersect{0}; //commit signals are valid when commmit_valid is assert
+   }
 
 endgroup: cg_request
 


### PR DESCRIPTION
Hello,
This PR related to cvxif coverage model, I filter cross for commit interface , as the protocol say, all commit signals are valid when commit valid is assert, so no need to create bins when commit valid is low.