### PR TITLE
Add rvfi memory signals to rvfi interface

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -74,7 +74,14 @@ interface uvma_rvfi_instr_if_t
     input logic [(NMEM*XLEN/8)-1:0]  rvfi_mem_wmask,
 
     input logic [2:0]                instr_prot,
-    input logic [NMEM*3-1:0]         mem_prot
+    input logic [1:0]                rvfi_instr_memtype,
+    input logic                      rvfi_instr_dbg,
+    input logic [ NMEM*3-1:0]        mem_prot,
+    input logic [ 1*NMEM-1:0]        rvfi_mem_exokay,
+    input logic [ 1*NMEM-1:0]        rvfi_mem_err,
+    input logic [ 6*NMEM-1:0]        rvfi_mem_atop,
+    input logic [ 2*NMEM-1:0]        rvfi_mem_memtype,
+    input logic [ NMEM-1  :0]        rvfi_mem_dbg
   );
 
   typedef logic[4*NMEM-1:0] mem_mask_t;


### PR DESCRIPTION
Add rvfi memory signals to rvfi interface. The usermanual is not up to date, but the added rvfi memory signals are official signals in the same manner as rvfi_mem_prot. This PR is connected to other PRs that is not yet made, that is why it looks so "empty". It should not cause any problem to merge it though.

instr/data_prop is not as the other signals, that is because I am lazy and has not changed it. I could do it if that is preferred though.