### PR TITLE
Small fixes

### DIFF
--- a/cv32e40s/regress/cv32e40s_full.yaml
+++ b/cv32e40s/regress/cv32e40s_full.yaml
@@ -54,6 +54,11 @@ builds:
     cfg: pma_test_cfg_2
     dir: cv32e40s/sim/uvmt
 
+  uvmt_cv32e40s_pma_2_clic:
+    cmd: make comp_corev-dv comp
+    cfg: pma_test_cfg_2_clic
+    dir: cv32e40s/sim/uvmt
+
   uvmt_cv32e40s_pma_3:
     cmd: make comp_corev-dv comp
     cfg: pma_test_cfg_3
@@ -585,7 +590,7 @@ tests:
 
   minhv_pma_block:
     description: test minhv=1 and pma block of mepc address
-    builds: [ uvmt_cv32e40s_pma_2 ]
+    builds: [ uvmt_cv32e40s_pma_2_clic ]
     dir: cv32e40s/sim/uvmt
     cmd: make test TEST=minhv_pma_block
 

--- a/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_sl_trigger_match.sv
+++ b/cv32e40s/tb/uvmt/support_logic/uvmt_cv32e40s_sl_trigger_match.sv
@@ -76,11 +76,11 @@ module uvmt_cv32e40s_sl_trigger_match
         (rvfi.is_umode && in_support_if.tdata1_array[t][TDATA1_ET_U_MODE]));
 
 
-        // Trigger match instruction:
+      // Trigger match instruction:
       assign trigger_match_execute[t] = csr_conditions_m2_m6[t]
         && in_support_if.tdata1_array[t][TDATA1_EXECUTE]
         && system_conditions
-        && !rvfi.rvfi_trap.clicptr //TODO: KD: burde finne ut hvorfor clicptr er et unntak.
+        && !rvfi.rvfi_trap.clicptr
         && (((rvfi.rvfi_pc_rdata == in_support_if.tdata2_array[t]) && in_support_if.tdata1_array[t][TDATA1_MSB_MATCH:TDATA1_LSB_MATCH] == TDATA1_MATCH_WHEN_EQUAL)
         || ((rvfi.rvfi_pc_rdata >= in_support_if.tdata2_array[t]) && in_support_if.tdata1_array[t][TDATA1_MSB_MATCH:TDATA1_LSB_MATCH] == TDATA1_MATCH_WHEN_GREATER_OR_EQUAL)
         || ((rvfi.rvfi_pc_rdata < in_support_if.tdata2_array[t]) && in_support_if.tdata1_array[t][TDATA1_MSB_MATCH:TDATA1_LSB_MATCH] == TDATA1_MATCH_WHEN_LESSER));

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_triggers_assert_cov.sv
@@ -202,28 +202,33 @@ module uvmt_cv32e40s_triggers_assert_cov
   /////////// Sequences ///////////
 
   sequence seq_csr_read_mmode(csr_addr);
+    @(posedge clknrst_if.clk)
     valid_instr_in_mmode
     && rvfi_if.is_csr_read(csr_addr)
     && rvfi_if.rvfi_rd1_addr != 0;
   endsequence
 
   sequence seq_csr_write_mmode(csr_addr);
+    @(posedge clknrst_if.clk)
     valid_instr_in_mmode
     && rvfi_if.is_csr_write(csr_addr);
   endsequence
 
   sequence seq_csr_read_dmode(csr_addr);
+    @(posedge clknrst_if.clk)
     valid_instr_in_dmode
     && rvfi_if.is_csr_read(csr_addr)
     && rvfi_if.rvfi_rd1_addr != 0;
   endsequence
 
   sequence seq_csr_write_dmode(csr_addr);
+    @(posedge clknrst_if.clk)
     valid_instr_in_dmode
     && rvfi_if.is_csr_write(csr_addr);
   endsequence
 
   sequence seq_tdata1_m2_m6_or_disabled(t);
+    @(posedge clknrst_if.clk)
     valid_instr_in_dmode
     && tselect_pre_state == t
     && (tdata1_pre_state[MSB_TYPE:LSB_TYPE] == TTYPE_MCONTROL
@@ -232,6 +237,7 @@ module uvmt_cv32e40s_triggers_assert_cov
   endsequence
 
   sequence seq_etrigger_hit(t, priv_lvl, exception);
+    @(posedge clknrst_if.clk)
     support_if.trigger_match_exception[t]
     && !rvfi_if.rvfi_dbg_mode
     && priv_lvl
@@ -309,7 +315,7 @@ module uvmt_cv32e40s_triggers_assert_cov
 
   /////////// Assertions and Coverages ///////////
 
-  //Verify that it isonly possible to do 13 Memory transactions:
+  //Verify that it is only possible to do 13 Memory transactions:
   //TODO XIF: this might not be the case for xif, as it can potentionally do more:
 
   a_dt_max_memory_transaction: assert property (
@@ -453,9 +459,9 @@ module uvmt_cv32e40s_triggers_assert_cov
 
     //4)
     a_dt_tselect_higher_than_dbg_num_triggers: assert property(
-      rvfi_if.is_csr_instr(ADDR_TSELECT)
+      rvfi_if.rvfi_valid
       |->
-      rvfi_if.rvfi_rd1_wdata < CORE_PARAM_DBG_NUM_TRIGGERS
+      tselect_post_state < CORE_PARAM_DBG_NUM_TRIGGERS
     ) else `uvm_error(info_tag, "The CSR tselect is set to equal or higher than the number of trigger.\n");
 
 
@@ -946,6 +952,7 @@ module uvmt_cv32e40s_triggers_assert_cov
       && rvfi_if.rvfi_dbg_mode
       && dcsr_if.rvfi_csr_wmask
       |->
+      //If DCSR is written (wmask != 0) there must have been a csr write operation, and not due to a sideeffect of a trigger match
       rvfi_if.is_csr_write(ADDR_DCSR)
     ) else `uvm_error(info_tag, "Action is taken when there is a trigger match while in debug mode (dcsr is changed even though we dont do a dcsr write operation).\n");
 
@@ -954,6 +961,7 @@ module uvmt_cv32e40s_triggers_assert_cov
       && rvfi_if.rvfi_dbg_mode
       && dpc_if.rvfi_csr_wmask
       |->
+      //If DPC is written (wmask != 0) there must have been a csr write operation, and not due to a sideeffect of a trigger match
       rvfi_if.is_csr_write(ADDR_DPC)
     ) else `uvm_error(info_tag, "Action is taken when there is a trigger match while in debug mode (dpc is changed even though we dont do a dpc write operation).\n");
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_data_independent_timing_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_data_independent_timing_assert.sv
@@ -76,7 +76,7 @@ module uvmt_cv32e40s_xsecure_data_independent_timing_assert
     //There is therefor only 1 empty cycle after a branch instruction.
 
   sequence seq_no_mem_instr_for_cycles(x);
-    (!rvfi_if.is_mem_act)[*x];
+    @(posedge clk_i) (!rvfi_if.is_mem_act)[*x];
   endsequence
 
   a_xsecure_dataindtiming_branch_timing_pc_hardening_disabled: assert property (
@@ -114,7 +114,7 @@ module uvmt_cv32e40s_xsecure_data_independent_timing_assert
   //Verify that execution of division or (division)-remainder have non-varying timing when the data independent timing feature is enabled
 
   sequence seq_no_rvalid_for_past_34_cycles;
-    (!rvfi_if.rvfi_valid[*34] ##1 1);
+    @(posedge clk_i) (!rvfi_if.rvfi_valid[*34] ##1 1);
   endsequence
 
   a_xsecure_dataindtiming_div_rem_timing: assert property (

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_dummy_and_hint_assert.sv
@@ -702,6 +702,7 @@ module uvmt_cv32e40s_xsecure_dummy_and_hint_assert
   //Verify that the LFSR's seeds are reset when lockups are detected
 
   sequence seq_xsecure_dummy_hint_instr_LFSRx_lockup_detection(logic get_new_lfsr_value, logic seed_we, logic [31:0] seed_w_value, logic [31:0] lfsr_n);
+    @(posedge clk_i)
 
     (rnddummy_enabled || rndhint_enabled)
     && get_new_lfsr_value

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_pc_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_hardened_pc_assert.sv
@@ -195,6 +195,7 @@ module uvmt_cv32e40s_xsecure_hardened_pc_assert
   //Verify that the major alert is set due to pc hardening fault when the PC target of a jump instruction or a branch decision is unstable, and the PC hardening feature is enabled
 
   sequence seq_non_hardened_jump(kill, halt, instr, first_op, jump_addr);
+    @(posedge clk_i)
 
     (!kill && !halt) throughout
 

--- a/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
+++ b/cv32e40s/tb/uvmt/uvmt_cv32e40s_xsecure_assert/uvmt_cv32e40s_xsecure_interface_integrity_assert.sv
@@ -369,6 +369,7 @@ module uvmt_cv32e40s_xsecure_interface_integrity_assert
   //But only if integrity checking is enabled
 
   sequence seq_checksum_fault(rvalid, req_had_integrity, memory_op, rchk_input, rchk_calculated);
+    @(posedge clk_i)
     rvalid
     && req_had_integrity
     && memory_op

--- a/cv32e40s/tests/cfg/pma_test_cfg_2_clic.yaml
+++ b/cv32e40s/tests/cfg/pma_test_cfg_2_clic.yaml
@@ -2,8 +2,10 @@ name: pma_test_cfg_2
 description: PMA configuration for the PMA_TEST_CFG_2 test case
 compile_flags: >
    +define+PMA_TEST_CFG_2
+   +define+CLIC_EN
    +define+ZBA_ZBB_ZBC_ZBS
 plusargs: >
+   +enable_clic=1
    +enable_pma=1
    +enable_zca_extension=1
    +enable_zcb_extension=1
@@ -16,6 +18,13 @@ plusargs: >
    +enable_zbc_extension=1
    +enable_zbs_extension=1
 ovpsim: >
+   --override cpu/CLICLEVELS=256
+   --override cpu/CLICXCSW=T
+   --override cpu/CLICXNXTI=T
+   --override cpu/CLICSELHVEC=T
+   --override cpu/CLICINTCTLBITS=8
+   --override cpu/CLIC_version=master
+   --override cpu/externalCLIC=T
    --override cpu/PMP_registers=64
    --override cpu/PMP_undefined=T
    --override cpu/PMP_initialparams=T

--- a/cv32e40s/tests/programs/custom/mhpmcounter_write_test/test.yaml
+++ b/cv32e40s/tests/programs/custom/mhpmcounter_write_test/test.yaml
@@ -1,4 +1,4 @@
 name: mhpmcounter_write_test
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >
-    Write to mhpmcounters. Is only verifyed by ISS, should be verifyed that we get excpected behaviour?
+    Write to the mhpmcounters.


### PR DESCRIPTION
make pma 2 clic config
clock sequences for questa
remove todos, 
remove old comment
add comment to make assertions more understandable.

Addresses some of the comments in this PR https://github.com/openhwgroup/core-v-verif/pull/2314


Formal compiles
Ci check: pass