### PR TITLE
Restore DSim

### DIFF
--- a/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/instr_lib/cv32e40p_float_instr_lib.sv
@@ -419,8 +419,11 @@ class cv32e40p_float_zfinx_base_instr_stream extends cv32e40p_base_instr_stream;
     if (more_weight_for_fdiv_fsqrt_gen || use_only_for_fdiv_fsqrt_gen) begin
       if (select_fp_instr) // is fp
         if ($urandom_range(1) || use_only_for_fdiv_fsqrt_gen)
-          // Metrics DSim throws an "InvalidTypeAssign" error given the conditional
-          // assigment below, so it has been expanded into two assignments.
+          // Metrics DSim throws an "InvalidTypeAssign" error given the (commented out)
+          // conditional assigment below. It has been expanded into two assignments.
+          // Note that Metrics considers their interpretation of the LRM to be the
+          // correct one (that is, the code is illegal). See the link below:
+          // https://accellera.mantishub.io/view.php?id=2390
           //     include_instr = new[1] ($urandom_range(1) ? {FDIV_S} : {FSQRT_S});
           if ($urandom_range(1))
             include_instr = new[1] ({FDIV_S});
@@ -1161,9 +1164,11 @@ class cv32e40p_constraint_mc_fp_instr_stream extends cv32e40p_float_zfinx_base_i
 
     if (instr.group inside {RV32F, RV32FC, RV32ZFINX}) begin : BODY
 
-      // Metrics DSim throws an "InvalidTypeAssign" error given the conditional
-      // assigment below, so it has been expanded into two assignments.
-      //  .include_group((is_zfinx) ? {RV32ZFINX} : {RV32F, RV32FC})
+      // Metrics DSim throws an "InvalidTypeAssign" error given the (commented out)
+      // conditional assigment below. It has been expanded into two assignments.
+      // Note that Metrics considers their interpretation of the LRM to be the
+      // correct one (that is, the code is illegal). See the link below:
+      // https://accellera.mantishub.io/view.php?id=2390
 
       riscv_instr_group_t tmp_include_group[];
       if (is_zfinx)
@@ -1406,10 +1411,13 @@ class cv32e40p_fp_op_fwd_instr_stream extends cv32e40p_float_zfinx_base_instr_st
     exclude_instr = new[33+8+3] ({`EXCLUDE_INSTR_LIST, `STORE_INSTR_LIST, `FP_STORE_INSTR_LIST});
     // always exclude RV32C because it only uses 8 common gpr/fpr. We cover more than 8 registers here
     exclude_group = new[2] ({RV32C, RV32FC});
-    // 
+
     if (instr_order_per_block[idx] == IS_FP) begin
-      // Metrics DSim throws an "InvalidTypeAssign" error given the conditional
-      // assigment below, so it has been expanded into two assignments.
+      // Metrics DSim throws an "InvalidTypeAssign" error given the (commented out)
+      // conditional assigment below. It has been expanded into two assignments.
+      // Note that Metrics considers their interpretation of the LRM to be the
+      // correct one (that is, the code is illegal). See the link below:
+      // https://accellera.mantishub.io/view.php?id=2390
       //    include_group = new[1] ((is_zfinx) ? {RV32ZFINX} : {RV32F});
       if (is_zfinx)
         include_group = new[1] ({RV32ZFINX});

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model.sv
@@ -113,9 +113,13 @@ function void uvme_cv32e40p_cov_model_c::build_phase(uvm_phase phase);
 
    debug_covg = uvme_debug_covg::type_id::create("debug_covg", this);
    uvm_config_db#(uvme_cv32e40p_cntxt_c)::set(this, "debug_covg", "cntxt", cntxt);
-   
-   rv32x_hwloop_covg = uvme_rv32x_hwloop_covg::type_id::create("rv32x_hwloop_covg", this);
-   interrupt_covg_v2 = uvme_interrupt_covg_v2::type_id::create("interrupt_covg_v2", this);
+
+   // The Metrics DSim compiler says:
+   // A name of the form uvme_rv32x_hwloop_covg::type_id where uvme_rv32x_hwloop_covg is
+   // the default specialization of a parameterized class is not valid.
+   // Try uvme_rv32x_hwloop_covg#()::type_id instead.
+   rv32x_hwloop_covg = uvme_rv32x_hwloop_covg#()::type_id::create("rv32x_hwloop_covg", this);
+   interrupt_covg_v2 = uvme_interrupt_covg_v2#()::type_id::create("interrupt_covg_v2", this);
 
    if( (cfg.rv32f_fcov_en == 1) && (cfg.zfinx_fcov_en == 0) ) begin
       cv32e40p_fp_instr_covg = uvme_cv32e40p_fp_instr_covg::type_id::create("cv32e40p_fp_instr_covg", this);

--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -317,7 +317,7 @@ endtask : run_phase
 function void uvme_cv32e40p_env_c::end_of_elaboration_phase(uvm_phase phase);
    super.end_of_elaboration_phase(phase);
 
-   `uvm_info("UVME_CV32E40P_ENV", $sformatf("Top-level environment configuration:\n%s", cfg.sprint()), UVM_LOW)
+   `uvm_info("UVME_CV32E40P_ENV", $sformatf("Top-level environment configuration:\n%s", cfg.sprint()), UVM_DEBUG)
 
 endfunction : end_of_elaboration_phase
 

--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -317,7 +317,7 @@ endtask : run_phase
 function void uvme_cv32e40p_env_c::end_of_elaboration_phase(uvm_phase phase);
    super.end_of_elaboration_phase(phase);
 
-   `uvm_info("UVME_CV32E40P_ENV", $sformatf("Top-level environment configuration:\n%s", cfg.sprint()), UVM_DEBUG)
+   `uvm_info("UVME_CV32E40P_ENV", $sformatf("Top-level environment configuration:\n%s", cfg.sprint()), UVM_LOW)
 
 endfunction : end_of_elaboration_phase
 

--- a/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
+++ b/cv32e40p/env/uvme/vseq/uvme_cv32e40p_random_debug_vseq.sv
@@ -89,8 +89,9 @@ function uvme_cv32e40p_reduced_rand_debug_req_c::new(string name="uvme_cv32e40p_
 endfunction : new
 
 task uvme_cv32e40p_reduced_rand_debug_req_c::rand_delay();
-    std::randomize(dly) with {  dly inside {[1:10000]};
-                             };
+    if (! std::randomize(dly) with {  dly inside {[1:10000]}; } ) begin
+        `uvm_fatal("RAND_DEBUG_RAND_DELAY", "Cannot randomize dly")
+    end
     #(dly);
 endtask : rand_delay
 

--- a/cv32e40p/sim/tools/dsim/ccov_scopes.txt
+++ b/cv32e40p/sim/tools/dsim/ccov_scopes.txt
@@ -12,4 +12,4 @@
 #       -code-cov-scope-specs ccov_scopes.txt \
 #       -f $(MANIFEST)
 #
-path uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_wrapper_i.core_i +
+path uvmt_cv32e40p_tb.dut_wrap.cv32e40p_tb_wrapper_i.cv32e40p_top_i.core_i +

--- a/cv32e40p/tb/uvmt/uvmt_cv32e40p_macros.sv
+++ b/cv32e40p/tb/uvmt/uvmt_cv32e40p_macros.sv
@@ -226,7 +226,7 @@
     // 1 - To cover directives instr/data gnt assert-deassert when req is low
     `define TB_HACK_1_OBI_GNT(TYPE) initial begin : hack_obi_intf_gnt_signal_1_``TYPE \
       if ($test$plusargs("tb_hack_1_obi_gnt_signal")) begin \
-        int success_addr_phase_cnt = 0, hack_cnt = 0; \
+        automatic int success_addr_phase_cnt = 0, hack_cnt = 0; \
         forever begin \
           @(posedge obi_memory_``TYPE``_if.clk); \
             if (obi_memory_``TYPE``_if.req && obi_memory_``TYPE``_if.gnt) success_addr_phase_cnt++; \

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -256,8 +256,8 @@ function void uvmt_cv32e40p_base_test_c::end_of_elaboration_phase(uvm_phase phas
 
    super.end_of_elaboration_phase(phase);
 
-   `uvm_info("BASE TEST", $sformatf("Top-level environment configuration:\n%s", env_cfg.sprint()), UVM_NONE)
-   `uvm_info("BASE TEST", $sformatf("Testcase configuration:\n%s", test_cfg.sprint()), UVM_NONE)
+   `uvm_info("BASE TEST", $sformatf("Top-level environment configuration:\n%s", env_cfg.sprint()), UVM_DEBUG)
+   `uvm_info("BASE TEST", $sformatf("Testcase configuration:\n%s", test_cfg.sprint()), UVM_DEBUG)
 
 endfunction : end_of_elaboration_phase
 

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -256,8 +256,8 @@ function void uvmt_cv32e40p_base_test_c::end_of_elaboration_phase(uvm_phase phas
 
    super.end_of_elaboration_phase(phase);
 
-   `uvm_info("BASE TEST", $sformatf("Top-level environment configuration:\n%s", env_cfg.sprint()), UVM_DEBUG)
-   `uvm_info("BASE TEST", $sformatf("Testcase configuration:\n%s", test_cfg.sprint()), UVM_DEBUG)
+   `uvm_info("BASE TEST", $sformatf("Top-level environment configuration:\n%s", env_cfg.sprint()), UVM_LOW)
+   `uvm_info("BASE TEST", $sformatf("Testcase configuration:\n%s", test_cfg.sprint()), UVM_LOW)
 
 endfunction : end_of_elaboration_phase
 

--- a/mk/uvmt/dsim.mk
+++ b/mk/uvmt/dsim.mk
@@ -26,7 +26,7 @@
 DSIM                    = dsim
 DSIM_HOME              ?= /tools/Metrics/dsim
 DSIM_CMP_FLAGS         ?= $(TIMESCALE) $(SV_CMP_FLAGS) -top uvmt_$(CV_CORE_LC)_tb
-DSIM_ERR_SUPPRESS      ?= MultiBlockWrite:ReadingOutputModport
+DSIM_ERR_SUPPRESS      ?= MultiBlockWrite:ReadingOutputModport:IneffectiveDynamicCast:LatchInferred
 DSIM_UVM_ARGS          ?= +incdir+$(UVM_HOME)/src $(UVM_HOME)/src/uvm_pkg.sv
 DSIM_WORK              ?= $(SIM_CFG_RESULTS)/dsim_work
 DSIM_IMAGE             ?= dsim.out
@@ -35,8 +35,8 @@ DSIM_CODE_COV_SCOPE    ?= $(MAKE_PATH)/../tools/dsim/ccov_scopes.txt
 DSIM_USE_ISS           ?= YES
 
 DSIM_FILE_LIST         ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
-DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
-DSIM_COMPILE_ARGS      += +define+$(CV_CORE_UC)_TRACE_EXECUTION
+#DSIM_FILE_LIST         += -f $(DV_UVMT_PATH)/imperas_iss.flist
+DSIM_COMPILE_ARGS      += +define+DSIM+$(CV_CORE_UC)_TRACE_EXECUTION+CV32E40P_RVFI
 
 DSIM_USER_COMPILE_ARGS ?=
 ifeq ($(USE_ISS),YES)
@@ -135,7 +135,8 @@ mk_results:
 
 ################################################################################
 # DSIM compile target
-comp: mk_results $(CV_CORE_PKG) $(SVLIB_PKG) $(OVP_MODEL_DPI)
+#comp: mk_results $(CV_CORE_PKG) $(SVLIB_PKG) $(OVP_MODEL_DPI)
+comp: mk_results $(CV_CORE_PKG) $(SVLIB_PKG)
 	$(DSIM) \
 		$(DSIM_CMP_FLAGS) \
 		-suppress $(DSIM_ERR_SUPPRESS) \
@@ -174,6 +175,8 @@ ifneq ($(call IS_NO,$(COMP)),NO)
 DSIM_SIM_PREREQ = comp
 endif
 
+#			-sv_lib $(OVP_MODEL_DPI) \
+
 test: $(DSIM_SIM_PREREQ) hex gen_ovpsim_ic
 	mkdir -p $(SIM_RUN_RESULTS) && \
 	cd $(SIM_RUN_RESULTS) && \
@@ -188,7 +191,6 @@ test: $(DSIM_SIM_PREREQ) hex gen_ovpsim_ic
 			-sv_lib $(UVM_HOME)/src/dpi/libuvm_dpi.so \
 			-sv_lib $(DPI_DASM_LIB) \
 			-sv_lib $(abspath $(SVLIB_LIB)) \
-			-sv_lib $(OVP_MODEL_DPI) \
 			+UVM_TESTNAME=$(TEST_UVM_TEST) \
 			+firmware=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).hex \
 			+elf_file=$(SIM_TEST_PROGRAM_RESULTS)/$(TEST_PROGRAM)$(OPT_RUN_INDEX_SUFFIX).elf \
@@ -357,5 +359,5 @@ clean:
 	rm -rf $(SIM_RESULTS)
 
 # All generated files plus the clone of the RTL
-clean_all: clean clean_riscv-dv clean_test_programs clean_bsp clean_compliance clean_embench clean_dpi_dasm_spike clean_svlib
+clean_all: clean clean_riscv-dv clean_test_programs clean_bsp clean_embench clean_dpi_dasm_spike clean_svlib
 	rm -rf $(CV_CORE_PKG)


### PR DESCRIPTION
This PR re-establishes [Metrics DSim](https://www.metrics.ca/) as one of the SV simulators supported by CORE-V-VERIF.  Changes fall into one of the following categories:
- Fixes to Makefiles and associated scripts.
- Workarounds for specific DSim parser issues.  These are clearly identified in comments (look for "Metrics DSim") and do not alter the function or the code.
- Increased the verbosity level for printing the testcase and environment configurations (from UVM_NONE to UVM_DEBUG).

Tested these changes with VCS, Questasim and DSim.