### PR TITLE
[Xcelium support] Remove void from DPI definition

### DIFF
--- a/lib/uvm_agents/uvma_axi/src/uvma_axi_pkg.sv
+++ b/lib/uvm_agents/uvma_axi/src/uvma_axi_pkg.sv
@@ -35,7 +35,7 @@ package uvma_axi_pkg;
 
    import "DPI-C" function read_elf(input string filename);
    import "DPI-C" function byte get_section(output longint address, output longint len);
-   import "DPI-C" context function void read_section_sv(input longint address, inout byte buffer[]);
+   import "DPI-C" context function read_section_sv(input longint address, inout byte buffer[]);
 
    localparam NrSlaves      = 2; // actually masters, but slaves on the crossbar
    localparam IdWidth       = 4; // 4 is recommended by AXI standard, so lets stick to it, do not change


### PR DESCRIPTION
Those minor fixes are suggested in the context of supporting Cadence Xcelium simulator for cva6 verification.
Xcelium does not allow the DPI function to be to return a void value.

This means in CVA6 repository, the reference to this function must be updated! If a positive feedback is given, I should created a PR should on cva6 repository and update the core-v-verif hash submodule.

This has been check with VCS 2021.09: the behavior is the same than previous on our side.
