### PR TITLE
Adding make targets needed to run riscof arch-tests for cv32e40x

### DIFF
--- a/bin/clonetb
+++ b/bin/clonetb
@@ -81,7 +81,7 @@ clone() {
 clone_cv32e40x() {
   CV_CORE=cv32e40x
   VERIF_ENV_REPO=https://github.com/openhwgroup/cv32e40x-dv.git
-  VERIF_ENV_REF=a78635844f929fe7a852e3ddcd15dd809c377850
+  VERIF_ENV_REF=d2ef40f9338a05af4ed9551a1c75d53370744e64
   clone
 
   ignore_cloned_directory

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -232,7 +232,7 @@ endif
 ###############################################################################
 # cfg
 CFGYAML2MAKE = $(CORE_V_VERIF)/bin/cfgyaml2make
-CFG_YAML_PARSE_TARGETS=comp ldgen comp_corev-dv gen_corev-dv test hex clean_hex corev-dv sanity-veri-run bsp compliance
+CFG_YAML_PARSE_TARGETS=comp ldgen comp_corev-dv gen_corev-dv test hex clean_hex corev-dv sanity-veri-run bsp compliance riscof_sim_run
 ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(CFG),)
 ifneq ($(CFG_PATH_OVERRIDE),)

--- a/mk/riscof.mk
+++ b/mk/riscof.mk
@@ -2,6 +2,7 @@
 #
 # Copyright 2023 OpenHW Group
 # Copyright 2023 Dolphin Design
+# Copyright 2024 Silicon Labs
 #
 # Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mk/riscof.mk
+++ b/mk/riscof.mk
@@ -1,0 +1,95 @@
+###############################################################################
+#
+# Copyright 2023 OpenHW Group
+# Copyright 2023 Dolphin Design
+#
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://solderpad.org/licenses/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+#
+# This Makefile adds RISCOF RISCV-ARCH-TEST SUITE, related make variables
+# to support running of riscof's riscv-arch-test suite within the core-v-verif
+# testbench
+#
+###############################################################################
+
+RISCOF_ARCH_TEST_SUITE_PKG   := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscof/riscof_arch_test_suite
+RISCOF_SIM ?= NO
+
+RISCOF_TEST_PLUSARGS ?= +signature=DUT-$(CV_CORE).signature
+RISCOF_TEST_RUN_DIR ?=$(SIM_CFG_RESULTS)/riscof_dut_work
+SIM_RISCOF_ARCH_TESTS_RESULTS ?= $(RISCOF_TEST_RUN_DIR)
+
+RISCOF_CONFIG_FILE    ?= config.ini
+RISCOF_VERBOSE        ?= info
+
+###############################################################################
+# Generate command to clone RISCOF RISCV-ARCH-TEST SUITE
+RISCOF_TEST_SUITE_CLONE_CMD = git clone -b $(RISCOF_ARCH_TEST_SUITE_BRANCH) --single-branch $(RISCOF_ARCH_TEST_SUITE_REPO) --recurse $(RISCOF_ARCH_TEST_SUITE_PKG)
+
+ifeq ($(RISCOF_ARCH_TEST_SUITE_TAG), latest)
+  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = riscof --verbose $(RISCOF_VERBOSE) arch-test --clone --dir $(RISCOF_ARCH_TEST_SUITE_PKG)
+else
+  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = $(RISCOF_TEST_SUITE_CLONE_CMD); cd $(RISCOF_ARCH_TEST_SUITE_PKG); git checkout $(RISCOF_ARCH_TEST_SUITE_TAG)
+endif
+
+###############################################################################
+#Clean riscof riscv-arch-test suite
+clean_riscof_arch_test_suite:
+	rm -rf $(RISCOF_ARCH_TEST_SUITE_PKG)
+
+
+###############################################################################
+#Clone the riscv-arch-test suite in core-v-verif for running the tests
+clone_riscof_arch_test_suite: $(RISCOF_ARCH_TEST_SUITE_PKG)
+
+$(RISCOF_ARCH_TEST_SUITE_PKG):
+	$(CLONE_RISCOF_ARCH_TEST_SUITE_CMD)
+
+###############################################################################
+#RISCOF Validate YAML Command
+ifeq ($(call IS_YES,$(RISCOF_SIM)),YES)
+RISCOF_VALIDATE_YAML_CMD = riscof validateyaml --config=$(RISCOF_CONFIG_FILE) --work-dir=$(SIM_CFG_RESULTS)/riscof_work
+else
+RISCOF_VALIDATE_YAML_CMD = echo $(RISCOF_SIM)
+endif
+
+.PHONY: riscof_validate_yaml
+riscof_validate_yaml:
+	$(shell $(RISCOF_VALIDATE_YAML_CMD))
+
+###############################################################################
+#RISCOF Get Testlist Command
+ifeq ($(call IS_YES,$(RISCOF_SIM)),YES)
+RISCOF_GET_TESTLIST_CMD = riscof testlist --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(SIM_CFG_RESULTS)/riscof_work
+else
+RISCOF_GET_TESTLIST_CMD = echo $(RISCOF_SIM)
+endif
+
+.PHONY: riscof_get_testlist
+riscof_get_testlist: 
+	$(shell $(RISCOF_GET_TESTLIST_CMD))
+
+#################################################################################
+##RISCOF Run Command
+RISCOF_RUN_ALL_CMD = riscof --verbose $(RISCOF_VERBOSE) run --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(SIM_CFG_RESULTS)/riscof_work
+ifeq ($(call IS_NO,$(RISCOF_REF_RUN)),NO)
+  RISCOF_RUN_ALL_CMD += --no-ref-run
+endif
+ifeq ($(call IS_NO,$(RISCOF_DUT_RUN)),NO)
+  RISCOF_RUN_ALL_CMD += --no-dut-run
+endif
+
+.PHONY: riscof_run_all
+riscof_run_all: 
+	$(shell $(RISCOF_RUN_ALL_CMD))

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -358,6 +358,11 @@ isacov_logdiff:
 		@(test ! -s $(ISACOV_LOGDIR)/isacov_logdiff && echo OK) || (echo FAIL; false)
 
 ###############################################################################
+# RISCOF Makefile:
+#    - RISCOF Compliance Test Suite and Variables for build and simulations
+include $(CORE_V_VERIF)/mk/riscof.mk
+
+###############################################################################
 # Include the targets/rules for the selected SystemVerilog simulator
 #ifeq ($(SIMULATOR), unsim)
 #include unsim.mk


### PR DESCRIPTION
Porting over the RISC-V architecture tests from E40P over to the cv32e40x. This makes it possible to run the full riscof complience test suite for the cv32e40x.