### PR TITLE
CVXIF Agent: Ignore Supervisor and User mode when it's not supported

### DIFF
--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_cov_model.sv
@@ -25,7 +25,9 @@
    //covergroup instances
 
 covergroup cg_request(
-    string name
+    string name,
+    bit mode_s_supported,
+    bit mode_u_supported
     ) with function sample(uvma_cvxif_req_item_c req_item);
 
     option.per_instance = 1;
@@ -48,6 +50,8 @@ covergroup cg_request(
    }
 
    cp_mode : coverpoint req_item.issue_req.mode {
+    ignore_bins IGN_S_MODE = {PRIV_LVL_S} iff (!mode_s_supported);
+    ignore_bins IGN_U_MODE = {PRIV_LVL_U} iff (!mode_u_supported);
     bins MODE [] = {[0:$]};
    }
 
@@ -255,7 +259,9 @@ function void uvma_cvxif_cov_model_c::build_phase(uvm_phase phase);
       `uvm_fatal("CNTXT", "Context handle is null")
    end
 
-   request_cg  = new("request_cg");
+   request_cg  = new("request_cg",
+                     .mode_s_supported(cfg.mode_s_supported),
+                     .mode_u_supported(cfg.mode_u_supported));
    response_cg = new("response_cg",
                     .dual_read_write_support(cfg.dual_read_write_support_x),
                     .load_store_support(cfg.load_store_support_x));

--- a/lib/uvm_agents/uvma_cvxif/src/obj/uvma_cvxif_cfg.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/obj/uvma_cvxif_cfg.sv
@@ -31,6 +31,9 @@ class uvma_cvxif_cfg_c extends uvm_object;
    rand bit seq_cus_instr_x2_enabled;
    rand bit reg_cus_crosses_enabled;
 
+   rand bit mode_s_supported;
+   rand bit mode_u_supported;
+
    constraint reasonable_values {
       soft uvma_cvxif_issue_ready inside     {[4:10]};
       soft uvma_cvxif_issue_not_ready inside {[1:2]};
@@ -64,6 +67,8 @@ class uvma_cvxif_cfg_c extends uvm_object;
       `uvm_field_int ( load_store_support_x,           UVM_DEFAULT)
       `uvm_field_int ( seq_cus_instr_x2_enabled,       UVM_DEFAULT)
       `uvm_field_int ( reg_cus_crosses_enabled,        UVM_DEFAULT)
+      `uvm_field_int ( mode_s_supported,               UVM_DEFAULT)
+      `uvm_field_int ( mode_u_supported,               UVM_DEFAULT)
    `uvm_object_utils_end
 
    /**


### PR DESCRIPTION
This MR, ignore req.mode bins if supervisor mode or user mode isn't supported