### PR TITLE
use correct csr privlevel path

### DIFF
--- a/cv32e40s/sim/ExternalRepos.mk
+++ b/cv32e40s/sim/ExternalRepos.mk
@@ -15,7 +15,7 @@ export SHELL = /bin/bash
 
 CV_CORE_REPO   ?= https://github.com/openhwgroup/cv32e40s
 CV_CORE_BRANCH ?= master
-CV_CORE_HASH   ?= 41cbecf7690efd0ccd75b32bc31aab09c5dede56
+CV_CORE_HASH   ?= 9a66cb971edca4613d5df12a869db3511ee24a75
 CV_CORE_TAG    ?= none
 
 #RISCVDV_REPO    ?= https://github.com/google/riscv-dv

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_tb.sv
@@ -878,7 +878,7 @@ module uvmt_cv32e40s_tb;
 
       //CSRs:
       .mstateen0            (core_i.cs_registers_i.mstateen0_csr_i.rdata_q),
-      .priv_lvl             (core_i.cs_registers_i.priv_lvl_i.rdata_q),
+      .priv_lvl             (core_i.cs_registers_i.privlvl_user.priv_lvl_i.rdata_q),
       .jvt                  (core_i.cs_registers_i.jvt_csr_i.rdata_q),
       .mstatus              (core_i.cs_registers_i.mstatus_csr_i.rdata_q),
       .cpuctrl              (core_i.cs_registers_i.xsecure.cpuctrl_csr_i.rdata_q),
@@ -888,7 +888,7 @@ module uvmt_cv32e40s_tb;
 
       //Shadows:
       .mstateen0_shadow     (core_i.cs_registers_i.mstateen0_csr_i.gen_hardened.shadow_q),
-      .priv_lvl_shadow      (core_i.cs_registers_i.priv_lvl_i.gen_hardened.shadow_q),
+      .priv_lvl_shadow      (core_i.cs_registers_i.privlvl_user.priv_lvl_i.gen_hardened.shadow_q),
       .jvt_shadow           (core_i.cs_registers_i.jvt_csr_i.gen_hardened.shadow_q),
       .mstatus_shadow       (core_i.cs_registers_i.mstatus_csr_i.gen_hardened.shadow_q),
       .cpuctrl_shadow       (core_i.cs_registers_i.xsecure.cpuctrl_csr_i.gen_hardened.shadow_q),


### PR DESCRIPTION
RTL has added an if statement that needs to be included in the path.

Formal compiles
Ci check is all red
But after this bug is fixed: https://github.com/openhwgroup/cv32e40s/issues/499
It is all green except clic config tests (clic and debug_test2) (which I think is a clic problem and not something caused by this change, as that would be weird)