### PR TITLE
Update CVE2 Makefiles, etc. to support VCS

### DIFF
--- a/bin/ci_check
+++ b/bin/ci_check
@@ -263,9 +263,7 @@ if not (prcmd):
         print ('This will delete your previously cloned RTL repo plus all previously generated files')
         ask_user()
         os.chdir(os.path.abspath(os.path.join(topdir, args.core.lower(), 'sim/uvmt')))
-        os.system('make clean_all')
-        #os.chdir(os.path.join(topdir, '{}/sim/core'.format(args.core.lower())))
-        #os.system('make clean_all')
+        os.system('make clean_all SIMULATOR={}'.format(args.simulator))
         os.chdir(os.path.join(topdir, 'bin'))
 
 ################################################################################

--- a/cv32e20/regress/cv32e20_ci_check.yaml
+++ b/cv32e20/regress/cv32e20_ci_check.yaml
@@ -19,28 +19,28 @@ tests:
     cmd: make hello-world
     cmd: make test COREV=YES TEST=hello-world
     
-  interrupt_test:
-    build: uvmt_cv32e20
-    description: Interrupt directed test  
-    dir: cv32e20/sim/uvmt
-    cmd: make test COREV=YES TEST=interrupt_test
+#  interrupt_test:
+#    build: uvmt_cv32e20
+#    description: Interrupt directed test  
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=interrupt_test
     
-  corev_rand_interrupt:
-    build: uvmt_cv32e20
-    description: Interrupt random test
-    dir: cv32e20/sim/uvmt
-    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
+#  corev_rand_interrupt:
+#    build: uvmt_cv32e20
+#    description: Interrupt random test
+#    dir: cv32e20/sim/uvmt
+#    cmd: make gen_corev-dv test COREV=YES TEST=corev_rand_interrupt
 #    num: 2
 
-  illegal:
-    build: uvmt_cv32e20
-    dir: cv32e20/sim/uvmt
-    cmd: make test COREV=YES TEST=illegal
+#  illegal:
+#    build: uvmt_cv32e20
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=illegal
 
-  debug_test:
-    build: uvmt_cv32e20
-    dir: cv32e20/sim/uvmt
-    cmd: make test COREV=YES TEST=debug_test
+#  debug_test:
+#    build: uvmt_cv32e20
+#    dir: cv32e20/sim/uvmt
+#    cmd: make test COREV=YES TEST=debug_test
 
   csr_instructions:
     build: uvmt_cv32e20

--- a/cv32e20/sim/uvmt/.gitignore
+++ b/cv32e20/sim/uvmt/.gitignore
@@ -1,1 +1,2 @@
 make.cmd
+*_results

--- a/cv32e20/tb/uvmt/uvmt_cv32e20.flist
+++ b/cv32e20/tb/uvmt/uvmt_cv32e20.flist
@@ -28,7 +28,8 @@
 -f ${DV_UVMA_INTERRUPT_PATH}/uvma_interrupt_pkg.flist
 -f ${DV_UVMA_OBI_MEMORY_PATH}/src/uvma_obi_memory_pkg.flist
 -f ${DV_UVMA_DEBUG_PATH}/uvma_debug_pkg.flist
--f $(DV_SVLIB_PATH)/svlib_pkg.flist
+//-f $(DV_SVLIB_PATH)/svlib_pkg.flist
+-f ../../../../../vendor_lib/verilab/svlib_pkg.flist
 
 // Environments
 -f ${DV_UVME_PATH}/uvme_cv32e20_pkg.flist

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_cov_model.sv
@@ -20,6 +20,12 @@
 `ifndef __UVMA_OBI_MEMORY_COV_MODEL_SV__
 `define __UVMA_OBI_MEMORY_COV_MODEL_SV__
 
+`ifdef UNSUPPORTED_WITH //TODO - Remove ifdef when the issue in VCS simulator is fixed
+  `define WITH iff
+`else
+   `define WITH with
+`endif
+
    /*
    * Covergroups
    * Decalred at package-level to enable mutliple instances per monitor class (e.g. read/write)
@@ -49,23 +55,23 @@ covergroup cg_obi(string name,
    option.name         = name;
 
    we: coverpoint (trn.access_type) {
-      ignore_bins IGN_WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE} with (!write_enabled);
-      ignore_bins IGN_READ =  {UVMA_OBI_MEMORY_ACCESS_READ} with (!read_enabled);
+      ignore_bins IGN_WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE} `WITH (!write_enabled);
+      ignore_bins IGN_READ =  {UVMA_OBI_MEMORY_ACCESS_READ} `WITH (!read_enabled);
       bins WRITE = {UVMA_OBI_MEMORY_ACCESS_WRITE};
       bins READ = {UVMA_OBI_MEMORY_ACCESS_READ};
    }
 
    memtype: coverpoint (trn.memtype) {
-      ignore_bins IGN_MEMTYPE = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_MEMTYPE = {[0:$]} `WITH (!is_1p2);
    }
 
    prot: coverpoint (trn.prot) {
-      ignore_bins IGN_MEMTYPE = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_MEMTYPE = {[0:$]} `WITH (!is_1p2);
       ignore_bins IGN_RSVD_PRIV = {3'b100, 3'b101};
    }
 
    err: coverpoint (trn.err) {
-      ignore_bins IGN_ERR = {[0:$]} with (!is_1p2);
+      ignore_bins IGN_ERR = {[0:$]} `WITH (!is_1p2);
    }
 
 endgroup : cg_obi
@@ -263,6 +269,7 @@ function void uvma_obi_memory_cov_model_c::sample_slv_seq_item();
    
 endfunction : sample_slv_seq_item
 
+`undef WITH //TODO - Remove ifdef when the issue in VCS simulator is fixed
 
 `endif // __UVMA_OBI_MEMORY_COV_MODEL_SV__
 

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -685,6 +685,7 @@ SVLIB_CXX    = gcc
 
 svlib: $(SVLIB_PKG)
 	$(SVLIB_CXX) $(SVLIB_CFLAGS) $(SVLIB) $(SVLIB_SRC) -I$(DPI_INCLUDE) -o $(SVLIB_LIB)
+	cp $(SVLIB_PKG)/../svlib_dpi.so $(SVLIB_PKG)/../svlib_dpi
 
 .PHONY: firmware-clean
 firmware-clean:

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -30,7 +30,8 @@ endif
 
 # Executables
 VCS              = $(CV_SIM_PREFIX) vcs
-SIMV             = $(CV_TOOL_PREFIX) simv -licwait 20
+#SIMV             = $(CV_TOOL_PREFIX) simv -licwait 20
+SIMV             = simv -licwait 20
 DVE              = $(CV_TOOL_PREFIX) dve
 #VERDI            = $(CV_TOOL_PREFIX)verdi
 URG               = $(CV_SIM_PREFIX) urg
@@ -39,20 +40,25 @@ URG               = $(CV_SIM_PREFIX) urg
 VCS_DIR         ?= $(SIM_CFG_RESULTS)/vcs.d
 VCS_ELAB_COV     = -cm line+cond+tgl+fsm+branch+assert  -cm_dir $(MAKECMDGOALS)/$(MAKECMDGOALS).vdb
 
-# modifications to already defined variables to take into account VCS
-VCS_OVP_MODEL_DPI = $(OVP_MODEL_DPI:.so=)                    # remove extension as VCS adds it
+# Modifications to already defined variables to take into account that VCS
+# does not require the ".so" extension for shared objects.
+VCS_OVP_MODEL_DPI = $(OVP_MODEL_DPI:.so=)
+VCS_DPI_DASM_LIB  = $(DPI_DASM_LIB:.so=)
+VCS_SVLIB_LIB     = $(SVLIB_LIB:.so=)
+
 VCS_TIMESCALE = $(shell echo "$(TIMESCALE)" | tr ' ' '=')    # -timescale=1ns/1ps
 
 VCS_UVM_VERBOSITY ?= UVM_MEDIUM
 
 # Flags
-#VCS_UVMHOME_ARG ?= /opt/uvm/1800.2-2017-0.9/
-VCS_UVMHOME_ARG ?= /opt/synopsys/vcs-mx/O-2018.09-SP1-1/etc/uvm
-VCS_UVM_ARGS          ?= +incdir+$(VCS_UVMHOME_ARG)/src $(VCS_UVMHOME_ARG)/src/uvm_pkg.sv +UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) -ntb_opts uvm-1.2
+VCS_VERSION     ?= S-2021.09-SP1
+VCS_UVMHOME_ARG ?= /synopsys/vcs/$(VCS_VERSION)/etc/uvm-1.2
+VCS_UVM_ARGS    ?= +incdir+$(VCS_UVMHOME_ARG)/src $(VCS_UVMHOME_ARG)/src/uvm_pkg.sv +UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) -ntb_opts uvm-1.2
 
 VCS_COMP_FLAGS  ?= -lca -sverilog \
-										$(SV_CMP_FLAGS) $(VCS_UVM_ARGS) $(VCS_TIMESCALE) \
-										-assert svaext -race=all -ignore unique_checks -full64
+                   $(SV_CMP_FLAGS) $(VCS_UVM_ARGS) $(VCS_TIMESCALE) \
+                   +define+CV32E20_RVFI+RVFI \
+                   -assert svaext -ignore unique_checks -full64 -licwait 20
 VCS_GUI         ?=
 VCS_RUN_COV      = -cm line+cond+tgl+fsm+branch+assert -cm_dir $(MAKECMDGOALS).vdb
 
@@ -86,12 +92,18 @@ endif
 # Waveform generation
 # WAVES=YES enables waveform generation for entire testbench
 # ADV_DEBUG=YES currently not supported
+# FSDB=YES enables FSDB waveform file generation for entire testbench
 ifeq ($(call IS_YES,$(WAVES)),YES)
 ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
 $(error ADV_DEBUG not yet supported by VCS )
-VCS_USER_COMPILE_ARGS = +vcs+vcdpluson
+VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
 else
-VCS_USER_COMPILE_ARGS = +vcs+vcdpluson
+ifeq ($(call IS_YES,$(FSDB)),YES)
+VCS_USER_COMPILE_ARGS += -debug_access+all +vcs+fsdbon -kdb
+VCS_RUN_WAVES_FLAGS  ?= -ucli -i $(abspath $(MAKE_PATH)/../tools/vcs/vcs_wave.tcl)
+else
+VCS_USER_COMPILE_ARGS += +vcs+vcdpluson
+endif
 endif
 endif
 
@@ -128,33 +140,58 @@ endif
 ifeq ($(call IS_YES,$(MERGE)),YES)
 COV_ARGS = -dir cov_work/scope/merged
 else
-COV_ARGS = -dir $(TEST_NAME).vdb
+COV_ARGS = -dir $(TEST_RUN_NAME).vdb
 endif
 
+
+ifeq ($(call IS_YES,$(CHECK_SIM_RESULT)),YES)
+CHECK_SIM_LOG ?= $(abspath $(SIM_RUN_RESULTS))/vcs-$(TEST_RUN_NAME).log
+POST_TEST = \
+	@if grep -q "SIMULATION FAILED" $(CHECK_SIM_LOG); then \
+		exit 1; \
+	fi
+endif
 
 ################################################################################
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
-VCS_FILE_LIST += -f $(DV_UVMT_PATH)/imperas_iss.flist
-VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION+RVFI+UVM
+VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION+UNSUPPORTED_WITH
 ifeq ($(call IS_YES,$(USE_ISS)),YES)
+    VCS_USER_COMPILE_ARGS += +define+USE_ISS
+    VCS_USER_COMPILE_ARGS += +define+USE_IMPERASDV
+    VCS_FILE_LIST_IDV ?= -f $(DV_UVMT_PATH)/imperas_dv.flist
     VCS_PLUSARGS += +USE_ISS
+    VCS_PLUSARGS += +USE_IMPERASDV
+    VCS_PLUSARGS += -sv_lib $(basename $(IMPERAS_DV_MODEL))
+    ifeq ($(call IS_YES,$(COV)),YES)
+        VCS_USER_COMPILE_ARGS += +define+IMPERAS_COV
+        VCS_PLUSARGS += +IDV_TRACE2COV=1
+    endif
 else
 	VCS_PLUSARGS += +DISABLE_OVPSIM
+	VCS_FILE_LIST_IDV ?=
 endif
 
+# TODO: determine impact of removing VCS_OVP_MODEL_DPI with USE_ISS=YES
+#                        -sv_lib $(VCS_OVP_MODEL_DPI) \
+# TODO: removing VCS_DPIDASM_LIB effectively disables ISACOV
+#                        -sv_lib $(VCS_DPI_DASM_LIB) \
+
 VCS_RUN_BASE_FLAGS   ?= $(VCS_GUI) \
-                        $(VCS_PLUSARGS) +ntb_random_seed=$(RNDSEED) \
-						-sv_lib $(VCS_OVP_MODEL_DPI) \
-						-sv_lib $(DPI_DASM_LIB) \
-						-sv_lib $(abspath $(SVLIB_LIB))
+                        $(VCS_PLUSARGS) \
+                        +ntb_random_seed=$(RNDSEED) \
+                        -assert nopostproc \
+                        -sv_lib $(abspath $(VCS_SVLIB_LIB))
 
 # Simulate using latest elab
 VCS_RUN_FLAGS        ?=
 VCS_RUN_FLAGS        += $(VCS_RUN_BASE_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_WAVES_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_COV_FLAGS)
-VCS_RUN_FLAGS        += $(USER_RUN_FLAGS)
+
+# Special var to point to tool and installation dependent path of DPI headers.
+# Used to recompile dpi_dasm_spike if needed (by default, not needed).
+DPI_INCLUDE          ?= $(shell dirname $(shell which vcs))/../lib
 
 ###############################################################################
 # Targets
@@ -176,17 +213,19 @@ hello-world:
 	$(MAKE) test TEST=hello-world
 
 VCS_COMP = $(VCS_COMP_FLAGS) \
+		$(CFG_COMPILE_FLAGS) \
 		$(QUIET) \
 		$(VCS_UVM_ARGS) \
 		$(VCS_USER_COMPILE_ARGS) \
 		+incdir+$(DV_UVME_PATH) \
 		+incdir+$(DV_UVMT_PATH) \
 		-f $(CV_CORE_MANIFEST) \
+		$(VCS_FILE_LIST_IDV) \
 		$(VCS_FILE_LIST) \
 		$(UVM_PLUSARGS)
 
-comp: mk_vcs_dir $(CV_CORE_PKG) $(SVLIB_PKG) $(OVP_MODEL_DPI)
-	cd $(SIM_CFG_RESULTS)/$(CFG) && $(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
+comp: mk_vcs_dir $(CV_CORE_PKG) $(SVLIB_PKG)
+	cd $(VCS_DIR) && $(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
 	@echo "$(BANNER)"
 	@echo "* $(SIMULATOR) compile complete"
 	@echo "* Log: $(SIM_CFG_RESULTS)/vcs.log"
@@ -211,24 +250,33 @@ gen_ovpsim_ic:
 	@if [ ! -z "$(CFG_OVPSIM)" ]; then \
 		echo "$(CFG_OVPSIM)" > $(SIM_RUN_RESULTS)/ovpsim.ic; \
 	fi
-export IMPERAS_TOOLS=$(SIM_RUN_RESULTS)/ovpsim.ic
 
 ################################################################################
 # The new general test target
 
 test: $(VCS_SIM_PREREQ) hex gen_ovpsim_ic
-	echo $(IMPERAS_TOOLS)
+	@echo "$(BANNER)"
+	@echo "* Running simulation"
+	@echo "* with VCS_RUN_FLAGS = $(VCS_RUN_FLAGS)"
+	@echo "$(BANNER)"
 	mkdir -p $(SIM_RUN_RESULTS)
 	cd $(SIM_RUN_RESULTS) && \
-		$(VCS_RESULTS)/$(CFG)/$(SIMV) \
-			-l vcs-$(TEST_NAME).log \
-			-cm_name $(TEST_NAME) $(VCS_RUN_FLAGS) \
-			$(CFG_PLUSARGS) \
-			$(TEST_PLUSARGS) \
-			+UVM_TESTNAME=$(TEST_UVM_TEST) \
-    		+elf_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
-			+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
-			+itb_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
+	export IMPERAS_TOOLS=$(SIM_RUN_RESULTS)/ovpsim.ic && \
+	export IMPERAS_QUEUE_LICENSE=1 && \
+		$(VCS_DIR)/$(SIMV) \
+                -l vcs-$(TEST)_$(GEN_START_INDEX)_$(GEN_NUM_TESTS).log \
+		-cm_name $(TEST_RUN_NAME) \
+		$(VCS_RUN_FLAGS) \
+		$(CFG_PLUSARGS) \
+		$(TEST_PLUSARGS) \
+		$(TEST_CFG_FILE_PLUSARGS) \
+		+UVM_TESTNAME=$(TEST_UVM_TEST) \
+		+UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) \
+		+elf_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
+		+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
+		+itb_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).itb
+	@echo "* Log: $(SIM_RUN_RESULTS)/vcs-$(TEST)_$(GEN_START_INDEX)_$(GEN_NUM_TESTS).log"
+	$(POST_TEST)
 
 ###############################################################################
 # Run a single test-program from the RISC-V Compliance Test-suite. The parent
@@ -263,13 +311,61 @@ compliance: $(VCS_COMPLIANCE_PREREQ)
 		+firmware=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).hex \
 		+elf_file=$(COMPLIANCE_PKG)/work/$(RISCV_ISA)/$(COMPLIANCE_PROG).elf
 
+################################################################################
+# RISCOF RISCV-ARCH-TEST DUT simulation targets
+VCS_RISCOF_SIM_PREREQ = $(RISCOF_TEST_RUN_DIR)/$(TEST).elf
+
+comp_dut_riscof_sim:
+	@echo "$(BANNER)"
+	@echo "* Compiling vcs in $(SIM_RISCOF_ARCH_TESTS_RESULTS)"
+	@echo "* Log: $(SIM_RISCOF_ARCH_TESTS_RESULTS)/vcs.log"
+	@echo "$(BANNER)"
+	mkdir -p $(SIM_RISCOF_ARCH_TESTS_RESULTS) && \
+	cd $(SIM_RISCOF_ARCH_TESTS_RESULTS) && \
+		$(VCS) $(VCS_COMP) -top uvmt_$(CV_CORE_LC)_tb
+
+comp_dut_rtl_riscof_sim: $(CV_CORE_PKG) $(SVLIB_PKG) comp_dut_riscof_sim
+
+setup_riscof_sim: clean_riscof_arch_test_suite clone_riscof_arch_test_suite comp_dut_rtl_riscof_sim
+
+gen_riscof_ovpsim_ic:
+	@touch $(RISCOF_TEST_RUN_DIR)/ovpsim.ic
+	@if [ ! -z "$(CFG_OVPSIM)" ]; then \
+		echo "$(CFG_OVPSIM)" > $(RISCOF_TEST_RUN_DIR)/ovpsim.ic; \
+	fi
+
+# Target to run RISCOF DUT sim with VCS
+riscof_sim_run: $(VCS_RISCOF_SIM_PREREQ) comp_dut_rtl_riscof_sim gen_riscof_ovpsim_ic
+	@echo "$(BANNER)"
+	@echo "* Running vcs in $(RISCOF_TEST_RUN_DIR)"
+	@echo "* Log: $(RISCOF_TEST_RUN_DIR)/vcs-$(TEST).log"
+	@echo "$(BANNER)"
+	cd $(RISCOF_TEST_RUN_DIR) && \
+	export IMPERAS_TOOLS=$(RISCOF_TEST_RUN_DIR)/ovpsim.ic && \
+	export IMPERAS_QUEUE_LICENSE=1 && \
+		$(RISCOF_TEST_RUN_DIR)/$(SIMV) \
+			-l vcs-$(TEST).log \
+			-cm_name $(TEST) \
+			$(VCS_RUN_FLAGS) \
+			$(CFG_PLUSARGS) \
+			$(RISCOF_TEST_PLUSARGS) \
+			+UVM_TESTNAME=uvmt_cv32e40p_riscof_firmware_test_c \
+			+UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) \
+			+firmware=$(TEST).hex \
+			+elf_file=$(TEST).elf \
+			+itb_file=$(TEST).itb
+	@echo "* Log: $(RISCOF_TEST_RUN_DIR)/vcs-$(TEST).log"
+
+
 ###############################################################################
 # Use Google instruction stream generator (RISCV-DV) to create new test-programs
 comp_corev-dv: $(RISCVDV_PKG) $(CV_CORE_PKG)
 	mkdir -p $(SIM_COREVDV_RESULTS)
 	cd $(SIM_COREVDV_RESULTS) && \
 	$(VCS) $(VCS_COMP_FLAGS) \
-		$(QUIET) $(VCS_USER_COMPILE_ARGS) \
+		$(QUIET) \
+		$(VCS_UVM_ARGS) \
+		$(VCS_USER_COMPILE_ARGS) \
 		$(VCS_PMA_INC) \
 		+incdir+$(CV_CORE_COREVDV_PKG)/target/$(CV_CORE_LC) \
 		+incdir+$(RISCVDV_PKG)/user_extension \
@@ -282,7 +378,11 @@ comp_corev-dv: $(RISCVDV_PKG) $(CV_CORE_PKG)
 
 corev-dv: clean_riscv-dv clone_riscv-dv comp_corev-dv
 
-gen_corev-dv:
+gen_corev-dv: comp_corev-dv
+	@echo "$(BANNER)"
+	@echo "* Generating $(TEST) with corev-dv..."
+	@echo "* with VCS_RUN_FLAGS = $(VCS_RUN_FLAGS) "
+	@echo "$(BANNER)"
 	mkdir -p $(SIM_COREVDV_RESULTS)/$(TEST)
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
 		mkdir -p $(SIM_TEST_RESULTS)/$$idx/test_program; \
@@ -296,10 +396,11 @@ gen_corev-dv:
 			+asm_file_name_opts=$(TEST) \
 			+ldgen_cp_test_path=$(SIM_TEST_RESULTS) \
 			$(CFG_PLUSARGS) \
+			$(TEST_CFG_FILE_PLUSARGS) \
 			$(GEN_PLUSARGS)
 	for (( idx=${GEN_START_INDEX}; idx < $$((${GEN_START_INDEX} + ${GEN_NUM_TESTS})); idx++ )); do \
 		cp -f ${BSP}/link_corev-dv.ld ${SIM_TEST_RESULTS}/$$idx/test_program/link.ld; \
-		cp ${VCS_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${SIM_TEST_RESULTS}/$$idx/test_program; \
+		cp ${SIM_COREVDV_RESULTS}/${TEST}/${TEST}_$$idx.S ${SIM_TEST_RESULTS}/$$idx/test_program; \
 	done
 
 ################################################################################
@@ -317,13 +418,7 @@ cov_merge:
 ifeq ($(call IS_YES,$(MERGE)),YES)
   COVERAGE_TARGET_DIR=$(SIM_CFG_RESULTS)/$(MERGED_COV_DIR)
 else
-  COVERAGE_TARGET_DIR=$(SIM_CFG_RESULTS)/$(TEST_NAME)
-endif
-
-ifeq ($(call IS_YES,$(MERGE)),YES)
-  COVERAGE_TARGET_DIR=$(SIM_RESULTS)/$(MERGED_COV_DIR)
-else
-  COVERAGE_TARGET_DIR=$(SIM_RESULTS)/$(TEST_NAME)_$(RUN_INDEX)
+  COVERAGE_TARGET_DIR=$(SIM_RUN_RESULTS)
 endif
 
 # the report is in html format: use a browser to access it when GUI mode is selected
@@ -342,6 +437,10 @@ clean:
 	@echo "$(MAKEFILE_LIST)"
 	rm -rf $(SIM_RESULTS)
 
+clean_test:
+	@echo "Cleaning $(SIM_RUN_RESULTS)..."
+	rm -rf $(SIM_RUN_RESULTS)
+
 # Files created by Eclipse when using the Imperas ISS + debugger
 clean_eclipse:
 	rm  -f eguieclipse.log
@@ -349,6 +448,8 @@ clean_eclipse:
 	rm  -f stdout.txt
 	rm  -rf workspace
 
-# All generated files plus the clone of the RTL
-clean_all: clean clean_eclipse clean_riscv-dv clean_test_programs clean-bsp clean_compliance clean_embench clean_dpi_dasm_spike clean_svlib
+clean_rtl:
 	rm -rf $(CV_CORE_PKG)
+
+# All generated files plus the clone of the RTL
+clean_all: clean clean_test clean_rtl clean_eclipse clean_riscv-dv clean_test_programs clean_bsp clean_compliance clean_embench clean_dpi_dasm_spike clean_svlib 


### PR DESCRIPTION
This pull-request is in support of [CVE2 Task #37](https://github.com/openhwgroup/cve2/issues/37).  Specifically, this PR updates various files in CORE-V-VERIF to support simulation of the CV32E20 with VCS.  I also took the liberty of updating the CI regression list to include only those test-programs that are known to pass at this time.