### PR TITLE
Register parameterized uvml_mem_c with `uvm_object_param_utils and update write()/read() as virtual

### DIFF
--- a/lib/uvm_libs/uvml_mem/uvml_mem.sv
+++ b/lib/uvm_libs/uvml_mem/uvml_mem.sv
@@ -1,5 +1,7 @@
 //
 // Copyright 2021 Datum Technology Corporation
+// Copyright 2024 CoreLab Tech
+//
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 //
 // Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may
@@ -36,7 +38,7 @@ class uvml_mem_c#(int XLEN=DEFAULT_XLEN) extends uvm_object;
       soft mem_default != MEM_DEFAULT_X;
    }
 
-   `uvm_object_utils_begin(uvml_mem_c);
+   `uvm_object_param_utils_begin(uvml_mem_c#(XLEN));
       `uvm_field_enum(uvml_mem_default_enum, mem_default, UVM_DEFAULT)
       `uvm_field_int (mem_default_const_value,            UVM_DEFAULT)
    `uvm_object_utils_end
@@ -49,12 +51,12 @@ class uvml_mem_c#(int XLEN=DEFAULT_XLEN) extends uvm_object;
    /**
     * Write to memory array
     */
-   extern function void write(bit[XLEN-1:0] addr, reg[7:0] data);
+   extern virtual function void write(bit[XLEN-1:0] addr, reg[7:0] data);
 
    /**
     * Read from memory array, substituing a default value in case value is not in memory
     */
-   extern function reg[7:0] read(bit[XLEN-1:0] addr);
+   extern virtual function reg[7:0] read(bit[XLEN-1:0] addr);
 
    /**
     * Wrapper around readmemh for underlying memory


### PR DESCRIPTION
1. Register parameterized `uvml_mem_c` class with `uvm_object_param_utils` per chapter 6.2.2 of uvm user guide 1.2.
2. Update write()/read() method as virtual.


> 6.2.2 Factory Registration
> You must tell the factory how to generate objects of specific types. In UVM, there are a number of ways to
> do this allocation.
> — The recommended method is to use the `uvm_object_utils(T) or `uvm_compo-
> nent_utils(T) macro in a derivative uvm_object or uvm_component class declaration,
> respectively. These macros contain code that will register the given type with the factory. **If T is a
> parameterized type, use `uvm_object_param_utils` or 
> `uvm_component_param_utils`,** , e.g.,
> `uvm_object_utils(packet)
> ‘uvm_component_param_utils(my_driver)