### PR TITLE
Corrected a non-expected behavior due to PR2439

### DIFF
--- a/cv32e40p/env/corev-dv/cv32e40p_load_store_instr_lib.sv
+++ b/cv32e40p/env/corev-dv/cv32e40p_load_store_instr_lib.sv
@@ -17,7 +17,7 @@
 
 
  class cv32e40p_multi_page_load_store_instr_stream extends riscv_multi_page_load_store_instr_stream;
-    rand bit          has_taken_avail_comp_reg[];
+    rand int          has_taken_avail_comp_reg[];
     riscv_reg_t       s0_a5_avail_regs[];
 
     constraint with_compress_instructions_c {
@@ -48,7 +48,7 @@
 
 
  class cv32e40p_mem_region_stress_test extends riscv_mem_region_stress_test;
-    rand bit          has_taken_avail_comp_reg[];
+    rand int          has_taken_avail_comp_reg[];
     riscv_reg_t       s0_a5_avail_regs[];
 
     constraint with_compress_instructions_c {


### PR DESCRIPTION
In #2439, I introduced a fix to prevent all compressed-dedicated registers to be reserved for some streams, but I didn't pay attention that `.sum()` method for arrays is type-conservative, so it was always giving 0 or 1 in the constraints solver...

By luck, it solved the issue for the specific testcase I gave, but (of course...) the error came back for another testcase : 

```
make gen_corev-dv TEST=corev_rand_instr_test CV_CORE=cv32e40p COREV=1 CFG=pulp_fpu_zfinx_1cyclat TEST_CFG_FILE=floating_pt_zfinx_instr_en,disable_all_trn_logs SIMULATOR=vsim SEED=784606021
```

(I hope) I solved this for good. 
