### PR TITLE
Naming convention fix for isacov-isa_decode

### DIFF
--- a/lib/isa_decoder/isa_decoder.sv
+++ b/lib/isa_decoder/isa_decoder.sv
@@ -293,7 +293,7 @@
 
     casex (format)
       I_TYPE: begin
-        if (asm.instr inside { FENCEI, ECALL, EBREAK, MRET, DRET, WFI, WFE }) begin
+        if (asm.instr inside { FENCE_I, ECALL, EBREAK, MRET, DRET, WFI, WFE }) begin
           asm.rd.valid    = 0;
           asm.rs1.valid   = 0;
           asm.rs2.valid   = 0;
@@ -711,7 +711,7 @@
 
       (   (instr.uncompressed.opcode              == MISC_MEM)
        && (instr.uncompressed.format.i.funct3     == 3'b001)) :
-        asm = build_asm(FENCEI, I_TYPE, instr);
+        asm = build_asm(FENCE_I, I_TYPE, instr);
 
       (   (instr.uncompressed.opcode              == SYSTEM)
        && (instr.uncompressed.format.i.imm        == 12'b0000_0000_0000)) :
@@ -1032,9 +1032,9 @@
         asm = build_asm(CTZ, I_TYPE, instr);
 
       (   (instr.uncompressed.opcode              == OP_IMM)
-       && (instr.uncompressed.format.i.funct3     == FUNCT3_ORCB)
+       && (instr.uncompressed.format.i.funct3     == FUNCT3_ORC_B)
        && (instr.uncompressed.format.i.imm        == 12'b0010_1000_0111)) :
-        asm = build_asm(ORCB, I_TYPE, instr);
+        asm = build_asm(ORC_B, I_TYPE, instr);
 
       (   (instr.uncompressed.opcode              == OP)
        && (instr.uncompressed.format.r.funct3     == FUNCT3_ORN)
@@ -1079,17 +1079,17 @@
       (   (instr.uncompressed.opcode              == OP_IMM)
        && (instr.uncompressed.format.i.funct3     == FUNCT3_SEXT)
        && (instr.uncompressed.format.i.imm        == 12'b0110_0000_0100)) :
-        asm = build_asm(SEXTB, I_TYPE, instr);
+        asm = build_asm(SEXT_B, I_TYPE, instr);
 
       (   (instr.uncompressed.opcode              == OP_IMM)
        && (instr.uncompressed.format.i.funct3     == FUNCT3_SEXT)
        && (instr.uncompressed.format.i.imm        == 12'b0110_0000_0101)) :
-        asm = build_asm(SEXTH, I_TYPE, instr);
+        asm = build_asm(SEXT_H, I_TYPE, instr);
 
       (   (instr.uncompressed.opcode              == OP)
-       && (instr.uncompressed.format.i.funct3     == FUNCT3_ZEXTH)
+       && (instr.uncompressed.format.i.funct3     == FUNCT3_ZEXT_H)
        && (instr.uncompressed.format.i.imm        == 12'b0000_1000_0000)) :
-        asm = build_asm(ZEXTH, I_TYPE, instr);
+        asm = build_asm(ZEXT_H, I_TYPE, instr);
 
       //Zbc
       (   (instr.uncompressed.opcode              == OP)
@@ -1331,24 +1331,24 @@
 
       //Zcb
       (   (instr.compressed.opcode                        == C1)
-       && (instr.compressed.format.cu.funct5              == FUNCT5_C_ZEXTB)
+       && (instr.compressed.format.cu.funct5              == FUNCT5_C_ZEXT_B)
        && (instr.compressed.format.cu.funct6              == 6'b100111)) :
-        asm = build_asm(C_ZEXTB, CU_TYPE, instr);
+        asm = build_asm(C_ZEXT_B, CU_TYPE, instr);
 
       (   (instr.compressed.opcode                        == C1)
-       && (instr.compressed.format.cu.funct5              == FUNCT5_C_SEXTB)
+       && (instr.compressed.format.cu.funct5              == FUNCT5_C_SEXT_B)
        && (instr.compressed.format.cu.funct6              == 6'b100111)) :
-        asm = build_asm(C_SEXTB, CU_TYPE, instr);
+        asm = build_asm(C_SEXT_B, CU_TYPE, instr);
 
       (   (instr.compressed.opcode                        == C1)
-       && (instr.compressed.format.cu.funct5              == FUNCT5_C_ZEXTH)
+       && (instr.compressed.format.cu.funct5              == FUNCT5_C_ZEXT_H)
        && (instr.compressed.format.cu.funct6              == 6'b100111)) :
-        asm = build_asm(C_ZEXTH, CU_TYPE, instr);
+        asm = build_asm(C_ZEXT_H, CU_TYPE, instr);
 
       (   (instr.compressed.opcode                        == C1)
-       && (instr.compressed.format.cu.funct5              == FUNCT5_C_SEXTH)
+       && (instr.compressed.format.cu.funct5              == FUNCT5_C_SEXT_H)
        && (instr.compressed.format.cu.funct6              == 6'b100111)) :
-        asm = build_asm(C_SEXTH, CU_TYPE, instr);
+        asm = build_asm(C_SEXT_H, CU_TYPE, instr);
 
       (   (instr.compressed.opcode                        == C1)
        && (instr.compressed.format.cu.funct5              == FUNCT5_C_NOT)

--- a/lib/isa_decoder/isa_typedefs.sv
+++ b/lib/isa_decoder/isa_typedefs.sv
@@ -27,7 +27,7 @@
     // Unknown for instructions that cannot be decoded
     UNKNOWN_INSTR = 0,
     FENCE,
-    FENCEI,
+    FENCE_I,
     MRET,
     DRET,
     ECALL,
@@ -101,7 +101,7 @@
     MAXU,
     CPOP,
     CTZ,
-    ORCB,
+    ORC_B,
     ORN,
     CLZ,
     ANDN,
@@ -110,9 +110,9 @@
     RORI,
     XNOR,
     REV8,
-    SEXTB,
-    SEXTH,
-    ZEXTH,
+    SEXT_B,
+    SEXT_H,
+    ZEXT_H,
     //Zbc
     CLMUL,
     CLMULH,
@@ -171,10 +171,10 @@
     C_LH,
     C_SB,
     C_SH,
-    C_ZEXTB,
-    C_SEXTB,
-    C_ZEXTH,
-    C_SEXTH,
+    C_ZEXT_B,
+    C_SEXT_B,
+    C_ZEXT_H,
+    C_SEXT_H,
     C_NOT,
     C_MUL,
     //Zcmp
@@ -438,11 +438,11 @@
 
   // Minor opcodes for logical operators and sign extend (FUNCT3_SEXT)
   typedef enum logic [2:0] {
-    FUNCT3_XNOR = 3'b100,
-    FUNCT3_ORCB = 3'b101,
-    FUNCT3_ORN  = 3'b110,
-    FUNCT3_ANDN = 3'b111,
-    FUNCT3_SEXT = 3'b001
+    FUNCT3_XNOR  = 3'b100,
+    FUNCT3_ORC_B = 3'b101,
+    FUNCT3_ORN   = 3'b110,
+    FUNCT3_ANDN  = 3'b111,
+    FUNCT3_SEXT  = 3'b001
   } zbb_logical_minor_opcode_e;
 
   // Minor opcodes for rotate instructions
@@ -455,9 +455,9 @@
   // and zero extend halfword instruction (FUNCT3_ZEXTH).
   // FUNCT3_C is correct for all count isntructions.
   typedef enum logic [2:0] {
-    FUNCT3_REV8  = 3'b101,
-    FUNCT3_C     = 3'b001,
-    FUNCT3_ZEXTH = 3'b100
+    FUNCT3_REV8   = 3'b101,
+    FUNCT3_C      = 3'b001,
+    FUNCT3_ZEXT_H = 3'b100
   } zbb_rev8_c_zexth_minor_opcode_e;
 
   typedef enum logic [2:0] {
@@ -523,10 +523,10 @@
   } a_minor_opcode_e;
 
   typedef enum logic [4:0] {
-    FUNCT5_C_SEXTB  = 5'b11001,
-    FUNCT5_C_ZEXTB  = 5'b11000,
-    FUNCT5_C_ZEXTH  = 5'b11010,
-    FUNCT5_C_SEXTH  = 5'b11011,
+    FUNCT5_C_SEXT_B  = 5'b11001,
+    FUNCT5_C_ZEXT_B  = 5'b11000,
+    FUNCT5_C_ZEXT_H  = 5'b11010,
+    FUNCT5_C_SEXT_H  = 5'b11011,
     FUNCT5_C_NOT    = 5'b11101
   } funct5_compressed_e;
 


### PR DESCRIPTION
Sync'ed naming convention between isacov and disassembler to fix coverage capture failure
ci_check OK