### PR TITLE
Fix kslraw.u instruction in P extension, version 0.9.11

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0027-fix-p-ext-kslraw-u.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0027-fix-p-ext-kslraw-u.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h b/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h
+index ebecb615..86c233e2 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h
+@@ -6,7 +6,7 @@ sreg_t sa = int64_t(RS2) << (64 - 6) >> (64 - 6);
+ if (sa < 0) {
+   sa = -sa;
+   sa = (sa == 32) ? 31 : sa;
+-  WRITE_RD(sext32(((rs1 >> (sa - 1)) + 1)) >> 1);
++  WRITE_RD((sext32(((rs1 >> (sa - 1)))) + 1) >> 1);
+ } else {
+   auto res = rs1 << sa;
+   P_SAT(res, 32);

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/kslraw_u.h
@@ -6,7 +6,7 @@ sreg_t sa = int64_t(RS2) << (64 - 6) >> (64 - 6);
 if (sa < 0) {
   sa = -sa;
   sa = (sa == 32) ? 31 : sa;
-  WRITE_RD(sext32(((rs1 >> (sa - 1)) + 1)) >> 1);
+  WRITE_RD((sext32(((rs1 >> (sa - 1)))) + 1) >> 1);
 } else {
   auto res = rs1 << sa;
   P_SAT(res, 32);


### PR DESCRIPTION
Credit goes to my colleague **Han** for his contributions.

Per P ext 0.9.11, fix kslraw.u behavior.

```
if (Rs2[5:0] s< 0) {
  sa = -Rs2[5:0];
  sa = (sa == 32)? 31 : sa;
  res[31:-1] = SE33(Rs1[31:(sa-1)]) + 1;
  rst[31:0] = res[31:0];
} else {
  sa = Rs2[5:0];
  tmp[(31+sa):0] = Rs1.W[0] u<< sa;
  if (tmp s> (2^31)-1) {
    rst[31:0] = (2^31)-1;
    OV = 1;
  } else if (tmp s< -2^31) {
    rst[31:0] = -2^31;
    OV = 1
  } else {
    rst[31:0] = tmp[31:0];
  }
}
Rd = rst[31:0]; // RV32
Rd = SE64(rst[31:0]); // RV64
```