### PR TITLE
Control Spike parameters from cmdline.

### DIFF
--- a/vendor/riscv/riscv-isa-sim/riscv/Params.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Params.cc
@@ -15,15 +15,15 @@ void Params::parse_params(string base, Params &baseParams, Params &newParams) {
   }
 }
 void Params::cfg_to_params(cfg_t &cfg, Params &params) {
-  params.set("/top/", "isa", std::string(cfg.isa()));
-  params.set("/top/", "priv", std::string(cfg.priv()));
-  params.set("/top/", "boot_addr",
+  params.set_string("/top/", "isa", std::string(cfg.isa()));
+  params.set_string("/top/", "priv", std::string(cfg.priv()));
+  params.set_uint64_t("/top/", "boot_addr",
              (unsigned long)cfg.start_pc.value_or(0x10000UL));
 
-  params.set("/top/core/0/", "isa", std::string(cfg.isa()));
-  params.set("/top/core/0/", "priv", std::string(cfg.priv()));
-  params.set("/top/core/0/", "misaligned", cfg.misaligned);
-  params.set("/top/core/0/", "pmpregions", (cfg.pmpregions));
+  params.set_string("/top/core/0/", "isa", std::string(cfg.isa()));
+  params.set_string("/top/core/0/", "priv", std::string(cfg.priv()));
+  params.set_bool("/top/core/0/", "misaligned", cfg.misaligned);
+  params.set_uint64_t("/top/core/0/", "pmpregions", (cfg.pmpregions));
 }
 
 void print_center(string &str, const size_t line_length) {
@@ -68,7 +68,7 @@ void print_row_separator(size_t size) {
 
 void print_header() {
   print_row_separator(table_size);
-  Param table_header = {"Name", "", "", "Default", "Type", "Description"};
+  Param table_header = {"Name", "", "", 0, false, "Default", "Type", "Description"};
   print_param(table_header);
   print_row_separator(table_size);
 }

--- a/vendor/riscv/riscv-isa-sim/riscv/Params.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Params.h
@@ -6,6 +6,9 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <errno.h>
+#include <sstream>
+#include <type_traits>
 
 #pragma once
 
@@ -15,7 +18,9 @@ namespace openhw {
 typedef struct {
   string base;
   string name;
-  any a;
+  string a_string;
+  uint64_t a_uint64_t;
+  bool   a_bool;
   string default_value;
   string type;
   string description;
@@ -28,23 +33,97 @@ public:
   //              Base                 Name
   std::unordered_map<string, mapParam> v;
 
-  std::any operator[](string str) { return this->get(str).a; }
+  Param operator[](string str) { return this->get(str); }
 
+#if 0
   void set(string base, string name, any value, string type = "",
            string default_value = "", string description = "") {
     Param p = {base, name, value, default_value, type, description};
     v[base][name] = p;
   }
+#endif
 
   void set(string base, string name, Param &p) { v[base][name] = p; }
 
+  void set_string(string base, string name, string value,
+		  string default_value = "", string description = "") {
+    Param p = { base, name, value, 0, 0, default_value, "string", description };
+    v[base][name] = p;
+  }
+
+  void set_uint64_t(string base, string name, uint64_t value,
+		  string default_value = "", string description = "") {
+    Param p = { base, name, "", value, false, default_value, "uint64_t", description };
+    v[base][name] = p;
+  }
+
+  void set_uint64_t(string base, string name, string strval,
+		  string default_value = "", string description = "") {
+    uint64_t val;
+    istringstream(strval) >> val;
+    Param p = { base, name, "", val, false, default_value, "uint64_t", description };
+    v[base][name] = p;
+  }
+
+  void set_bool(string base, string name, bool value,
+		  string default_value = "", string description = "") {
+    Param p = { base, name, "", 0, value, default_value, "bool", description };
+    v[base][name] = p;
+  }
+
+  void set_bool(string base, string name, string strval,
+		  string default_value = "", string description = "") {
+    bool val;
+    istringstream(strval) >> std::boolalpha >> val;
+    Param p = { base, name, "", 0, val, default_value, "bool", description };
+    v[base][name] = p;
+  }
+
   // Set arbitrary parameter from cmdline expression PATH=VALUE.
-  void setFromCmdline(string pathEqVal) {
-    regex regexp("(.+)/([^/=]+)=([^=]+)");
+  void setFromCmdline(string pathColonTypeEqVal) {
+    regex regexp("(.+)/([^/:=]+):?([^=]*)=([^=]+)");
     std::smatch match;
 
-    std::regex_match(pathEqVal, match, regexp);
-    set(match[1].str(), match[2].str(), match[3].str());
+    std::regex_match(pathColonTypeEqVal, match, regexp);
+    std::cerr << "Params::setFromCmdLine(): setting parameter '" << match[1].str() << "/" << match[2].str() << "' of type '" << match[3].str() << "' to value '" << match[4].str() << "'\n";
+    if (match[3].str() == "uint64_t") {
+      // 64-bit unsigned integer
+      errno = 0;
+      unsigned long uintval = strtoul(match[4].str().c_str(), NULL, 10);
+      std::cerr << "### Using unsigned long uintval = " << uintval << "\n";
+      if (errno == 0)
+        set_uint64_t(match[1].str() + "/", match[2].str(), uintval, match[3].str());
+      else
+        std::cerr << "??? conversion of '" << match[4].str() << "' to unsigned int FAILED!\n";
+    } else if (match[3].str() == "bool") {
+      // Boolean value: convert 0/1 directly as numbers, "true"/"false" as boolalpha
+      bool val;
+      if (match[4].str() == "0" || match[4].str() == "1")
+	istringstream(match[4].str()) >> val;
+      else
+	istringstream(match[4].str()) >> std::boolalpha >> val;
+      std::cerr << "### Using bool val = " << std::boolalpha << val << "\n";
+      set_bool(match[1].str() + "/", match[2].str(), val, match[3].str());
+    }
+    Param parm = get(match[1].str() + "/", match[2].str());
+
+    // Visual debug code...
+    if (parm.name == "")
+       std::cerr << "** Could not get newly set parameter '" << match[1].str() << "/" << match[2].str() << "' !!!\n";
+    else {
+      std::cerr << "Params::setFromCmdLine(): managed to set parameter '" << match[1].str() << "/" << match[2].str()
+		<< "' of type '" << match[3].str()
+		<< "' to value '" ;
+      if (parm.type == "string")
+	std::cerr << parm.a_string;
+      else if (parm.type == "uint64_t")
+	std::cerr << parm.a_uint64_t;
+      else if (parm.type == "bool")
+	std::cerr << std::boolalpha << parm.a_bool;
+      else
+	std::cerr << "<UNKNOWN_TYPE<" << parm.type << ">>";
+      std::cerr << "'\n";
+    }
   }
 
   Param get(string base, string name) {

--- a/vendor/riscv/riscv-isa-sim/riscv/Params.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Params.h
@@ -38,6 +38,15 @@ public:
 
   void set(string base, string name, Param &p) { v[base][name] = p; }
 
+  // Set arbitrary parameter from cmdline expression PATH=VALUE.
+  void setFromCmdline(string pathEqVal) {
+    regex regexp("(.+)/([^/=]+)=([^=]+)");
+    std::smatch match;
+
+    std::regex_match(pathEqVal, match, regexp);
+    set(match[1].str(), match[2].str(), match[3].str());
+  }
+
   Param get(string base, string name) {
     auto it = v.find(base);
     if (it != this->v.end()) {

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -240,7 +240,7 @@ void Processor::default_params(string base, openhw::Params &params) {
   params.set_bool(base, "misaligned", false, "false",
              "Support for misaligned memory operations");
 
-  params.set(base, "csr_counters_injection", std::any(false), "bool", "false",
+  params.set_bool(base, "csr_counters_injection", false, "false",
              "Allow to set CSRs getting values from a DPI");
 }
 

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -106,8 +106,8 @@ Processor::Processor(
   Processor::default_params(base, this->params);
   Params::parse_params(base, this->params, params);
 
-  string isa_str = std::any_cast<string>(this->params[base + "isa"]);
-  string priv_str = std::any_cast<string>(this->params[base + "priv"]);
+  string isa_str = this->params[base + "isa"].a_string;
+  string priv_str = this->params[base + "priv"].a_string;
   std::cout << "[SPIKE] Proc 0 | ISA: " << isa_str << " PRIV: " << priv_str << std::endl;
   this->isa =
       (const isa_parser_t *)new isa_parser_t(isa_str.c_str(), priv_str.c_str());
@@ -118,15 +118,17 @@ Processor::Processor(
     register_extension(e.second);
   }
 
-  this->n_pmp = std::any_cast<uint64_t>(this->params[base + "pmpregions"]);
+  this->n_pmp = (this->params[base + "pmpregions"]).a_uint64_t;
 
   ((cfg_t *)cfg)->misaligned =
-      std::any_cast<bool>(this->params[base + "misaligned"]);
+      (this->params[base + "misaligned"]).a_bool;
+
 
   this->csr_counters_injection =
-      std::any_cast<bool>(this->params[base + "csr_counters_injection"]);
+      (this->params[base + "csr_counters_injection"]).a_bool;
   string extensions_str =
-      std::any_cast<string>(this->params[base + "extensions"]);
+      (this->params[base + "extensions"]).a_string;
+
   string delimiter = ",";
   size_t found = extensions_str.rfind(delimiter);
 
@@ -158,29 +160,23 @@ Processor::Processor(
 
   this->reset();
 
-  uint64_t new_pc = std::any_cast<uint64_t>(this->params[base + "boot_addr"]);
+  uint64_t new_pc = (this->params[base + "boot_addr"]).a_uint64_t;
   this->state.pc = new_pc;
 
-  this->put_csr(CSR_PMPADDR0,
-                std::any_cast<uint64_t>(this->params[base + "pmpaddr0"]));
-  this->put_csr(CSR_PMPCFG0,
-                std::any_cast<uint64_t>(this->params[base + "pmpcfg0"]));
+  this->put_csr(CSR_PMPADDR0, (this->params[base + "pmpaddr0"]).a_uint64_t);
+  this->put_csr(CSR_PMPCFG0, (this->params[base + "pmpcfg0"]).a_uint64_t);
 
   this->state.csrmap[CSR_MVENDORID] =
-      std::make_shared<const_csr_t>(this, CSR_MVENDORID, std::any_cast<uint64_t>(this->params[base + "mvendorid"]));
+      std::make_shared<const_csr_t>(this, CSR_MVENDORID, (this->params[base + "mvendorid"]).a_uint64_t);
   this->state.csrmap[CSR_MHARTID] =
-      std::make_shared<const_csr_t>(this, CSR_MHARTID, std::any_cast<uint64_t>(this->params[base + "mhartid"]));
+      std::make_shared<const_csr_t>(this, CSR_MHARTID, (this->params[base + "mhartid"]).a_uint64_t);
   this->state.csrmap[CSR_MARCHID] =
-      std::make_shared<const_csr_t>(this, CSR_MHARTID, std::any_cast<uint64_t>(this->params[base + "marchid"]));
+      std::make_shared<const_csr_t>(this, CSR_MHARTID, (this->params[base + "marchid"]).a_uint64_t);
 
-  bool fs_field_we_enable =
-      std::any_cast<bool>(this->params[base + "status_fs_field_we_enable"]);
-  bool fs_field_we =
-      std::any_cast<bool>(this->params[base + "status_fs_field_we"]);
-  bool vs_field_we_enable =
-      std::any_cast<bool>(this->params[base + "status_vs_field_we_enable"]);
-  bool vs_field_we =
-      std::any_cast<bool>(this->params[base + "status_vs_field_we"]);
+  bool fs_field_we_enable = (this->params[base + "status_fs_field_we_enable"]).a_bool;
+  bool fs_field_we = (this->params[base + "status_fs_field_we"]).a_bool;
+  bool vs_field_we_enable = (this->params[base + "status_vs_field_we_enable"]).a_bool;
+  bool vs_field_we = (this->params[base + "status_vs_field_we"]).a_bool;
 
   reg_t sstatus_mask = this->state.mstatus->get_param_write_mask();
   if (fs_field_we_enable)
@@ -192,8 +188,8 @@ Processor::Processor(
   this->state.mstatus->set_param_write_mask(sstatus_mask);
 
   bool misa_we_enable =
-      std::any_cast<bool>(this->params[base + "misa_we_enable"]);
-  bool misa_we = std::any_cast<bool>(this->params[base + "misa_we"]);
+      (this->params[base + "misa_we_enable"]).a_bool;
+  bool misa_we = (this->params[base + "misa_we"]).a_bool;
   if (misa_we_enable)
     this->state.misa->set_we(misa_we);
 }
@@ -207,42 +203,41 @@ void Processor::take_trap(trap_t &t, reg_t epc) {
 Processor::~Processor() { delete this->isa; }
 
 void Processor::default_params(string base, openhw::Params &params) {
-  params.set(base, "isa", any(std::string("RV32GC")), "string", "RV32GC",
+  params.set_string(base, "isa", "RV32GC", "RV32GC",
              "ISA");
-  params.set(base, "priv", any(std::string(DEFAULT_PRIV)), "string",
+  params.set_string(base, "priv", DEFAULT_PRIV,
              DEFAULT_PRIV, "Privilege Level");
-  params.set(base, "boot_addr", any(0x80000000UL), "uint64_t", "0x80000000UL",
+  params.set_uint64_t(base, "boot_addr", 0x80000000UL, "0x80000000UL",
              "First PC of the core");
-  params.set(base, "mmu_mode", any(std::string("sv39")), "string", "sv39",
+  params.set_string(base, "mmu_mode", "sv39", "sv39",
              "Memory virtualization mode");
 
-  params.set(base, "pmpregions", std::any(0x0UL), "uint64_t", "0x0",
+  params.set_uint64_t(base, "pmpregions", 0x0UL, "0x0",
              "Number of PMP regions");
-  params.set(base, "pmpaddr0", any(0x0UL), "uint64_t", "0x0",
+  params.set_uint64_t(base, "pmpaddr0", 0x0UL, "0x0",
              "Default PMPADDR0 value");
-  params.set(base, "pmpcfg0", any(0x0UL), "uint64_t", "0x0",
+  params.set_uint64_t(base, "pmpcfg0", 0x0UL, "0x0",
              "Default PMPCFG0 value");
-  params.set(base, "marchid", any(0x3UL), "uint64_t", "0x3", "MARCHID value");
-  params.set(base, "mhartid", any(0x0UL), "uint64_t", "0x0", "MHARTID value");
-  params.set(base, "mvendorid", any(0x00000602UL), "uint64_t", "0x00000602UL",
+  params.set_uint64_t(base, "marchid", 0x3UL, "0x3", "MARCHID value");
+  params.set_uint64_t(base, "mhartid", 0x0UL, "0x0", "MHARTID value");
+  params.set_uint64_t(base, "mvendorid", 0x00000602UL, "0x00000602UL",
              "MVENDORID value");
-  params.set(base, "extensions", any(std::string("")), "string",
-             "\"extension1,extension2\"", "Possible extensions: cv32a60x");
+  params.set_string(base, "extensions", "", "", "Possible extensions: cv32a60x, cvxif");
 
-  params.set(base, "status_fs_field_we_enable", any(false), "bool", "false",
+  params.set_bool(base, "status_fs_field_we_enable", false, "false",
              "XSTATUS CSR FS Write Enable param enable");
-  params.set(base, "status_fs_field_we", any(false), "bool", "false",
+  params.set_bool(base, "status_fs_field_we", false, "false",
              "XSTATUS CSR FS Write Enable");
-  params.set(base, "status_vs_field_we_enable", any(false), "bool", "false",
+  params.set_bool(base, "status_vs_field_we_enable", false, "false",
              "XSTATUS CSR VS Write Enable param enable");
-  params.set(base, "status_vs_field_we", any(false), "bool", "false",
+  params.set_bool(base, "status_vs_field_we", false, "false",
              "XSTATUS CSR VS Write Enable");
-  params.set(base, "misa_we_enable", any(true), "bool", "true",
+  params.set_bool(base, "misa_we_enable", true, "true",
              "MISA CSR Write Enable param enable");
-  params.set(base, "misa_we", any(false), "bool", "false",
+  params.set_bool(base, "misa_we", false, "false",
              "MISA CSR Write Enable value");
 
-  params.set(base, "misaligned", std::any(false), "bool", "false",
+  params.set_bool(base, "misaligned", false, "false",
              "Support for misaligned memory operations");
 
   params.set(base, "csr_counters_injection", std::any(false), "bool", "false",

--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
@@ -36,28 +36,28 @@ debug_module_config_t dm_config = {.progbufsize = 2,
                                    .support_impebreak = true};
 
 void Simulation::default_params(openhw::Params &params) {
-  params.set("/top/", "generic_core_config", std::any(true), "bool", "true",
+  params.set_bool("/top/", "generic_core_config", true, "true",
              "Make generic configuration for all cores");
 
-  params.set("/top/", "bootrom", std::any(true), "bool", "true",
+  params.set_bool("/top/", "bootrom", true, "true",
              "bootrom enable");
-  params.set("/top/", "bootrom_base", std::any(0x10000UL), "uint64_t",
+  params.set_uint64_t("/top/", "bootrom_base", 0x10000UL,
              "0x10000", "bootrom address");
-  params.set("/top/", "bootrom_size", std::any(0x1000UL), "uint64_t", "0x1000",
+  params.set_uint64_t("/top/", "bootrom_size", 0x1000UL, "0x1000",
              "bootrom size");
 
-  params.set("/top/", "dram", std::any(true), "bool", "true", "DRAM enable");
-  params.set("/top/", "dram_base", std::any(0x80000000UL), "uint64_t",
+  params.set_bool("/top/", "dram", true, "true", "DRAM enable");
+  params.set_uint64_t("/top/", "dram_base", 0x80000000UL,
              "0x80000000", "DRAM base address");
-  params.set("/top/", "dram_size", std::any(0x400UL * 1024 * 1024), "uint64_t",
+  params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024,
              "0x40000000", "DRAM size");
 
-  params.set("/top/", "log_commits", std::any(true), "bool", "False",
+  params.set_bool("/top/", "log_commits", true, "True",
              "Log commit enable");
 
-  params.set("/top/", "max_steps_enabled", std::any(false), "bool", "False",
+  params.set_bool("/top/", "max_steps_enabled", false, "False",
              "Maximum steps enable");
-  params.set("/top/", "max_steps", std::any(200000UL), "uint64_t", "200000",
+  params.set_uint64_t("/top/", "max_steps", 200000UL, "200000",
              "Maximum steps that the simulation can do ");
 
   Processor::default_params("/top/cores/", params);
@@ -89,18 +89,18 @@ Simulation::Simulation(
   for (auto &x : this->mems)
     bus.add_device(x.first, x.second);
 
-  string isa_str = std::any_cast<string>(this->params["/top/isa"]);
-  string priv_str = std::any_cast<string>(this->params["/top/priv"]);
+  string isa_str = (this->params["/top/isa"]).a_string;
+  string priv_str = (this->params["/top/priv"]).a_string;
   this->isa = isa_parser_t(isa_str.c_str(), priv_str.c_str());
 
   this->reset();
 
-  bool commitlog = std::any_cast<bool>(this->params["/top/log_commits"]);
+  bool commitlog = (this->params["/top/log_commits"]).a_bool;
   this->configure_log(commitlog, commitlog);
 
-  this->max_steps = std::any_cast<uint64_t>(this->params["/top/max_steps"]);
+  this->max_steps = (this->params["/top/max_steps"]).a_uint64_t;
   this->max_steps_enabled =
-      std::any_cast<bool>(this->params["/top/max_steps_enabled"]);
+      (this->params["/top/max_steps_enabled"]).a_bool;
 
   target.init(sim_thread_main, this);
   host = context_t::current();
@@ -132,7 +132,7 @@ int Simulation::run() {
       vspike = this->step(1, vreference);
     }
   } catch (std::ios_base::failure e) {
-    std::cout << "[SPIKE] Max steps exceed" << std::endl;
+    std::cout << "[SPIKE] Max steps exceeded!" << std::endl;
   }
   return sim_t::exit_code();
 }
@@ -141,11 +141,11 @@ void Simulation::make_mems(const std::vector<mem_cfg_t> &layout) {
   for (const auto &cfg : layout)
     mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
 
-  bool bootrom = std::any_cast<bool>(this->params["/top/bootrom"]);
+  bool bootrom = (this->params["/top/bootrom"]).a_bool;
   uint64_t bootrom_base =
-      std::any_cast<uint64_t>(this->params["/top/bootrom_base"]);
+      (this->params["/top/bootrom_base"]).a_uint64_t;
   uint64_t bootrom_size =
-      std::any_cast<uint64_t>(this->params["/top/bootrom_size"]);
+      (this->params["/top/bootrom_size"]).a_uint64_t;
   if (bootrom) {
     auto bootrom_device = std::make_pair(bootrom_base, new mem_t(bootrom_size));
 
@@ -169,9 +169,9 @@ void Simulation::make_mems(const std::vector<mem_cfg_t> &layout) {
     this->mems.push_back(bootrom_device);
   }
 
-  bool dram = std::any_cast<bool>(this->params["/top/dram"]);
-  uint64_t dram_base = std::any_cast<uint64_t>(this->params["/top/dram_base"]);
-  uint64_t dram_size = std::any_cast<uint64_t>(this->params["/top/dram_size"]);
+  bool dram = (this->params["/top/dram"]).a_bool;
+  uint64_t dram_base = (this->params["/top/dram_base"]).a_uint64_t;
+  uint64_t dram_size = (this->params["/top/dram_size"]).a_uint64_t;
   if (dram) {
     this->mems.push_back(std::make_pair(dram_base, new mem_t(dram_size)));
   }

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
@@ -38,39 +38,41 @@ Params params;
 
 extern "C" void spike_set_default_params(const char *profile) {
   if (strcmp(profile, "cva6") == 0) {
-    params.set("/top/", "isa", std::any(std::string("RV64GC")));
-    params.set("/top/", "priv", any(std::string(DEFAULT_PRIV))); // MSU
-    params.set("/top/", "num_procs", std::any(0x1UL));
-    params.set("/top/", "bootrom", std::any(true));
-    params.set("/top/", "generic_core_config", std::any(true));
-    params.set("/top/", "dram_base", std::any(0x80000000UL));
-    params.set("/top/", "dram_size", std::any(0x400UL * 1024 * 1024));
-    params.set("/top/", "max_steps_enabled", std::any(false));
-    params.set("/top/", "max_steps", std::any(2000000UL));
+    params.set_string("/top/", "isa", std::string("RV64GC"));
+    params.set_string("/top/", "priv", std::string(DEFAULT_PRIV)); // MSU
+    params.set_uint64_t("/top/", "num_procs", 0x1UL);
+    params.set_bool("/top/", "bootrom", true);
+    params.set_bool("/top/", "generic_core_config", true);
+    params.set_uint64_t("/top/", "dram_base", 0x80000000UL);
+    params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024);
+    params.set_bool("/top/", "max_steps_enabled", false);
+    params.set_uint64_t("/top/", "max_steps", 2000000UL);
 
-    params.set("/top/core/0/", "name", std::any(std::string("cva6")));
-    params.set("/top/core/0/", "isa", std::any(std::string("RV64GC")));
+    params.set_string("/top/core/0/", "name", std::string("cva6"));
+    params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
   }
 }
 
 extern "C" void spike_set_param_uint64_t(const char *base, const char *name,
                                          uint64_t value) {
-  params.set(base, name, value);
+  params.set_uint64_t(base, name, value);
 }
+
 extern "C" void spike_set_param_str(const char *base, const char *name,
                                     const char *value) {
-  params.set(base, name, std::string(value));
+  params.set_string(base, name, std::string(value));
 }
+
 extern "C" void spike_set_param_bool(const char *base, const char *name,
                                      bool value) {
-  params.set(base, name, std::any(value));
+  params.set_bool(base, name, value);
 }
 
 extern "C" void spike_create(const char *filename) {
   std::cerr << "[SPIKE] Starting 'spike_create'...\n";
 
   // TODO parse params from yaml
-  string isa_str = std::any_cast<string>(params["/top/isa"]);
+  string isa_str = (params["/top/isa"]).a_string;
 
   cfg_t *config = new cfg_t(
       /*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
@@ -105,15 +107,12 @@ extern "C" void spike_create(const char *filename) {
       std::cerr << "  " << s << ",\n";
     std::cerr << "}\n";
 
-    std::any a_num_procs = params["/top/num_procs"];
-    ;
-    uint64_t num_procs = a_num_procs.has_value()
-                             ? std::any_cast<uint64_t>(a_num_procs)
+    Param a_num_procs = params["/top/num_procs"];
+    uint64_t num_procs = (a_num_procs).a_uint64_t
+                             ? (a_num_procs).a_uint64_t
                              : config->nprocs();
-    std::any a_generic_config = params["/top/generic_core_config"];
-    bool generic_config = a_generic_config.has_value()
-                              ? std::any_cast<bool>(a_generic_config)
-                              : false;
+    Param a_generic_config = params["/top/generic_core_config"];
+    bool generic_config = (a_generic_config).a_bool;
 
     mapParam coreParams = params.get_base("/top/cores/");
 

--- a/vendor/riscv/riscv-isa-sim/riscv/sim.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/sim.cc
@@ -99,8 +99,8 @@ sim_t::sim_t(const cfg_t *cfg, bool halted,
 
   debug_mmu = new mmu_t(this, cfg->endianness, NULL);
 
-  std::any a_num_procs = params["/top/num_procs"];;
-  uint64_t num_procs = a_num_procs.has_value() ? std::any_cast<uint64_t>(a_num_procs) : cfg->nprocs();
+  openhw::Param a_num_procs = params["/top/num_procs"];
+  uint64_t num_procs = a_num_procs.a_uint64_t ? (a_num_procs).a_uint64_t : cfg->nprocs();
 
   for (size_t i = 0; i < num_procs; i++) {
     procs[i] = new openhw::Processor(&isa, cfg, this, cfg->hartids()[i], halted,

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -451,6 +451,8 @@ int main(int argc, char** argv)
   };
 
   option_parser_t parser;
+  openhw::Params params;
+
   parser.help(&suggest_help);
   parser.option('h', "help", 0, [&](const char UNUSED *s){help(0);});
   parser.option('v', "version", 0, [&](const char UNUSED *s){version(0);});
@@ -499,6 +501,7 @@ int main(int argc, char** argv)
     }
   });
   parser.option(0, "steps", 1, [&](const char* s){max_steps = strtoull(s, 0, 0);});
+  parser.option(0, "param", 1, [&](const char* s){params.setFromCmdline(s);});
   parser.option(0, "dm-progsize", 1,
       [&](const char* s){dm_config.progbufsize = atoul_safe(s);});
   parser.option(0, "dm-no-impebreak", 0,
@@ -599,7 +602,6 @@ int main(int argc, char** argv)
     }
     cfg.hartids = default_hartids;
   }
-  openhw::Params params;
 
   if (max_steps != 0) {
     params.set("/top/", "max_steps", max_steps);

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -115,6 +115,8 @@ static void help(int exit_code = 1)
   fprintf(stderr, "  --steps=<n>           Stop simulation after reaching specified number of steps "
           "(default: unlimited)\n");
   fprintf(stderr, "  --nb_register_source=<n>     Set the number of register source usable(2 or 3)\n");
+  fprintf(stderr, "  --param <path>=<val>  Set parameter to specified value (see 'spike --print-params' for a full list.)\n"
+                  "                          This flag can be used multiple times.\n");
 
   exit(exit_code);
 }

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -606,16 +606,19 @@ int main(int argc, char** argv)
   }
 
   if (max_steps != 0) {
-    params.set("/top/", "max_steps", max_steps);
-    params.set("/top/", "max_steps_enabled", bool(true));
+    params.set_uint64_t("/top/", "max_steps", max_steps);
+    params.set_bool("/top/", "max_steps_enabled", true);
     std::cout << "[SPIKE] Max simulation steps: " << max_steps << std::endl;
   }
   openhw::Params::cfg_to_params(cfg, params);
-  params.set("/top/", "num_procs", cfg.nprocs());
-  params.set("/top/core/0/", "boot_addr", 0x10000UL);
-  params.set("/top/core/0/", "pmpregions", 0x0UL);
-  params.set("/top/core/0/", "isa", std::string(cfg.isa()));
-  params.set("/top/core/0/", "priv", std::string(cfg.priv()));
+  params.set_uint64_t("/top/", "num_procs", cfg.nprocs());
+  params.set_uint64_t("/top/core/0/", "boot_addr", 0x10000UL);
+  params.set_uint64_t("/top/core/0/", "pmpregions", 0x0UL);
+  params.set_string("/top/core/0/", "isa", std::string(cfg.isa()));
+  params.set_string("/top/core/0/", "priv", std::string(cfg.priv()));
+
+  openhw::Param param = params.get("/top/core/0/misa_we");
+  std::cerr << "[spike.cc:main()] Value of '/top/core/0/misa_we' = " << (param.name != "" ? (param.a_bool ? "true" : "false") : "UNDEFINED") << "\n";
 
   openhw::Simulation s(&cfg, halted,
           mems, plugin_devices, htif_args, dm_config, log_path, dtb_enabled, dtb_file,


### PR DESCRIPTION
* vendor/riscv/riscv-isa-sim/riscv/Params.h (Param::setFromCmdline): New.
* vendor/riscv/riscv-isa-sim/spike_main/spike.cc (main): Declare 'params'<br>
  variable ahead of cmdline options.  Add cmdline option '--param PATH=VALUE'.<br>
  Add corresponding help string.