### PR TITLE
"dut_wrap" - Make Overridable

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -43,8 +43,6 @@
  */
 
 module uvmt_cv32e40s_dut_wrap
-  import cv32e40s_pkg::*;
-  import uvm_pkg::*; // needed for the UVM messaging service (`uvm_info(), etc.)
 #(
     parameter INSTR_ADDR_WIDTH  =  32,
     parameter INSTR_RDATA_WIDTH =  32,

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -35,12 +35,16 @@
 `ifndef __UVMT_CV32E40S_DUT_WRAP_SV__
 `define __UVMT_CV32E40S_DUT_WRAP_SV__
 
+`default_nettype none
+
 
 /**
  * Module wrapper for CV32E40S RTL DUT.
  */
+
 module uvmt_cv32e40s_dut_wrap
   import cv32e40s_pkg::*;
+  import uvm_pkg::*; // needed for the UVM messaging service (`uvm_info(), etc.)
 #(
     parameter INSTR_ADDR_WIDTH  =  32,
     parameter INSTR_RDATA_WIDTH =  32,
@@ -59,91 +63,18 @@ module uvmt_cv32e40s_dut_wrap
     uvma_fencei_if_t                fencei_if
   );
 
-    import uvm_pkg::*; // needed for the UVM messaging service (`uvm_info(), etc.)
-    /*
-    // signals connecting core to memory
-    logic                         instr_req;
-    logic                         instr_gnt;
-    logic                         instr_rvalid;
-    logic [INSTR_ADDR_WIDTH-1 :0] instr_addr;
-    logic [INSTR_RDATA_WIDTH-1:0] instr_rdata;
+    logic         debug_havereset;
+    logic         debug_running;
+    logic         debug_halted;
+    logic         debug_pc_valid;
+    logic [31:0]  debug_pc;
 
-    logic                         data_req;
-    logic                         data_gnt;
-    logic                         data_rvalid;
-    logic [31:0]                  data_addr;
-    logic                         data_we;
-    logic [3:0]                   data_be;
-    logic [31:0]                  data_rdata;
-    logic [31:0]                  data_wdata;
-
-    logic [31:0]                  irq;
-  */
-    logic                         debug_havereset;
-    logic                         debug_running;
-    logic                         debug_halted;
-    logic                         debug_pc_valid;
-    logic [31:0]                  debug_pc;
-
-    assign debug_if.clk      = clknrst_if.clk;
-    assign debug_if.reset_n  = clknrst_if.reset_n;
-
-    // --------------------------------------------
-    // OBI Instruction agent v1.2 signal tie-offs
-    assign obi_instr_if.we        = 'b0;
-    assign obi_instr_if.be        = 'hf; // Always assumes 32-bit full bus reads on instruction OBI
-    assign obi_instr_if.auser     = 'b0;
-    assign obi_instr_if.wuser     = 'b0;
-    assign obi_instr_if.aid       = 'b0;
-    assign obi_instr_if.wdata     = 'b0;
-    assign obi_instr_if.rready    = 1'b1;
-    assign obi_instr_if.rreadypar = 1'b0;
-
-    // --------------------------------------------
-    // OBI Data agent v1.2 signal tie-offs
-    assign obi_data_if.auser      = 'b0;
-    assign obi_data_if.wuser      = 'b0;
-    assign obi_data_if.aid        = 'b0;
-    assign obi_data_if.rready     = 1'b1;
-    assign obi_data_if.rreadypar  = 1'b0;
-
-    // --------------------------------------------
-    // Connect to uvma_interrupt_if
-    assign interrupt_if.clk         = clknrst_if.clk;
-    assign interrupt_if.reset_n     = clknrst_if.reset_n;
-    assign interrupt_if.irq_id      = $bits(interrupt_if.irq_id)'(cv32e40s_wrapper_i.core_i.irq_id); // cast to avoid the warning with clic (TODO: tieoff with clic instead?)
-    assign interrupt_if.irq_ack     = cv32e40s_wrapper_i.core_i.irq_ack;
-
-    // --------------------------------------------
-    assign clic_if.clk              = clknrst_if.clk;
-    assign clic_if.reset_n          = clknrst_if.reset_n;
-    assign clic_if.irq_ack          = cv32e40s_wrapper_i.core_i.irq_ack;
-
-    // --------------------------------------------
-    assign wfe_wu_if.clk              = clknrst_if.clk;
-    assign wfe_wu_if.reset_n          = clknrst_if.reset_n;
-
-    // --------------------------------------------
-    // Connect to core_cntrl_if
-    assign core_cntrl_if.b_ext = uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT;
-    `ifndef FORMAL
-    initial begin
-      core_cntrl_if.pma_cfg = new[PMA_NUM_REGIONS];
-      foreach (core_cntrl_if.pma_cfg[i]) begin
-        core_cntrl_if.pma_cfg[i].word_addr_low  = PMA_CFG[i].word_addr_low;
-        core_cntrl_if.pma_cfg[i].word_addr_high = PMA_CFG[i].word_addr_high;
-        core_cntrl_if.pma_cfg[i].main           = PMA_CFG[i].main;
-        core_cntrl_if.pma_cfg[i].bufferable     = PMA_CFG[i].bufferable;
-        core_cntrl_if.pma_cfg[i].cacheable      = PMA_CFG[i].cacheable;
-        core_cntrl_if.pma_cfg[i].integrity      = PMA_CFG[i].integrity;
-      end
-    end
-    `endif
+    logic  alert_major;
+    logic  alert_minor;
 
 
-
-    // --------------------------------------------
     // instantiate the core
+
     cv32e40s_wrapper #(
       .B_EXT            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT),
       .CLIC             (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC),
@@ -238,5 +169,7 @@ module uvmt_cv32e40s_dut_wrap
         );
 
 endmodule : uvmt_cv32e40s_dut_wrap
+
+`default_nettype wire
 
 `endif // __UVMT_CV32E40S_DUT_WRAP_SV__

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_dut_wrap.sv
@@ -42,30 +42,9 @@
 module uvmt_cv32e40s_dut_wrap
   import cv32e40s_pkg::*;
 #(
-    // DUT (riscv_core) parameters.
-    parameter logic [31:0]           DM_REGION_START                     = 32'hF0000000,
-    parameter logic [31:0]           DM_REGION_END                       = 32'hF0003FFF,
-    parameter lfsr_cfg_t             LFSR0_CFG                           = LFSR_CFG_DEFAULT,
-    parameter lfsr_cfg_t             LFSR1_CFG                           = LFSR_CFG_DEFAULT,
-    parameter lfsr_cfg_t             LFSR2_CFG                           = LFSR_CFG_DEFAULT,
-    parameter m_ext_e                M_EXT                               = M,
-    parameter mseccfg_t              PMP_MSECCFG_RV                      = MSECCFG_DEFAULT,
-    parameter cv32e40s_pkg::b_ext_e  B_EXT                               = cv32e40s_pkg::B_NONE,
-    parameter int                    PMA_NUM_REGIONS                     =  0,
-    parameter pma_cfg_t              PMA_CFG[PMA_NUM_REGIONS-1 : 0]      = '{default:PMA_R_DEFAULT},
-    parameter int                    PMP_NUM_REGIONS                     = 0,
-    parameter pmpncfg_t              PMP_PMPNCFG_RV[PMP_NUM_REGIONS-1:0] = '{default:PMPNCFG_DEFAULT},
-    parameter logic [31:0]           PMP_PMPADDR_RV[PMP_NUM_REGIONS-1:0] = '{default:32'h0},
-    parameter int                    PMP_GRANULARITY                     = 0,
-    parameter logic                  CLIC                                = 0,
-    parameter int                    CLIC_ID_WIDTH                       = 5,
-    parameter int                    DBG_NUM_TRIGGERS                    = 1,
-    parameter rv32_e                 RV32                                = RV32I,
-
-    // Remaining parameters are used by TB components only
-    parameter INSTR_ADDR_WIDTH    =  32,
-    parameter INSTR_RDATA_WIDTH   =  32,
-    parameter RAM_ADDR_WIDTH      =  20
+    parameter INSTR_ADDR_WIDTH  =  32,
+    parameter INSTR_RDATA_WIDTH =  32,
+    parameter RAM_ADDR_WIDTH    =  20
   )
   (
     uvma_clknrst_if_t               clknrst_if,
@@ -146,7 +125,7 @@ module uvmt_cv32e40s_dut_wrap
 
     // --------------------------------------------
     // Connect to core_cntrl_if
-    assign core_cntrl_if.b_ext = B_EXT;
+    assign core_cntrl_if.b_ext = uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT;
     `ifndef FORMAL
     initial begin
       core_cntrl_if.pma_cfg = new[PMA_NUM_REGIONS];
@@ -166,27 +145,25 @@ module uvmt_cv32e40s_dut_wrap
     // --------------------------------------------
     // instantiate the core
     cv32e40s_wrapper #(
-                      .B_EXT                (B_EXT),
-                      .DBG_NUM_TRIGGERS     (DBG_NUM_TRIGGERS),
-                      .DM_REGION_END        (DM_REGION_END),
-                      .DM_REGION_START      (DM_REGION_START),
-                      .LFSR0_CFG            (LFSR0_CFG),
-                      .LFSR1_CFG            (LFSR1_CFG),
-                      .LFSR2_CFG            (LFSR2_CFG),
-                      .M_EXT                (M_EXT),
-                      .PMA_CFG              (PMA_CFG),
-                      .PMA_NUM_REGIONS      (PMA_NUM_REGIONS),
-                      .PMP_GRANULARITY      (PMP_GRANULARITY),
-                      .PMP_MSECCFG_RV       (PMP_MSECCFG_RV),
-                      .PMP_NUM_REGIONS      (PMP_NUM_REGIONS),
-                      .PMP_PMPADDR_RV       (PMP_PMPADDR_RV),
-                      .PMP_PMPNCFG_RV       (PMP_PMPNCFG_RV),
-                      .RV32                 (RV32),
-                      .CLIC                 (CLIC),
-                      .CLIC_ID_WIDTH        (CLIC_ID_WIDTH)
-                      )
-    cv32e40s_wrapper_i
-        (
+      .B_EXT            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT),
+      .CLIC             (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC),
+      .CLIC_ID_WIDTH    (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC_ID_WIDTH),
+      .DBG_NUM_TRIGGERS (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DBG_NUM_TRIGGERS),
+      .DM_REGION_END    (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DM_REGION_END),
+      .DM_REGION_START  (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DM_REGION_START),
+      .LFSR0_CFG        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR0_CFG),
+      .LFSR1_CFG        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR1_CFG),
+      .LFSR2_CFG        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR2_CFG),
+      .M_EXT            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_M_EXT),
+      .PMA_CFG          (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_CFG),
+      .PMA_NUM_REGIONS  (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
+      .PMP_GRANULARITY  (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY),
+      .PMP_MSECCFG_RV   (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_MSECCFG_RV),
+      .PMP_NUM_REGIONS  (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS),
+      .PMP_PMPADDR_RV   (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_PMPADDR_RV),
+      .PMP_PMPNCFG_RV   (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_PMPNCFG_RV),
+      .RV32             (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_RV32)
+    ) cv32e40s_wrapper_i (
          .clk_i                  ( clknrst_if.clk                 ),
          .rst_ni                 ( clknrst_if.reset_n             ),
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -97,24 +97,6 @@ module uvmt_cv32e40s_tb;
    * a few mods to bring unused ports from the CORE to this level using SV interfaces.
    */
    uvmt_cv32e40s_dut_wrap  #(
-                             .B_EXT                (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT),
-                             .DBG_NUM_TRIGGERS     (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DBG_NUM_TRIGGERS),
-                             .DM_REGION_END        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DM_REGION_END),
-                             .DM_REGION_START      (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_DM_REGION_START),
-                             .LFSR0_CFG            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR0_CFG),
-                             .LFSR1_CFG            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR1_CFG),
-                             .LFSR2_CFG            (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_LFSR2_CFG),
-                             .M_EXT                (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_M_EXT),
-                             .PMA_CFG              (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_CFG),
-                             .PMA_NUM_REGIONS      (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMA_NUM_REGIONS),
-                             .PMP_GRANULARITY      (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_GRANULARITY),
-                             .PMP_MSECCFG_RV       (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_MSECCFG_RV),
-                             .PMP_NUM_REGIONS      (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_NUM_REGIONS),
-                             .PMP_PMPADDR_RV       (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_PMPADDR_RV),
-                             .PMP_PMPNCFG_RV       (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_PMP_PMPNCFG_RV),
-                             .RV32                 (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_RV32),
-                             .CLIC                 (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC),
-                             .CLIC_ID_WIDTH        (uvmt_cv32e40s_base_test_pkg::CORE_PARAM_CLIC_ID_WIDTH),
                              .INSTR_ADDR_WIDTH     (ENV_PARAM_INSTR_ADDR_WIDTH),
                              .INSTR_RDATA_WIDTH    (ENV_PARAM_INSTR_DATA_WIDTH),
                              .RAM_ADDR_WIDTH       (ENV_PARAM_RAM_ADDR_WIDTH)

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -91,27 +91,77 @@ module uvmt_cv32e40s_tb;
       uvmt_imperas_dv_if_t imperas_dv_if();
    `endif
 
-  /**
-   * DUT WRAPPER instance:
-   * This is an update of the riscv_wrapper.sv from PULP-Platform RI5CY project with
-   * a few mods to bring unused ports from the CORE to this level using SV interfaces.
-   */
-   uvmt_cv32e40s_dut_wrap  #(
-                             .INSTR_ADDR_WIDTH     (ENV_PARAM_INSTR_ADDR_WIDTH),
-                             .INSTR_RDATA_WIDTH    (ENV_PARAM_INSTR_DATA_WIDTH),
-                             .RAM_ADDR_WIDTH       (ENV_PARAM_RAM_ADDR_WIDTH)
-                            )
-                            dut_wrap (
-                              .clknrst_if(clknrst_if),
-                              .interrupt_if(interrupt_if),
-                              .vp_status_if(vp_status_if),
-                              .core_cntrl_if(core_cntrl_if),
-                              .core_status_if(core_status_if),
-                              .obi_instr_if(obi_instr_if),
-                              .obi_data_if(obi_data_if),
-                              .fencei_if(fencei_if),
-                              .clic_if(clic_if),
-                              .*);
+
+  // "dut_wrap"
+
+  uvmt_cv32e40s_dut_wrap  #(
+    .INSTR_ADDR_WIDTH  (ENV_PARAM_INSTR_ADDR_WIDTH),
+    .INSTR_RDATA_WIDTH (ENV_PARAM_INSTR_DATA_WIDTH),
+    .RAM_ADDR_WIDTH    (ENV_PARAM_RAM_ADDR_WIDTH)
+  ) dut_wrap (
+    .clknrst_if     (clknrst_if),
+    .interrupt_if   (interrupt_if),
+    .vp_status_if   (vp_status_if),
+    .core_cntrl_if  (core_cntrl_if),
+    .core_status_if (core_status_if),
+    .obi_instr_if   (obi_instr_if),
+    .obi_data_if    (obi_data_if),
+    .fencei_if      (fencei_if),
+    .clic_if        (clic_if),
+    .*
+  );
+
+  assign debug_if.clk     = clknrst_if.clk;
+  assign debug_if.reset_n = clknrst_if.reset_n;
+
+  // OBI Instruction agent v1.2 signal tie-offs
+  assign obi_instr_if.we        = 'b0;
+  assign obi_instr_if.be        = 'hf; // Always assumes 32-bit full bus reads on instruction OBI
+  assign obi_instr_if.auser     = 'b0;
+  assign obi_instr_if.wuser     = 'b0;
+  assign obi_instr_if.aid       = 'b0;
+  assign obi_instr_if.wdata     = 'b0;
+  assign obi_instr_if.rready    = 1'b1;
+  assign obi_instr_if.rreadypar = 1'b0;
+
+  // OBI Data agent v1.2 signal tie-offs
+  assign obi_data_if.auser     = 'b0;
+  assign obi_data_if.wuser     = 'b0;
+  assign obi_data_if.aid       = 'b0;
+  assign obi_data_if.rready    = 1'b1;
+  assign obi_data_if.rreadypar = 1'b0;
+
+  // Connect to uvma_interrupt_if
+  assign interrupt_if.clk     = clknrst_if.clk;
+  assign interrupt_if.reset_n = clknrst_if.reset_n;
+  assign interrupt_if.irq_id  = $bits(interrupt_if.irq_id)'(dut_wrap.cv32e40s_wrapper_i.core_i.irq_id); // cast to avoid the warning with clic (TODO: tieoff with clic instead?)
+  assign interrupt_if.irq_ack = dut_wrap.cv32e40s_wrapper_i.core_i.irq_ack;
+
+  assign clic_if.clk     = clknrst_if.clk;
+  assign clic_if.reset_n = clknrst_if.reset_n;
+  assign clic_if.irq_ack = dut_wrap.cv32e40s_wrapper_i.core_i.irq_ack;
+
+  assign wfe_wu_if.clk     = clknrst_if.clk;
+  assign wfe_wu_if.reset_n = clknrst_if.reset_n;
+
+  // Connect to core_cntrl_if
+  assign core_cntrl_if.b_ext = uvmt_cv32e40s_base_test_pkg::CORE_PARAM_B_EXT;
+  `ifndef FORMAL
+    initial begin
+      core_cntrl_if.pma_cfg = new[CORE_PARAM_PMA_NUM_REGIONS];
+      foreach (core_cntrl_if.pma_cfg[i]) begin
+        core_cntrl_if.pma_cfg[i].word_addr_low  = CORE_PARAM_PMA_CFG[i].word_addr_low;
+        core_cntrl_if.pma_cfg[i].word_addr_high = CORE_PARAM_PMA_CFG[i].word_addr_high;
+        core_cntrl_if.pma_cfg[i].main           = CORE_PARAM_PMA_CFG[i].main;
+        core_cntrl_if.pma_cfg[i].bufferable     = CORE_PARAM_PMA_CFG[i].bufferable;
+        core_cntrl_if.pma_cfg[i].cacheable      = CORE_PARAM_PMA_CFG[i].cacheable;
+        core_cntrl_if.pma_cfg[i].integrity      = CORE_PARAM_PMA_CFG[i].integrity;
+      end
+    end
+  `endif
+
+
+  // "rvfi_instr_if"
 
   bind cv32e40s_wrapper
     uvma_rvfi_instr_if_t#(uvmt_cv32e40s_base_test_pkg::ILEN,


### PR DESCRIPTION
This PR reduces the responsibilities of `dut_wrap` so it is easier to redefine this module outside of core-v-verif.

Test status:
* ci_check - All green.
* Formal - Still runable.