### PR TITLE
Add wrongly removed tdata3 coverage

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -370,6 +370,32 @@ module uvmt_cv32e40s_triggers_assert_cov
     p_dt_tcsr_not_implemented(ADDR_TDATA3)
   ) else `uvm_error(info_tag, "Access to tdata3 does not cause an illegal exception (when no higher priority exception has occured)\n");
 
+  // Assertions and coverages for when there are debug triggers:
+  if (CORE_PARAM_DBG_NUM_TRIGGERS != 0) begin
+
+    //2)
+    c_dt_access_tdata3_m2: cover property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL
+    );
+
+    c_dt_access_tdata3_etrigger: cover property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_ETRIGGER
+    );
+
+    c_dt_access_tdata3_m6: cover property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL6
+    );
+
+    c_dt_access_tdata3_disabled: cover property (
+      rvfi_if.is_csr_instr(ADDR_TDATA3)
+      && tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_DISABLED
+    );
+  end
+
+
   //- Vplan:
   //Have 0 triggers, access any trigger register and check that illegal instruction exception occurs.
   //Check that no triggers ever fire. Check that "tselect" is 0.


### PR DESCRIPTION
Formal compiles
hello-world passes
ci check is running

The coverage is removed in this PR: https://github.com/openhwgroup/core-v-verif/pull/2226
But the vplan ask to have these coverage points:
![image](https://github.com/openhwgroup/core-v-verif/assets/110398284/691fae66-f843-4603-b619-fc2711caca0a)
So therefore reinserting the coverage points.