### PR TITLE
coverage fixes

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -370,33 +370,6 @@ module uvmt_cv32e40s_triggers_assert_cov
     p_dt_tcsr_not_implemented(ADDR_TDATA3)
   ) else `uvm_error(info_tag, "Access to tdata3 does not cause an illegal exception (when no higher priority exception has occured)\n");
 
-
-  // Assertions and coverages for when there are debug triggers:
-  if (CORE_PARAM_DBG_NUM_TRIGGERS != 0) begin
-
-    //2)
-    c_dt_access_tdata3_m2: cover property (
-      rvfi_if.is_csr_instr(ADDR_TDATA3)
-      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL
-    );
-
-    c_dt_access_tdata3_etrigger: cover property (
-      rvfi_if.is_csr_instr(ADDR_TDATA3)
-      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
-    );
-
-    c_dt_access_tdata3_m6: cover property (
-      rvfi_if.is_csr_instr(ADDR_TDATA3)
-      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
-    );
-
-    c_dt_access_tdata3_disabled: cover property (
-      rvfi_if.is_csr_instr(ADDR_TDATA3)
-      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_DISABLED
-    );
-  end
-
-
   //- Vplan:
   //Have 0 triggers, access any trigger register and check that illegal instruction exception occurs.
   //Check that no triggers ever fire. Check that "tselect" is 0.

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -329,7 +329,13 @@ function void uvma_isacov_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(IL
     endcase
   end
 
-  mon_trn.instr.set_valid_flags();
+  if (cfg.decoder == SPIKE) begin
+    mon_trn.instr.set_valid_flags();
+  end else begin // if ISA_DECODER
+    mon_trn.instr.rd_valid  = instr_asm.rd.valid;
+    mon_trn.instr.rs1_valid = instr_asm.rs1.valid;
+    mon_trn.instr.rs2_valid = instr_asm.rs2.valid;
+  end
 
   // Set enumerations for register values as reported from RVFI
   if (mon_trn.instr.rs1_valid) begin


### PR DESCRIPTION
* isacov fix for zb* instructions (isa decoder only, not for spike dasm)
* removed tdata3 cover properties as tdata3 is no longer present in the core