### PR TITLE
Bugfix/unsupported with

### DIFF
--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
@@ -12,7 +12,7 @@
 `define __UVMA_CVXIF_COV_MODEL_SV__
 
 `ifdef UNSUPPORTED_WITH //TODO - Remove ifdef when the issue in VCS simulator is fixed
-  `define WITH `WITH
+  `define WITH iff
 `else
    `define WITH with
 `endif


### PR DESCRIPTION
This fix is suggested in the context of supporting Cadence Xcelium simulator for cva6 verification.

There is a VCS bug which does not support correctly the difference between with and iff keywords. A missing define needs to be added in order to allow xcelium to compile.

This has been check with VCS 2021.09.