### PR TITLE
Added flag to prevent xcelium from searching for cds.lib/hdl.var

### DIFF
--- a/mk/uvmt/xrun.mk
+++ b/mk/uvmt/xrun.mk
@@ -46,6 +46,7 @@ XRUN_COMP_FLAGS  ?=               \
     -access +rwc                  \
     -nowarn UEXPSC                \
     -lwdgen                       \
+    -nocsf                        \
     -sv                           \
     -uvm                          \
     -uvmhome $(XRUN_UVMHOME_ARG)  \
@@ -56,6 +57,7 @@ XRUN_LDGEN_COMP_FLAGS ?=  \
     -64bit                \
     -disable_sem2009      \
     -access +rwc          \
+    -nocsf                \
     -nowarn UEXPSC        \
     -nowarn DLCPTH        \
     -sv                   \
@@ -71,7 +73,7 @@ XRUN_SINGLE_STEP ?=
 XRUN_ELAB_COV     = -covdut uvmt_$(CV_CORE_LC)_tb -coverage b:e:f:t:u
 XRUN_ELAB_COVFILE = -covfile $(abspath $(MAKE_PATH)/../tools/xrun/covfile.tcl)
 XRUN_RUN_COV      = -covscope uvmt_$(CV_CORE_LC)_tb -nowarn CGDEFN
-XRUN_RUN_BASE_FLAGS += -sv_lib $(DPI_DASM_LIB)
+XRUN_RUN_BASE_FLAGS += -nocsf -sv_lib $(DPI_DASM_LIB)
 
 # Only append the IMPERAS_DV_MODEL sv_lib flag if the file actually exists)
 ifneq (,$(wildcard $(IMPERAS_DV_MODEL)))


### PR DESCRIPTION
… unless explicitly specified

- Prevents slow elaboration when library files are not available