### PR TITLE
Added behavior discussed in Issue 2123 for USE_ISS

### DIFF
--- a/mk/core/core.mk
+++ b/mk/core/core.mk
@@ -48,8 +48,15 @@ UVM_PLUSARGS ?=
 CV_SIMULATOR ?= unsim
 SIMULATOR    ?= $(CV_SIMULATOR)
 
-# Optionally exclude the OVPsim (not recommended)
-USE_ISS      ?= YES
+# If USE_ISS is not specified, it will decide by default to enable the ISS if imperas_home is defined
+ifndef USE_ISS
+ifneq ($(IMPERAS_HOME),)
+USE_ISS = YES
+else
+USE_ISS = NO
+endif
+$(info Info: USE_ISS is not specified when invoking make command, defaulting USE_ISS to $(USE_ISS) (check for IMPERAS_HOME in your environment))
+endif
 
 # Common configuration variables
 CFG             ?= default

--- a/mk/uvmt/uvmt.mk
+++ b/mk/uvmt/uvmt.mk
@@ -70,8 +70,15 @@ UVM_PLUSARGS ?=
 CV_SIMULATOR ?= unsim
 SIMULATOR    ?= $(CV_SIMULATOR)
 
-# Optionally exclude the OVPsim (not recommended)
-USE_ISS      ?= YES
+# If USE_ISS is not specified, it will decide by default to enable the ISS if imperas_home is defined
+ifndef USE_ISS
+ifneq ($(IMPERAS_HOME),)
+USE_ISS = YES
+else
+USE_ISS = NO
+endif
+$(info Info: USE_ISS is not specified when invoking make command, defaulting USE_ISS to $(USE_ISS) (check for IMPERAS_HOME in your environment))
+endif
 
 # Common configuration variables
 CFG          ?= default


### PR DESCRIPTION
I did not find anywhere in any up-to-date `cv32e40s/dev`, `cv32e40x/dev` and `master` what you told me in #2123, so I added my own version, don't hesitate to discard the PR if I missed it or I didn't search in the right place.

The modification will simply check if USE_ISS have been given as an argument to the make command, and if not, it will decide to update USE_ISS to YES or NO depending on the definition or not of the IMPERAS_HOME variable.

As a bonus, an info message telling the user what's going on. 

I found USE_ISS definition in two files, I don't remember using core.mk during the last months, but I copy and paste the code from uvmt.mk anyway. 

