### PR TITLE
[CVA6] Verilator Tandem Support

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_constants.sv
@@ -44,8 +44,9 @@ localparam DEFAULT_ILEN     = 32;
 localparam DEFAULT_XLEN     = 32;
 localparam DEFAULT_NRET     = 1;
 
-const string format_header_str = "%15s | RVFI | %8s | %6s | %8s | %8s | %s | %03s | %08s | %03s | %08s | %03s | %08s | %03s | %08s | %08s | %s";
-const string format_instr_str  = "%15s | RVFI | %8d | %6d | %8x | %8s | %s | x%-2d | %08x | x%-2d | %08x | x%-2d | %08x";
+const string format_header_str = "%8s | RVFI | %8s | %6s | %8s | %8s | %s | %03s | %08s | %03s | %08s | %03s | %08s | %03s | %08s | %08s | %s";
+const string format_instr_str  = "%8s | RVFI | %8d | %6d | %8x | %8s | %s | x%-2d | %08x | x%-2d | %08x | x%-2d | %08x";
+`define FORMAT_INSTR_STR_MACRO "%8s | RVFI | %8d | %6d | %8x | %8s | %s | x%-2d | %08x | x%-2d | %08x | x%-2d | %08x"
 const string format_mem_str    = "| %02s | %08x | %08s |";
 
 `endif // __UVMA_RVFI_CONSTANTS_SV__

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_tdefs.sv
@@ -26,19 +26,19 @@ typedef enum bit[MODE_WL-1:0] {
 } uvma_rvfi_mode;
 
 
-typedef struct {
+typedef struct packed {
    longint unsigned         nret_id;
    longint unsigned         cycle_cnt;
    longint unsigned         order;
    longint unsigned         insn;
-   byte unsigned            trap;
+   longint unsigned         trap;
    longint unsigned         cause;
-   byte unsigned            halt;
-   byte unsigned            intr;
-   int unsigned             mode;
-   int unsigned             ixl;
-   int unsigned             dbg;
-   int unsigned             dbg_mode;
+   longint unsigned         halt;
+   longint unsigned         intr;
+   longint unsigned         mode;
+   longint unsigned         ixl;
+   longint unsigned         dbg;
+   longint unsigned         dbg_mode;
    longint unsigned         nmip;
 
    longint unsigned         insn_interrupt;
@@ -72,6 +72,13 @@ typedef struct {
    longint unsigned         mem_wmask;
 
 } st_rvfi;
+
+`define ST_NUM_WORDS (($size(st_rvfi)/$size(longint unsigned)))
+
+typedef union {
+    st_rvfi rvfi;
+    bit [63:0] array [`ST_NUM_WORDS-1:0] ;
+} union_rvfi;
 
 function string get_mode_str(uvma_rvfi_mode mode);
    case (mode)

--- a/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_spike.sv
+++ b/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_spike.sv
@@ -20,7 +20,6 @@
  * Component that implements reference model functionality with Spike
  */
 
-import "DPI-C" function void spike_step(output st_rvfi rvfi);
 
 class uvmc_rvfi_spike#(int ILEN=DEFAULT_ILEN,
                                   int XLEN=DEFAULT_XLEN
@@ -55,13 +54,15 @@ class uvmc_rvfi_spike#(int ILEN=DEFAULT_ILEN,
     */
    virtual function uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) step (int i, uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) t);
 
-       st_rvfi rvfi;
+       st_rvfi s_core, s_reference_model;
        uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) t_reference_model;
 
-       spike_step(rvfi);
+       s_core = t.seq2rvfi();
+
+       rvfi_spike_step(s_core, s_reference_model);
 
        t_reference_model = new("t_reference_model");
-       t_reference_model.rvfi2seq(rvfi);
+       t_reference_model.rvfi2seq(s_reference_model);
        return t_reference_model;
 
    endfunction : step

--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -94,8 +94,9 @@ VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 #
 # These all appear on the command line, from lowest precedence to
 # highest.
+SPIKE_HASH_VERSION:= $(shell git log -1 --pretty=tformat:"%h" -- .. )
 
-default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -Wno-nonportable-include-path -g -O2 -fPIC
+default-CFLAGS   := -DPREFIX=\"$(prefix)\" -Wall -Wno-unused -Wno-nonportable-include-path -g -O2 -fPIC -DSPIKE_HASH_VERSION=0x$(SPIKE_HASH_VERSION)
 default-CXXFLAGS := $(default-CFLAGS) -std=c++17
 
 mcppbs-CPPFLAGS := @CPPFLAGS@

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -3,13 +3,10 @@
 
 namespace openhw
 {
-    st_rvfi Processor::step(size_t n)
+    st_rvfi Processor::step(size_t n, st_rvfi reference)
     {
         st_rvfi rvfi;
-        rvfi.insn = 0; rvfi.pc_rdata = 0;
-        rvfi.rd1_addr = 0; rvfi.rd1_wdata = 0;
-        rvfi.rs1_addr = 0; rvfi.rs1_rdata = 0;
-        rvfi.rs2_addr = 0; rvfi.rs2_rdata = 0;
+        memset(&rvfi, 0, sizeof(st_rvfi));
 
         this->taken_trap = false;
 
@@ -99,6 +96,11 @@ namespace openhw
         this->taken_trap = true;
         this->which_trap = t.cause();
         processor_t::take_trap(t, epc);
+    }
+
+    Processor::~Processor()
+    {
+        delete this->isa;
     }
 
 }

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
@@ -10,7 +10,8 @@ namespace openhw
             Processor(const isa_parser_t *isa, const cfg_t* cfg,
                 simif_t* sim, uint32_t id, bool halt_on_reset,
                 FILE *log_file, std::ostream& sout_, Params& params); // because of command line option --log and -s we need both
-            st_rvfi step(size_t n);
+            ~Processor();
+            st_rvfi step(size_t n, st_rvfi reference);
             void initParams();
         protected:
             bool taken_trap;

--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
@@ -58,7 +58,7 @@ namespace openhw
         * * @param n:  Number of instructions to be finished
         * *
         * */
-        st_rvfi nstep(size_t n);
+        std::vector<st_rvfi> step(size_t n, std::vector<st_rvfi>& vreference);
 
         /*
         * Proposed consturctor for the Simulation class

--- a/vendor/riscv/riscv-isa-sim/riscv/Types.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Types.h
@@ -9,19 +9,20 @@
 #include <sys/types.h>
 #include "Params.h"
 
-typedef struct {
+
+typedef struct  {
    uint64_t                 nret_id;
    uint64_t                 cycle_cnt;
    uint64_t                 order;
    uint64_t                 insn;
-   uint8_t                  trap;
+   uint64_t                 trap;
    uint64_t                 cause;
-   uint8_t                  halt;
-   uint8_t                  intr;
-   uint32_t                 mode;
-   uint32_t                 ixl;
-   uint32_t                 dbg;
-   uint32_t                 dbg_mode;
+   uint64_t                 halt;
+   uint64_t                 intr;
+   uint64_t                 mode;
+   uint64_t                 ixl;
+   uint64_t                 dbg;
+   uint64_t                 dbg_mode;
    uint64_t                 nmip;
 
    uint64_t                 insn_interrupt;

--- a/vendor/riscv/riscv-isa-sim/riscv/dts.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/dts.cc
@@ -154,11 +154,13 @@ std::string dts_compile(const std::string& dts)
       step = write(dts_pipe[1], buf+done, len-done);
       if (step == -1) {
         std::cerr << "Failed to write dts: " << strerror(errno) << std::endl;
-        exit(1);
+        // Verilator fix | exit -> _exit
+        _exit(1);
       }
     }
     close(dts_pipe[1]);
-    exit(0);
+    // Verilator fix | exit -> _exit
+    _exit(0);
   }
 
   pid_t dtb_pid;
@@ -178,7 +180,8 @@ std::string dts_compile(const std::string& dts)
     close(dtb_pipe[1]);
     execlp(DTC, DTC, "-O", "dtb", (char *)0);
     std::cerr << "Failed to run " DTC ": " << strerror(errno) << std::endl;
-    exit(1);
+    // Verilator fix | exit -> _exit
+    _exit(1);
   }
 
   close(dts_pipe[1]);

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -21,6 +21,12 @@
 #include <cinttypes>
 #include "../VERSION"
 
+static void version(int exit_code = 1)
+{
+  fprintf(stderr, SPIKE_VERSION " %x\n", SPIKE_HASH_VERSION);
+  exit(exit_code);
+}
+
 static void help(int exit_code = 1)
 {
   fprintf(stderr, "Spike RISC-V ISA Simulator " SPIKE_VERSION "\n\n");
@@ -30,6 +36,7 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  -m<n>                 Provide <n> MiB of target memory [default 2048]\n");
   fprintf(stderr, "  -m<a:m,b:n,...>       Provide memory regions of size m and n bytes\n");
   fprintf(stderr, "                          at base addresses a and b (with 4 KiB alignment)\n");
+  fprintf(stderr, "  -v                    Print Spike version\n");
   fprintf(stderr, "  -d                    Interactive debug mode\n");
   fprintf(stderr, "  -g                    Track histogram of PCs\n");
   fprintf(stderr, "  -l                    Generate a log of execution\n");
@@ -428,6 +435,7 @@ int main(int argc, char** argv)
   option_parser_t parser;
   parser.help(&suggest_help);
   parser.option('h', "help", 0, [&](const char UNUSED *s){help(0);});
+  parser.option('v', "version", 0, [&](const char UNUSED *s){version(0);});
   parser.option('d', 0, 0, [&](const char UNUSED *s){debug = true;});
   parser.option('g', 0, 0, [&](const char UNUSED *s){histogram = true;});
   parser.option('l', 0, 0, [&](const char UNUSED *s){log = true;});


### PR DESCRIPTION
Main changes of the PR:
- Making all `st_rvfi` uint64_t
- Changing dpi to use `svOpenArrayHandle`
- Passing `st_rvfi` to Processor
- Verilator v5.018 support