### PR TITLE
Removed dret to umode clears mintthresh assertion (no longer req)

### DIFF
--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_clic_interrupt_assert.sv
@@ -2943,19 +2943,6 @@ module uvmt_cv32e40s_clic_interrupt_assert
       `uvm_error(info_tag,
         $sformatf("mret to umode does not clear mintthresh"));
 
-    //dret to umode clears mintthresh
-    a_dret_umode_clear_mintthresh: assert property (
-      rvfi_if.is_dret
-      ##1 rvfi_valid[->1]
-      ##0 rvfi_if.is_umode
-      |->
-      csr_mintthresh_if.rvfi_csr_rdata == 0
-    )
-    else
-      `uvm_error(info_tag,
-        $sformatf("dret to umode does not clear mintthresh"));
-
-
     // this assert verifies that mode is correctly restored on an mret
     property p_mret_mode_mpp;
       logic [1:0] prev_mpp = '0;


### PR DESCRIPTION
Spec no longer has this requirement. 
vplan update in later commit