### PR TITLE
Updated default LFSR-coeffs/seed 

### DIFF
--- a/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
+++ b/cv32e40s/tests/uvmt/base-tests/uvmt_cv32e40s_base_test_constants.sv
@@ -173,9 +173,9 @@ parameter logic CLIC = CORE_PARAM_CLIC;
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h80000062, default_seed : 32'hbeef1234 };
    parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h8000007a, default_seed : 32'ha5a5a5a5 };
 `else
-   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR0_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
-   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
-   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::LFSR_CFG_DEFAULT;
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR0_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h80000057, default_seed : 32'habbacafe };
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR1_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h80000062, default_seed : 32'hbeef1234 };
+   parameter cv32e40s_pkg::lfsr_cfg_t CORE_PARAM_LFSR2_CFG = cv32e40s_pkg::lfsr_cfg_t'{ coeffs : 32'h8000007a, default_seed : 32'ha5a5a5a5 };
 `endif
 
 


### PR DESCRIPTION
... to ensure that these are not configured as zero.

To comply with user manual requirement that states that the coefficients must be non-zero