### PR TITLE
Adding build.os to ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,10 +4,10 @@
 
 version: 2
 
-#build:
-#  os: "ubuntu-20.04"
-#  tools:
-#    python: "3.9"
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.9"
 
 # Build from the docs/VerifStrat/source directory with Sphinx
 sphinx:


### PR DESCRIPTION
Message from RTD: The build.image config key on .readthedocs.yaml has been deprecated, and will be removed on October 16, 2023. Please use build.os on your configuration file to ensure that they continue building successfully and to stop receiving these notifications.