### PR TITLE
ISACOV : Coverage Update and tuning

### DIFF
--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_instr.sv
@@ -24,7 +24,8 @@ class uvma_isacov_instr_c#(int ILEN=DEFAULT_ILEN,
   bit           illegal;
 
   // Set for traped instructions, determines what should not be considered for coverage
-  bit [13:0]    trap;
+  bit [13:0]     trap;
+  bit [XLEN-1:0] cause;
 
   // Enumeration
   instr_name_t  name;
@@ -82,6 +83,7 @@ class uvma_isacov_instr_c#(int ILEN=DEFAULT_ILEN,
 
     `uvm_field_int(illegal,   UVM_ALL_ON | UVM_NOPRINT);
     `uvm_field_int(trap,      UVM_ALL_ON | UVM_NOPRINT);
+    `uvm_field_int(cause,      UVM_ALL_ON | UVM_NOPRINT);
     `uvm_field_int(csr_val,   UVM_ALL_ON | UVM_NOPRINT);
     `uvm_field_int(rs1,       UVM_ALL_ON | UVM_NOPRINT);
     `uvm_field_int(rs1_value, UVM_ALL_ON | UVM_NOPRINT);

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
@@ -27,6 +27,7 @@
 
 `define ISACOV_IGN_BINS \
     ignore_bins IGN_UNKNOWN = {UNKNOWN}; \
+    ignore_bins IGN_DRET = {DRET} `WITH (!debug_supported); \
     ignore_bins IGN_M = {MUL, MULH, MULHSU, MULHU, \
                          DIV, DIVU, REM, REMU, C_MUL} `WITH (!ext_m_supported); \
     ignore_bins IGN_C = {C_ADDI4SPN, C_LW, C_SW, C_NOP, \

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_mon.sv
@@ -141,6 +141,7 @@ function void uvma_isacov_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(IL
 
   // Mark trapped instructions from RVFI
   mon_trn.instr.trap = rvfi_instr.trap;
+  mon_trn.instr.cause = rvfi_instr.cause;
 
   // Attempt to decode instruction with Spike DASM
   instr_name = dasm_name(rvfi_instr.insn);

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_tdefs.sv
@@ -144,8 +144,7 @@ typedef enum {
   DIV_GROUP,
   ALOAD_GROUP,
   ASTORE_GROUP,
-  AMEM_GROUP,
-  ZCB_GROUP
+  AMEM_GROUP
 } instr_group_t;
 
 typedef enum bit[CSR_ADDR_WL-1:0] {


### PR DESCRIPTION
As in the CVA6 we don't have this trap signal (with 12 bit) to identify ecall_ebreak exception code, to work-arroud this I add cause flied and assign it ti rvfi_cause to terminate witch exception code, now we can cover ECALL, EBREAK, C_EBREAK instructions.
The second change is about the DRET instruction, so I conditional it to be define in the coverage if only we're in debug mode, if not is an illegal instruction (and no need to cover it).
The last change related to ZCB instruction, I fix C.MUL instruction covergroup & remove ZCB_GROUP (isn't used)