### PR TITLE
Add YAML interface to control Spike parameters in solo and tandem mode.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/yaml-cpp"]
+	path = vendor/riscv/riscv-isa-sim/yaml-cpp
+	url = https://github.com/jbeder/yaml-cpp.git

--- a/lib/uvm_components/uvmc_rvfi_reference_model/rvfi_spike.sv
+++ b/lib/uvm_components/uvmc_rvfi_reference_model/rvfi_spike.sv
@@ -21,56 +21,62 @@ import "DPI-C" function void spike_set_param_uint64_t(string base, string name, 
 import "DPI-C" function void spike_set_param_str(string base, string name, string value);
 import "DPI-C" function void spike_set_param_bool(string base, string name, bit value);
 import "DPI-C" function void spike_set_default_params(string profile);
+import "DPI-C" function void spike_set_params_from_file(string paramFilePath);
 
 import "DPI-C" function void spike_step_svLogic(inout vector_rvfi core, inout vector_rvfi reference_model);
 import "DPI-C" function void spike_step_struct(inout st_rvfi core, inout st_rvfi reference_model);
 
     function automatic void rvfi_initialize_spike(string core_name, st_core_cntrl_cfg core_cfg);
-        string binary, rtl_isa, rtl_priv;
+        string binary, config_file;
+        string rtl_isa, rtl_priv;
         string base;
 
         base = $sformatf("/top/core/%0d/", core_cfg.mhartid);
 
         if ($value$plusargs("elf_file=%s", binary))
-            `uvm_info("spike_tandem", $sformatf("Setting up Spike with binary %s...", binary), UVM_LOW);
+            `uvm_info("spike_tandem", $sformatf("Setting up Spike with binary %s ...", binary), UVM_LOW);
 
         if (binary == "") begin
             `uvm_error("spike_tandem", "We need a preloaded binary for tandem verification");
         end
 
-        rtl_isa = rvfi_get_isa_str(core_cfg);
-
-        rtl_priv = rvfi_get_priv_str(core_cfg);
-
-        if (core_cfg.ext_cv32a60x_supported) begin
-            void'(spike_set_param_str("/top/core/0/", "extensions", "cv32a60x"));
-        end
-
         void'(spike_set_default_params(core_name));
 
-        void'(spike_set_param_uint64_t("/top/", "num_procs", 64'h1));
+        if($value$plusargs("config_file=%s", config_file)) begin
+            void'(spike_set_params_from_file(config_file));
+        end else begin
+            rtl_isa = rvfi_get_isa_str(core_cfg);
 
-        void'(spike_set_param_str("/top/", "isa", rtl_isa));
-        void'(spike_set_param_str(base, "isa", rtl_isa));
-        void'(spike_set_param_str("/top/", "priv", rtl_priv));
-        void'(spike_set_param_str(base, "priv", rtl_priv));
-        void'(spike_set_param_bool("/top/", "misaligned", core_cfg.unaligned_access_supported));
+            rtl_priv = rvfi_get_priv_str(core_cfg);
 
-        if (core_cfg.boot_addr_valid) begin
-            void'(spike_set_param_uint64_t(base, "boot_addr", core_cfg.boot_addr));
-        end
+            if (core_cfg.ext_cv32a60x_supported) begin
+                void'(spike_set_param_str("/top/core/0/", "extensions", "cv32a60x"));
+            end
 
-        void'(spike_set_param_uint64_t(base, "pmpregions", core_cfg.pmp_regions));
-        void'(spike_set_param_uint64_t(base, "mhartid", core_cfg.mhartid));
-        void'(spike_set_param_uint64_t(base, "marchid", core_cfg.marchid));
-        void'(spike_set_param_uint64_t(base, "mvendorid", core_cfg.mvendorid));
-        void'(spike_set_param_bool(base, "misaligned", core_cfg.unaligned_access_supported));
+            void'(spike_set_param_uint64_t("/top/", "num_procs", 64'h1));
 
-        void'(spike_set_param_bool(base, "csr_counters_injection", 1'h1));
+            void'(spike_set_param_str("/top/", "isa", rtl_isa));
+            void'(spike_set_param_str(base, "isa", rtl_isa));
+            void'(spike_set_param_str("/top/", "priv", rtl_priv));
+            void'(spike_set_param_str(base, "priv", rtl_priv));
+            void'(spike_set_param_bool("/top/", "misaligned", core_cfg.unaligned_access_supported));
 
-        if (core_cfg.dram_valid) begin
-            void'(spike_set_param_uint64_t("/top/", "dram_base", core_cfg.dram_base));
-            void'(spike_set_param_uint64_t("/top/", "dram_size", core_cfg.dram_size));
+            if (core_cfg.boot_addr_valid) begin
+                void'(spike_set_param_uint64_t(base, "boot_addr", core_cfg.boot_addr));
+            end
+
+            void'(spike_set_param_uint64_t(base, "pmpregions", core_cfg.pmp_regions));
+            void'(spike_set_param_uint64_t(base, "mhartid", core_cfg.mhartid));
+            void'(spike_set_param_uint64_t(base, "marchid", core_cfg.marchid));
+            void'(spike_set_param_uint64_t(base, "mvendorid", core_cfg.mvendorid));
+            void'(spike_set_param_bool(base, "misaligned", core_cfg.unaligned_access_supported));
+
+            void'(spike_set_param_bool(base, "csr_counters_injection", 1'h1));
+
+            if (core_cfg.dram_valid) begin
+                void'(spike_set_param_uint64_t("/top/", "dram_base", core_cfg.dram_base));
+                void'(spike_set_param_uint64_t("/top/", "dram_size", core_cfg.dram_size));
+            end
         end
 
         void'(spike_create(binary));

--- a/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard_utils.sv
+++ b/lib/uvm_components/uvmc_rvfi_scoreboard/uvmc_rvfi_scoreboard_utils.sv
@@ -21,6 +21,7 @@ import "DPI-C" function void spike_set_param_uint64_t(string base, string name, 
 import "DPI-C" function void spike_set_param_str(string base, string name, string value);
 import "DPI-C" function void spike_set_param_bool(string base, string name, bit value);
 import "DPI-C" function void spike_set_default_params(string profile);
+import "DPI-C" function void spike_set_params_from_file(string paramFilePath);
 
     st_core_cntrl_cfg m_core_cfg;
 

--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -70,8 +70,9 @@ sprojs         := @subprojects@
 sprojs_enabled := @subprojects_enabled@
 
 EDA_INCLUDES := -I$(VCS_HOME)/include -I/$(QUESTASIM_HOME)/include -I$(XCEL_HOME)/include -I$(VERILATOR_INSTALL_DIR)/share/verilator/include/vltstd/
+YAML_CPP_INCLUDES := -I$(shell pwd)/../yaml-cpp/lib/include/
 
-sprojs_include := -I. -I$(src_dir) $(addprefix -I$(src_dir)/, $(sprojs_enabled)) $(EDA_INCLUDES)
+sprojs_include := -I. -I$(src_dir) $(addprefix -I$(src_dir)/, $(sprojs_enabled)) $(EDA_INCLUDES) $(YAML_CPP_INCLUDES)
 VPATH := $(addprefix $(src_dir)/, $(sprojs_enabled))
 
 #-------------------------------------------------------------------------
@@ -125,9 +126,9 @@ mcppbs-LDFLAGS := @LDFLAGS@ @BOOST_LDFLAGS@
 all-link-flags := $(mcppbs-LDFLAGS) $(LDFLAGS)
 
 comma := ,
-LD            := $(CXX)
-LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@
-LINK          := $(LD) -L. $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
+LD            := $(CXX) 
+LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ -lyaml-cpp
+LINK          := $(LD) -L. $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS))) -L$(shell pwd)/../yaml-cpp/lib/lib64
 
 # Library creation
 
@@ -383,6 +384,12 @@ check : check-cpp check-bin
 # Installation
 #-------------------------------------------------------------------------
 
+yaml-cpp :
+	mkdir -p $(shell pwd)/../yaml-cpp/lib
+	cmake -S $(shell pwd)/../yaml-cpp -B $(shell pwd)/../yaml-cpp/build -DCMAKE_INSTALL_PREFIX=$(shell pwd)/../yaml-cpp/lib -DYAML_BUILD_SHARED_LIBS=OFF
+	make -C $(shell pwd)/../yaml-cpp/build
+	make -C $(shell pwd)/../yaml-cpp/build install
+
 install-config-hdrs : config.h
 	$(MKINSTALLDIRS) $(install_hdrs_dir)
 	for dir in $(install_config_hdrs); \
@@ -498,8 +505,8 @@ junk += $(project_name)-*.tar.gz
 # Default
 #-------------------------------------------------------------------------
 
-all : $(install_hdrs) $(install_libs) $(install_exes)
-.PHONY : all
+all : yaml-cpp $(install_hdrs) $(install_libs) $(install_exes)
+.PHONY : yaml-cpp all
 
 #-------------------------------------------------------------------------
 # Makefile debugging

--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -389,6 +389,7 @@ yaml-cpp :
 	cmake -S $(shell pwd)/../yaml-cpp -B $(shell pwd)/../yaml-cpp/build -DCMAKE_INSTALL_PREFIX=$(shell pwd)/../yaml-cpp/lib -DYAML_BUILD_SHARED_LIBS=OFF
 	make -C $(shell pwd)/../yaml-cpp/build
 	make -C $(shell pwd)/../yaml-cpp/build install
+.PHONY : yaml-cpp
 
 install-config-hdrs : config.h
 	$(MKINSTALLDIRS) $(install_hdrs_dir)

--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
@@ -74,12 +74,10 @@ Simulation::Simulation(
     : sim_t(cfg, halted, mems, plugin_devices, args, dm_config, log_path,
             dtb_enabled, dtb_file, socket_enabled, cmd_file, params) {
 
-  Simulation::default_params(this->params);
   // It seems mandatory to set cache block size for MMU.
   // FIXME TODO: Use actual cache configuration (on/off, # of ways/sets).
   // FIXME TODO: Support multiple cores.
   get_core(0)->get_mmu()->set_cache_blocksz(reg_t(64));
-
   Params::parse_params("/top/", this->params, params);
 
   const std::vector<mem_cfg_t> layout;
@@ -92,7 +90,6 @@ Simulation::Simulation(
   string isa_str = (this->params["/top/isa"]).a_string;
   string priv_str = (this->params["/top/priv"]).a_string;
   this->isa = isa_parser_t(isa_str.c_str(), priv_str.c_str());
-
   this->reset();
 
   bool commitlog = (this->params["/top/log_commits"]).a_bool;

--- a/vendor/riscv/riscv-isa-sim/riscv/YamlParamSetter.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/YamlParamSetter.cc
@@ -1,0 +1,56 @@
+#include "YamlParamSetter.h"
+
+namespace openhw {
+    YamlParamSetter::YamlParamSetter(Params* params, std::string yamlFilePath) {
+        this->params = params;
+        this->yamlFilePath = yamlFilePath;
+    }
+
+    void YamlParamSetter::setParams() {
+        YAML::Node config = this->loadConfigFile();
+        this->setSimulationParameters(config["spike_param_tree"], "/top/", "/top/");
+
+        for(size_t i = 0; i < config["spike_param_tree"]["core_configs"].size(); i++){
+            this->setSimulationParameters(config["spike_param_tree"]["core_configs"][i], "/top/cores/", "/top/core/" + std::to_string(i) + "/");
+        }
+    }
+
+    YAML::Node YamlParamSetter::loadConfigFile() {
+        try{
+            YAML::Node config = YAML::LoadFile(this->yamlFilePath);
+            std::cerr << "[SPIKE] Successfully parsed config file" << endl;
+            return config;
+        } catch(exception& e) {
+            std::cerr << "[SPIKE] Loading config file failed... : " << e.what() << endl;
+            throw;
+        }
+    }
+
+    void YamlParamSetter::setSimulationParameters(YAML::Node config, std::string base, std::string paramBase) {
+        for(YAML::const_iterator it = config.begin(); it != config.end(); ++it) {
+            if (it->first.as<std::string>() == "core_configs") continue;
+            this->redefineParameter(base, paramBase, it);
+        }
+    }
+
+    void YamlParamSetter::redefineParameter(std::string base, std::string paramBase, YAML::const_iterator paramIterator) {
+        std::string paramName = paramIterator->first.as<std::string>();
+        std::string setValue = "";
+        Param param = this->params->get(base, paramName);
+        if (param.type == "string") {
+            std::string stringValue = paramIterator->second.as<std::string>();
+            this->params->set_string(paramBase, paramName, stringValue, param.default_value, param.description);
+            std::cout << "[OK] " << paramBase + paramName << ": " << stringValue << endl;
+        }
+        else if (param.type == "bool") {
+            bool boolValue = paramIterator->second.as<bool>();
+            this->params->set_bool(paramBase, paramName, boolValue, param.default_value, param.description);
+            std::cout << "[OK] " << paramBase + paramName << ": " << boolValue << endl;
+        }
+        else if (param.type == "uint64_t") {
+            uint64_t uint64Value = paramIterator->second.as<uint64_t>();
+            this->params->set_uint64_t(paramBase, paramName, uint64Value, param.default_value, param.description);
+            std::cout << "[OK] " << paramBase + paramName << ": " << uint64Value << endl;
+        }
+    }
+}

--- a/vendor/riscv/riscv-isa-sim/riscv/YamlParamSetter.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/YamlParamSetter.h
@@ -1,0 +1,18 @@
+#include "yaml-cpp/yaml.h"
+#include "Params.h"
+
+namespace openhw {
+
+    class YamlParamSetter {
+        private:
+            Params* params;
+            std::string yamlFilePath;
+        public:
+            YamlParamSetter(Params* params, std::string yamlFilePath);
+            void setParams();
+        private:
+            YAML::Node loadConfigFile();
+            void setSimulationParameters(YAML::Node config, std::string base, std::string paramBase);
+            void redefineParameter(std::string base, std::string paramBase, YAML::const_iterator paramIterator);
+    };
+}

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv.mk.in
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv.mk.in
@@ -14,6 +14,7 @@ riscv_install_shared_lib = yes
 riscv_install_prog_srcs = \
 
 riscv_install_hdrs = \
+	YamlParamSetter.h \
 	Params.h \
 	Types.h \
 	abstract_device.h \
@@ -53,6 +54,7 @@ riscv_precompiled_hdrs = \
 	insn_template.h \
 
 riscv_srcs = \
+	YamlParamSetter.cc \
 	Params.cc \
 	processor.cc \
 	Proc.cc \

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
@@ -4,6 +4,7 @@
 #include "Simulation.h"
 #include "Types.h"
 #include "riscv/mmu.h"
+#include "YamlParamSetter.h"
 
 #include "svdpi.h"
 #include <vpi_user.h>
@@ -35,6 +36,7 @@ std::vector<std::pair<reg_t, mem_t *>> mem_cuts;
 
 std::vector<mem_cfg_t> memory_map;
 Params params;
+std::unique_ptr<YamlParamSetter> paramSetter;
 
 extern "C" void spike_set_default_params(const char *profile) {
   if (strcmp(profile, "cva6") == 0) {
@@ -42,7 +44,7 @@ extern "C" void spike_set_default_params(const char *profile) {
     params.set_string("/top/", "priv", std::string(DEFAULT_PRIV)); // MSU
     params.set_uint64_t("/top/", "num_procs", 0x1UL);
     params.set_bool("/top/", "bootrom", true);
-    params.set_bool("/top/", "generic_core_config", true);
+    params.set_bool("/top/", "generic_core_config", false);
     params.set_uint64_t("/top/", "dram_base", 0x80000000UL);
     params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024);
     params.set_bool("/top/", "max_steps_enabled", false);
@@ -50,6 +52,7 @@ extern "C" void spike_set_default_params(const char *profile) {
 
     params.set_string("/top/core/0/", "name", std::string("cva6"));
     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
+    Simulation::default_params(params);
   }
 }
 
@@ -68,17 +71,23 @@ extern "C" void spike_set_param_bool(const char *base, const char *name,
   params.set_bool(base, name, value);
 }
 
+extern "C" void spike_set_params_from_file(const char *yaml_config_path) {
+  cerr << "[SPIKE] Setting parameters from file : " << yaml_config_path << endl;
+  paramSetter = std::make_unique<YamlParamSetter>(&params, yaml_config_path);
+  paramSetter->setParams();
+}
+
 extern "C" void spike_create(const char *filename) {
   std::cerr << "[SPIKE] Starting 'spike_create'...\n";
-
   // TODO parse params from yaml
-  string isa_str = (params["/top/isa"]).a_string;
+  string isa_str = (params["/top/core/0/isa"]).a_string;
+  string priv_str = (params["/top/core/0/priv"]).a_string;
 
   cfg_t *config = new cfg_t(
       /*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
       /*default_bootargs=*/nullptr,
       /*default_isa=*/isa_str.c_str(), // Built from the RTL configuration
-      /*default_priv=*/DEFAULT_PRIV,   // TODO FIXME Ditto
+      /*default_priv=*/priv_str.c_str(),   // TODO FIXME Ditto
       /*default_varch=*/DEFAULT_VARCH, // TODO FIXME Ditto
       /*default_misaligned=*/false,
       /*default_endianness*/ endianness_little,

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
@@ -42,18 +42,23 @@ extern "C" void spike_set_default_params(const char *profile) {
   if (strcmp(profile, "cva6") == 0) {
     params.set_string("/top/", "isa", std::string("RV64GC"));
     params.set_string("/top/", "priv", std::string(DEFAULT_PRIV)); // MSU
-    params.set_uint64_t("/top/", "num_procs", 0x1UL);
-    params.set_bool("/top/", "bootrom", true);
-    params.set_bool("/top/", "generic_core_config", false);
-    params.set_uint64_t("/top/", "dram_base", 0x80000000UL);
-    params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024);
-    params.set_bool("/top/", "max_steps_enabled", false);
-    params.set_uint64_t("/top/", "max_steps", 2000000UL);
-
     params.set_string("/top/core/0/", "name", std::string("cva6"));
     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
-    Simulation::default_params(params);
+  } else {
+    params.set_string("/top/", "isa", std::string("RV32IMC"));
+    params.set_string("/top/", "priv", std::string("M"));
+    params.set_string("/top/core/0/", "name", std::string("cv32a65x"));
+    params.set_string("/top/core/0/", "isa", std::string("RV32IMC"));
   }
+  params.set_uint64_t("/top/", "num_procs", 0x1UL);
+  params.set_bool("/top/", "bootrom", true);
+  params.set_bool("/top/", "generic_core_config", false);
+  params.set_uint64_t("/top/", "dram_base", 0x80000000UL);
+  params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024);
+  params.set_bool("/top/", "max_steps_enabled", false);
+  params.set_uint64_t("/top/", "max_steps", 2000000UL);
+
+  Simulation::default_params(params);
 }
 
 extern "C" void spike_set_param_uint64_t(const char *base, const char *name,

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -123,8 +123,7 @@ static void help(int exit_code = 1)
                   "                        A uint64_t value can be any unsigned number literal\n"
                   "                        in C/C++ syntax (42, 0x2a, etc.)\n"
                   "                        This flag can be used multiple times.\n");
-  fprintf(stderr, "  --param-file <Yaml file path>  Set parameters to file-specified value (see 'spike --print-params' for a full list.)\n"
-                  "                          This flag can be used multiple times.\n");
+  fprintf(stderr, "  --param-file <Yaml file path>  Set parameters to file-specified value (see 'spike --print-params' for a full list.)\n");
 
   exit(exit_code);
 }

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike.cc
@@ -19,11 +19,12 @@
 #include <fstream>
 #include <limits>
 #include <cinttypes>
+#include "YamlParamSetter.h"
 #include "../VERSION"
 
 static void version(int exit_code = 1)
 {
-  fprintf(stderr, SPIKE_VERSION " %x\n", SPIKE_HASH_VERSION);
+  cerr << SPIKE_VERSION << " " << std::hex << SPIKE_HASH_VERSION << endl;
   exit(exit_code);
 }
 
@@ -122,6 +123,8 @@ static void help(int exit_code = 1)
                   "                        A uint64_t value can be any unsigned number literal\n"
                   "                        in C/C++ syntax (42, 0x2a, etc.)\n"
                   "                        This flag can be used multiple times.\n");
+  fprintf(stderr, "  --param-file <Yaml file path>  Set parameters to file-specified value (see 'spike --print-params' for a full list.)\n"
+                  "                          This flag can be used multiple times.\n");
 
   exit(exit_code);
 }
@@ -459,6 +462,7 @@ int main(int argc, char** argv)
 
   option_parser_t parser;
   openhw::Params params;
+  std::unique_ptr<openhw::YamlParamSetter> paramSetter;
 
   parser.help(&suggest_help);
   parser.option('h', "help", 0, [&](const char UNUSED *s){help(0);});
@@ -509,6 +513,7 @@ int main(int argc, char** argv)
   });
   parser.option(0, "steps", 1, [&](const char* s){max_steps = strtoull(s, 0, 0);});
   parser.option(0, "param", 1, [&](const char* s){params.setFromCmdline(s);});
+  parser.option(0, "param-file", 1, [&](const char* s){paramSetter = std::make_unique<openhw::YamlParamSetter>(&params, s);});
   parser.option(0, "dm-progsize", 1,
       [&](const char* s){dm_config.progbufsize = atoul_safe(s);});
   parser.option(0, "dm-no-impebreak", 0,
@@ -613,7 +618,7 @@ int main(int argc, char** argv)
     }
     cfg.hartids = default_hartids;
   }
-
+  openhw::Simulation::default_params(params);
   if (max_steps != 0) {
     params.set_uint64_t("/top/", "max_steps", max_steps);
     params.set_bool("/top/", "max_steps_enabled", true);
@@ -623,7 +628,8 @@ int main(int argc, char** argv)
   params.set_uint64_t("/top/", "num_procs", cfg.nprocs());
   params.set_string("/top/core/0/", "isa", std::string(cfg.isa()));
   params.set_string("/top/core/0/", "priv", std::string(cfg.priv()));
-
+  if(paramSetter != NULL)
+    paramSetter->setParams();
   openhw::Param param = params.get("/top/core/0/misa_we");
   std::cerr << "[spike.cc:main()] Value of '/top/core/0/misa_we' = " << (param.name != "" ? (param.a_bool ? "true" : "false") : "UNDEFINED") << "\n";
 
@@ -631,6 +637,7 @@ int main(int argc, char** argv)
           mems, plugin_devices, htif_args, dm_config, log_path, dtb_enabled, dtb_file,
           socket,
           cmd_file, params);
+
   s.standalone_mode = 1;
   std::unique_ptr<remote_bitbang_t> remote_bitbang((remote_bitbang_t *) NULL);
   std::unique_ptr<jtag_dtm_t> jtag_dtm(


### PR DESCRIPTION
Add the ability to configure Spike via a YAML parameter file.
The YAML file can be used in both solo and tandem mode:

 - solo mode: use "--yaml-param FILENAME" to standalone Spike
 - tandem mode: pass "+configf_ile=FILENAME" to the RTL simulator.

The documentation is yet to come, and so is the Spike patch file.