### PR TITLE
Minor update to the dev_fix_debug_* test-programs to fix bit-rot issues.

### DIFF
--- a/cv32e40p/sim/tools/xrun/README.md
+++ b/cv32e40p/sim/tools/xrun/README.md
@@ -16,6 +16,7 @@ These TCL scripts can be passed to Xcelium by the core-v-verif Makefiles when us
 These XML files should be created using coverage tools such as IMC or Vmanager.  These are used to generate coverage reports that focus on necessary coverage while removing exceptions that are unhittable or not significant for the design being verified.
 
 *Note that some files are automatically generated and some are manually maintained.  This is indicated in the table.*
+*Note the files in the Table below were automatically generated for CV32E40P v1.0.0.  These files are not expected to work for any other version of CV32E40P.*
 
 | File | Maintenance | Description |
 |------|-------------|-------------|

--- a/cv32e40p/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
+++ b/cv32e40p/tests/programs/custom/debug_test_boot_set/debug_test_reset.c
@@ -21,6 +21,7 @@
 */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 extern volatile uint32_t test_debugger_entry;

--- a/cv32e40p/tests/programs/custom/debug_test_reset/debug_test_reset.c
+++ b/cv32e40p/tests/programs/custom/debug_test_reset/debug_test_reset.c
@@ -21,6 +21,7 @@
 */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 extern volatile uint32_t test_debugger_entry;

--- a/cv32e40p/tests/programs/custom/debug_test_trigger/debug_test.c
+++ b/cv32e40p/tests/programs/custom/debug_test_trigger/debug_test.c
@@ -21,6 +21,7 @@
 */
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 volatile int glb_hart_status  = 0; // Written by main code only, read by debug code

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -392,7 +392,7 @@ function void uvmt_cv32e40p_base_test_c::create_cfg();
 
    test_cfg = uvmt_cv32e40p_test_cfg_c::type_id::create("test_cfg");
    env_cfg  = uvme_cv32e40p_cfg_c     ::type_id::create("env_cfg" );
-   //ral      = env_cfg.ral;
+   test_randvars = uvmt_cv32e40p_test_randvars_c::type_id::create("test_randvars");
 
 endfunction : create_cfg
 


### PR DESCRIPTION
The test-programs in `cv32e40p/tests/programs/custom/debug_test_*` were no longer compiling due to:
1. Missing `#include <stdint.h>`
2. Null handle for `uvmt_cv32e40p_test_randvars_c::test_randvars`

This PR resolves both issues, and adds a minor cleanup of `cv32e40p/sim/tools/xrun/README.md`.