### PR TITLE
Update intro.rst - Latest links to user manuals of respective cores

### DIFF
--- a/docs/VerifStrat/source/intro.rst
+++ b/docs/VerifStrat/source/intro.rst
@@ -60,11 +60,11 @@ cores currently in development:
 - `CV32E40P RTL source <https://github.com/openhwgroup/cv32e40p>`_
 - `CV32E40P user manual <https://cv32e40p.readthedocs.io/en/latest/>`_
 - `CV32E40X RTL source <https://github.com/openhwgroup/cv32e40x>`_
-- `CV32E40X user manual <https://cv32e40x.readthedocs.io/en/latest/>`_
+- `CV32E40X user manual <https://docs.openhwgroup.org/projects/cv32e40x-user-manual/en/latest/>`_
 - `CV32E40S RTL source <https://github.com/openhwgroup/cv32e40s>`_
-- `CV32E40S user manual <https://cv32e40s.readthedocs.io/en/latest/>`_
+- `CV32E40S user manual <https://docs.openhwgroup.org/projects/cv32e40s-user-manual/en/latest/>`_
 - `CVA6 RTL source <https://github.com/openhwgroup/cva6>`_
-- `CVA6 user manual <https://cva6.readthedocs.io/en/latest/intro.html>`_
+- `CVA6 user manual <https://docs.openhwgroup.org/projects/cva6-user-manual/>`_
 
 The OpenHW Group also maintains the following repositories for stand-alone verification components:
 


### PR DESCRIPTION
The existing links for user manuals of
- cv32e40x https://cv32e40x.readthedocs.io/en/latest/
- cv32e40s https://cv32e40s.readthedocs.io/en/latest/
- cva6 https://cva6.readthedocs.io/en/latest/intro.html 
are not found.  
Modified the links to point the latest docs from the respective core repos.
- cv32e40x https://docs.openhwgroup.org/projects/cv32e40x-user-manual/en/latest/
- cv32e40s https://docs.openhwgroup.org/projects/cv32e40s-user-manual/en/latest/
- cva6 https://docs.openhwgroup.org/projects/cva6-user-manual/