### PR TITLE
s/release Vsim Fixes

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_seq_item.sv
+++ b/lib/uvm_agents/uvma_rvfi/seq/uvma_rvfi_instr_seq_item.sv
@@ -469,7 +469,7 @@ function void uvma_rvfi_instr_seq_item_c::rvfi2seq(st_rvfi rvfi);
     trap = rvfi.trap;
     halt = rvfi.halt;
     intr = rvfi.intr;
-    mode = rvfi.mode;
+    mode = uvma_rvfi_mode'(rvfi.mode);
     ixl = rvfi.ixl;
     dbg = rvfi.dbg;
     dbg_mode = rvfi.dbg_mode;


### PR DESCRIPTION
This PR fixes Questasim compilation after the previous PR.

After https://github.com/openhwgroup/core-v-verif/pull/2427, compilation did not work for me using vsim because of this need for an explicit cast.

Test status:
* xrun ci_check - pass
* vsim hello world - pass