### PR TITLE
glitch prefix, better decode logic usage

### DIFF
--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_support_logic.sv
@@ -20,6 +20,7 @@ module uvmt_cv32e40s_support_logic
   import cv32e40s_pkg::*;
   import uvmt_cv32e40s_pkg::*;
   import uvma_rvfi_pkg::*;
+  import isa_decoder_pkg::*;
   import uvmt_cv32e40s_base_test_pkg::*;
   (
     uvma_rvfi_instr_if_t rvfi,
@@ -65,6 +66,23 @@ module uvmt_cv32e40s_support_logic
   // ---------------------------------------------------------------------------
   // Support logic blocks
   // ---------------------------------------------------------------------------
+
+  // Decoder:
+  always_comb begin
+    out_support_if.asm_if = decode_instr(in_support_if.if_instr);
+  end
+  always_comb begin
+    out_support_if.asm_id = decode_instr(in_support_if.id_instr);
+  end
+  always_comb begin
+    out_support_if.asm_ex = decode_instr(in_support_if.ex_instr);
+  end
+  always_comb begin
+    out_support_if.asm_wb = decode_instr(in_support_if.wb_instr);
+  end
+  always_comb begin
+    out_support_if.asm_rvfi = decode_instr(rvfi.rvfi_insn);
+  end
 
 
   // Check if a new obi data req arrives after an exception is triggered.

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -1394,6 +1394,11 @@ module uvmt_cv32e40s_tb;
         .clk     (core_i.clk),
         .rst_n (rst_ni),
 
+        .if_instr (core_i.if_stage_i.prefetch_instr.bus_resp.rdata),
+        .id_instr (core_i.if_id_pipe.instr.bus_resp.rdata),
+        .ex_instr (core_i.id_ex_pipe.instr.bus_resp.rdata),
+        .wb_instr (core_i.ex_wb_pipe.instr.bus_resp.rdata),
+
         .tdata1_array (uvmt_cv32e40s_tb.tdata1_array),
         .tdata2_array (uvmt_cv32e40s_tb.tdata2_array),
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb_ifs.sv
@@ -271,6 +271,12 @@ interface uvmt_cv32e40s_support_logic_module_i_if_t
    input logic clk,
    input logic rst_n,
 
+   //Decoder:
+   input logic [31:0] if_instr,
+   input logic [31:0] id_instr,
+   input logic [31:0] ex_instr,
+   input logic [31:0] wb_instr,
+
    //Controller fsm control signals output
    input ctrl_fsm_t ctrl_fsm_o,
 
@@ -325,6 +331,11 @@ interface uvmt_cv32e40s_support_logic_module_i_if_t
      input  clk,
       rst_n,
 
+      if_instr,
+      id_instr,
+      ex_instr,
+      wb_instr,
+
       tdata1_array,
       tdata2_array,
 
@@ -373,6 +384,14 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
    import cv32e40s_pkg::*;
    import cv32e40s_rvfi_pkg::*;
    import uvmt_cv32e40s_base_test_pkg::*;
+   import isa_decoder_pkg::*;
+
+   //Decoder:
+   asm_t asm_if;
+   asm_t asm_id;
+   asm_t asm_ex;
+   asm_t asm_wb;
+   asm_t asm_rvfi;
 
    // Indicates that a new obi data req arrives after an exception is triggered.
    // Used to verify exception timing with multiop instruction
@@ -432,7 +451,13 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
    logic recorded_dbg_req;
 
    modport master_mp (
-      output req_after_exception,
+      output asm_if,
+         asm_id,
+         asm_ex,
+         asm_wb,
+         asm_rvfi,
+
+         req_after_exception,
          trigger_match_mem,
          trigger_match_execute,
          trigger_match_exception,
@@ -473,7 +498,13 @@ interface uvmt_cv32e40s_support_logic_module_o_if_t;
    );
 
    modport slave_mp (
-      input req_after_exception,
+      input asm_if,
+         asm_id,
+         asm_ex,
+         asm_wb,
+         asm_rvfi,
+
+         req_after_exception,
          trigger_match_mem,
          trigger_match_execute,
          trigger_match_exception,

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -1098,7 +1098,7 @@ module uvmt_cv32e40s_triggers_assert_cov
           EXC_CAUSE_INSTR_BUS_FAULT)
       ) else `uvm_error(info_tag, "The trigger match (exception match, user mode, instruction bus fault) does not send the core into debug mode.\n");
 
-      if (uvmt_cv32e40s_base_test_pkg::INTEGRITY_ERR_ENABLE) begin
+      if (INTEGRITY_ERRORS_ENABLED) begin
 
         a_glitch_dt_exception_trigger_hit_m_instr_integrity_fault: assert property(
           p_etrigger_hit(

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
@@ -412,10 +412,10 @@ module uvmt_cv32e40s_xsecure_dummy_and_hint_assert
 
     |->
     ((operand_a == (lfsr1))
-    || id_instr_decoded.rs1.gpr.raw == REGISTER_X0)
+    || id_instr_decoded.rs1.gpr.gpr == X0)
 
     && ((operand_b == (lfsr2))
-    || id_instr_decoded.rs2.gpr.raw == REGISTER_X0);
+    || id_instr_decoded.rs2.gpr.gpr == X0);
 
   endproperty
 
@@ -440,7 +440,7 @@ module uvmt_cv32e40s_xsecure_dummy_and_hint_assert
     && id_instr_decoded.instr != BLTU //branch instructions do not use a destination register
 
     |->
-    id_instr_decoded.rd.gpr.raw == REGISTER_X0;
+    id_instr_decoded.rd.gpr.gpr == X0;
   endproperty
 
 

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
@@ -178,6 +178,17 @@ parameter logic CLIC = CORE_PARAM_CLIC;
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
 `endif
 
+`ifdef PARAM_SET_0
+   // Sat from the include file
+`elsif PARAM_SET_1
+   // Sat from the include file
+`elsif INTEGRITY_ERR_ENABLE
+   parameter logic INTEGRITY_ERR_ENABLE = 1;
+`else
+   parameter logic INTEGRITY_ERR_ENABLE = 0;
+`endif
+
+
 
 // PMP
 

--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
@@ -178,14 +178,11 @@ parameter logic CLIC = CORE_PARAM_CLIC;
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
 `endif
 
-`ifdef PARAM_SET_0
-   // Sat from the include file
-`elsif PARAM_SET_1
-   // Sat from the include file
-`elsif INTEGRITY_ERR_ENABLE
-   parameter logic INTEGRITY_ERR_ENABLE = 1;
+
+`ifdef INTEGRITY_ERRORS_ENABLED
+   parameter logic INTEGRITY_ERRORS_ENABLED = 1;
 `else
-   parameter logic INTEGRITY_ERR_ENABLE = 0;
+   parameter logic INTEGRITY_ERRORS_ENABLED = 0;
 `endif
 
 


### PR DESCRIPTION
Only run trigger exception integrity assert if integrity faults are enabled.
Change support logic usage in xsecure dummy as mentioned here: https://github.com/openhwgroup/core-v-verif/pull/2124. 

ci_check: all green
formal integrity cutpoint run: the glitch_dt_* assertions is all green
formal no cutpoint run: the glitch_dt_*_noprecondition-s are on bound 32, and still running.