### PR TITLE
Add support to ratified B Standard Extension for Bit Manip. Instructions

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0021-add-support-to-ratified-B-standard-extension.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0021-add-support-to-ratified-B-standard-extension.patch
@@ -1,0 +1,16 @@
+diff --git a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+index 7335a147..ddb486a6 100644
+--- a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
++++ b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+@@ -326,6 +326,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
+   if (extension_table['H'] && !supervisor)
+     bad_isa_string(str, "'H' extension requires S mode");
+ 
++  // B Standard Extension for Bit Manipulation Instructions	  April 2024
++  if (extension_table[EXT_ZBA] && extension_table[EXT_ZBB] && extension_table[EXT_ZBS]) {
++    extension_table['B'] = true;
++  }
++
+   max_isa = max_xlen == 32 ? reg_t(1) << 30 : reg_t(2) << 62;
+   for (unsigned char ch = 'A'; ch <= 'Z'; ch++) {
+     if (extension_table[ch])

--- a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+++ b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
@@ -326,6 +326,11 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
   if (extension_table['H'] && !supervisor)
     bad_isa_string(str, "'H' extension requires S mode");
 
+  // B Standard Extension for Bit Manipulation Instructions	  April 2024
+  if (extension_table[EXT_ZBA] && extension_table[EXT_ZBB] && extension_table[EXT_ZBS]) {
+    extension_table['B'] = true;
+  }
+
   max_isa = max_xlen == 32 ? reg_t(1) << 30 : reg_t(2) << 62;
   for (unsigned char ch = 'A'; ch <= 'Z'; ch++) {
     if (extension_table[ch])


### PR DESCRIPTION
Add support to [B Standard Extension for Bit Manipulation Instructions](https://drive.google.com/file/d/1SgLoasaBjs5WboQMaU3wpHkjUwV71UZn/view?usp=drive_link) listed in [Ratified Extensions](https://wiki.riscv.org/display/HOME/Ratified+Extensions).


> Chapter 1. B Standard Extension for Bit
> Manipulation Instructions
> The B standard extension comprises instructions provided by the Zba, Zbb, and Zbs extensions.
> 1.1. Privileged Architecture Implications
> Bit 1 of the misa register encodes the presence of the B standard extension. When misa.B is 1, the
> implementation supports the instructions provided by the Zba, Zbb, and Zbs extensions. When
> misa.B is 0, it indicates that the implementation may not support one or more of the Zba, Zbb, or Zbs
> extensions.