### PR TITLE
Spike modifications for cv32e40s reference model

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0021-cv32e40s-support.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0021-cv32e40s-support.patch
@@ -1,0 +1,415 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+index c3d4149..ce0078c 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+@@ -20,15 +20,23 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   this->taken_trap = false;
+   this->which_trap = 0;
+ 
+-  rvfi.pc_rdata = this->get_state()->pc;
++  // Store the state before stepping
++  state_t prev_state = *this->get_state();
++
+   processor_t::step(n);
+ 
++  rvfi.pc_rdata = this->last_pc;
++
++  rvfi.pc_wdata = this->get_state()->pc; // Next predicted PC
++
+   rvfi.mode = this->get_state()->last_inst_priv;
+   rvfi.insn =
+       (uint32_t)(this->get_state()->last_inst_fetched.bits() & 0xffffffffULL);
+ 
+   // TODO FIXME Handle multiple/zero writes in a single insn.
+   auto &reg_commits = this->get_state()->log_reg_write;
++  auto &mem_write_commits = this->get_state()->log_mem_write;
++  auto &mem_read_commits = this->get_state()->log_mem_read;
+   int xlen = this->get_state()->last_inst_xlen;
+   int flen = this->get_state()->last_inst_flen;
+ 
+@@ -37,13 +45,69 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   rvfi.rs2_addr = this->get_state()->last_inst_fetched.rs2();
+   // TODO add rs2_value
+ 
+-  rvfi.trap = this->taken_trap;
+-  rvfi.trap |= (this->which_trap << 1);
+ 
++  if(this->next_rvfi_intr){
++    rvfi.intr = next_rvfi_intr;
++    this->next_rvfi_intr = 0;
++
++  }
++  
++  // Output dbg caused from EBREAK the previous instruction
++  if(this->next_debug) {
++    rvfi.dbg = this->next_debug;
++    this->next_debug = 0;
++  }
++
++  if(this->state.debug_mode  && (prev_state.debug_mode == 0)){
++    // New external debug request
++    if((this->halt_request != HR_NONE)){ 
++      rvfi.dbg = this->get_state()->dcsr->cause;
++      rvfi.dbg_mode = 1;
++
++    // EBREAK
++    } else if(this->get_state()->dcsr->cause == DCSR_CAUSE_SWBP) {
++      // EBREAK will set debug_mode to 1, but we should report this at the next instruction
++      rvfi.trap |= 1 << 0; //trap [0]
++      rvfi.trap |= 1 << 2; //debug [2]
++      rvfi.trap |= 0xE00 & ((DCSR_CAUSE_SWBP) << 9); //debug cause [11:9]
++      
++      this->next_debug = DCSR_CAUSE_SWBP;
++    }
++  }
++
++  // Set dbg_mode to 1 the first instruction in debug mode, but delay turning 
++  // off dbg_mode to the next instruction after turning off to keep dbg_mode on for dret
++  if( (this->halt_request != HR_NONE)  && (prev_state.debug_mode == 0)) {
++    rvfi.dbg_mode = 1;
++  } else {
++    rvfi.dbg_mode = prev_state.debug_mode;
++  }
++
++
++  if(this->taken_trap) {
++    //interrrupts are marked with the msb high in which_trap
++    if(this->which_trap & ((reg_t)1 << (isa->get_max_xlen() - 1))) { 
++      //Since spike steps two times to take an interrupt, we store the intr value to the next step to return with rvfi
++      this->next_rvfi_intr |= 1 << 0; //intr [0]
++      this->next_rvfi_intr |= 1 << 2; //interrupt [2]
++      this->next_rvfi_intr |= 0x3FF8 & ((this->which_trap & 0xFF) << 3); //cause[13:3]
++    } else{
++      rvfi.trap |= 1 << 0; //trap [0]
++      rvfi.trap |= 1 << 1; //exception [1]
++      rvfi.trap |= 0x1F8 & ((this->which_trap) << 3); //exception_cause [8:3]
++      //TODO:
++      //debug_cause     [11:9] debug cause
++      //cause_type      [13:12]
++      //clicptr         [14]  CLIC interrupt pending
++      this->next_rvfi_intr = rvfi.trap; //store value to return with rvfi.intr on the next step
++    }
++  }
++
++  uint64_t last_rd_addr = 0;
++  uint64_t last_rd_wdata = 0;
+   bool got_commit = false;
+   for (auto &reg : reg_commits) {
+-      if ((reg.first >> 4) > 32) {
+-          if ((reg.first >> 4) < 0xFFF) {
++    if((reg.first & 0xf) == 0x4) { //If CSR
+             for (size_t i = 0; i < CSR_SIZE; i++) {
+                 if (!rvfi.csr_valid[i]) {
+                     rvfi.csr_valid[i] = 1;
+@@ -54,14 +118,59 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+                 }
+             }
+           }
++    else {
++      if (got_commit) {
++        last_rd_addr = reg.first >> 4;
++        last_rd_wdata = reg.second.v[0];
++        continue;
+       }
+-      else {
+         // TODO FIXME Take into account the XLEN/FLEN for int/FP values.
+         rvfi.rd1_addr = reg.first >> 4;
+         rvfi.rd1_wdata = reg.second.v[0];
+         // TODO FIXME Handle multiple register commits per cycle.
+         // TODO FIXME This must be handled on the RVFI side as well.
++      got_commit = true; // Only latch first commit
++    }
++  }
++  // popret(z) should return rd1_addr = 0 instead of the SP to match with the cv32e40s core
++  if (((this->get_state()->last_inst_fetched.bits() & MASK_CM_POPRET) == MATCH_CM_POPRET) ||
++      ((this->get_state()->last_inst_fetched.bits() & MASK_CM_POPRETZ) == MATCH_CM_POPRETZ)) {
++    rvfi.rd1_addr = 0;
++    rvfi.rd1_wdata = 0;
++  }
++
++  bool mem_access = false; // TODO: support multiple memory writes/reads
++  int read_len;
++  for (auto &mem : mem_read_commits) {
++    //mem format: (addr, 0, size) (value is not stored for reads, but should be the same as rd)
++    if(!mem_access) {
++      rvfi.mem_addr = std::get<0>(mem);
++      if ((this->get_state()->last_inst_fetched.bits() & MASK_CM_POP) == MATCH_CM_POP         ||
++          (this->get_state()->last_inst_fetched.bits() & MASK_CM_POPRET) == MATCH_CM_POPRET   ||
++          (this->get_state()->last_inst_fetched.bits() & MASK_CM_POPRETZ) == MATCH_CM_POPRETZ ){    
++        rvfi.mem_rdata = last_rd_wdata; // During pop, rd1 returns sp, so instead return value read from memory 
++      } else {
++        rvfi.mem_rdata = rvfi.rd1_wdata; 
+       }
++      //mem_rmask should hold a bitmask of which bytes in mem_rdata contain valid data
++      read_len = std::get<2>(mem);
++      rvfi.mem_rmask = (1 << read_len) - 1;
++      mem_access = true;
++    }
++  }
++
++  int write_len;
++  for (auto &mem : mem_write_commits) {
++    //mem format: (addr, value, size)
++    if(!mem_access) {
++      rvfi.mem_addr = std::get<0>(mem);
++      rvfi.mem_wdata = std::get<1>(mem); // value
++      //mem_wmask should hold a bitmask of which bytes in mem_wdata contain valid data
++      write_len = std::get<2>(mem);
++      rvfi.mem_wmask = (1 << write_len) - 1;
++      mem_access = true;
++    }
++
+   }
+ 
+   if (csr_counters_injection) {
+@@ -107,6 +216,12 @@ Processor::Processor(
+   Params::parse_params(base, this->params, params);
+ 
+   string isa_str = this->params[base + "isa"].a_string;
++
++  // Add _xdummy to enable bit 23 in MISA if non standard extensions are used
++  if( (this->params[base+"nonstd_ext"]).a_bool) {
++    isa_str = isa_str + "_xdummy";
++  }
++
+   string priv_str = this->params[base + "priv"].a_string;
+   std::cout << "[SPIKE] Proc 0 | ISA: " << isa_str << " PRIV: " << priv_str << std::endl;
+   this->isa =
+@@ -192,6 +307,9 @@ Processor::Processor(
+   bool misa_we = (this->params[base + "misa_we"]).a_bool;
+   if (misa_we_enable)
+     this->state.misa->set_we(misa_we);
++
++  this->next_rvfi_intr = 0;
++
+ }
+ 
+ void Processor::take_trap(trap_t &t, reg_t epc) {
+@@ -242,6 +360,10 @@ void Processor::default_params(string base, openhw::Params &params) {
+ 
+   params.set_bool(base, "csr_counters_injection", false, "false",
+              "Allow to set CSRs getting values from a DPI");
++
++  params.set_bool(base, "nonstd_ext", false, "false",
++             "Non-standard extension used");
++
+ }
+ 
+ inline void Processor::set_XPR(reg_t num, reg_t value) {
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.h b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+index 5387ce1..12533f2 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+@@ -21,7 +21,8 @@ public:
+ protected:
+   bool csr_counters_injection;
+   bool taken_trap;
+-  uint8_t which_trap;
++  uint32_t which_trap;
++  reg_t next_rvfi_intr, next_debug;
+   virtual void take_trap(trap_t &t, reg_t epc); // take an exception
+ };
+ 
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+index 551ce79..946268e 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+@@ -52,6 +52,18 @@ void Simulation::default_params(openhw::Params &params) {
+   params.set_uint64_t("/top/", "dram_size", 0x400UL * 1024 * 1024,
+              "0x40000000", "DRAM size");
+ 
++  params.set_bool("/top/", "dbg", false, "false", "DBG enable");
++  params.set_uint64_t("/top/", "dbg_base", 0x1a110800UL,
++             "0x80000000", "DBG base address");
++  params.set_uint64_t("/top/", "dbg_size", 0x1000UL,
++             "0x40000000", "DBG size");
++
++  params.set_bool("/top/", "vp", false, "false", "Virtual peripherals enable");
++  params.set_uint64_t("/top/", "vp_base", 0x00800000UL,
++             "0x80000000", "VP base address");
++  params.set_uint64_t("/top/", "vp_size", 0x1000UL,
++             "0x40000000", "VP size");
++
+   params.set_bool("/top/", "log_commits", true, "True",
+              "Log commit enable");
+ 
+@@ -60,6 +72,9 @@ void Simulation::default_params(openhw::Params &params) {
+   params.set_uint64_t("/top/", "max_steps", 200000UL, "200000",
+              "Maximum steps that the simulation can do ");
+ 
++  params.set_bool("/top/", "dtb_enabled", true, "True",
++             "dtb_enabled");
++
+   Processor::default_params("/top/cores/", params);
+ }
+ 
+@@ -115,7 +130,7 @@ Simulation::Simulation(const cfg_t *cfg, string elf_path,
+                  plugin_devs, std::vector<std::string>() = {elf_path},
+                  dm_config,
+                  "tandem.log", // log_path
+-                 true,         // dtb_enabled
++                 (params["/top/dtb_enabled"]).a_bool, // dtb_enabled
+                  nullptr,      // dtb_file
+                  false,        // socket_enabled
+                  NULL,         // cmd_file
+@@ -175,6 +190,25 @@ void Simulation::make_mems(const std::vector<mem_cfg_t> &layout) {
+   if (dram) {
+     this->mems.push_back(std::make_pair(dram_base, new mem_t(dram_size)));
+   }
++
++  //dbg
++  bool dbg = (this->params["/top/dbg"]).a_bool;
++  uint64_t dbg_base = (this->params["/top/dbg_base"]).a_uint64_t;
++  uint64_t dbg_size = (this->params["/top/dbg_size"]).a_uint64_t;
++  if (dbg){
++    this->mems.push_back(std::make_pair(dbg_base, new mem_t(dbg_size)));
++  }
++
++
++  //CV_VP_REGISTER 
++  bool vp = (this->params["/top/vp"]).a_bool;
++  uint64_t vp_base = (this->params["/top/vp_base"]).a_uint64_t;
++  uint64_t vp_size = (this->params["/top/vp_size"]).a_uint64_t;
++  if (vp) {
++    this->mems.push_back(std::make_pair(vp_base, new mem_t(vp_size)));
++  }
++
++  
+ }
+ 
+ std::vector<st_rvfi> Simulation::step(size_t n,
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Types.h b/vendor/riscv/riscv-isa-sim/riscv/Types.h
+index d0b953f..496df0e 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Types.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/Types.h
+@@ -28,8 +28,7 @@ typedef struct {
+    uint64_t                 insn_interrupt;
+    uint64_t                 insn_interrupt_id;
+    uint64_t                 insn_bus_fault;
+-   uint64_t                 insn_nmi_store_fault;
+-   uint64_t                 insn_nmi_load_fault;
++   uint64_t                 insn_nmi_cause;
+ 
+    uint64_t                 pc_rdata;
+    uint64_t                 pc_wdata;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+index f71e61f..28695eb 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+@@ -992,13 +992,15 @@ bool wide_counter_csr_t::unlogged_write(const reg_t val) noexcept {
+   // takes precedence over the increment to instret.  However, Spike
+   // unconditionally increments instret after executing an instruction.
+   // Correct for this artifact by decrementing instret here.
+-   openhw::reg::unlogged_write( openhw::reg::unlogged_read()-1);
++
++  // disable since we (at the moment) check mcounterinhibit
++  //openhw::reg::unlogged_write( openhw::reg::unlogged_read()-1);
+   return true;
+ }
+ 
+ reg_t wide_counter_csr_t::written_value() const noexcept {
+   // Re-adjust for upcoming bump()
+-  return  openhw::reg::unlogged_read() + 1;
++  return  openhw::reg::unlogged_read(); //+ 1; // Disable since we dont always bump
+ }
+ 
+ // implement class time_counter_csr_t
+@@ -1239,9 +1241,10 @@ reg_t dcsr_csr_t::read() const noexcept {
+   v = set_field(v, DCSR_EBREAKH, ebreakh);
+   v = set_field(v, DCSR_EBREAKS, ebreaks);
+   v = set_field(v, DCSR_EBREAKU, ebreaku);
+-  v = set_field(v, DCSR_STOPCYCLE, 0);
++  v = set_field(v, DCSR_STOPCYCLE, 1); //TODO: Make configurable
+   v = set_field(v, DCSR_STOPTIME, 0);
+   v = set_field(v, DCSR_CAUSE, cause);
++  v = set_field(v, DCSR_MPRVEN, 1); // TODO: Make configurable
+   v = set_field(v, DCSR_STEP, step);
+   v = set_field(v, DCSR_PRV, prv);
+   return v;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h b/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h
+index 616cf59..d10e86b 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h
+@@ -17,7 +17,7 @@
+ 
+ // These needs to match the link.ld         
+ #define DEBUG_ROM_WHERETO 0x300
+-#define DEBUG_ROM_ENTRY   0x800
++#define DEBUG_ROM_ENTRY   0x1A110800 //TODO: make configurable
+ #define DEBUG_ROM_TVEC    0x808
+ 
+ #endif
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/encoding.h b/vendor/riscv/riscv-isa-sim/riscv/encoding.h
+index 48cb5c0..44cf70e 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/encoding.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/encoding.h
+@@ -87,6 +87,7 @@
+ #define DCSR_STOPTIME       (1<<9)
+ #define DCSR_CAUSE          (7<<6)
+ #define DCSR_DEBUGINT       (1<<5)
++#define DCSR_MPRVEN         (1<<4)
+ #define DCSR_HALT           (1<<3)
+ #define DCSR_STEP           (1<<2)
+ #define DCSR_PRV            (3<<0)
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/execute.cc b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+index 02b27c5..d922857 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/execute.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+@@ -342,10 +342,14 @@ void processor_t::step(size_t n)
+       in_wfi = true;
+     }
+ 
++    if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x4)) {
+     state.minstret->bump(instret);
++    }
+ 
+     // Model a hart whose CPI is 1.
++    if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x1)) {
+     state.mcycle->bump(instret);
++    }
+ 
+     n -= instret;
+   }
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+index 3222fc9..873b4bd 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+@@ -51,6 +51,38 @@ extern "C" void spike_set_default_params(const char *profile) {
+     params.set_string("/top/core/0/", "name", std::string("cva6"));
+     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
+   }
++  else if (strcmp(profile, "cv32e40s") == 0)
++  {
++    params.set_string("/top/", "isa", std::string("RV32I"));
++    params.set_string("/top/", "priv", std::string("MU"));
++    params.set_uint64_t("/top/", "num_procs", 0x1UL);
++    params.set_bool("/top/", "bootrom", false);
++    params.set_bool("/top/", "generic_core_config", true);
++    params.set_uint64_t("/top/", "dram_base", 0x00000000UL);
++    params.set_uint64_t("/top/", "dram_size", 0x400000UL);
++    params.set_bool("/top/", "max_steps_enabled", false);
++    params.set_uint64_t("/top/", "max_steps", 2000000UL);
++    params.set_bool("/top/", "dtb_enabled", false);
++
++
++    params.set_bool("/top/", "dbg", true);
++    params.set_uint64_t("/top/", "dbg_base", 0x1a110800UL);
++    params.set_uint64_t("/top/", "dbg_size", 0x1000UL);
++
++    //Virtual peripherals
++    params.set_bool("/top/", "vp", true);
++    params.set_uint64_t("/top/", "vp_base", 0x00800000UL);
++    params.set_uint64_t("/top/", "vp_size", 0x1000UL);
++
++
++    params.set_string("/top/core/0/", "name", std::string("cv32e40s"));
++    params.set_string("/top/core/0/", "isa", std::string("RV32I"));
++
++    params.set_uint64_t("/top/core/0/", "marchid", 0x15UL);
++    params.set_uint64_t("/top/core/0/", "misa", 0x40901104UL);
++    params.set_uint64_t("/top/core/0/", "mvendorid", 0x602UL);
++    params.set_uint64_t("/top/core/0/", "mcountinhibit", 0x5UL);
++  }
+ }
+ 
+ extern "C" void spike_set_param_uint64_t(const char *base, const char *name,

--- a/vendor/patches/riscv/riscv-isa-sim/0022-cv32e40s-refmodel-changes.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0022-cv32e40s-refmodel-changes.patch
@@ -1,0 +1,604 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+index ce0078c..2727d99 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+@@ -1,6 +1,7 @@
+ #include "Proc.h"
+ #include "disasm.h"
+ #include "extension.h"
++#include "mmu.h"
+ #include <algorithm>
+ #include <assert.h>
+ #include <cinttypes>
+@@ -16,6 +17,8 @@ namespace openhw {
+ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   st_rvfi rvfi;
+   memset(&rvfi, 0, sizeof(st_rvfi));
++  commit_log_reg_t prev_commit_log_reg = this->get_state()->log_reg_write;
++
+ 
+   this->taken_trap = false;
+   this->which_trap = 0;
+@@ -23,10 +26,21 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   // Store the state before stepping
+   state_t prev_state = *this->get_state();
+ 
++  // Disable WFI to handle the timing outside of spike.
++  in_wfi = false;
+   processor_t::step(n);
+ 
+   rvfi.pc_rdata = this->last_pc;
+ 
++  // Add overwritten values from memory writes during the step
++  prev_changes_t prev_changes(prev_state, this->get_state()->log_mem_pre_write);
++  if(max_previous_states > 0) {
++    previous_states.push_front(prev_changes);
++  }
++  if(previous_states.size() > max_previous_states) {
++    previous_states.pop_back();
++  }
++
+   rvfi.pc_wdata = this->get_state()->pc; // Next predicted PC
+ 
+   rvfi.mode = this->get_state()->last_inst_priv;
+@@ -50,6 +64,8 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+     rvfi.intr = next_rvfi_intr;
+     this->next_rvfi_intr = 0;
+ 
++    //Add csr changes that happened during first interrupt step
++    reg_commits.insert(prev_commit_log_reg.begin(), prev_commit_log_reg.end());
+   }
+   
+   // Output dbg caused from EBREAK the previous instruction
+@@ -108,27 +124,27 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   bool got_commit = false;
+   for (auto &reg : reg_commits) {
+     if((reg.first & 0xf) == 0x4) { //If CSR
+-            for (size_t i = 0; i < CSR_SIZE; i++) {
+-                if (!rvfi.csr_valid[i]) {
+-                    rvfi.csr_valid[i] = 1;
+-                    rvfi.csr_addr[i] = reg.first >> 4;
+-                    rvfi.csr_wdata[i] = reg.second.v[0];
+-                    rvfi.csr_wmask[i] = -1;
+-                    break;
+-                }
+-            }
++      for (size_t i = 0; i < CSR_SIZE; i++) {
++          if (!rvfi.csr_valid[i]) {
++              rvfi.csr_valid[i] = 1;
++              rvfi.csr_addr[i] = reg.first >> 4;
++              rvfi.csr_wdata[i] = reg.second.v[0];
++              rvfi.csr_wmask[i] = -1;
++              break;
+           }
++      }
++    }
+     else {
+       if (got_commit) {
+         last_rd_addr = reg.first >> 4;
+         last_rd_wdata = reg.second.v[0];
+         continue;
+       }
+-        // TODO FIXME Take into account the XLEN/FLEN for int/FP values.
+-        rvfi.rd1_addr = reg.first >> 4;
+-        rvfi.rd1_wdata = reg.second.v[0];
+-        // TODO FIXME Handle multiple register commits per cycle.
+-        // TODO FIXME This must be handled on the RVFI side as well.
++      // TODO FIXME Take into account the XLEN/FLEN for int/FP values.
++      rvfi.rd1_addr = reg.first >> 4;
++      rvfi.rd1_wdata = reg.second.v[0];
++      // TODO FIXME Handle multiple register commits per cycle.
++      // TODO FIXME This must be handled on the RVFI side as well.
+       got_commit = true; // Only latch first commit
+     }
+   }
+@@ -172,7 +188,7 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+     }
+ 
+   }
+-
++  
+   if (csr_counters_injection) {
+     // Inject values comming from the reference
+     if ((rvfi.insn & MASK_CSRRS) == MATCH_CSRRS) {
+@@ -201,6 +217,144 @@ st_rvfi Processor::step(size_t n, st_rvfi reference) {
+   return rvfi;
+ }
+ 
++void Processor::revert_step(uint32_t num_steps) {
++  FILE *log_file = this->get_log_file();
++
++
++  if (previous_states.size() < num_steps) {
++    throw std::runtime_error("Cannot revert more states than stored");
++  }
++
++  for(auto state: previous_states) {
++    fprintf(log_file, "pc: %lx | ", std::get<0>(state).pc);
++  }
++  fprintf(log_file, "\n");
++
++
++
++  fprintf(log_file, "revert %d steps from PC: %lx", num_steps, this->state.pc);
++
++  prev_changes_t prev_changes = previous_states[num_steps];
++  this->state = std::get<0>(prev_changes);
++
++  fprintf(log_file, " to PC: %lx\n", this->state.pc);
++
++  for (uint32_t i = 0; i <= num_steps; i++) {
++    prev_changes_t prev_changes = previous_states.front();
++    previous_states.pop_front();
++
++    commit_log_mem_t log_mem_pre_write = std::get<1>(prev_changes);
++    fprintf(log_file, "revert mem pc: %lx num: %ld\n", std::get<0>(prev_changes).pc, log_mem_pre_write.size());
++
++    for (auto mem_write : log_mem_pre_write) {
++      fprintf(log_file, "revert mem: addr: %lx val: %lx size: %x", std::get<0>(mem_write), std::get<1>(mem_write), std::get<2>(mem_write));
++      switch (std::get<2>(mem_write))
++      {
++      case 1:
++        this->get_mmu()->store<uint8_t>(std::get<0>(mem_write), (uint8_t)std::get<1>(mem_write),0);
++        break;
++      case 2:
++        this->get_mmu()->store<uint16_t>(std::get<0>(mem_write), (uint16_t)std::get<1>(mem_write),0);
++        break;
++      case 4:
++        this->get_mmu()->store<uint32_t>(std::get<0>(mem_write), (uint32_t)std::get<1>(mem_write),0);
++        break;
++      
++      default:
++        break;
++      }
++      fprintf(log_file, " OK\n");
++    }
++  }
++
++  //Clear commit logs since they contain information from the reverted steps
++  this->get_state()->log_mem_write.clear();
++  this->get_state()->log_reg_write.clear();
++  this->get_state()->log_mem_read.clear();
++  this->get_state()->log_mem_pre_write.clear();
++}
++
++bool Processor::will_trigger_interrupt(reg_t mip) {
++  state_t *state = this->get_state();
++
++  uint32_t old_mip = state->mip->read();
++  uint32_t mie = state->mie->read();
++  uint32_t mstatus = state->mstatus->read();
++  uint32_t old_en_irq = old_mip & mie;
++  uint32_t new_en_irq = mip & mie;
++
++
++  // Only take interrupt if interrupt is enabled, not in debug mode, does not have a halt request, 
++  // and the interrupt is new and not zero
++  if( get_field(mstatus, MSTATUS_MIE) &&
++      !state->debug_mode  &&
++      (this->halt_request != processor_t::HR_REGULAR) &&
++      //(old_en_irq == 0 ) && 
++      (new_en_irq != 0)) 
++  {
++    return true;
++  } else {
++    return false;
++  }
++}
++
++bool Processor::interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed) {
++  state_t *state = this->get_state();
++
++  reg_t mask = 0xFFFF0888; // TODO: automatically generate this
++
++  st_rvfi vref; //Passed to step, but not used
++
++  this->interrupt_allowed = interrupt_allowed;
++
++  state->mie->write_with_mask(mask, mie);
++
++  if(interrupt_allowed && will_trigger_interrupt(mip)) {
++    fprintf(this->get_log_file(), "interrupt mip %lx\n", mip);
++
++    this->revert_step(revert_steps);
++
++    state->mip->write_with_mask(mask, mip);
++
++    // This step only sets the correct state for the interrupt, but does not actually execute an instruction
++    // Another step needs to be taken to actually step through the instruction
++    // Therefore we discard the rvfi values returned from this step
++    this->step(1, vref);
++
++    return true;
++  } else {
++    state->mip->write_with_mask(mask, mip);
++    return false;
++  }
++ 
++}
++
++bool Processor::set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed){
++  bool debug_taken = false; 
++
++  // NOTE: This is a workaround to allow the new debug to take over while the ebreak is still in the pipeline
++  // If a new debug request is made while debug is allowed and a ebreak caused debug is active, disable debug mode to take the new debug.
++  // When the ebread retires from the pipeline shell, debug_allowed will be 0, so this will only happen while the ebreak is still in the pipeline
++  if(debug_req && debug_allowed && (this->state.dcsr->cause == DCSR_CAUSE_SWBP)) {
++    this->state.debug_mode = 0; // Set debug mode to 0, to allow external debug to overwrite potetial ebreak caused debug
++  }
++
++  if(!(this->state.debug_mode) && debug_req && debug_allowed && (this->halt_request == HR_NONE)){
++    this->halt_request = HR_REGULAR;
++    debug_taken = true;
++  } else if (this->state.debug_mode) {
++    this->halt_request = HR_NONE;
++  }
++  
++
++  if(debug_taken) {
++    this->revert_step(revert_steps);
++  }
++
++  return debug_taken;
++}
++
++
+ Processor::Processor(
+     const isa_parser_t *isa, const cfg_t *cfg, simif_t *sim, uint32_t id,
+     bool halt_on_reset, FILE *log_file, std::ostream &sout_,
+@@ -310,6 +464,8 @@ Processor::Processor(
+ 
+   this->next_rvfi_intr = 0;
+ 
++  this->max_previous_states = (this->params[base + "num_prev_states_stored"]).a_uint64_t;
++
+ }
+ 
+ void Processor::take_trap(trap_t &t, reg_t epc) {
+@@ -364,6 +520,9 @@ void Processor::default_params(string base, openhw::Params &params) {
+   params.set_bool(base, "nonstd_ext", false, "false",
+              "Non-standard extension used");
+ 
++  params.set_uint64_t(base, "num_prev_states_stored", 0UL, "0",
++             "The number of previous states stored for reverting");
++
+ }
+ 
+ inline void Processor::set_XPR(reg_t num, reg_t value) {
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.h b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+index 12533f2..1661567 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+@@ -3,6 +3,7 @@
+ #include "processor.h"
+ 
+ namespace openhw {
++typedef std::tuple<state_t, commit_log_mem_t> prev_changes_t;
+ class Processor : public processor_t {
+ public:
+   Processor(const isa_parser_t *isa, const cfg_t *cfg, simif_t *sim,
+@@ -12,6 +13,10 @@ public:
+                              // need both
+   ~Processor();
+   st_rvfi step(size_t n, st_rvfi reference);
++  void revert_step(uint32_t num_steps);
++  bool will_trigger_interrupt(reg_t mip);
++  bool interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
++  bool set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed);
+ 
+   static void default_params(string base, openhw::Params &params);
+ 
+@@ -19,6 +24,8 @@ public:
+   inline void set_FPR(reg_t num, float128_t value);
+ 
+ protected:
++  std::deque<prev_changes_t> previous_states;
++  uint64_t max_previous_states;
+   bool csr_counters_injection;
+   bool taken_trap;
+   uint32_t which_trap;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+index 946268e..4820967 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+@@ -94,7 +94,7 @@ Simulation::Simulation(
+   // FIXME TODO: Use actual cache configuration (on/off, # of ways/sets).
+   // FIXME TODO: Support multiple cores.
+   get_core(0)->get_mmu()->set_cache_blocksz(reg_t(64));
+-
++  
+   Params::parse_params("/top/", this->params, params);
+ 
+   const std::vector<mem_cfg_t> layout;
+@@ -236,6 +236,19 @@ std::vector<st_rvfi> Simulation::step(size_t n,
+   return vspike;
+ }
+ 
++
++bool Simulation::interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed) {
++  return ((Processor *)procs[0])->interrupt(mip, mie, revert_steps, interrupt_allowed);
++}
++
++bool Simulation::set_debug_req(bool debug_req, uint32_t revert_steps, bool debug_allowed) {
++  return ((Processor *)procs[0])->set_debug(debug_req, revert_steps, debug_allowed);
++}
++
++void Simulation::revert_state(int num_steps) {
++  ((Processor *)procs[0])->revert_step(num_steps);
++}
++
+ #if 0 // FORNOW Unused code, disable until needed.
+ void Simulation::set_debug(bool value)
+ {
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Simulation.h b/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
+index 9ade57a..7254da5 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
+@@ -60,6 +60,32 @@ public:
+   std::vector<st_rvfi> step(size_t n, std::vector<st_rvfi> &vreference);
+ 
+   /*
++   * Set the MIP register
++   * *
++   * * @param mask:  The value to be set
++   * * @param revert_steps: Number of steps to revert if the interrupt will be taken 
++   * * @param interrupt_allowed: True if interrupt is allowed to be taken 
++   * * @return:  True if interrupt will be taken, false if not
++   * */
++  bool interrupt(reg_t mask, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
++
++  /*
++   * Set the debug request
++   * * 
++   * * @param debug_req:  True if debug request is set
++   * * @param revert_steps: Number of steps to revert if the debug request is taken
++   * * @param debug_allowed: True if debug is allowed to be taken
++   */
++  bool set_debug_req(bool debug_req, uint32_t revert_steps, bool debug_allowed);
++
++  /*
++   * Revert the state  
++   * *
++   * * @param num_steps:  number of steps to revert
++   * */
++  void revert_state(int num_steps);
++
++  /*
+    * Proposed constuctor for the Simulation class
+    * *
+    * * @param params: parameters to configure the simulation behaviour
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+index 28695eb..597d187 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+@@ -734,12 +734,13 @@ mie_csr_t::mie_csr_t(processor_t* const proc, const reg_t addr):
+ }
+ 
+ reg_t mie_csr_t::write_mask() const noexcept {
++  const reg_t custom_ints = 0xffff0000;
+   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
+   const reg_t lscof_int = proc->extension_enabled(EXT_SSCOFPMF) ? MIP_LCOFIP : 0;
+   const reg_t hypervisor_ints = proc->extension_enabled('H') ? MIP_HS_MASK : 0;
+   const reg_t coprocessor_ints = (reg_t)proc->any_custom_extensions() << IRQ_COP;
+   const reg_t delegable_ints = supervisor_ints | coprocessor_ints | lscof_int;
+-  const reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP;
++  const reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP | custom_ints;
+   return all_ints;
+ }
+ 
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/execute.cc b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+index d922857..20f9b57 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/execute.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+@@ -12,6 +12,7 @@ static void commit_log_reset(processor_t* p)
+   p->get_state()->log_reg_write.clear();
+   p->get_state()->log_mem_read.clear();
+   p->get_state()->log_mem_write.clear();
++  p->get_state()->log_mem_pre_write.clear();
+ }
+ 
+ static void commit_log_stash_privilege(processor_t* p)
+@@ -67,6 +68,7 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
+   auto& reg = p->get_state()->log_reg_write;
+   auto& load = p->get_state()->log_mem_read;
+   auto& store = p->get_state()->log_mem_write;
++  auto& prev = p->get_state()->log_mem_pre_write;
+   int priv = p->get_state()->last_inst_priv;
+   int xlen = p->get_state()->last_inst_xlen;
+   int flen = p->get_state()->last_inst_flen;
+@@ -148,6 +150,14 @@ static void commit_log_print_insn(processor_t *p, reg_t pc, insn_t insn)
+     fprintf(log_file, " ");
+     commit_log_print_value(log_file, std::get<2>(item) << 3, std::get<1>(item));
+   }
++
++  for (auto item : prev) {
++    fprintf(log_file, " pre mem ");
++    commit_log_print_value(log_file, xlen, std::get<0>(item));
++    fprintf(log_file, " ");
++    commit_log_print_value(log_file, std::get<2>(item) << 3, std::get<1>(item));
++
++  }
+   fprintf(log_file, "\n");
+ }
+ 
+@@ -329,6 +339,7 @@ void processor_t::step(size_t n)
+     catch(trap_debug_mode&)
+     {
+       enter_debug_mode(DCSR_CAUSE_SWBP);
++      instret++; // Count the EBREAK instruction as executed to return rvfi for the instruction
+     }
+     catch (wait_for_interrupt_t &t)
+     {
+@@ -343,12 +354,12 @@ void processor_t::step(size_t n)
+     }
+ 
+     if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x4)) {
+-    state.minstret->bump(instret);
++      state.minstret->bump(instret);
+     }
+ 
+     // Model a hart whose CPI is 1.
+     if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x1)) {
+-    state.mcycle->bump(instret);
++      state.mcycle->bump(instret);
+     }
+ 
+     n -= instret;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/mmu.h b/vendor/riscv/riscv-isa-sim/riscv/mmu.h
+index ef054cf..425a3d1 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/mmu.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/mmu.h
+@@ -94,16 +94,25 @@ public:
+     reg_t vpn = addr >> PGSHIFT;
+     bool aligned = (addr & (sizeof(T) - 1)) == 0;
+     bool tlb_hit = tlb_store_tag[vpn % TLB_ENTRIES] == vpn;
++    target_endian<T> previous_value;
+ 
+     if (xlate_flags == 0 && likely(aligned && tlb_hit)) {
++      //Store previous value before writing
++      previous_value = *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr);
++
+       *(target_endian<T>*)(tlb_data[vpn % TLB_ENTRIES].host_offset + addr) = to_target(val);
+     } else {
++      //Store previous value before writing
++      load_slow_path(addr, sizeof(T), (uint8_t*)&previous_value, xlate_flags);
++
+       target_endian<T> target_val = to_target(val);
+       store_slow_path(addr, sizeof(T), (const uint8_t*)&target_val, xlate_flags, true, false);
+     }
+ 
+-    if (unlikely(proc && proc->get_log_commits_enabled()))
++    if (unlikely(proc && proc->get_log_commits_enabled())) {
+       proc->state.log_mem_write.push_back(std::make_tuple(addr, val, sizeof(T)));
++      proc->state.log_mem_pre_write.push_back(std::make_tuple(addr, from_target(previous_value), sizeof(T)));
++    }
+   }
+ 
+   template<typename T>
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/processor.cc b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+index c8260eb..d6ec7f7 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/processor.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+@@ -525,6 +525,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
+   log_reg_write.clear();
+   log_mem_read.clear();
+   log_mem_write.clear();
++  log_mem_pre_write.clear();
+   last_inst_priv = 0;
+   last_inst_xlen = 0;
+   last_inst_flen = 0;
+@@ -643,7 +644,7 @@ void processor_t::set_mmu_capability(int cap)
+ void processor_t::take_interrupt(reg_t pending_interrupts)
+ {
+   // Do nothing if no pending interrupts
+-  if (!pending_interrupts) {
++  if (!pending_interrupts || !interrupt_allowed) {
+     return;
+   }
+ 
+@@ -670,9 +671,41 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
+ 
+   const bool nmie = !(state.mnstatus && !get_field(state.mnstatus->read(), MNSTATUS_NMIE));
+   if (!state.debug_mode && nmie && enabled_interrupts) {
+-    // nonstandard interrupts have highest priority
+-    if (enabled_interrupts >> (IRQ_M_EXT + 1))
+-      enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
++    //// nonstandard interrupts have highest priority
++    if (enabled_interrupts & (1 << 31))
++      enabled_interrupts = (1 << 31);
++    else if (enabled_interrupts & (1 << 30))
++      enabled_interrupts = (1 << 30);
++    else if (enabled_interrupts & (1 << 29))
++      enabled_interrupts = (1 << 29);
++    else if (enabled_interrupts & (1 << 28))
++      enabled_interrupts = (1 << 28);
++    else if (enabled_interrupts & (1 << 27))
++      enabled_interrupts = (1 << 27);
++    else if (enabled_interrupts & (1 << 26))
++      enabled_interrupts = (1 << 26);
++    else if (enabled_interrupts & (1 << 25))
++      enabled_interrupts = (1 << 25);
++    else if (enabled_interrupts & (1 << 24))
++      enabled_interrupts = (1 << 24);
++    else if (enabled_interrupts & (1 << 23))
++      enabled_interrupts = (1 << 23);
++    else if (enabled_interrupts & (1 << 22))
++      enabled_interrupts = (1 << 22);
++    else if (enabled_interrupts & (1 << 21))
++      enabled_interrupts = (1 << 21);
++    else if (enabled_interrupts & (1 << 20))
++      enabled_interrupts = (1 << 20);
++    else if (enabled_interrupts & (1 << 19))
++      enabled_interrupts = (1 << 19);
++    else if (enabled_interrupts & (1 << 18))
++      enabled_interrupts = (1 << 18);
++    else if (enabled_interrupts & (1 << 17))
++      enabled_interrupts = (1 << 17);
++    else if (enabled_interrupts & (1 << 16))
++      enabled_interrupts = (1 << 16);
++    //if (enabled_interrupts >> (IRQ_M_EXT + 1))
++    //  enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
+     // standard interrupt priority is MEI, MSI, MTI, SEI, SSI, STI
+     else if (enabled_interrupts & MIP_MEIP)
+       enabled_interrupts = MIP_MEIP;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/processor.h b/vendor/riscv/riscv-isa-sim/riscv/processor.h
+index 618c4d5..82679b1 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/processor.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/processor.h
+@@ -173,6 +173,7 @@ struct state_t
+   commit_log_reg_t log_reg_write;
+   commit_log_mem_t log_mem_read;
+   commit_log_mem_t log_mem_write;
++  commit_log_mem_t log_mem_pre_write;
+   reg_t last_inst_priv;
+   int last_inst_xlen;
+   int last_inst_flen;
+@@ -322,6 +323,7 @@ protected:
+   bool check_triggers_icount;
+   std::vector<bool> impl_table;
+   openhw::Params params;
++  bool interrupt_allowed;
+ 
+   // Note: does not include single-letter extensions in misa
+   std::bitset<NUM_ISA_EXTENSIONS> extension_enable_table;
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+index 873b4bd..0784534 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+@@ -50,7 +50,7 @@ extern "C" void spike_set_default_params(const char *profile) {
+ 
+     params.set_string("/top/core/0/", "name", std::string("cva6"));
+     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
+-  }
++  } 
+   else if (strcmp(profile, "cv32e40s") == 0)
+   {
+     params.set_string("/top/", "isa", std::string("RV32I"));
+@@ -82,6 +82,8 @@ extern "C" void spike_set_default_params(const char *profile) {
+     params.set_uint64_t("/top/core/0/", "misa", 0x40901104UL);
+     params.set_uint64_t("/top/core/0/", "mvendorid", 0x602UL);
+     params.set_uint64_t("/top/core/0/", "mcountinhibit", 0x5UL);
++
++    params.set_uint64_t("/top/core/0/", "num_prev_states_stored", 4UL);
+   }
+ }
+ 
+@@ -213,3 +215,18 @@ extern "C" void spike_step_svLogic(svLogicVecVal* reference,
+   spike_step_struct(reference_rvfi, spike_rvfi);
+   rvfi2sv(spike_rvfi, spike);
+ }
++
++extern "C" bool spike_interrupt(uint32_t mip, uint32_t mie, uint32_t revert_steps, bool interrupt_allowed)
++{
++  return sim->interrupt(mip, mie, revert_steps, interrupt_allowed);
++}
++
++extern "C" bool spike_set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed)
++{
++  return sim->set_debug_req(debug_req, revert_steps, debug_allowed);
++}
++
++extern "C" void spike_revert_state(int num_steps)
++{
++  sim->revert_state(num_steps);
++}

--- a/vendor/patches/riscv/riscv-isa-sim/0022-cv32e40s-refmodel-changes.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0022-cv32e40s-refmodel-changes.patch
@@ -281,9 +281,48 @@ index 12533f2..1661567 100644
                               // need both
    ~Processor();
    st_rvfi step(size_t n, st_rvfi reference);
++
++  /*
++   * Step function
++   * *
++   * * @param n:  Number of instructions to be finished
++   * */
+   st_rvfi step(size_t n, st_rvfi reference);
++
++
++  /*
++   * Revert the state of the processor to a previous state.
++   * *
++   * * @param num_steps:  Number of steps to revert
++   * */
 +  void revert_step(uint32_t num_steps);
++
++  /* 
++   * Check if a given mip will trigger an interrupt.
++   * * @param mip:  The value to be set
++   * * @return:  True if interrupt will be taken, false if not
++   * */
 +  bool will_trigger_interrupt(reg_t mip);
++
++  /*
++   * Externally inject an interrupt into Spike. This sets the mip register, and 
++   * takes the interrupt if it is allowed to be taken, given the state and inputs. 
++   * *
++   * * @param mip:  The value to be set
++   * * @param mie:  mie injected from external CSR
++   * * @param revert_steps: Number of steps to revert if the interrupt will be taken. This is to account for pipeline flushes.
++   * * @param interrupt_allowed: True if interrupt is allowed to be taken 
++   * * @return:  True if interrupt will be taken, false if not
++   * */
 +  bool interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
++
++  /*
++   * Set the debug request
++   * * 
++   * * @param debug_req:  True if debug request is set
++   * * @param revert_steps: Number of steps to revert if the debug request is taken
++   * * @param debug_allowed: True if debug is allowed to be taken
++   * */
 +  bool set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed);
  
    static void default_params(string base, openhw::Params &params);
@@ -557,7 +596,7 @@ index 618c4d5..82679b1 100644
    bool check_triggers_icount;
    std::vector<bool> impl_table;
    openhw::Params params;
-+  bool interrupt_allowed;
++  bool interrupt_allowed = true;
  
    // Note: does not include single-letter extensions in misa
    std::bitset<NUM_ISA_EXTENSIONS> extension_enable_table;

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
@@ -3,6 +3,7 @@
 #include "processor.h"
 
 namespace openhw {
+typedef std::tuple<state_t, commit_log_mem_t> prev_changes_t;
 class Processor : public processor_t {
 public:
   Processor(const isa_parser_t *isa, const cfg_t *cfg, simif_t *sim,
@@ -12,6 +13,10 @@ public:
                              // need both
   ~Processor();
   st_rvfi step(size_t n, st_rvfi reference);
+  void revert_step(uint32_t num_steps);
+  bool will_trigger_interrupt(reg_t mip);
+  bool interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
+  bool set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed);
 
   static void default_params(string base, openhw::Params &params);
 
@@ -19,6 +24,8 @@ public:
   inline void set_FPR(reg_t num, float128_t value);
 
 protected:
+  std::deque<prev_changes_t> previous_states;
+  uint64_t max_previous_states;
   bool csr_counters_injection;
   bool taken_trap;
   uint32_t which_trap;

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
@@ -12,10 +12,48 @@ public:
             Params &params); // because of command line option --log and -s we
                              // need both
   ~Processor();
+
+  /*
+   * Step function
+   * *
+   * * @param n:  Number of instructions to be finished
+   * */
   st_rvfi step(size_t n, st_rvfi reference);
+
+
+  /*
+   * Revert the state of the processor to a previous state.
+   * *
+   * * @param num_steps:  Number of steps to revert
+   * */
   void revert_step(uint32_t num_steps);
+
+  /* 
+   * Check if a given mip will trigger an interrupt.
+   * * @param mip:  The value to be set
+   * * @return:  True if interrupt will be taken, false if not
+   * */
   bool will_trigger_interrupt(reg_t mip);
+
+  /*
+   * Externally inject an interrupt into Spike. This sets the mip register, and 
+   * takes the interrupt if it is allowed to be taken, given the state and inputs. 
+   * *
+   * * @param mip:  The value to be set
+   * * @param mie:  mie injected from external CSR
+   * * @param revert_steps: Number of steps to revert if the interrupt will be taken. This is to account for pipeline flushes.
+   * * @param interrupt_allowed: True if interrupt is allowed to be taken 
+   * * @return:  True if interrupt will be taken, false if not
+   * */
   bool interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
+
+  /*
+   * Set the debug request
+   * * 
+   * * @param debug_req:  True if debug request is set
+   * * @param revert_steps: Number of steps to revert if the debug request is taken
+   * * @param debug_allowed: True if debug is allowed to be taken
+   * */
   bool set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed);
 
   static void default_params(string base, openhw::Params &params);

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
@@ -21,7 +21,8 @@ public:
 protected:
   bool csr_counters_injection;
   bool taken_trap;
-  uint8_t which_trap;
+  uint32_t which_trap;
+  reg_t next_rvfi_intr, next_debug;
   virtual void take_trap(trap_t &t, reg_t epc); // take an exception
 };
 

--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.cc
@@ -94,7 +94,7 @@ Simulation::Simulation(
   // FIXME TODO: Use actual cache configuration (on/off, # of ways/sets).
   // FIXME TODO: Support multiple cores.
   get_core(0)->get_mmu()->set_cache_blocksz(reg_t(64));
-
+  
   Params::parse_params("/top/", this->params, params);
 
   const std::vector<mem_cfg_t> layout;
@@ -234,6 +234,19 @@ std::vector<st_rvfi> Simulation::step(size_t n,
     }
   }
   return vspike;
+}
+
+
+bool Simulation::interrupt(reg_t mip, reg_t mie, uint32_t revert_steps, bool interrupt_allowed) {
+  return ((Processor *)procs[0])->interrupt(mip, mie, revert_steps, interrupt_allowed);
+}
+
+bool Simulation::set_debug_req(bool debug_req, uint32_t revert_steps, bool debug_allowed) {
+  return ((Processor *)procs[0])->set_debug(debug_req, revert_steps, debug_allowed);
+}
+
+void Simulation::revert_state(int num_steps) {
+  ((Processor *)procs[0])->revert_step(num_steps);
 }
 
 #if 0 // FORNOW Unused code, disable until needed.

--- a/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Simulation.h
@@ -60,6 +60,32 @@ public:
   std::vector<st_rvfi> step(size_t n, std::vector<st_rvfi> &vreference);
 
   /*
+   * Set the MIP register
+   * *
+   * * @param mask:  The value to be set
+   * * @param revert_steps: Number of steps to revert if the interrupt will be taken 
+   * * @param interrupt_allowed: True if interrupt is allowed to be taken 
+   * * @return:  True if interrupt will be taken, false if not
+   * */
+  bool interrupt(reg_t mask, reg_t mie, uint32_t revert_steps, bool interrupt_allowed);
+
+  /*
+   * Set the debug request
+   * * 
+   * * @param debug_req:  True if debug request is set
+   * * @param revert_steps: Number of steps to revert if the debug request is taken
+   * * @param debug_allowed: True if debug is allowed to be taken
+   */
+  bool set_debug_req(bool debug_req, uint32_t revert_steps, bool debug_allowed);
+
+  /*
+   * Revert the state  
+   * *
+   * * @param num_steps:  number of steps to revert
+   * */
+  void revert_state(int num_steps);
+
+  /*
    * Proposed constuctor for the Simulation class
    * *
    * * @param params: parameters to configure the simulation behaviour

--- a/vendor/riscv/riscv-isa-sim/riscv/Types.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Types.h
@@ -28,8 +28,7 @@ typedef struct {
    uint64_t                 insn_interrupt;
    uint64_t                 insn_interrupt_id;
    uint64_t                 insn_bus_fault;
-   uint64_t                 insn_nmi_store_fault;
-   uint64_t                 insn_nmi_load_fault;
+   uint64_t                 insn_nmi_cause;
 
    uint64_t                 pc_rdata;
    uint64_t                 pc_wdata;

--- a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
@@ -734,12 +734,13 @@ mie_csr_t::mie_csr_t(processor_t* const proc, const reg_t addr):
 }
 
 reg_t mie_csr_t::write_mask() const noexcept {
+  const reg_t custom_ints = 0xffff0000;
   const reg_t supervisor_ints = proc->extension_enabled('S') ? MIP_SSIP | MIP_STIP | MIP_SEIP : 0;
   const reg_t lscof_int = proc->extension_enabled(EXT_SSCOFPMF) ? MIP_LCOFIP : 0;
   const reg_t hypervisor_ints = proc->extension_enabled('H') ? MIP_HS_MASK : 0;
   const reg_t coprocessor_ints = (reg_t)proc->any_custom_extensions() << IRQ_COP;
   const reg_t delegable_ints = supervisor_ints | coprocessor_ints | lscof_int;
-  const reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP;
+  const reg_t all_ints = delegable_ints | hypervisor_ints | MIP_MSIP | MIP_MTIP | MIP_MEIP | custom_ints;
   return all_ints;
 }
 

--- a/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/csrs.cc
@@ -992,13 +992,15 @@ bool wide_counter_csr_t::unlogged_write(const reg_t val) noexcept {
   // takes precedence over the increment to instret.  However, Spike
   // unconditionally increments instret after executing an instruction.
   // Correct for this artifact by decrementing instret here.
-   openhw::reg::unlogged_write( openhw::reg::unlogged_read()-1);
+
+  // disable since we (at the moment) check mcounterinhibit
+  //openhw::reg::unlogged_write( openhw::reg::unlogged_read()-1);
   return true;
 }
 
 reg_t wide_counter_csr_t::written_value() const noexcept {
   // Re-adjust for upcoming bump()
-  return  openhw::reg::unlogged_read() + 1;
+  return  openhw::reg::unlogged_read(); //+ 1; // Disable since we dont always bump
 }
 
 // implement class time_counter_csr_t
@@ -1239,9 +1241,10 @@ reg_t dcsr_csr_t::read() const noexcept {
   v = set_field(v, DCSR_EBREAKH, ebreakh);
   v = set_field(v, DCSR_EBREAKS, ebreaks);
   v = set_field(v, DCSR_EBREAKU, ebreaku);
-  v = set_field(v, DCSR_STOPCYCLE, 0);
+  v = set_field(v, DCSR_STOPCYCLE, 1); //TODO: Make configurable
   v = set_field(v, DCSR_STOPTIME, 0);
   v = set_field(v, DCSR_CAUSE, cause);
+  v = set_field(v, DCSR_MPRVEN, 1); // TODO: Make configurable
   v = set_field(v, DCSR_STEP, step);
   v = set_field(v, DCSR_PRV, prv);
   return v;

--- a/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/debug_rom_defines.h
@@ -17,7 +17,7 @@
 
 // These needs to match the link.ld         
 #define DEBUG_ROM_WHERETO 0x300
-#define DEBUG_ROM_ENTRY   0x800
+#define DEBUG_ROM_ENTRY   0x1A110800 //TODO: make configurable
 #define DEBUG_ROM_TVEC    0x808
 
 #endif

--- a/vendor/riscv/riscv-isa-sim/riscv/encoding.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/encoding.h
@@ -87,6 +87,7 @@
 #define DCSR_STOPTIME       (1<<9)
 #define DCSR_CAUSE          (7<<6)
 #define DCSR_DEBUGINT       (1<<5)
+#define DCSR_MPRVEN         (1<<4)
 #define DCSR_HALT           (1<<3)
 #define DCSR_STEP           (1<<2)
 #define DCSR_PRV            (3<<0)

--- a/vendor/riscv/riscv-isa-sim/riscv/execute.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/execute.cc
@@ -342,10 +342,14 @@ void processor_t::step(size_t n)
       in_wfi = true;
     }
 
+    if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x4)) {
     state.minstret->bump(instret);
+    }
 
     // Model a hart whose CPI is 1.
+    if(!(this->get_csr(CSR_MCOUNTINHIBIT) & 0x1)) {
     state.mcycle->bump(instret);
+    }
 
     n -= instret;
   }

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
@@ -525,6 +525,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   log_reg_write.clear();
   log_mem_read.clear();
   log_mem_write.clear();
+  log_mem_pre_write.clear();
   last_inst_priv = 0;
   last_inst_xlen = 0;
   last_inst_flen = 0;
@@ -643,7 +644,7 @@ void processor_t::set_mmu_capability(int cap)
 void processor_t::take_interrupt(reg_t pending_interrupts)
 {
   // Do nothing if no pending interrupts
-  if (!pending_interrupts) {
+  if (!pending_interrupts || !interrupt_allowed) {
     return;
   }
 
@@ -670,9 +671,41 @@ void processor_t::take_interrupt(reg_t pending_interrupts)
 
   const bool nmie = !(state.mnstatus && !get_field(state.mnstatus->read(), MNSTATUS_NMIE));
   if (!state.debug_mode && nmie && enabled_interrupts) {
-    // nonstandard interrupts have highest priority
-    if (enabled_interrupts >> (IRQ_M_EXT + 1))
-      enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
+    //// nonstandard interrupts have highest priority
+    if (enabled_interrupts & (1 << 31))
+      enabled_interrupts = (1 << 31);
+    else if (enabled_interrupts & (1 << 30))
+      enabled_interrupts = (1 << 30);
+    else if (enabled_interrupts & (1 << 29))
+      enabled_interrupts = (1 << 29);
+    else if (enabled_interrupts & (1 << 28))
+      enabled_interrupts = (1 << 28);
+    else if (enabled_interrupts & (1 << 27))
+      enabled_interrupts = (1 << 27);
+    else if (enabled_interrupts & (1 << 26))
+      enabled_interrupts = (1 << 26);
+    else if (enabled_interrupts & (1 << 25))
+      enabled_interrupts = (1 << 25);
+    else if (enabled_interrupts & (1 << 24))
+      enabled_interrupts = (1 << 24);
+    else if (enabled_interrupts & (1 << 23))
+      enabled_interrupts = (1 << 23);
+    else if (enabled_interrupts & (1 << 22))
+      enabled_interrupts = (1 << 22);
+    else if (enabled_interrupts & (1 << 21))
+      enabled_interrupts = (1 << 21);
+    else if (enabled_interrupts & (1 << 20))
+      enabled_interrupts = (1 << 20);
+    else if (enabled_interrupts & (1 << 19))
+      enabled_interrupts = (1 << 19);
+    else if (enabled_interrupts & (1 << 18))
+      enabled_interrupts = (1 << 18);
+    else if (enabled_interrupts & (1 << 17))
+      enabled_interrupts = (1 << 17);
+    else if (enabled_interrupts & (1 << 16))
+      enabled_interrupts = (1 << 16);
+    //if (enabled_interrupts >> (IRQ_M_EXT + 1))
+    //  enabled_interrupts = enabled_interrupts >> (IRQ_M_EXT + 1) << (IRQ_M_EXT + 1);
     // standard interrupt priority is MEI, MSI, MTI, SEI, SSI, STI
     else if (enabled_interrupts & MIP_MEIP)
       enabled_interrupts = MIP_MEIP;

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.h
@@ -323,7 +323,7 @@ protected:
   bool check_triggers_icount;
   std::vector<bool> impl_table;
   openhw::Params params;
-  bool interrupt_allowed;
+  bool interrupt_allowed = true;
 
   // Note: does not include single-letter extensions in misa
   std::bitset<NUM_ISA_EXTENSIONS> extension_enable_table;

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.h
@@ -173,6 +173,7 @@ struct state_t
   commit_log_reg_t log_reg_write;
   commit_log_mem_t log_mem_read;
   commit_log_mem_t log_mem_write;
+  commit_log_mem_t log_mem_pre_write;
   reg_t last_inst_priv;
   int last_inst_xlen;
   int last_inst_flen;
@@ -322,6 +323,7 @@ protected:
   bool check_triggers_icount;
   std::vector<bool> impl_table;
   openhw::Params params;
+  bool interrupt_allowed;
 
   // Note: does not include single-letter extensions in misa
   std::bitset<NUM_ISA_EXTENSIONS> extension_enable_table;

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
@@ -51,6 +51,38 @@ extern "C" void spike_set_default_params(const char *profile) {
     params.set_string("/top/core/0/", "name", std::string("cva6"));
     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
   }
+  else if (strcmp(profile, "cv32e40s") == 0)
+  {
+    params.set_string("/top/", "isa", std::string("RV32I"));
+    params.set_string("/top/", "priv", std::string("MU"));
+    params.set_uint64_t("/top/", "num_procs", 0x1UL);
+    params.set_bool("/top/", "bootrom", false);
+    params.set_bool("/top/", "generic_core_config", true);
+    params.set_uint64_t("/top/", "dram_base", 0x00000000UL);
+    params.set_uint64_t("/top/", "dram_size", 0x400000UL);
+    params.set_bool("/top/", "max_steps_enabled", false);
+    params.set_uint64_t("/top/", "max_steps", 2000000UL);
+    params.set_bool("/top/", "dtb_enabled", false);
+
+
+    params.set_bool("/top/", "dbg", true);
+    params.set_uint64_t("/top/", "dbg_base", 0x1a110800UL);
+    params.set_uint64_t("/top/", "dbg_size", 0x1000UL);
+
+    //Virtual peripherals
+    params.set_bool("/top/", "vp", true);
+    params.set_uint64_t("/top/", "vp_base", 0x00800000UL);
+    params.set_uint64_t("/top/", "vp_size", 0x1000UL);
+
+
+    params.set_string("/top/core/0/", "name", std::string("cv32e40s"));
+    params.set_string("/top/core/0/", "isa", std::string("RV32I"));
+
+    params.set_uint64_t("/top/core/0/", "marchid", 0x15UL);
+    params.set_uint64_t("/top/core/0/", "misa", 0x40901104UL);
+    params.set_uint64_t("/top/core/0/", "mvendorid", 0x602UL);
+    params.set_uint64_t("/top/core/0/", "mcountinhibit", 0x5UL);
+  }
 }
 
 extern "C" void spike_set_param_uint64_t(const char *base, const char *name,

--- a/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/riscv_dpi.cc
@@ -50,7 +50,7 @@ extern "C" void spike_set_default_params(const char *profile) {
 
     params.set_string("/top/core/0/", "name", std::string("cva6"));
     params.set_string("/top/core/0/", "isa", std::string("RV64GC"));
-  }
+  } 
   else if (strcmp(profile, "cv32e40s") == 0)
   {
     params.set_string("/top/", "isa", std::string("RV32I"));
@@ -82,6 +82,8 @@ extern "C" void spike_set_default_params(const char *profile) {
     params.set_uint64_t("/top/core/0/", "misa", 0x40901104UL);
     params.set_uint64_t("/top/core/0/", "mvendorid", 0x602UL);
     params.set_uint64_t("/top/core/0/", "mcountinhibit", 0x5UL);
+
+    params.set_uint64_t("/top/core/0/", "num_prev_states_stored", 4UL);
   }
 }
 
@@ -212,4 +214,19 @@ extern "C" void spike_step_svLogic(svLogicVecVal* reference,
   sv2rvfi(reference_rvfi, reference);
   spike_step_struct(reference_rvfi, spike_rvfi);
   rvfi2sv(spike_rvfi, spike);
+}
+
+extern "C" bool spike_interrupt(uint32_t mip, uint32_t mie, uint32_t revert_steps, bool interrupt_allowed)
+{
+  return sim->interrupt(mip, mie, revert_steps, interrupt_allowed);
+}
+
+extern "C" bool spike_set_debug(bool debug_req, uint32_t revert_steps, bool debug_allowed)
+{
+  return sim->set_debug_req(debug_req, revert_steps, debug_allowed);
+}
+
+extern "C" void spike_revert_state(int num_steps)
+{
+  sim->revert_state(num_steps);
 }


### PR DESCRIPTION
This PR adds the changes to Spike necessary to support the reference model in #2432.
I have attempted to split it into two main contributions:
- Added spike support for CV32E40S 
  - Configuration of memory regions
  - Modifications to CSRs
  - Modifications to RVFI
- Modified spike to work with the reference model
  - Injection of interrupts and debug requests
  - Modifications to interrupt handling in spike, adding an interrupt_allowed check and external interrupts
  - Store and revert to previous states

(@silabs-robin, I can't add reviewers)