### PR TITLE
Only cross with cp_group in csr_hazard coverpoint

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -1951,7 +1951,7 @@ covergroup cg_sequential(string name,
                                                                      BRANCH_GROUP};
   }
 
-  cross_seq_csr_hazard_x2: cross cp_csr, cp_instr, cp_csr_hazard {
+  cross_seq_csr_hazard_x2: cross cp_csr, cp_group, cp_csr_hazard {
     // Ignore non-hazard bins
     ignore_bins IGN_HAZ = binsof(cp_csr_hazard) intersect {0};
   }


### PR DESCRIPTION
This MR is related to update csr_hazard cross in isacov coverage model, instead of cross csr_hazard with cp_instr (this give more then 20000 bin to cover), I replace it with cp_group this reduce a little bit the combination to be cover.

N.B : I don't konw if this cross is necessary for our verification goals