### PR TITLE
Enable cvxif extension for Spike when cvxif variable is set

### DIFF
--- a/cva6/regress/dv-generated-xif-tests.sh
+++ b/cva6/regress/dv-generated-xif-tests.sh
@@ -30,6 +30,7 @@ if ! [ -n "$list_num" ]; then
 fi
 
 export cov=1 #enable the Code Coverage
+export cvxif=1 #enable cvxif extension for Spike
 
 cd cva6/sim/
 dd=$(date '+%Y-%m-%d')

--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -101,11 +101,15 @@ else
 	cov-run-opt  =
 endif
 
+ifdef cvxif
+	spike_extension = --extension=cvxif
+endif
+
 ###############################################################################
 # Spike specific commands, variables
 ###############################################################################
 spike:
-	$(tool_path)/spike $(spike_stepout) --extension=cvxif --log-commits --isa=$(variant) -l $(elf)
+	$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) -l $(elf)
 	cp $(log).iss $(log)
 
 ###############################################################################


### PR DESCRIPTION
Hello, this PR related to enable/disable when we desire, using an environment variable.
Cvxif extension is enabled when **cvxif ** variable is set, and disable otherwise