### PR TITLE
Cleaning up the riscof makefile and fixing cwd issue

### DIFF
--- a/mk/riscof.mk
+++ b/mk/riscof.mk
@@ -26,64 +26,16 @@
 
 RISCOF_ARCH_TEST_SUITE_PKG   := $(CORE_V_VERIF)/$(CV_CORE_LC)/vendor_lib/riscof/riscof_arch_test_suite
 RISCOF_SIM ?= NO
-
 RISCOF_TEST_PLUSARGS ?= +signature=DUT-$(CV_CORE).signature
 RISCOF_TEST_RUN_DIR ?=$(SIM_CFG_RESULTS)/riscof_dut_work
+RISCOF_WORK_DIR ?= $(SIM_CFG_RESULTS)/riscof_work
 SIM_RISCOF_ARCH_TESTS_RESULTS ?= $(RISCOF_TEST_RUN_DIR)
-
-RISCOF_CONFIG_FILE    ?= config.ini
-RISCOF_VERBOSE        ?= info
-
-###############################################################################
-# Generate command to clone RISCOF RISCV-ARCH-TEST SUITE
+RISCOF_CONFIG_FILE ?= config.ini
+RISCOF_VERBOSE ?= info
 RISCOF_TEST_SUITE_CLONE_CMD = git clone -b $(RISCOF_ARCH_TEST_SUITE_BRANCH) --single-branch $(RISCOF_ARCH_TEST_SUITE_REPO) --recurse $(RISCOF_ARCH_TEST_SUITE_PKG)
+RISCOF_RUN_ALL_CMD = riscof --verbose $(RISCOF_VERBOSE) run --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(RISCOF_WORK_DIR)
+RISCOF_CWD ?= $(MAKE_PATH)
 
-ifeq ($(RISCOF_ARCH_TEST_SUITE_TAG), latest)
-  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = riscof --verbose $(RISCOF_VERBOSE) arch-test --clone --dir $(RISCOF_ARCH_TEST_SUITE_PKG)
-else
-  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = $(RISCOF_TEST_SUITE_CLONE_CMD); cd $(RISCOF_ARCH_TEST_SUITE_PKG); git checkout $(RISCOF_ARCH_TEST_SUITE_TAG)
-endif
-
-###############################################################################
-#Clean riscof riscv-arch-test suite
-clean_riscof_arch_test_suite:
-	rm -rf $(RISCOF_ARCH_TEST_SUITE_PKG)
-
-
-###############################################################################
-#Clone the riscv-arch-test suite in core-v-verif for running the tests
-clone_riscof_arch_test_suite: $(RISCOF_ARCH_TEST_SUITE_PKG)
-
-$(RISCOF_ARCH_TEST_SUITE_PKG):
-	$(CLONE_RISCOF_ARCH_TEST_SUITE_CMD)
-
-###############################################################################
-#RISCOF Validate YAML Command
-ifeq ($(call IS_YES,$(RISCOF_SIM)),YES)
-RISCOF_VALIDATE_YAML_CMD = riscof validateyaml --config=$(RISCOF_CONFIG_FILE) --work-dir=$(SIM_CFG_RESULTS)/riscof_work
-else
-RISCOF_VALIDATE_YAML_CMD = echo $(RISCOF_SIM)
-endif
-
-.PHONY: riscof_validate_yaml
-riscof_validate_yaml:
-	$(shell $(RISCOF_VALIDATE_YAML_CMD))
-
-###############################################################################
-#RISCOF Get Testlist Command
-ifeq ($(call IS_YES,$(RISCOF_SIM)),YES)
-RISCOF_GET_TESTLIST_CMD = riscof testlist --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(SIM_CFG_RESULTS)/riscof_work
-else
-RISCOF_GET_TESTLIST_CMD = echo $(RISCOF_SIM)
-endif
-
-.PHONY: riscof_get_testlist
-riscof_get_testlist: 
-	$(shell $(RISCOF_GET_TESTLIST_CMD))
-
-#################################################################################
-##RISCOF Run Command
-RISCOF_RUN_ALL_CMD = riscof --verbose $(RISCOF_VERBOSE) run --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(SIM_CFG_RESULTS)/riscof_work
 ifeq ($(call IS_NO,$(RISCOF_REF_RUN)),NO)
   RISCOF_RUN_ALL_CMD += --no-ref-run
 endif
@@ -91,6 +43,30 @@ ifeq ($(call IS_NO,$(RISCOF_DUT_RUN)),NO)
   RISCOF_RUN_ALL_CMD += --no-dut-run
 endif
 
-.PHONY: riscof_run_all
-riscof_run_all: 
-	$(shell $(RISCOF_RUN_ALL_CMD))
+ifeq ($(RISCOF_ARCH_TEST_SUITE_TAG), latest)
+  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = riscof --verbose $(RISCOF_VERBOSE) arch-test --clone --dir $(RISCOF_ARCH_TEST_SUITE_PKG)
+else
+  CLONE_RISCOF_ARCH_TEST_SUITE_CMD = $(RISCOF_TEST_SUITE_CLONE_CMD); cd $(RISCOF_ARCH_TEST_SUITE_PKG); git checkout $(RISCOF_ARCH_TEST_SUITE_TAG)
+endif
+
+.PHONY: mk_work_dir clean_riscof_arch_test_suite riscof_validate_yaml riscof_get_testlist riscof_run_all
+
+mk_work_dir:
+	$(MKDIR_P) $(RISCOF_WORK_DIR)
+
+clean_riscof_arch_test_suite:
+	rm -rf $(RISCOF_ARCH_TEST_SUITE_PKG)
+
+clone_riscof_arch_test_suite: $(RISCOF_ARCH_TEST_SUITE_PKG)
+
+$(RISCOF_ARCH_TEST_SUITE_PKG):
+	$(CLONE_RISCOF_ARCH_TEST_SUITE_CMD)
+
+riscof_validate_yaml: mk_work_dir
+	cd $(RISCOF_CWD) && riscof validateyaml --config=$(RISCOF_CONFIG_FILE) --work-dir=$(RISCOF_WORK_DIR)
+
+riscof_get_testlist: mk_work_dir
+	cd $(RISCOF_CWD) && riscof testlist --config=$(RISCOF_CONFIG_FILE) --suite=$(RISCOF_ARCH_TEST_SUITE_PKG)/ --env=$(RISCOF_ARCH_TEST_SUITE_PKG)/riscv-test-suite/env --work-dir=$(RISCOF_WORK_DIR)
+
+riscof_run_all: mk_work_dir
+	cd $(RISCOF_CWD) && $(RISCOF_RUN_ALL_CMD)


### PR DESCRIPTION
The riscof tool requires you to run the riscof tool from a certain path as the config file paths are relative to the location where you execute riscof from. So in this change we are more explicit on setting the current working directory before running any of the riscof commands.

Also removing much of the headers/banner from the makefile to make it more readable and compact.