### PR TITLE
'gen_csr_access_test' - Make Executable

### DIFF
--- a/bin/gen_csr_access_test.py
+++ b/bin/gen_csr_access_test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import os
 import argparse


### PR DESCRIPTION
This PR makes `gen_csr_access_test` executable (file permissions and shebang).

It is a minor change that was done while fixing https://github.com/openhwgroup/cv32e40x-dv/pull/37 and https://github.com/openhwgroup/cv32e40x/pull/940.