### PR TITLE
[Xcelium support] Bugfix uvm sysverilog compliant

### DIFF
--- a/lib/uvm_agents/uvma_axi/src/comps/uvma_axi_seq_item_logger.sv
+++ b/lib/uvm_agents/uvma_axi/src/comps/uvma_axi_seq_item_logger.sv
@@ -34,7 +34,6 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
    /**
     * Writes contents of t to disk.
     */
-//   virtual function void write(uvma_axi_base_seq_item_c trs);
    virtual function void write(uvma_axi_base_seq_item_c t);
       if(cntxt.reset_state == UVMA_AXI_RESET_STATE_POST_RESET)begin
 

--- a/lib/uvm_agents/uvma_axi/src/comps/uvma_axi_seq_item_logger.sv
+++ b/lib/uvm_agents/uvma_axi/src/comps/uvma_axi_seq_item_logger.sv
@@ -34,7 +34,8 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
    /**
     * Writes contents of t to disk.
     */
-   virtual function void write(uvma_axi_base_seq_item_c trs);
+//   virtual function void write(uvma_axi_base_seq_item_c trs);
+   virtual function void write(uvma_axi_base_seq_item_c t);
       if(cntxt.reset_state == UVMA_AXI_RESET_STATE_POST_RESET)begin
 
          string write_address_access = "";
@@ -61,16 +62,16 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
          string r_id_str     = "";
          string r_access_complet = "";
 
-         if(trs.aw_valid && trs.aw_ready) begin
+         if(t.aw_valid && t.aw_ready) begin
 
             write_address_access = "write_address_access";
-            if(trs.aw_lock) begin
+            if(t.aw_lock) begin
                aw_access_type = "Exclusive_access";
             end else begin
                aw_access_type = "Normal_access";
             end
-            aw_address = $sformatf("%h", trs.aw_addr);
-            aw_id_str = $sformatf("%b", trs.aw_id);
+            aw_address = $sformatf("%h", t.aw_addr);
+            aw_id_str = $sformatf("%b", t.aw_id);
             fwrite($sformatf("----> %t | %s | %s | %s | %s", $realtime(), write_address_access, aw_address, aw_access_type, aw_id_str));
 
          end else begin
@@ -82,11 +83,11 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
 
          end
 
-         if(trs.w_valid && trs.w_ready) begin
+         if(t.w_valid && t.w_ready) begin
 
             write_data_access = "write_data_access";
-            w_data = $sformatf("%h", trs.w_data);
-            if(trs.w_last) begin
+            w_data = $sformatf("%h", t.w_data);
+            if(t.w_last) begin
                w_access_complet = "Yes";
             end else begin
                w_access_complet = "No";
@@ -101,17 +102,17 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
 
          end
 
-         if(trs.b_valid && trs.b_ready) begin
+         if(t.b_valid && t.b_ready) begin
 
             write_response_access = "write_response_access";
-            case (trs.b_resp)
+            case (t.b_resp)
                00 : b_err = "No Err";
                01 : b_err  = "Err";
                10 : b_err  = "Err";
                11 : b_err  = "Err";
                default : b_err = " ? ";
             endcase
-            b_id_str = $sformatf("%b", trs.b_id);
+            b_id_str = $sformatf("%b", t.b_id);
             fwrite($sformatf("----> %t | %s | __ | %s | __ | %s", $realtime(), write_response_access, b_id_str, b_err));
 
          end else begin
@@ -122,16 +123,16 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
 
          end
 
-         if(trs.ar_valid && trs.ar_ready) begin
+         if(t.ar_valid && t.ar_ready) begin
 
             read_address_access = "read_address_access";
-            if(trs.ar_lock) begin
+            if(t.ar_lock) begin
                ar_access_type = "Exclusive_access";
             end else begin
                ar_access_type = "Normal_access";
             end
-            ar_address = $sformatf("%h", trs.ar_addr);
-            ar_id_str = $sformatf("%b", trs.ar_id);
+            ar_address = $sformatf("%h", t.ar_addr);
+            ar_id_str = $sformatf("%b", t.ar_id);
             fwrite($sformatf("----> %t | %s | %s | %s | %s", $realtime(), read_address_access, ar_address, ar_access_type, ar_id_str));
 
          end else begin
@@ -143,17 +144,17 @@ class uvma_axi_seq_item_logger_c extends uvml_logs_seq_item_logger_c #(
 
          end
 
-         if(trs.r_valid && trs.r_ready) begin
+         if(t.r_valid && t.r_ready) begin
 
             read_data_access = "read_data_access";
-            r_data = $sformatf("%h", trs.r_data);
-            r_id_str = $sformatf("%b", trs.r_id);
-            if(trs.r_last) begin
+            r_data = $sformatf("%h", t.r_data);
+            r_id_str = $sformatf("%b", t.r_id);
+            if(t.r_last) begin
                r_access_complet = "Yes";
             end else begin
                r_access_complet = "No";
             end
-            case (trs.r_resp)
+            case (t.r_resp)
                00 : r_err = "No Err";
                01 : r_err  = "Err";
                10 : r_err  = "Err";

--- a/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
@@ -173,7 +173,9 @@ module uvma_cvxif_assert #(parameter X_ID_WIDTH    = cvxif_pkg::X_ID_WIDTH,
       end
    end
    property p_result_dualwrite;
-      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we[X_RFW_WIDTH/riscv::XLEN-1])) |-> cvxif_assert.cvxif_resp_o.x_result.we[0];
+//      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we[X_RFW_WIDTH/riscv::XLEN-1])) |-> cvxif_assert.cvxif_resp_o.x_result.we[0];
+//      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we[X_RFW_WIDTH/riscv::XLEN-1])) |-> cvxif_assert.cvxif_resp_o.x_result.we;
+      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we)) |-> cvxif_assert.cvxif_resp_o.x_result.we;
    endproperty
 
 endmodule : uvma_cvxif_assert

--- a/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
@@ -173,8 +173,6 @@ module uvma_cvxif_assert #(parameter X_ID_WIDTH    = cvxif_pkg::X_ID_WIDTH,
       end
    end
    property p_result_dualwrite;
-//      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we[X_RFW_WIDTH/riscv::XLEN-1])) |-> cvxif_assert.cvxif_resp_o.x_result.we[0];
-//      (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we[X_RFW_WIDTH/riscv::XLEN-1])) |-> cvxif_assert.cvxif_resp_o.x_result.we;
       (cvxif_assert.cvxif_resp_o.x_result_valid && (cvxif_assert.cvxif_resp_o.x_result.we)) |-> cvxif_assert.cvxif_resp_o.x_result.we;
    endproperty
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
@@ -95,10 +95,10 @@ class uvma_rvfi_agent_c#(int ILEN=DEFAULT_ILEN,
     */
    extern function void connect_trn_loggers();
 
-//    /**
-//     * Connects reference model port to monitor analysis ports.
-//     */
-//    extern function void connect_reference_model();
+   /**
+    * Connects reference model port to monitor analysis ports.
+    */
+   //extern function void connect_reference_model();
 
 endclass : uvma_rvfi_agent_c
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
@@ -95,11 +95,6 @@ class uvma_rvfi_agent_c#(int ILEN=DEFAULT_ILEN,
     */
    extern function void connect_trn_loggers();
 
-   /**
-    * Connects reference model port to monitor analysis ports.
-    */
-   //extern function void connect_reference_model();
-
 endclass : uvma_rvfi_agent_c
 
 

--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_agent.sv
@@ -95,10 +95,10 @@ class uvma_rvfi_agent_c#(int ILEN=DEFAULT_ILEN,
     */
    extern function void connect_trn_loggers();
 
-   /**
-    * Connects reference model port to monitor analysis ports.
-    */
-   extern function void connect_reference_model();
+//    /**
+//     * Connects reference model port to monitor analysis ports.
+//     */
+//    extern function void connect_reference_model();
 
 endclass : uvma_rvfi_agent_c
 

--- a/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_reference_model.sv
+++ b/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_reference_model.sv
@@ -27,8 +27,6 @@ class uvmc_rvfi_reference_model#(int ILEN=DEFAULT_ILEN,
    `uvm_component_utils_end
 
 
-//     uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_imp;
-//     uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_port;
     uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_imp;
     uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN)) m_analysis_port;
 

--- a/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_reference_model.sv
+++ b/lib/uvm_components/uvmc_rvfi_reference_model/uvmc_rvfi_reference_model.sv
@@ -27,8 +27,10 @@ class uvmc_rvfi_reference_model#(int ILEN=DEFAULT_ILEN,
    `uvm_component_utils_end
 
 
+//     uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_imp;
+//     uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_port;
     uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_imp;
-    uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_reference_model) m_analysis_port;
+    uvm_analysis_port#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN)) m_analysis_port;
 
    // Core configuration (used to extract list of CSRs)
    uvma_core_cntrl_cfg_c         cfg;

--- a/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard.sv
+++ b/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard.sv
@@ -23,12 +23,14 @@
  * Scoreboard component which compares RVFI transactions comming from the
  * core and the reference model
  */
+// class uvmc_rvfi_scoreboard_c#(int ILEN=DEFAULT_ILEN,
+//                                   int XLEN=DEFAULT_XLEN) extends uvm_scoreboard#(
+//    .T_TRN  (uvml_trn_seq_item_c),
+//    .T_CFG  (uvma_rvfi_cfg_c    ),
+//    .T_CNTXT(uvma_rvfi_cntxt_c  )
+// );
 class uvmc_rvfi_scoreboard_c#(int ILEN=DEFAULT_ILEN,
-                                  int XLEN=DEFAULT_XLEN) extends uvm_scoreboard#(
-   .T_TRN  (uvml_trn_seq_item_c),
-   .T_CFG  (uvma_rvfi_cfg_c    ),
-   .T_CNTXT(uvma_rvfi_cntxt_c  )
-);
+                                  int XLEN=DEFAULT_XLEN) extends uvm_scoreboard;
 
    uvm_analysis_imp_rvfi_instr_reference_model#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_scoreboard_c) m_imp_reference_model;
    uvm_analysis_imp_rvfi_instr_core#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvmc_rvfi_scoreboard_c) m_imp_core;

--- a/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard.sv
+++ b/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard.sv
@@ -23,12 +23,6 @@
  * Scoreboard component which compares RVFI transactions comming from the
  * core and the reference model
  */
-// class uvmc_rvfi_scoreboard_c#(int ILEN=DEFAULT_ILEN,
-//                                   int XLEN=DEFAULT_XLEN) extends uvm_scoreboard#(
-//    .T_TRN  (uvml_trn_seq_item_c),
-//    .T_CFG  (uvma_rvfi_cfg_c    ),
-//    .T_CNTXT(uvma_rvfi_cntxt_c  )
-// );
 class uvmc_rvfi_scoreboard_c#(int ILEN=DEFAULT_ILEN,
                                   int XLEN=DEFAULT_XLEN) extends uvm_scoreboard;
 


### PR DESCRIPTION
Those minor fixes are suggested in the context of supporting Cadence Xcelium simulator for cva6 verification.
Those modifications allows Xcelium to compile and does not impact VCS usage.

This has been check with VCS 2021.09.
