### PR TITLE
Questasim - Fix ADV_DEBUG

### DIFF
--- a/mk/uvmt/vsim.mk
+++ b/mk/uvmt/vsim.mk
@@ -42,9 +42,9 @@ DPI_INCLUDE            ?= $(abspath $(shell which $(VLIB))/../../include)
 
 # Default flags
 VSIM_USER_FLAGS         ?=
-VOPT_COV  				?= +cover=setf+$(RTLSRC_VLOG_TB_TOP).
-VSIM_COV 				?= -coverage
-VOPT_WAVES_ADV_DEBUG    ?= -designfile design.bin
+VOPT_COV                ?= +cover=setf+$(RTLSRC_VLOG_TB_TOP).
+VSIM_COV                ?= -coverage
+VOPT_WAVES_ADV_DEBUG    ?= -designfile $(SIM_CFG_RESULTS)/design.bin
 VSIM_WAVES_ADV_DEBUG    ?= -qwavedb=+signal+assertion+ignoretxntime+msgmode=both
 VSIM_WAVES_DO           ?= $(VSIM_SCRIPT_DIR)/waves.tcl
 
@@ -255,15 +255,15 @@ endif
 ################################################################################
 # Interactive simulation
 ifeq ($(call IS_YES,$(GUI)),YES)
-ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
-VSIM_FLAGS += -visualizer=+designfile=../design.bin
+    ifeq ($(call IS_YES,$(ADV_DEBUG)),YES)
+        VSIM_FLAGS += -visualizer=+designfile=$(SIM_CFG_RESULTS)/design.bin
+    else
+        VSIM_FLAGS += -gui
+    endif
+    VSIM_FLAGS += -do $(VSIM_SCRIPT_DIR)/gui.tcl
 else
-VSIM_FLAGS += -gui
-endif
-VSIM_FLAGS += -do $(VSIM_SCRIPT_DIR)/gui.tcl
-else
-VSIM_FLAGS += -batch
-VSIM_FLAGS += -do $(VSIM_SCRIPT_DIR)/vsim.tcl
+    VSIM_FLAGS += -batch
+    VSIM_FLAGS += -do $(VSIM_SCRIPT_DIR)/vsim.tcl
 endif
 
 ################################################################################


### PR DESCRIPTION
This PR fixes `ADV_DEBUG=1` to work for vsim.

--------

Without `ADV_DEBUG=1` I get an ancient GUI (where I can't even find the "start" button).

Without this fix, I run
`make test TEST=hello-world SIMULATOR=vsim USE_ISS=0  GUI=1 ADV_DEBUG=1 WAVES=1`
and get:
```
Fatal Error :
Design File ../design.bin not found ...
```
Because the `../design.bin` path is slightly off.

--------

Test status:
* Hello world with GUI (ADV_DEBUG) - Pass
* `ci_check` - Pass, except...
    * ... 4 runs say failed even though they print pass in the log, because Questa prints a message about not liking seeds with negative values.
    * I think it is extremely unlikely that this PR has introduced this, as it touches something unrelated, so since all logs print "SIMULATION PASSED" I deem it as passed.