### PR TITLE
Asserts - OBI Max Outstanding

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -777,7 +777,8 @@ module uvmt_cv32e40s_tb;
 
   bind cv32e40s_wrapper
     uvmt_cv32e40s_integration_assert  integration_assert_i (
-      .rvfi_if (dut_wrap.cv32e40s_wrapper_i.rvfi_instr_if),
+      .rvfi_if    (dut_wrap.cv32e40s_wrapper_i.rvfi_instr_if),
+      .support_if (support_logic_module_o_if.slave_mp),
       .*
     );
 


### PR DESCRIPTION
This PR adds a simple check for maximum outstanding OBI transactions.

Reason:
https://github.com/openhwgroup/core-v-verif/pull/2177#discussion_r1315723317
I was at a crossroads, faced with a dilemma, the choice of trusting the words of men or the words of a machine.
I chose the machine.

Test status:
* ci_check - All good.
* Formal - The new checks pass, the new covers are reached.