### PR TITLE
modified run_phase -> main_phase

### DIFF
--- a/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
+++ b/cv32e40p/env/uvme/uvme_cv32e40p_env.sv
@@ -88,7 +88,7 @@ class uvme_cv32e40p_env_c extends uvm_env;
    /**
     * Creates and starts the instruction and virtual peripheral sequences in active mode.
     */
-   extern virtual task run_phase(uvm_phase phase);
+   extern virtual task main_phase(uvm_phase phase);
 
    /**
     * Get virtual interface handles from UVM Configuration Database.
@@ -225,7 +225,7 @@ endfunction: connect_phase
 //   2. The calls to randomize() are on sequences that are only randomized
 //      once in this ENV.
 //
-task uvme_cv32e40p_env_c::run_phase(uvm_phase phase);
+task uvme_cv32e40p_env_c::main_phase(uvm_phase phase);
 
    uvma_obi_memory_fw_preload_seq_c fw_preload_seq;
    uvma_obi_memory_slv_seq_c        instr_slv_seq;
@@ -310,7 +310,7 @@ task uvme_cv32e40p_env_c::run_phase(uvm_phase phase);
       join_none
    end
 
-endtask : run_phase
+endtask : main_phase
 //@DVT_LINTER_WAIVER_END "MT20220302_01"
 
 

--- a/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
+++ b/cv32e40p/tests/uvmt/base-tests/uvmt_cv32e40p_base_test.sv
@@ -110,7 +110,7 @@ class uvmt_cv32e40p_base_test_c extends uvm_test;
     * 1. Triggers the start of clock generation via start_clk()
     * 2. Starts the watchdog timeout via watchdog_timeout()
     */
-   extern virtual task run_phase(uvm_phase phase);
+   extern virtual task main_phase(uvm_phase phase);
 
    /**
     * Runs reset_vseq.
@@ -262,13 +262,13 @@ function void uvmt_cv32e40p_base_test_c::end_of_elaboration_phase(uvm_phase phas
 endfunction : end_of_elaboration_phase
 
 
-task uvmt_cv32e40p_base_test_c::run_phase(uvm_phase phase);
+task uvmt_cv32e40p_base_test_c::main_phase(uvm_phase phase);
 
-   super.run_phase(phase);
+   super.main_phase(phase);
 
    watchdog_timer();
 
-endtask : run_phase
+endtask : main_phase
 
 
 task uvmt_cv32e40p_base_test_c::reset_phase(uvm_phase phase);

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv
@@ -76,7 +76,7 @@ class uvmt_cv32e40p_firmware_test_c extends uvmt_cv32e40p_base_test_c;
    /**
     *  Enable program execution, wait for completion.
     */
-   extern virtual task run_phase(uvm_phase phase);
+   extern virtual task main_phase(uvm_phase phase);
 
    /**
    * Start random debug sequencer
@@ -122,10 +122,10 @@ task uvmt_cv32e40p_firmware_test_c::configure_phase(uvm_phase phase);
 endtask : configure_phase
 
 
-task uvmt_cv32e40p_firmware_test_c::run_phase(uvm_phase phase);
+task uvmt_cv32e40p_firmware_test_c::main_phase(uvm_phase phase);
 
    // start_clk() and watchdog_timer() are called in the base_test
-   super.run_phase(phase);
+   super.main_phase(phase);
 
    if ($test$plusargs("gen_random_debug") || $test$plusargs("gen_reduced_rand_dbg_req")) begin
     fork
@@ -151,7 +151,7 @@ task uvmt_cv32e40p_firmware_test_c::run_phase(uvm_phase phase);
    end
 
    phase.raise_objection(this);
-   @(posedge env_cntxt.clknrst_cntxt.vif.reset_n);
+   //@(posedge env_cntxt.clknrst_cntxt.vif.reset_n);
    repeat (33) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
    `uvm_info("TEST", "Started RUN", UVM_NONE)
    // The firmware is expected to write exit status and pass/fail indication to the Virtual Peripheral
@@ -165,7 +165,7 @@ task uvmt_cv32e40p_firmware_test_c::run_phase(uvm_phase phase);
    `uvm_info("TEST", $sformatf("Finished RUN: exit status is %0h", vp_status_vif.exit_value), UVM_NONE)
    phase.drop_objection(this);
 
-endtask : run_phase
+endtask : main_phase
 
 task uvmt_cv32e40p_firmware_test_c::reset_debug();
     uvme_cv32e40p_random_debug_reset_c debug_vseq;

--- a/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_riscof_firmware_test.sv
+++ b/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_riscof_firmware_test.sv
@@ -84,7 +84,7 @@ class uvmt_cv32e40p_riscof_firmware_test_c extends uvmt_cv32e40p_base_test_c;
     /**
      *  Enable program execution, wait for completion.
      */
-    extern virtual task run_phase(uvm_phase phase);
+    extern virtual task main_phase(uvm_phase phase);
 
     extern function void write_riscof_signature();
 
@@ -139,12 +139,12 @@ function void uvmt_cv32e40p_riscof_firmware_test_c::post_randomize();
 endfunction : post_randomize
 
 
-task uvmt_cv32e40p_riscof_firmware_test_c::run_phase(uvm_phase phase);
+task uvmt_cv32e40p_riscof_firmware_test_c::main_phase(uvm_phase phase);
 
-    super.run_phase(phase);
+    super.main_phase(phase);
 
     phase.raise_objection(this);
-    @(posedge env_cntxt.clknrst_cntxt.vif.reset_n);
+    //@(posedge env_cntxt.clknrst_cntxt.vif.reset_n);
     repeat (33) @(posedge env_cntxt.clknrst_cntxt.vif.clk);
     `uvm_info("TEST", "Started RUN", UVM_NONE)
 
@@ -162,7 +162,7 @@ task uvmt_cv32e40p_riscof_firmware_test_c::run_phase(uvm_phase phase);
 
     phase.drop_objection(this);
 
-endtask : run_phase
+endtask : main_phase
 
 function void uvmt_cv32e40p_riscof_firmware_test_c::write_riscof_signature();
     bit[31:0]     mem_read;


### PR DESCRIPTION
As per issue #1933 , I have modified `run_phase` to `main_phase` to be in consistent with the use of other run time phases (`reset_phase`, `confgure_phase`) in the base test, firmware test and firmware riscof test. 
Now the problem with line 154 in [uvmt_cv32e40p_firmware_test.sv](https://github.com/openhwgroup/core-v-verif/blob/cv32e40p/dev/cv32e40p/tests/uvmt/compliance-tests/uvmt_cv32e40p_firmware_test.sv) is statements below are waiting on posedge of resetn. If we use `run_phase` it works fine because `run_phase` starts at time 0 in parallel with `reset_phase` and senses the posedge of resetn whenever it happens. But when I use `main_phase` instead, I observed the line 154 waits on for resetn posedge and it never happens because the `reset_phase` has already completed. Due to this the test hangs and never finishes. So, to run ci_check, I have commented the line 154, and checks passed as expected. The question : is it okay if we do not wait for posedge of resetn? if we were to wait on reset, then it is better to fork off the current reset, configure and run phase tasks in only one run_phase so the reset posedge in one thread can be detected correctly by other forked thread.

On the other hand, if we would like to add _on-the-fly reset_ feature as @MikeOpenHWGroup explained, then it is better to use reset, configure and main phases instead of `run_phase`.