### PR TITLE
Add debug_test to CI regression

### DIFF
--- a/cv32e20/regress/cv32e20_ci_check.yaml
+++ b/cv32e20/regress/cv32e20_ci_check.yaml
@@ -37,10 +37,10 @@ tests:
 #    dir: cv32e20/sim/uvmt
 #    cmd: make test COREV=YES TEST=illegal
 
-#  debug_test:
-#    build: uvmt_cv32e20
-#    dir: cv32e20/sim/uvmt
-#    cmd: make test COREV=YES TEST=debug_test
+  debug_test:
+    build: uvmt_cv32e20
+    dir: cv32e20/sim/uvmt
+    cmd: make test COREV=YES TEST=debug_test
 
   csr_instructions:
     build: uvmt_cv32e20


### PR DESCRIPTION
The (partial) debug_test is now passing, so it can be added back to the CI regression.