### PR TITLE
Enabled wfe_test and xsecure_* tests in full regression

### DIFF
--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -541,3 +541,20 @@ tests:
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=debug_test_0_triggers
 
+  wfe_test:
+    description: Short directed wfe test
+    builds: [ uvmt_cv32e40s_clic, uvmt_cv32e40s ]
+    dir: cv32e40s/sim/uvmt
+    cmd: make test TEST=wfe_test
+
+  xsecure_test:
+    description: xsecure test
+    builds: [ uvmt_cv32e40s_clic ]
+    dir: cv32e40s/sim/uvmt
+    cmd: make test TEST=xsecure_test
+
+  xsecure_csrs:
+    description: xsecure csr test
+    builds: [ uvmt_cv32e40s_clic, uvmt_cv32e40s ]
+    dir: cv32e40s/sim/uvmt
+    cmd: make test TEST=xsecure_csrs

--- a/cv32e40s/tests/cfg/clic_default.yaml
+++ b/cv32e40s/tests/cfg/clic_default.yaml
@@ -5,6 +5,7 @@ compile_flags:
     +define+CLIC_EN
     +define+PMP_ENABLE_64
 ovpsim: >
+    --override cpu/hpmcounter_undefined=T
     --override cpu/CLICLEVELS=256
     --override cpu/CLICXCSW=T
     --override cpu/CLICXNXTI=T


### PR DESCRIPTION
Added missing hpmcounter-flag to ISS settings

ci_check ok,
full regression w/o ref. model shows no direct test breakage
fv no impact