### PR TITLE
Updated cv32e40x-dv hash to latest

### DIFF
--- a/bin/clonetb
+++ b/bin/clonetb
@@ -80,7 +80,7 @@ clone() {
 clone_cv32e40x() {
   CV_CORE=cv32e40x
   VERIF_ENV_REPO=https://github.com/openhwgroup/cv32e40x-dv.git
-  VERIF_ENV_REF=0a6e88658895be031bff00918f7bf8083b4f5e64
+  VERIF_ENV_REF=277124a8e7b638411269f45c60090d39d4a74610
   clone
 
   ignore_cloned_directory


### PR DESCRIPTION
ci_check ok
Pulls in update that resolves debug_test_trigger test errors in regressions