### PR TITLE
Updated cv32e40s core hash to 41cbecf7690efd0ccd75b32bc31aab09c5dede56

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 8e560bf57d39800a15bdd1be6a19b25ec3f57b36
+CV_CORE_HASH   ?= 41cbecf7690efd0ccd75b32bc31aab09c5dede56
 CV_CORE_TAG    ?= none
 
 #RISCVDV_REPO    ?= https://github.com/google/riscv-dv


### PR DESCRIPTION
* Fixed: Testbench and core out of sync