### PR TITLE
added asserts verifying m_none

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_integration_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_integration_assert.sv
@@ -120,7 +120,7 @@ module uvmt_cv32e40s_integration_assert
 
     a_m_none_div_trap: assert property(
       rvfi_if.rvfi_valid &&
-      rvfi_if.instr_asm.instr inside{DIV, DIVU}
+      rvfi_if.instr_asm.instr inside{DIV, DIVU, REM, REMU}
       |->
       rvfi_if.rvfi_trap.trap
     ) else `uvm_error(info_tag, "Divide instruction is not illegal when M_EXT = M_NONE");

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -776,7 +776,10 @@ module uvmt_cv32e40s_tb;
   // Core integration assertions
 
   bind cv32e40s_wrapper
-    uvmt_cv32e40s_integration_assert  integration_assert_i (.*);
+    uvmt_cv32e40s_integration_assert  integration_assert_i (
+      .rvfi_if (dut_wrap.cv32e40s_wrapper_i.rvfi_instr_if),
+      .*
+    );
 
 
   bind cv32e40s_wrapper


### PR DESCRIPTION
These asserts verify that CV32E40S upholds M_NONE, MUL and DIV instructions should never retire without trapping.