### PR TITLE
Incorporate UNSUPPORTED_WITH kludge for VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ VRMDATA
 *whetstone*
 *.do
 *eembc*
+*.code-workspace

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model_macros.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model_macros.sv
@@ -1,0 +1,13 @@
+// Copyright 2024 OpenHW Group
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-210
+`ifndef __UVMA_CV32E40P_COV_MODEL_MACROS_SV__
+`define __UVMA_CV32E40P_COV_MODEL_MACROS_SV__
+
+// Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
+`ifdef UNSUPPORTED_WITH
+  `define WITH iff
+`else
+   `define WITH with
+`endif
+
+`endif // __UVMA_CV32E40P_COV_MODEL_MACROS_SV__

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
@@ -35,6 +35,8 @@ class uvme_cv32e40p_fp_instr_covg extends uvm_component;
     extern task run_phase(uvm_phase phase);
     extern task sample_clk_i();
 
+    `include "uvme_cv32e40p_cov_model_macros.sv"
+
     `define FPU_MULTICYCLE_WINDOW_ILLEGAL_CASES \
      illegal_bins clk_2_19_group_NON_DIVSQRT  = ( (!binsof(cp_curr_fpu_apu_op) intersect {APU_OP_FDIV, APU_OP_FSQRT}) && (!binsof(cp_f_multicycle_clk_window) intersect {1}) ) \
                                                    with ( (cp_f_multicycle_clk_window != 0) & (fpu_latency == 0) ); \
@@ -391,7 +393,9 @@ class uvme_cv32e40p_fp_instr_covg extends uvm_component;
                                                                     (`COVIF_CB.apu_gnt == 1) &&
                                                                     (`COVIF_CB.apu_rvalid_i == 1) ) {
 
-            bins rd[] = {[0:31]} with (fpu_latency == 0);
+            // FIXME: this is a kludge for a known VCS issue
+            //bins rd[] = {[0:31]} with (fpu_latency == 0);
+            bins rd[] = {[0:31]} `WITH (fpu_latency == 0);
         }
 
         // from bhv_logic_3

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
@@ -19,6 +19,13 @@
 `define __UVMA_ISACOV_MACROS_SV__
 
 // Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
+`ifdef UNSUPPORTED_WITH
+  `define WITH iff
+`else
+   `define WITH with
+`endif
+
+// Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
 `define ISACOV_IGN_BINS \
     ignore_bins IGN_UNKNOWN = {UNKNOWN}; \
     ignore_bins IGN_M = {MUL, MULH, MULHSU, MULHU, \

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -156,6 +156,9 @@ endif
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 
+# FIXME: this is a kludge to work-around a known VCS bug
+VCS_USER_COMPILE_ARGS += +define+UNSUPPORTED_WITH
+
 ifeq ($(call IS_YES,$(ENABLE_TRACE_LOG)),YES)
     VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
     VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION


### PR DESCRIPTION
This pull-request resolves an issue with #2392 that impacts VCS.   It incorporates the so-called `UNSUPPORTED_WITH` work-around that is in use by multiple CORE-V-VERIF projects.  It is ugly, but works and needs to be in place until at least the next release of VCS.