### PR TITLE
fix random spike crash in CI

### DIFF
--- a/cva6/sim/Makefile
+++ b/cva6/sim/Makefile
@@ -109,7 +109,8 @@ endif
 # Spike specific commands, variables
 ###############################################################################
 spike:
-	$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) -l $(elf)
+	LD_LIBRARY_PATH="$$(realpath ../../tools/spike/lib):$$LD_LIBRARY_PATH" \
+		$(tool_path)/spike $(spike_stepout) $(spike_extension) --log-commits --isa=$(variant) -l $(elf)
 	cp $(log).iss $(log)
 
 ###############################################################################


### PR DESCRIPTION
The one runner building spike may not be the same as the ones running
spike.  Because of RUNPATH in spike binary, the `.so` files were looked
for in the runner which has built spike.  This may be a good default for
users but not for CI as this runner is not guaranteed to keep the same
`.so` files, hence the random crashes.

Even without crashing, the found `.so` file was not guaranteed to be the
correct version.

This fix makes sure that the `.so` files are first looked for in the
runner which has downloaded spike as an artifact.

Co-authored-by: Jules Fauchon <jules.fauchon@thalesgroup.com>