### PR TITLE
Added zcmt directed test (40S only), moved structs to bsp

### DIFF
--- a/cv32e40s/bsp/bsp.h
+++ b/cv32e40s/bsp/bsp.h
@@ -29,6 +29,43 @@ enum {
   EXC_CAUSE_INSTR_INTEGRITY_FAULT = 25,
 };
 
+typedef enum {
+  PMPMODE_OFF   = 0,
+  PMPMODE_TOR   = 1,
+  PMPMODE_NA4   = 2,
+  PMPMODE_NAPOT = 3
+} pmp_mode_t;
+
+// Verbosity levels (Akin to the uvm verbosity concept)
+typedef enum {
+  V_OFF    = 0,
+  V_LOW    = 1,
+  V_MEDIUM = 2,
+  V_HIGH   = 3,
+  V_DEBUG  = 4
+} verbosity_t;
+
+// Matches funct3 values for CSR instructions
+typedef enum {
+  CSRRW  = 1,
+  CSRRS  = 2,
+  CSRRC  = 3,
+  CSRRWI = 5,
+  CSRRSI = 6,
+  CSRRCI = 7
+} csr_instr_access_t;
+
+typedef union {
+  struct {
+    volatile uint32_t opcode   : 7;
+    volatile uint32_t rd       : 5;
+    volatile uint32_t funct3   : 3;
+    volatile uint32_t rs1_uimm : 5;
+    volatile uint32_t csr      : 12;
+  } volatile fields;
+  volatile uint32_t raw;
+} __attribute__((packed)) csr_instr_t;
+
 typedef union {
   struct {
     volatile uint32_t  load     : 1;
@@ -53,3 +90,76 @@ typedef union {
   } __attribute__((packed)) volatile fields;
   volatile uint32_t raw;
 } __attribute__((packed)) mcontrol6_t;
+
+typedef union {
+  struct {
+    volatile uint32_t uie   : 1;  //     0
+    volatile uint32_t sie   : 1;  //     1
+    volatile uint32_t wpri  : 1;  //     2
+    volatile uint32_t mie   : 1;  //     3
+    volatile uint32_t upie  : 1;  //     4
+    volatile uint32_t spie  : 1;  //     5
+    volatile uint32_t wpri0 : 1;  //     6
+    volatile uint32_t mpie  : 1;  //     7
+    volatile uint32_t spp   : 1;  //     8
+    volatile uint32_t wpri1 : 2;  // 10: 9
+    volatile uint32_t mpp   : 2;  // 12:11
+    volatile uint32_t fs    : 2;  // 14:13
+    volatile uint32_t xs    : 2;  // 16:15
+    volatile uint32_t mprv  : 1;  //    17
+    volatile uint32_t sum   : 1;  //    18
+    volatile uint32_t mxr   : 1;  //    19
+    volatile uint32_t tvm   : 1;  //    20
+    volatile uint32_t tw    : 1;  //    21
+    volatile uint32_t tsr   : 1;  //    22
+    volatile uint32_t wpri3 : 8;  // 30:23
+    volatile uint32_t sd    : 1;  //    31
+  } volatile fields;
+  volatile uint32_t raw;
+} __attribute__((packed)) mstatus_t;
+
+typedef union {
+  struct {
+    volatile uint32_t mml           : 1;
+    volatile uint32_t mmwp          : 1;
+    volatile uint32_t rlb           : 1;
+    volatile uint32_t reserved_31_3 : 29;
+  } __attribute__((packed)) volatile fields;
+  volatile uint32_t raw : 32;
+} __attribute__((packed)) mseccfg_t;
+
+typedef union {
+  struct {
+    volatile uint32_t reserved_1_0  : 2;
+    volatile uint32_t jvt_access    : 1;
+    volatile uint32_t reserved_31_3 : 29;
+  } __attribute__((packed)) volatile fields;
+  volatile uint32_t raw : 32;
+} __attribute__((packed)) mstateen0_t;
+
+typedef union {
+  struct {
+    volatile uint32_t r            : 1;
+    volatile uint32_t w            : 1;
+    volatile uint32_t x            : 1;
+    volatile uint32_t a            : 1;
+    volatile uint32_t reserved_6_5 : 2;
+    volatile uint32_t l            : 1;
+  } __attribute__((packed)) volatile fields;
+  volatile uint32_t raw : 8;
+} __attribute__((packed)) pmpsubcfg_t;
+
+typedef union {
+  struct {
+    volatile uint32_t cfg : 8;
+  } __attribute__((packed)) volatile reg_idx[4];
+  volatile uint32_t raw : 32;
+} __attribute__((packed)) pmpcfg_t;
+
+typedef union {
+  struct {
+    volatile uint32_t mode : 6;
+    volatile uint32_t base : 26;
+  } __attribute__((packed)) volatile fields;
+  volatile uint32_t raw : 32;
+} __attribute__((packed)) jvt_t;

--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -554,7 +554,7 @@ tests:
     cmd: make test TEST=debug_test_0_triggers
 
   wfe_test:
-    description: Short directed wfe test (needs PMP support)
+    description: Short directed wfe test
     builds: [ uvmt_cv32e40s_clic, uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=wfe_test
@@ -570,3 +570,9 @@ tests:
     builds: [ uvmt_cv32e40s_clic, uvmt_cv32e40s ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=xsecure_csrs
+
+  zcmt_test:
+    description: zcmt user-mode, mstateen0 directed test
+    builds: [ uvmt_cv32e40s_clic ]
+    dir: cv32e40s/sim/uvmt
+    cmd: make test TEST=zcmt_test

--- a/cv32e40s/tests/programs/custom/pmp_csr_access_test/pmp_csr_access_test.c
+++ b/cv32e40s/tests/programs/custom/pmp_csr_access_test/pmp_csr_access_test.c
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <assert.h>
+#include "bsp.h"
 #include "corev_uvmt.h"
 
 // MUST be 31 or less (bit position-1 in result array determines test pass/fail
@@ -44,34 +45,6 @@
   const volatile char * const volatile name = __FUNCTION__; \
   _Pragma("GCC diagnostic pop")
 
-typedef union {
-  struct {
-    volatile uint32_t opcode   : 7;
-    volatile uint32_t rd       : 5;
-    volatile uint32_t funct3   : 3;
-    volatile uint32_t rs1_uimm : 5;
-    volatile uint32_t csr      : 12;
-  } volatile fields;
-  volatile uint32_t raw;
-} __attribute__((packed)) csr_instr_t;
-
-// Matches funct3 values for CSR instructions
-typedef enum {
-  CSRRW  = 1,
-  CSRRS  = 2,
-  CSRRC  = 3,
-  CSRRWI = 5,
-  CSRRSI = 6,
-  CSRRCI = 7
-} csr_instr_access_t;
-
-typedef enum {
-  PMPMODE_OFF   = 0,
-  PMPMODE_TOR   = 1,
-  PMPMODE_NA4   = 2,
-  PMPMODE_NAPOT = 3
-} pmp_mode_t;
-
 // ---------------------------------------------------------------
 // Convenience macros for bit fields
 // ---------------------------------------------------------------
@@ -79,15 +52,6 @@ typedef enum {
 #define PMPCFG_BASE   0x3a0
 #define PMPADDR_BASE  0x3b0
 #define MSECCFG_BASE  0x747
-
-// Verbosity levels (Akin to the uvm verbosity concept)
-typedef enum {
-  V_OFF    = 0,
-  V_LOW    = 1,
-  V_MEDIUM = 2,
-  V_HIGH   = 3,
-  V_DEBUG  = 4
-} verbosity_t;
 
 // ---------------------------------------------------------------
 // Global variables

--- a/cv32e40s/tests/programs/custom/wfe_test/wfe_test.c
+++ b/cv32e40s/tests/programs/custom/wfe_test/wfe_test.c
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 #include <assert.h>
+#include "bsp.h"
 #include "corev_uvmt.h"
 
 // MUST be 31 or less (bit position-1 in result array determines test pass/fail
@@ -50,81 +51,9 @@
   const volatile char * const volatile name = __FUNCTION__; \
   _Pragma("GCC diagnostic pop")
 
-typedef union {
-  struct {
-    volatile uint32_t uie   : 1;  //     0
-    volatile uint32_t sie   : 1;  //     1
-    volatile uint32_t wpri  : 1;  //     2
-    volatile uint32_t mie   : 1;  //     3
-    volatile uint32_t upie  : 1;  //     4
-    volatile uint32_t spie  : 1;  //     5
-    volatile uint32_t wpri0 : 1;  //     6
-    volatile uint32_t mpie  : 1;  //     7
-    volatile uint32_t spp   : 1;  //     8
-    volatile uint32_t wpri1 : 2;  // 10: 9
-    volatile uint32_t mpp   : 2;  // 12:11
-    volatile uint32_t fs    : 2;  // 14:13
-    volatile uint32_t xs    : 2;  // 16:15
-    volatile uint32_t mprv  : 1;  //    17
-    volatile uint32_t sum   : 1;  //    18
-    volatile uint32_t mxr   : 1;  //    19
-    volatile uint32_t tvm   : 1;  //    20
-    volatile uint32_t tw    : 1;  //    21
-    volatile uint32_t tsr   : 1;  //    22
-    volatile uint32_t wpri3 : 8;  // 30:23
-    volatile uint32_t sd    : 1;  //    31
-  } volatile fields;
-  volatile uint32_t raw;
-} __attribute__((packed)) mstatus_t;
-
-typedef union {
-  struct {
-    volatile uint32_t mml           : 1;
-    volatile uint32_t mmwp          : 1;
-    volatile uint32_t rlb           : 1;
-    volatile uint32_t reserved_31_3 : 29;
-  } __attribute__((packed)) volatile fields;
-  volatile uint32_t raw : 32;
-} mseccfg_t;
-
-typedef union {
-  struct {
-    volatile uint32_t r            : 1;
-    volatile uint32_t w            : 1;
-    volatile uint32_t x            : 1;
-    volatile uint32_t a            : 1;
-    volatile uint32_t reserved_6_5 : 2;
-    volatile uint32_t l            : 1;
-  } __attribute__((packed)) volatile fields;
-  volatile uint32_t raw : 8;
-} __attribute__((packed)) pmpsubcfg_t;
-
-typedef union {
-  struct {
-    volatile uint32_t cfg : 8;
-  } __attribute__((packed)) volatile reg_idx[4];
-  volatile uint32_t raw : 32;
-} __attribute__((packed)) pmpcfg_t;
-
-typedef enum {
-  PMPMODE_OFF   = 0,
-  PMPMODE_TOR   = 1,
-  PMPMODE_NA4   = 2,
-  PMPMODE_NAPOT = 3
-} pmp_mode_t;
-
 // ---------------------------------------------------------------
 // Convenience macros for bit fields
 // ---------------------------------------------------------------
-
-// Verbosity levels (Akin to the uvm verbosity concept)
-typedef enum {
-  V_OFF    = 0,
-  V_LOW    = 1,
-  V_MEDIUM = 2,
-  V_HIGH   = 3,
-  V_DEBUG  = 4
-} verbosity_t;
 
 // ---------------------------------------------------------------
 // Global variables

--- a/cv32e40s/tests/programs/custom/zcmt_test/test.yaml
+++ b/cv32e40s/tests/programs/custom/zcmt_test/test.yaml
@@ -1,0 +1,7 @@
+name: zcmt_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    zcmt directed test
+plusargs: >
+cflags: >
+  -mno-relax

--- a/cv32e40s/tests/programs/custom/zcmt_test/zcmt_test.c
+++ b/cv32e40s/tests/programs/custom/zcmt_test/zcmt_test.c
@@ -33,7 +33,7 @@
 // status, thus we are limited to 31 tests with this construct.
 #define NUM_TESTS 11
 // Set which test index to start testing at (for quickly running specific tests during development)
-#define START_TEST_IDX 5
+#define START_TEST_IDX 0
 
 
 // __FUNCTION__ is C99 and newer, -Wpedantic flags a warning that
@@ -71,7 +71,6 @@ volatile verbosity_t global_verbosity = V_LOW;
 
 volatile uint32_t * volatile g_expect_illegal;
 volatile uint32_t * volatile g_expect_tablejmp;
-volatile uint32_t * volatile g_expect_tablejmp_idx;
 volatile uint32_t * volatile g_csr_instr;
 volatile uint32_t * volatile g_csr_instr_rd_val;
 volatile uint32_t * volatile g_csr_instr_rs1_val;
@@ -216,7 +215,6 @@ int main(int argc, char **argv){
 
   g_expect_illegal      = calloc(1, sizeof(uint32_t));
   g_expect_tablejmp     = calloc(1, sizeof(uint32_t));
-  g_expect_tablejmp_idx = calloc(1, sizeof(uint32_t));
   g_csr_instr           = calloc(1, sizeof(uint32_t));
   g_csr_instr_rd_val    = calloc(1, sizeof(uint32_t));
   g_csr_instr_rs1_val   = calloc(1, sizeof(uint32_t));
@@ -251,7 +249,6 @@ int main(int argc, char **argv){
   retval = get_result(test_res, tests);
 
   free((void *)g_expect_illegal       );
-  free((void *)g_expect_tablejmp_idx  );
   free((void *)g_csr_instr            );
   free((void *)g_csr_instr_rd_val     );
   free((void *)g_csr_instr_rs1_val    );

--- a/cv32e40s/tests/programs/custom/zcmt_test/zcmt_test.c
+++ b/cv32e40s/tests/programs/custom/zcmt_test/zcmt_test.c
@@ -1,0 +1,1747 @@
+//
+// Copyright 2022 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+//
+// Author: Henrik Fegran
+//
+// zcmt directed test
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <assert.h>
+#include "bsp.h"
+#include "corev_uvmt.h"
+
+// MUST be 31 or less (bit position-1 in result array determines test pass/fail
+// status, thus we are limited to 31 tests with this construct.
+#define NUM_TESTS 11
+// Set which test index to start testing at (for quickly running specific tests during development)
+#define START_TEST_IDX 5
+
+
+// __FUNCTION__ is C99 and newer, -Wpedantic flags a warning that
+// this is not ISO C, thus we wrap this instatiation in a macro
+// ignoring this GCC warning to avoid a long list of warnings during
+// compilation.
+#define SET_FUNC_INFO \
+  _Pragma("GCC diagnostic push") \
+  _Pragma("GCC diagnostic ignored \"-Wpedantic\"") \
+  const volatile char * const volatile name = __FUNCTION__; \
+  _Pragma("GCC diagnostic pop")
+
+
+// ---------------------------------------------------------------
+// Convenience macros for bit fields
+// ---------------------------------------------------------------
+#define MARCHID_CV32E40X 0x14
+#define MARCHID_CV32E40S 0x15
+
+#define OPCODE_SYSTEM  0x73
+
+#define MSTATEEN0_ADDR 0x30c
+#define MSECCFG_ADDR   0x747
+#define PMPCFG0_ADDR   0x3a0
+#define PMPADDR0_ADDR  0x3b0
+#define JVT_ADDR       0x017
+
+
+// ---------------------------------------------------------------
+// Global variables
+// ---------------------------------------------------------------
+// Print verbosity, consider implementing this as a virtual
+// peripheral setting to be controlled from UVM.
+volatile verbosity_t global_verbosity = V_LOW;
+
+volatile uint32_t * volatile g_expect_illegal;
+volatile uint32_t * volatile g_expect_tablejmp;
+volatile uint32_t * volatile g_expect_tablejmp_idx;
+volatile uint32_t * volatile g_csr_instr;
+volatile uint32_t * volatile g_csr_instr_rd_val;
+volatile uint32_t * volatile g_csr_instr_rs1_val;
+
+volatile uint32_t * volatile g_recovery_cm_jt;
+
+extern volatile uint32_t jvt_table;
+extern volatile uint32_t recovery_cm_jt_m_0;
+extern volatile uint32_t recovery_cm_jt_m_1;
+extern volatile uint32_t recovery_cm_jt_m_31;
+extern volatile uint32_t recovery_cm_jt_u_0;
+extern volatile uint32_t recovery_cm_jt_u_1;
+extern volatile uint32_t recovery_cm_jt_u_31;
+// ---------------------------------------------------------------
+// Test prototypes - should match
+// uint32_t <name>(uint32_t index, uint8_t report_name)
+//
+// Use template below for implementation
+// ---------------------------------------------------------------
+uint32_t mstateen0_rw_m(uint32_t index, uint8_t report_name);
+uint32_t mstateen0_rw_u_illegal(uint32_t index, uint8_t report_name);
+uint32_t jvt_rw_m(uint32_t index, uint8_t report_name);
+uint32_t jvt_rw_u_illegal(uint32_t index, uint8_t report_name);
+uint32_t jvt_rw_u_legal(uint32_t index, uint8_t report_name);
+uint32_t cm_jt_m(uint32_t index, uint8_t report_name);
+uint32_t cm_jalt_m(uint32_t index, uint8_t report_name);
+uint32_t cm_jt_u_illegal(uint32_t index, uint8_t report_name);
+uint32_t cm_jalt_u_illegal(uint32_t index, uint8_t report_name);
+uint32_t cm_jt_u_legal(uint32_t index, uint8_t report_name);
+uint32_t cm_jalt_u_legal(uint32_t index, uint8_t report_name);
+
+// ---------------------------------------------------------------
+// Generic test template:
+// ---------------------------------------------------------------
+// uint32_t <test_name>(uint32_t index, uint8_t report_name){
+//   volatile uint8_t test_fail = 0;
+//   /* Test variable instantiation */
+//
+//   SET_FUNC_INFO
+//
+//   if (report_name) {
+//     cvprintf(V_LOW, "\"%s\"", name);
+//     return 0;
+//   }
+//
+//   /* Insert test code here /*
+//
+//   if (test_fail) {
+//     cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+//     return index + 1;
+//   }
+//   cvprintf(V_MEDIUM, "\nTest: \"%s\" OK!\n", name);
+//   return 0;
+// }
+// ---------------------------------------------------------------
+
+// ---------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------
+/*
+ * set_test_status
+ *
+ * Sets the pass/fail criteria for a given tests and updates
+ * the 32bit test status variable.
+ *
+ * - test_no: current test index
+ * - val_prev: status vector variable, holding previous test results
+ */
+uint32_t set_test_status(uint32_t test_no, uint32_t val_prev);
+
+/*
+ * get_result
+ *
+ * Reports result of self checking tests
+ *
+ * - res: result-vector from previously run tests
+ * - ptr: Pointer to test functions, this is intended to be
+ *        invoked with "report_name == 1" here, as that will
+ *        only print the name of the test and not actually
+ *        run it.
+ */
+int get_result(uint32_t res, uint32_t (* volatile ptr[])(uint32_t, uint8_t));
+
+/*
+ * cvprintf
+ *
+ * verbosity controlled printf
+ * use as printf, but with an added verbosity-level setting
+ *
+ */
+int cvprintf(verbosity_t verbosity, const char *format, ...);
+
+/*
+ * set_mseccfg
+ *
+ * Sets up mseccfg with the provided
+ * mseccfg_t object
+ */
+void set_mseccfg(mseccfg_t mseccfg);
+
+/*
+ * set_pmpcfg
+ *
+ * Sets up pmp configuration for a given region
+ * (defined in pmpcfg_t object)
+ */
+void set_pmpcfg(pmpsubcfg_t pmpsubcfg, uint32_t reg_no);
+
+/*
+ * increment_mepc
+ *
+ * Increments mepc,
+ * incr_val 0 = auto detect
+ *          2 = halfword
+ *          4 = word
+ */
+void increment_mepc(volatile uint32_t incr_val);
+
+/*
+ * has_pmp_configured
+ *
+ * Returns 1 if pmp is enabled/supported else returns 0
+ */
+uint32_t has_pmp_configured(void);
+
+/*
+ * Non-standard illegal instruction and ecall handlers
+ */
+void handle_illegal_insn(void);
+void handle_ecall(void);
+void handle_ecall_u(void);
+
+// ---------------------------------------------------------------
+// Test entry point
+// ---------------------------------------------------------------
+int main(int argc, char **argv){
+
+  volatile uint32_t (* volatile tests[NUM_TESTS])(volatile uint32_t, volatile uint8_t);
+
+  volatile uint32_t test_res = 0x1;
+  volatile int      retval   = 0;
+
+  g_expect_illegal      = calloc(1, sizeof(uint32_t));
+  g_expect_tablejmp     = calloc(1, sizeof(uint32_t));
+  g_expect_tablejmp_idx = calloc(1, sizeof(uint32_t));
+  g_csr_instr           = calloc(1, sizeof(uint32_t));
+  g_csr_instr_rd_val    = calloc(1, sizeof(uint32_t));
+  g_csr_instr_rs1_val   = calloc(1, sizeof(uint32_t));
+  g_recovery_cm_jt      = calloc(1, sizeof(uint32_t));
+
+  // Add function pointers to new tests here
+  tests[0]  = mstateen0_rw_m;
+  tests[1]  = mstateen0_rw_u_illegal;
+  tests[2]  = jvt_rw_m;
+  tests[3]  = jvt_rw_u_illegal;
+  tests[4]  = jvt_rw_u_legal;
+  tests[5]  = cm_jt_m;
+  tests[6]  = cm_jalt_m;
+  tests[7]  = cm_jt_u_illegal;
+  tests[8]  = cm_jalt_u_illegal;
+  tests[9]  = cm_jt_u_legal;
+  tests[10] = cm_jalt_u_legal;
+
+  // TODO silabs-hfegran: defering these tests to a later PR
+  //tests[11] = cm_jt_m_trap_m;
+  //tests[12] = cm_jt_u_trap_u;
+  //tests[11] = cm_jalt_m_trap;
+  //tests[12] = cm_jalt_u_trap;
+
+  // Run all tests in list above
+  cvprintf(V_LOW, "\nZcmt Test start\n\n");
+  for (volatile int i = START_TEST_IDX; i < NUM_TESTS; i++) {
+    test_res = set_test_status(tests[i](i, (volatile uint32_t)(0)), test_res);
+  }
+
+  // Report failures
+  retval = get_result(test_res, tests);
+
+  free((void *)g_expect_illegal       );
+  free((void *)g_expect_tablejmp_idx  );
+  free((void *)g_csr_instr            );
+  free((void *)g_csr_instr_rd_val     );
+  free((void *)g_csr_instr_rs1_val    );
+  free((void *)g_recovery_cm_jt       );
+  return retval; // Nonzero for failing tests
+}
+
+// -----------------------------------------------------------------------------
+
+int cvprintf(volatile verbosity_t verbosity, const char * volatile format, ...){
+  va_list args;
+  volatile int retval = 0;
+
+  va_start(args, format);
+
+  if (verbosity <= global_verbosity){
+    retval = vprintf(format, args);
+  }
+  va_end(args);
+  return retval;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t set_test_status(uint32_t test_no, uint32_t val_prev){
+  volatile uint32_t res;
+  res = val_prev | (1 << test_no);
+  return res;
+}
+
+// -----------------------------------------------------------------------------
+
+int get_result(uint32_t res, uint32_t (* volatile ptr[])(uint32_t, uint8_t)){
+  cvprintf(V_LOW, "=========================\n");
+  cvprintf(V_LOW, "=        SUMMARY        =\n");
+  cvprintf(V_LOW, "=========================\n");
+  for (int i = START_TEST_IDX; i < NUM_TESTS; i++){
+    if ((res >> (i+1)) & 0x1) {
+      cvprintf (V_LOW, "Test %0d FAIL: ", i);
+      (void)ptr[i](i, 1);
+      cvprintf (V_LOW, "\n");
+    } else {
+      cvprintf (V_LOW, "Test %0d PASS: ", i);
+      (void)ptr[i](i, 1);
+      cvprintf (V_LOW, "\n");
+    }
+  }
+  if (res == 1) {
+    cvprintf(V_LOW, "\n\tALL SELF CHECKS PASS!\n\n");
+    return 0;
+  } else {
+    cvprintf(V_LOW, "\n\tSELF CHECK FAILURES OCCURRED!\n\n");
+    return res;
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t has_pmp_configured(void) {
+  volatile uint32_t pmpaddr0 = 0xffffffff;
+  volatile uint32_t pmpaddr0_backup = 0;
+  volatile uint32_t marchid = 0x0;
+
+  __asm__ volatile (R"(
+    csrrs %[marchid], marchid, zero
+  )":[marchid] "=r"(marchid));
+
+  // CV32E40X does not support PMP, skip
+  switch (marchid) {
+    case (MARCHID_CV32E40X):
+      return 0;
+      break;
+    case (MARCHID_CV32E40S):
+      ;; // Do nothing and continue execution
+      break;
+  }
+
+  __asm__ volatile (R"(
+    csrrw %[pmpaddr0_backup] , pmpaddr0, %[pmpaddr0]
+    csrrw %[pmpaddr0], pmpaddr0, %[pmpaddr0_backup]
+  )" :[pmpaddr0_backup] "+r"(pmpaddr0_backup),
+      [pmpaddr0]        "+r"(pmpaddr0));
+
+  return (pmpaddr0 != 0);
+}
+
+// -----------------------------------------------------------------------------
+
+void set_mseccfg(mseccfg_t mseccfg){
+
+  __asm__ volatile ( R"(
+    csrrs x0, mseccfg, %[cfg_vec]
+  )"
+      :
+      : [cfg_vec] "r"(mseccfg.raw)
+      :);
+
+  cvprintf(V_DEBUG, "Wrote mseccfg: 0x%08lx\n", mseccfg.raw);
+}
+
+// -----------------------------------------------------------------------------
+
+void __attribute__((naked)) call_word_instr(uint32_t instr_word){
+  __asm__ volatile ( R"(
+    .global ptr_loc
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw s0, 4(sp)
+
+    la s0, ptr_loc
+    sw a0, 0(s0)
+    fence.i
+    # ensure that we have a location to write our pointer
+    ptr_loc: .word(0x00000000)
+
+    lw s0, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+    ret
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t csr_instr(csr_instr_access_t funct3, uint32_t addr, uint32_t rs1_uimm_val) {
+  volatile csr_instr_t csr_instr = { 0 };
+
+  *g_csr_instr_rd_val  = 0;
+  *g_csr_instr_rs1_val = rs1_uimm_val;
+
+  switch (funct3) {
+    case CSRRW:
+    case CSRRS:
+    case CSRRC:
+      csr_instr = (csr_instr_t){
+        .fields.opcode   = OPCODE_SYSTEM,
+        .fields.rd       = 11, // a1 reg
+        .fields.funct3   = funct3,
+        .fields.rs1_uimm = (rs1_uimm_val == 0) ? 0 : 12, // a2 reg unless zero specified
+        .fields.csr      = addr
+      };
+      break;
+    case CSRRWI:
+    case CSRRSI:
+    case CSRRCI:
+      csr_instr = (csr_instr_t){
+        .fields.opcode   = OPCODE_SYSTEM,
+        .fields.rd       = 11, // a1 reg
+        .fields.funct3   = funct3,
+        .fields.rs1_uimm = rs1_uimm_val,
+        .fields.csr      = addr
+      };
+      break;
+    default: return 0;
+  }
+
+  *g_csr_instr = csr_instr.raw;
+
+  __asm__ volatile ( R"(
+    addi sp, sp, -16
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+    sw a2, 8(sp)
+    sw ra, 12(sp)
+
+    lw a0, g_csr_instr
+    lw a0, 0(a0)
+    lw a2, g_csr_instr_rs1_val
+    lw a2, 0(a2)
+    # must ensure that a1 is not some garbage value
+    add a1, zero, zero
+    jal ra, call_word_instr
+    lw a2, g_csr_instr_rd_val
+    sw a1, 0(a2)
+
+    lw ra, 12(sp)
+    lw a2, 8(sp)
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 16
+  )");
+
+  return *g_csr_instr_rd_val;
+}
+
+// -----------------------------------------------------------------------------
+
+void increment_mepc(volatile uint32_t incr_val) {
+  volatile uint32_t mepc = 0;
+
+  __asm__ volatile ( R"(
+    csrrs %[mepc], mepc, zero
+  )" : [mepc] "=r"(mepc));
+
+  if (incr_val == 0) {
+    // No increment specified, check *mepc instruction
+    if (((*(uint32_t *)mepc) & 0x3UL) == 0x3UL) {
+      // non-compressed
+      mepc += 4;
+    } else {
+      // compressed
+      mepc += 2;
+    }
+  } else {
+    // explicitly requested increment
+    mepc += incr_val;
+  }
+
+  __asm__ volatile ( R"(
+    csrrw zero, mepc, %[mepc]
+  )" :: [mepc] "r"(mepc));
+}
+
+// -----------------------------------------------------------------------------
+
+void __attribute__((naked)) handle_ecall(void){
+  __asm__ volatile ( R"(
+    j handle_ecall_u
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+void __attribute__((naked)) handle_ecall_u(void){
+  __asm__ volatile ( R"(
+    ## handle_ecall_u swaps privilege level,
+    ## if in M-mode -> mret to U
+    ## else U-mode -> mret to M
+
+    addi sp, sp, -12
+    sw   a0, 0(sp)
+    sw   a1, 4(sp)
+    sw   a2, 8(sp)
+
+    # Get current priv-mode
+    csrrs a2, mstatus, zero
+
+    # clear out non-mpp bits and set up a2 to update mpp
+    lui a1, 2
+    addi a1, a1, -2048
+    and a2, a2, a1
+
+    # check if we trapped from U or M-mode
+    beq a1, a2, 1f
+    j 2f
+
+    # mpp = M-mode -> U-mode
+    1:
+    csrrc zero, mstatus, a1
+    j 3f
+
+    # mpp = U-mode -> M-mode
+    2:
+    csrrs zero, mstatus, a1
+
+    3:
+    # Set 0 as argument for increment_mepc
+    addi a0, zero, 0
+    call increment_mepc
+
+    lw   a2, 8(sp)
+    lw   a1, 4(sp)
+    lw   a0, 0(sp)
+    addi sp, sp, 12
+
+    # return to regular bsp handler flow
+    j end_handler_ret
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+void __attribute__((naked)) handle_illegal_insn(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw   s0, 0(sp)
+    sw   s1, 4(sp)
+
+    # Decrement *g_expect_illegal
+    lw s0, g_expect_illegal
+    lw s1, 0(s0)
+    addi s1, s1, -1
+    sw s1, 0(s0)
+
+    lw s1, 4(sp)
+    lw s0, 0(sp)
+    addi sp, sp, 8
+
+    j end_handler_incr_mepc
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+void set_pmpcfg(pmpsubcfg_t pmpsubcfg, uint32_t reg_no){
+  volatile pmpcfg_t temp   = { 0 };
+  volatile pmpcfg_t pmpcfg = { 0 };
+
+  temp.reg_idx[reg_no % 4].cfg   = 0xff;
+  pmpcfg.reg_idx[reg_no % 4].cfg = pmpsubcfg.raw;
+
+  (void)csr_instr(CSRRC, PMPCFG0_ADDR + (reg_no / 4), temp.raw);
+  (void)csr_instr(CSRRS, PMPCFG0_ADDR + (reg_no / 4), pmpcfg.raw);
+
+  return;
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((naked)) void jvt_code(void) {
+  __asm__ volatile ( R"(
+    .option push
+    .option norvc
+    .global jvt_table
+    .extern jvt_index_1
+    .align 6
+    jvt_table:
+    index_0: .word(jvt_index_0)
+    index_1: .word(jvt_index_1)
+    .space 116, 0x0
+    index_31: .word(jvt_index_31)
+    index_32: .word(jvt_index_32)
+    .space 8
+    index_35: nop
+    .space 172, 0x0
+    index_79: .word(jvt_index_79)
+    .space 172, 0x0
+    index_123: nop
+    .space 524, 0x0
+    index_255: .word(jvt_index_255)
+    .option pop
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_0(void) {
+  __asm__ volatile ( R"(
+    lw a0, g_recovery_cm_jt
+    lw a0, 0(a0)
+    jalr zero, 0(a0)
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_1(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+
+    lw a0, g_expect_tablejmp
+    lw a1, 0(a0)
+    addi a1, a1, -1
+    sw a1, 0(a0)
+
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+
+    lw a0, g_recovery_cm_jt
+    lw a0, 0(a0)
+    jalr zero, 0(a0)
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_31(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+
+    lw a0, g_expect_tablejmp
+    lw a1, 0(a0)
+    addi a1, a1, -31
+    sw a1, 0(a0)
+
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+
+    lw a0, g_recovery_cm_jt
+    lw a0, 0(a0)
+    jalr zero, 0(a0)
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_32(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+
+    lw a0, g_expect_tablejmp
+    lw a1, 0(a0)
+    addi a1, a1, -32
+    sw a1, 0(a0)
+
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+    ret
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_79(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+
+    lw a0, g_expect_tablejmp
+    lw a1, 0(a0)
+    addi a1, a1, -79
+    sw a1, 0(a0)
+
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+    ret
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+__attribute__((optimize("align-functions=4"), naked)) void jvt_index_255(void) {
+  __asm__ volatile ( R"(
+    addi sp, sp, -8
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+
+    lw a0, g_expect_tablejmp
+    lw a1, 0(a0)
+    addi a1, a1, -255
+    sw a1, 0(a0)
+
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 8
+    ret
+
+  )");
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t mstateen0_rw_m(uint32_t index, uint8_t report_name){
+  volatile uint8_t     test_fail = 0;
+  volatile mstateen0_t mstateen0 = { 0 };
+  volatile mstateen0_t mstateen0_rval = { 0 };
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // CSRRW 0
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW 1 to bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0.fields.jvt_access = 1;
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  // Read pre-value, should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW 0 to bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0.fields.jvt_access = 0;
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW all 1s
+  *g_expect_illegal = 0;
+  mstateen0.raw = 0xffffffffUL;
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRC clear all bits
+  *g_expect_illegal = 0;
+  mstateen0.raw = 0xffffffffUL;
+  mstateen0_rval.raw = csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  // Check pre-value, only bit 2 should be 1
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Remaining bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRS set bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0.raw = 0x0UL;
+  mstateen0.fields.jvt_access = 1;
+  mstateen0_rval.raw = csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRC bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0.raw = 0x0UL;
+  mstateen0.fields.jvt_access = 1;
+  mstateen0_rval.raw = csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRS set all bits
+  *g_expect_illegal = 0;
+  mstateen0.raw = 0xffffffffUL;
+  mstateen0_rval.raw = csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI set bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x4UL);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI set all lower bits
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all lower bits
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRSI set bit 2
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x4UL);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI all lower bits
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x1fUL);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRSI set all lower bits
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI bit 2 (jvt)
+  *g_expect_illegal = 0;
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  // Read pre-value, jvt should be one
+  test_fail += (mstateen0_rval.fields.jvt_access != 1) ? 1 : 0;
+  mstateen0_rval.fields.jvt_access = 0;
+  // Check that all others bits were zero (RO bits)
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t mstateen0_rw_u_illegal(uint32_t index, uint8_t report_name){
+  volatile uint8_t     test_fail      = 0;
+  volatile mseccfg_t   mseccfg        = { 0 };
+  volatile mstateen0_t mstateen0      = { 0 };
+  volatile mstateen0_t mstateen0_rval = { 0 };
+  volatile uint32_t    pmpaddr        = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  // Switch to user mode
+  __asm__ volatile ( R"( ecall )");
+
+  // CSRRW 0
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRW 1 to bit 2 (jvt)
+  *g_expect_illegal = 2;
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRW 0 to bit 2 (jvt)
+  *g_expect_illegal = 2;
+  mstateen0.fields.jvt_access = 0;
+  (void)csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRW all 1s
+  *g_expect_illegal = 2;
+  mstateen0.raw = 0xffffffffUL;
+  (void)csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRW, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRC clear all bits
+  *g_expect_illegal = 2;
+  mstateen0.raw = 0xffffffffUL;
+  (void)csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRS set bit 2 (jvt)
+  *g_expect_illegal = 2;
+  mstateen0.raw = 0x0UL;
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRC bit 2 (jvt)
+  *g_expect_illegal = 2;
+  mstateen0.raw = 0x0UL;
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRS set all bits
+  *g_expect_illegal = 2;
+  mstateen0.raw = 0xffffffffUL;
+  (void)csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  mstateen0_rval.raw = csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRWI clear bit 2 (jvt)
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRWI set bit 2 (jvt)
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x4UL);
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x4UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRCI bit 2 (jvt)
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRWI set all bits
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRWI, MSTATEEN0_ADDR, 0xfffUL);
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0xfffUL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRWI clear all bits
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  mstateen0_rval.raw = csr_instr(CSRRWI, MSTATEEN0_ADDR, 0x0UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRSI set bit 2
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x4UL);
+  mstateen0_rval.raw = csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x4UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRCI all lower bits
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x1fUL);
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x1fUL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRSI set all lower bits
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x1fUL);
+  mstateen0_rval.raw = csr_instr(CSRRSI, MSTATEEN0_ADDR, 0x1fUL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+  // CSRRCI bit 2 (jvt)
+  *g_expect_illegal = 2;
+  (void)csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  mstateen0_rval.raw = csr_instr(CSRRCI, MSTATEEN0_ADDR, 0x4UL);
+  test_fail += (mstateen0_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+  assert(!test_fail);
+
+
+  // Switch back to machine mode
+  __asm__ volatile ( R"( ecall )");
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t jvt_rw_m(uint32_t index, uint8_t report_name){
+  volatile uint8_t test_fail = 0;
+  volatile jvt_t   jvt       = { 0 };
+  volatile jvt_t   jvt_rval  = { 0 };
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // CSRRW 0
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRW, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW all 1s
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRW, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRC clear all bits
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRC, JVT_ADDR, jvt.raw);
+  // Check pre-value, should be all 1s
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x3ffffffUL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRS set all bits
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRS, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  // Read pre-value, all bits should be 1
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x3ffffffUL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI set all lower bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI clear all lower bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRCI, JVT_ADDR, 0x1fUL);
+  // Read pre-value, all bits should be 1
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRSI set all lower bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  // Read pre-value, all bits should be 1
+  test_fail += (jvt_rval.fields.mode != 0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t jvt_rw_u_illegal(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail = 0;
+  volatile mseccfg_t mseccfg   = { 0 };
+  volatile uint32_t  jvt_rval  = 0UL;
+  volatile uint32_t  jvt       = 0UL;
+  volatile uint32_t  pmpaddr   = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  // Switch to user mode
+  __asm__ volatile ( R"( ecall )");
+
+  // CSRRW 0
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRW, JVT_ADDR, jvt);
+  (void)csr_instr(CSRRW, JVT_ADDR, jvt);
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW all 1s
+  *g_expect_illegal = 2;
+  jvt = 0xffffffffUL;
+  jvt_rval = csr_instr(CSRRW, JVT_ADDR, jvt);
+  (void)csr_instr(CSRRW, JVT_ADDR, jvt);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRC clear all bits
+  *g_expect_illegal = 2;
+  jvt = 0xffffffffUL;
+  jvt_rval = csr_instr(CSRRC, JVT_ADDR, jvt);
+  (void)csr_instr(CSRRC, JVT_ADDR, jvt);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRS set all bits
+  *g_expect_illegal = 2;
+  jvt = 0xffffffffUL;
+  jvt_rval = csr_instr(CSRRS, JVT_ADDR, jvt);
+  (void)csr_instr(CSRRS, JVT_ADDR, jvt);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all bits
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  (void)csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI set all lower bits
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRWI, JVT_ADDR, 0xfffUL);
+  (void)csr_instr(CSRRWI, JVT_ADDR, 0xfffUL);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI clear all lower bits
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRCI, JVT_ADDR, 0xfffUL);
+  (void)csr_instr(CSRRCI, JVT_ADDR, 0xfffUL);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRSI set all lower bits
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRWI, JVT_ADDR, 0xfffUL);
+  (void)csr_instr(CSRRWI, JVT_ADDR, 0xfffUL);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all
+  *g_expect_illegal = 2;
+  jvt_rval = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  (void)csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  test_fail += (jvt_rval != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // Switch back to machine mode
+  __asm__ volatile ( R"( ecall )");
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t jvt_rw_u_legal(uint32_t index, uint8_t report_name){
+  volatile uint8_t     test_fail = 0;
+  volatile mseccfg_t   mseccfg   = { 0 };
+  volatile jvt_t       jvt_rval  = { 0 };
+  volatile jvt_t       jvt       = { 0 };
+  volatile mstateen0_t mstateen0 = { 0 };
+  volatile uint32_t    pmpaddr   = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+
+  // Switch to user mode
+  __asm__ volatile ( R"( ecall )");
+
+  // CSRRW jvt_t
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRW, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRW all 1s
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRW, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRC clear all bits
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRC, JVT_ADDR, jvt.raw);
+  // Check pre-value, should be all 1s
+  test_fail += (jvt_rval.fields.mode != 0x0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x3ffffffUL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRS set all bits
+  *g_expect_illegal = 0;
+  jvt.raw = 0xffffffffUL;
+  jvt_rval.raw = csr_instr(CSRRS, JVT_ADDR, jvt.raw);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  // Read pre-value, all bits should be 1
+  test_fail += (jvt_rval.fields.mode != 0x0) ? 1 : 0;
+  test_fail += (jvt_rval.fields.base != 0x3ffffffUL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI set all lower bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRCI clear all lower bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRCI, JVT_ADDR, 0x1fUL);
+  // Read pre-value, all bits should be 0 due to RO .mode
+  test_fail += (jvt_rval.raw != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRSI set all bits
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x1fUL);
+  // Check pre-value, all bits should be zero
+  test_fail += (jvt_rval.raw != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // CSRRWI clear all
+  *g_expect_illegal = 0;
+  jvt_rval.raw = csr_instr(CSRRWI, JVT_ADDR, 0x0UL);
+  // Read pre-value, all bits should be 0 due to RO .mode
+  test_fail += (jvt_rval.raw != 0x0UL) ? 1 : 0;
+  test_fail += (*g_expect_illegal != 0) ? 1 : 0;
+
+  // Switch back to machine mode
+  __asm__ volatile ( R"( ecall )");
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t cm_jt_m(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail = 0;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+
+  *g_expect_tablejmp = 1 + 31;
+  __asm__ volatile ( R"(
+    .global recovery_cm_jt_m_0
+    .global recovery_cm_jt_m_1
+    .global recovery_cm_jt_m_31
+    addi sp, sp, -12
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+    sw a2, 8(sp)
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_m_0
+    sw a1, 0(a0)
+
+    cm.jt  0
+    recovery_cm_jt_m_0:
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_m_1
+    sw a1, 0(a0)
+
+    cm.jt  1
+    recovery_cm_jt_m_1:
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_m_31
+    sw a1, 0(a0)
+
+    cm.jt 31
+    recovery_cm_jt_m_31:
+
+    lw a2, 8(sp)
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 12
+  )" ::: "ra", "memory");
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t cm_jalt_m(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail = 0;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+  *g_expect_tablejmp = 32 + 79 + 255;
+
+  __asm__ volatile ( R"(
+    cm.jalt 32
+    cm.jalt 79
+    cm.jalt 255
+  )" ::: "ra", "memory");
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t cm_jt_u_illegal(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail = 0;
+  volatile mseccfg_t mseccfg   = { 0 };
+  volatile uint32_t  pmpaddr   = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+  *g_expect_tablejmp = 0;
+
+  __asm__ volatile ( R"(
+    ecall
+    cm.jt 0
+    cm.jt 1
+    cm.jt 15
+    cm.jt 16
+    cm.jt 30
+    cm.jt 31
+    ecall
+  )" ::: "ra", "memory");
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+uint32_t cm_jalt_u_illegal(uint32_t index, uint8_t report_name) {
+  volatile uint8_t   test_fail = 0;
+  volatile mseccfg_t mseccfg   = { 0 };
+  volatile uint32_t  pmpaddr   = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+  *g_expect_tablejmp = 0;
+
+  __asm__ volatile ( R"(
+    ecall
+    cm.jalt 32
+    cm.jalt 33
+    cm.jalt 127
+    cm.jalt 128
+    cm.jalt 254
+    cm.jalt 255
+    ecall
+  )" ::: "ra", "memory");
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t cm_jt_u_legal(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail   = 0;
+  volatile mseccfg_t mseccfg     = { 0 };
+  volatile mstateen0_t mstateen0 = { 0 };
+  volatile uint32_t  pmpaddr     = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+
+  *g_expect_tablejmp = 0 + 1 + 31;
+
+  __asm__ volatile ( R"(
+    .global recovery_cm_jt_u_0
+    .global recovery_cm_jt_u_1
+    .global recovery_cm_jt_u_31
+    ecall
+    addi sp, sp, -12
+    sw a0, 0(sp)
+    sw a1, 4(sp)
+    sw a2, 8(sp)
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_u_0
+    sw a1, 0(a0)
+
+    cm.jt  0
+    recovery_cm_jt_u_0:
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_u_1
+    sw a1, 0(a0)
+
+    cm.jt  1
+    recovery_cm_jt_u_1:
+
+    lw a0, g_recovery_cm_jt
+    la a1, recovery_cm_jt_u_31
+    sw a1, 0(a0)
+
+    cm.jt 31
+    recovery_cm_jt_u_31:
+
+    lw a2, 8(sp)
+    lw a1, 4(sp)
+    lw a0, 0(sp)
+    addi sp, sp, 12
+    ecall
+  )" ::: "ra", "memory");
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+
+uint32_t cm_jalt_u_legal(uint32_t index, uint8_t report_name){
+  volatile uint8_t   test_fail   = 0;
+  volatile mseccfg_t mseccfg     = { 0 };
+  volatile mstateen0_t mstateen0 = { 0 };
+  volatile uint32_t  pmpaddr     = 0xffffffffUL;
+
+  SET_FUNC_INFO
+
+  if (report_name) {
+    cvprintf(V_LOW, "\"%s\"", name);
+    return 0;
+  }
+
+  // Enable pmp-access for u-mode *full access for convenience*
+  mseccfg.fields.rlb = 1;
+  (void)csr_instr(CSRRW, MSECCFG_ADDR, mseccfg.raw);
+
+  set_pmpcfg((pmpsubcfg_t){
+      .fields.r = 1,
+      .fields.w = 1,
+      .fields.x = 1,
+      .fields.a = PMPMODE_TOR,
+      .fields.l = 0
+  }, 0);
+
+  (void)csr_instr(CSRRW, PMPADDR0_ADDR, pmpaddr);
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRS, MSTATEEN0_ADDR, mstateen0.raw);
+
+  (void)csr_instr(CSRRW, JVT_ADDR, ((uint32_t)&jvt_table));
+
+  *g_expect_tablejmp = 32 + 79 + 255;
+
+  __asm__ volatile ( R"(
+    ecall
+    cm.jalt 32
+    cm.jalt 79
+    cm.jalt 255
+    ecall
+  )" ::: "ra", "memory");
+
+  mstateen0.fields.jvt_access = 1;
+  (void)csr_instr(CSRRC, MSTATEEN0_ADDR, mstateen0.raw);
+
+  test_fail += (*g_expect_tablejmp != 0) ? 1 : 0;
+
+  if (test_fail) {
+    // Should never be here in this test case unless something goes really wrong
+    cvprintf(V_LOW, "\nTest: \"%s\" FAIL!\n", name);
+    return index + 1;
+  }
+  cvprintf(V_MEDIUM, "\nTest: \"%s\" No self checking in this test, OK!\n", name);
+  return 0;
+}
+


### PR DESCRIPTION
* Initial commit to close some obvious mstateen0/umode/zcmt coverage holes (not relevant for 40X)
* Moved commonly used structs to bsp.h
* Cleanup in wfe and pmp_csr_access tests