### PR TITLE
Fix comment, and xsecure prefix.

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -359,11 +359,9 @@ module uvmt_cv32e40s_triggers_assert_cov
 
   //- Vplan:
   //Check that attempts to access "tdata3" raise an illegal instruction exception, always. (Unless overruled by a higher priority.)
-  //Verify that tdata3 is illegal for all tdata2 types.
 
   //- Assertion verification:
   //1) Check that attempts to access "tdata3" raise an illegal instruction exception, always. (Unless overruled by a higher priorit
-  //2) Verify that tdata3 is illegal for all tdata2 types.
 
   //1)
   a_dt_tdata3_not_implemented: assert property (

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
@@ -706,7 +706,7 @@ module uvmt_cv32e40s_xsecure_interface_integrity_assert
   ) else `uvm_error(info_tag_glitch, "The NMI caused by an associated parity/checksum error does not have exception code 1027 or 1026.\n");
 
   //Load instructions
-  c_glitch_xsecure_security_parity_checksum_fault_NMI_load_instruction: cover property (
+  c_glitch_xsecure_integrity_parity_checksum_fault_NMI_load_instruction: cover property (
 
     obi_data_rvalid
     && data_integrity_err
@@ -715,7 +715,7 @@ module uvmt_cv32e40s_xsecure_interface_integrity_assert
   );
 
   //Store instructions
-  c_glitch_xsecure_security_parity_checksum_fault_NMI_store_instruction: cover property (
+  c_glitch_xsecure_integrity_parity_checksum_fault_NMI_store_instruction: cover property (
 
     obi_data_rvalid
     && data_integrity_err


### PR DESCRIPTION
Remove comment about already removed code (see https://github.com/openhwgroup/core-v-verif/pull/2232)
Fix xsecure prefix.

Formal compiles
Hello-world passes
Didnt see the need for a ci check.