### PR TITLE
[WIP] vendor/riscv/riscv-isa-sim: fix yaml-cpp build

### DIFF
--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -249,7 +249,7 @@ lib$(1).a : $$($(2)_objs) $$($(2)_c_objs)
 	rm -f $$@
 	$(AR) rcs $$@ $$^
 lib$(1).so : $$($(2)_objs) $$($(2)_c_objs) $$($(2)_lib_libnames_shared) $$($(2)_lib_libnames)
-	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS)
+	$(LINK) -shared -o $$@ $(if $(filter Darwin,$(shell uname -s)),-install_name $(install_libs_dir)/$$@) $$^ $$($(2)_lib_libnames) $(LIBS) $$($(2)_LDFLAGS)
 
 $(2)_junk += lib$(1).a
 $(2)_junk += $$(if $$($(2)_install_shared_lib),lib$(1).so,)
@@ -268,7 +268,7 @@ $$($(2)_test_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_test_exes) : %-utst : %.t.o $$($(2)_test_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_test_libnames) $(LIBS)
+	$(LINK) -o $$@ $$< $$($(2)_test_libnames) $(LIBS) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_test_deps)
 $(2)_junk += \
@@ -295,7 +295,7 @@ $$($(2)_prog_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
+	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_prog_deps)
 $(2)_junk += $$($(2)_prog_objs) $$($(2)_prog_deps) $$($(2)_prog_exes)
@@ -310,7 +310,7 @@ $$($(2)_install_prog_objs) : %.o : %.cc $$($(2)_gen_hdrs)
 	$(COMPILE) -c $$<
 
 $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS)
+	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \
@@ -506,8 +506,8 @@ junk += $(project_name)-*.tar.gz
 # Default
 #-------------------------------------------------------------------------
 
-all : yaml-cpp $(install_hdrs) $(install_libs) $(install_exes)
-.PHONY : yaml-cpp all
+all : $(install_hdrs) $(install_libs) $(install_exes)
+.PHONY : all
 
 #-------------------------------------------------------------------------
 # Makefile debugging

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv.mk.in
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv.mk.in
@@ -8,6 +8,7 @@ riscv_subproject_deps = \
 	softfloat \
 
 riscv_CFLAGS = -fPIC
+riscv_LDFLAGS = -lyaml-cpp
 
 riscv_install_shared_lib = yes
 
@@ -92,6 +93,7 @@ riscv_test_srcs =
 
 riscv_gen_hdrs = \
 	insn_list.h \
+	yaml-cpp \
 
 
 riscv_insn_ext_i = \

--- a/vendor/riscv/riscv-isa-sim/spike_main/spike_main.mk.in
+++ b/vendor/riscv/riscv-isa-sim/spike_main/spike_main.mk.in
@@ -14,3 +14,6 @@ spike_main_install_prog_srcs = \
 spike_main_srcs = \
 
 spike_main_CFLAGS = -fPIC
+
+spike_main_gen_hdrs = \
+	yaml-cpp \


### PR DESCRIPTION
There are several issues building spike in CVA6 CI:

1. The `yaml-cpp` target added by Valentin outputs `.h` files so it must be run before compiling `riscv` which directly depends on it, and `spike_main` which indirectly depends on it.
   The way it was added did not guarantee that so we encountered non-deterministic "missing included .h file" errors at compile-time.
   This should be fixed in this PR thanks to `gen_hdrs` variables.
2. (There was an issue with submodule recursive clone but that is solved in CVA6 repository)
3. There is the same issue at link-time. An `_LDFLAGS` variable has been added but I feel it does not fix the thing. So this change might not be relevant, and I unfortunately have no time to fix now.
4. With the current version, some VCS-UVM simulations fail.