### PR TITLE
Update parameters in package to be defined as macros

### DIFF
--- a/lib/uvm_agents/uvma_axi5/src/uvma_axi_macros.sv
+++ b/lib/uvm_agents/uvma_axi5/src/uvma_axi_macros.sv
@@ -9,15 +9,20 @@
 `ifndef __UVMA_AXI_MACROS_SV__
   `define __UVMA_AXI_MACROS_SV__
 
-  `define UVMA_AXI_ADDR_MAX_WIDTH           64
-  `define UVMA_AXI_DATA_MAX_WIDTH           64
-  `define UVMA_AXI_USER_MAX_WIDTH           512
-  `define UVMA_AXI_ID_MAX_WIDTH             64
-  // `define UVMA_AXI_STRB_MAX_WIDTH           8
+  `define IFNDEF_DEFINE(name,value) \
+    `ifndef name \
+      `define name value \
+  `endif
 
-  `define UVMA_AXI_MAX_NB_TXN_BURST         256
-  `define UVMA_AXI_LOOP_MAX_WIDTH           8
-  `define UVMA_AXI_MMUSID_MAX_WIDTH         32
-  `define UVMA_AXI_MMUSSID_MAX_WIDTH        20
+  `IFNDEF_DEFINE(UVMA_AXI_ADDR_MAX_WIDTH    , 64  )
+  `IFNDEF_DEFINE(UVMA_AXI_DATA_MAX_WIDTH    , 64  )
+  `IFNDEF_DEFINE(UVMA_AXI_USER_MAX_WIDTH    , 512 )
+  `IFNDEF_DEFINE(UVMA_AXI_ID_MAX_WIDTH      , 64  )
+  // `IFNDEF_DEFINE(UVMA_AXI_STRB_MAX_WIDTH , 8   )
+
+  `IFNDEF_DEFINE(UVMA_AXI_MAX_NB_TXN_BURST  , 256 )
+  `IFNDEF_DEFINE(UVMA_AXI_LOOP_MAX_WIDTH    , 8   )
+  `IFNDEF_DEFINE(UVMA_AXI_MMUSID_MAX_WIDTH  , 32  )
+  `IFNDEF_DEFINE(UVMA_AXI_MMUSSID_MAX_WIDTH , 20  )
 
 `endif // __UVMA_AXI_MACROS_SV__

--- a/lib/uvm_agents/uvma_axi5/src/uvma_axi_macros.sv
+++ b/lib/uvm_agents/uvma_axi5/src/uvma_axi_macros.sv
@@ -1,0 +1,23 @@
+// Copyright 2024 CoreLab Tech
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+
+`ifndef __UVMA_AXI_MACROS_SV__
+  `define __UVMA_AXI_MACROS_SV__
+
+  `define UVMA_AXI_ADDR_MAX_WIDTH           64
+  `define UVMA_AXI_DATA_MAX_WIDTH           64
+  `define UVMA_AXI_USER_MAX_WIDTH           512
+  `define UVMA_AXI_ID_MAX_WIDTH             64
+  // `define UVMA_AXI_STRB_MAX_WIDTH           8
+
+  `define UVMA_AXI_MAX_NB_TXN_BURST         256
+  `define UVMA_AXI_LOOP_MAX_WIDTH           8
+  `define UVMA_AXI_MMUSID_MAX_WIDTH         32
+  `define UVMA_AXI_MMUSSID_MAX_WIDTH        20
+
+`endif // __UVMA_AXI_MACROS_SV__

--- a/lib/uvm_agents/uvma_axi5/src/uvma_axi_pkg.sv
+++ b/lib/uvm_agents/uvma_axi5/src/uvma_axi_pkg.sv
@@ -1,4 +1,5 @@
 // Copyright 2022 Thales DIS SAS
+// Copyright 2024 CoreLab Tech
 //
 // Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
 
 // Pre-processor macros
 `include "uvm_macros.svh"
-
+`include "uvma_axi_macros.sv"
 
 // Interfaces / Modules / Checkers
 `include "uvma_axi_aw_assert.sv"
@@ -34,16 +35,16 @@ package uvma_axi_pkg;
    import uvml_logs_pkg ::*;
 
    // Package Parameters
-   parameter int MAX_NB_TXN_BURST = 256 ; // Maximum value from the protocol
+   parameter int MAX_NB_TXN_BURST  = `UVMA_AXI_MAX_NB_TXN_BURST  ; // Maximum value from the protocol
 
-   parameter int MAX_ID_WIDTH   = 64   ; // subjective maximum
-   parameter int MAX_ADDR_WIDTH = 64   ; // subjective maximum
-   parameter int MAX_DATA_WIDTH = 64   ; // subjective maximum
-   parameter int MAX_USER_WIDTH = 512  ; // subjective maximum
+   parameter int MAX_ID_WIDTH      = `UVMA_AXI_ID_MAX_WIDTH      ; // subjective maximum
+   parameter int MAX_ADDR_WIDTH    = `UVMA_AXI_ADDR_MAX_WIDTH    ; // subjective maximum
+   parameter int MAX_DATA_WIDTH    = `UVMA_AXI_DATA_MAX_WIDTH    ; // subjective maximum
+   parameter int MAX_USER_WIDTH    = `UVMA_AXI_USER_MAX_WIDTH    ; // subjective maximum
 
-   parameter int MAX_LOOP_WIDTH    = 8  ; // Maximum from the protocol
-   parameter int MAX_MMUSID_WIDTH  = 32 ; // Maximum from the protocol
-   parameter int MAX_MMUSSID_WIDTH = 20 ; // Maximum from the protocol
+   parameter int MAX_LOOP_WIDTH    = `UVMA_AXI_LOOP_MAX_WIDTH    ; // Maximum from the protocol
+   parameter int MAX_MMUSID_WIDTH  = `UVMA_AXI_MMUSID_MAX_WIDTH  ; // Maximum from the protocol
+   parameter int MAX_MMUSSID_WIDTH = `UVMA_AXI_MMUSSID_MAX_WIDTH ; // Maximum from the protocol
 
    `include "uvma_axi_tdefs.sv"
 

--- a/lib/uvm_libs/uvml_mem/uvml_mem_constants.sv
+++ b/lib/uvm_libs/uvml_mem/uvml_mem_constants.sv
@@ -1,6 +1,7 @@
 // 
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2024 CoreLab Tech
 // 
 // Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +20,6 @@
 `ifndef __UVML_MEM_CONSTANTS_SV__
 `define __UVML_MEM_CONSTANTS_SV__
 
-
-parameter DEFAULT_XLEN = 32;
+parameter DEFAULT_XLEN = `UVML_MEM_XLEN;
 
 `endif // __UVML_MEM_CONSTANTS_SV__

--- a/lib/uvm_libs/uvml_mem/uvml_mem_macros.sv
+++ b/lib/uvm_libs/uvml_mem/uvml_mem_macros.sv
@@ -1,6 +1,7 @@
 // 
 // Copyright 2020 OpenHW Group
 // Copyright 2020 Datum Technology Corporation
+// Copyright 2024 CoreLab Tech
 // 
 // Licensed under the Solderpad Hardware License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,8 +20,8 @@
 `ifndef __UVML_MEM_MACROS_SV__
 `define __UVML_MEM_MACROS_SV__
 
-
-
-
+`ifndef UVML_MEM_XLEN
+  `define UVML_MEM_XLEN 32
+`endif
 
 `endif // __UVML_MEM_MACROS_SV__


### PR DESCRIPTION
To make AXI and MEM agents be used as different address/data/... widths, this PR refers to Mentor's below page and update parameters as macros.

Mentor's link here,
https://verificationacademy.com/forums/t/override-parameters-in-sv-package/33682/4