### PR TITLE
Explicitly clear minhv at the end of mret_after_minhv test

### DIFF
--- a/cv32e40s/tests/programs/custom/clic/clic.c
+++ b/cv32e40s/tests/programs/custom/clic/clic.c
@@ -2721,6 +2721,13 @@ uint32_t mret_with_minhv(uint32_t index, uint8_t report_name) {
     :[mcause] "r"(mcause.raw)
     :"t0");
 
+  // Clear minhv-bit
+  mcause.clic.minhv = 0;
+
+  __asm__ volatile (R"(
+    csrrw zero, mcause, %[mcause]
+  )"::[mcause] "r"(mcause.raw));
+
   test_fail += (result != 0);
 
   if (test_fail) {


### PR DESCRIPTION
Only C-test change, passes without ISS (known ISS mismatch)