### PR TITLE
Remove UNSUPPORTED_WITH workaround for VCS (resolved as of V-2023.12-1)

### DIFF
--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model_macros.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_cov_model_macros.sv
@@ -3,11 +3,6 @@
 `ifndef __UVMA_CV32E40P_COV_MODEL_MACROS_SV__
 `define __UVMA_CV32E40P_COV_MODEL_MACROS_SV__
 
-// Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
-`ifdef UNSUPPORTED_WITH
-  `define WITH iff
-`else
-   `define WITH with
-`endif
+// Place any CV32E40P coverage model specific macros here...
 
 `endif // __UVMA_CV32E40P_COV_MODEL_MACROS_SV__

--- a/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
+++ b/cv32e40p/env/uvme/cov/uvme_cv32e40p_fp_instr_covg.sv
@@ -393,9 +393,7 @@ class uvme_cv32e40p_fp_instr_covg extends uvm_component;
                                                                     (`COVIF_CB.apu_gnt == 1) &&
                                                                     (`COVIF_CB.apu_rvalid_i == 1) ) {
 
-            // FIXME: this is a kludge for a known VCS issue
-            //bins rd[] = {[0:31]} with (fpu_latency == 0);
-            bins rd[] = {[0:31]} `WITH (fpu_latency == 0);
+            bins rd[] = {[0:31]} with (fpu_latency == 0);
         }
 
         // from bhv_logic_3

--- a/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
+++ b/lib/uvm_agents/uvma_isacov/uvma_isacov_macros.sv
@@ -19,13 +19,6 @@
 `define __UVMA_ISACOV_MACROS_SV__
 
 // Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
-`ifdef UNSUPPORTED_WITH
-  `define WITH iff
-`else
-   `define WITH with
-`endif
-
-// Macro to remove instrucitons that are not supported based on standard ext_*_supported variable names (from commmon core control cfg class)
 `define ISACOV_IGN_BINS \
     ignore_bins IGN_UNKNOWN = {UNKNOWN}; \
     ignore_bins IGN_M = {MUL, MULH, MULHSU, MULHU, \

--- a/mk/uvmt/vcs.mk
+++ b/mk/uvmt/vcs.mk
@@ -52,7 +52,8 @@ VCS_UVM_VERBOSITY ?= UVM_MEDIUM
 
 # Flags
 VCS_VERSION     ?= S-2021.09-SP1
-VCS_UVMHOME_ARG ?= /synopsys/vcs/$(VCS_VERSION)/etc/uvm-1.2
+VCS_HOME        ?= /synopsys/vcs/$(VCS_VERSION)
+VCS_UVMHOME_ARG ?= $(VCS_HOME)/etc/uvm-1.2
 VCS_UVM_ARGS    ?= +incdir+$(VCS_UVMHOME_ARG)/src $(VCS_UVMHOME_ARG)/src/uvm_pkg.sv +UVM_VERBOSITY=$(VCS_UVM_VERBOSITY) -ntb_opts uvm-1.2
 
 VCS_COMP_FLAGS  ?= -lca -sverilog \
@@ -156,9 +157,6 @@ endif
 
 VCS_FILE_LIST ?= -f $(DV_UVMT_PATH)/uvmt_$(CV_CORE_LC).flist
 
-# FIXME: this is a kludge to work-around a known VCS bug
-VCS_USER_COMPILE_ARGS += +define+UNSUPPORTED_WITH
-
 ifeq ($(call IS_YES,$(ENABLE_TRACE_LOG)),YES)
     VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_TRACE_EXECUTION
     VCS_USER_COMPILE_ARGS += +define+$(CV_CORE_UC)_RVFI_TRACE_EXECUTION
@@ -191,9 +189,16 @@ VCS_RUN_BASE_FLAGS   ?= $(VCS_GUI) \
                         -assert nopostproc \
                         -sv_lib $(abspath $(VCS_SVLIB_LIB))
 
+# The following INFO message appeared in the run-logs as of VCS Runtime version V-2023.12-1_Full64:
+#    Info: [VCS_SAVE_RESTORE_INFO] ASLR (Address Space Layout Randomization) is detected on the machine.
+#    To enable $save functionality, ASLR will be switched off and simv re-executed.
+#    Please use '-no_save' simv switch to avoid re-execution or '-suppress=ASLR_DETECTED_INFO' to suppress this message.
+VCS_SAVE_RESTORE_INFO_FLAGS ?= -no_save
+
 # Simulate using latest elab
 VCS_RUN_FLAGS        ?=
 VCS_RUN_FLAGS        += $(VCS_RUN_BASE_FLAGS)
+VCS_RUN_FLAGS        += $(VCS_SAVE_RESTORE_INFO_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_WAVES_FLAGS)
 VCS_RUN_FLAGS        += $(VCS_RUN_COV_FLAGS)
 


### PR DESCRIPTION
This pull-request backs out the workaround added in #2393.  The implication is that VCS users must have an up-to-date version such as `U-2023.03-SP1` or `V-2023.12-1` (or newer).