### PR TITLE
[Spike Yaml] Remove unnecessary dependencies between Spike and Yaml libs.

### DIFF
--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -160,8 +160,8 @@ all-link-flags := $(mcppbs-LDFLAGS) $(LDFLAGS)
 comma := ,
 LD            := $(CXX)
 LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@
-LIBS_EXE      := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ -lyaml-cpp
-LINK          := $(LD) -L. -L$(YAMLDIR)/build $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
+LIBS_EXE      := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ $(install_libs_dir)/libyaml-cpp.a
+LINK          := $(LD) -L. -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
 
 # Library creation
 
@@ -433,17 +433,12 @@ install-hdrs : $(install_hdrs)
     $(INSTALL_HDR) $(src_dir)/$$file $(install_hdrs_dir)/`dirname $$file`; \
   done
 
-# All install_libs depend on the installation of the yaml-cpp shared library.
-$(install_libs) : $(install_libs_dir)/libyaml-cpp.so
 install-libs : $(install_libs)
 	$(MKINSTALLDIRS) $(install_libs_dir)
 	for file in $^; \
   do \
     $(INSTALL_LIB) $$file $(install_libs_dir); \
   done
-
-# All install_exes depend on the installation of the yaml-cpp shared library.
-$(install_exes) : $(install_libs_dir)/libyaml-cpp.so
 
 install-exes : $(install_exes)
 	$(MKINSTALLDIRS) $(install_exes_dir)

--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -158,8 +158,9 @@ mcppbs-LDFLAGS := @LDFLAGS@ @BOOST_LDFLAGS@
 all-link-flags := $(mcppbs-LDFLAGS) $(LDFLAGS)
 
 comma := ,
-LD            := $(CXX) 
-LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ -lyaml-cpp
+LD            := $(CXX)
+LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@
+LIBS_EXE      := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ -lyaml-cpp
 LINK          := $(LD) -L. -L$(YAMLDIR)/build $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
 
 # Library creation
@@ -300,7 +301,7 @@ $$($(2)_test_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_test_exes) : %-utst : %.t.o $$($(2)_test_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_test_libnames) $(LIBS) $$($(2)_LDFLAGS)
+	$(LINK) -o $$@ $$< $$($(2)_test_libnames) $(LIBS_EXE) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_test_deps)
 $(2)_junk += \
@@ -327,7 +328,7 @@ $$($(2)_prog_objs) : %.o : %.cc
 	$(COMPILE) -c $$<
 
 $$($(2)_prog_exes) : % : %.o $$($(2)_prog_libnames) 
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS) $$($(2)_LDFLAGS)
+	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS_EXE) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_prog_deps)
 $(2)_junk += $$($(2)_prog_objs) $$($(2)_prog_deps) $$($(2)_prog_exes)
@@ -342,7 +343,7 @@ $$($(2)_install_prog_objs) : %.o : %.cc $$($(2)_gen_hdrs)
 	$(COMPILE) -c $$<
 
 $$($(2)_install_prog_exes) : % : %.o $$($(2)_prog_libnames)
-	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS) $$($(2)_LDFLAGS)
+	$(LINK) -o $$@ $$< $$($(2)_prog_libnames) $(LIBS_EXE) $$($(2)_LDFLAGS)
 
 $(2)_deps += $$($(2)_install_prog_deps)
 $(2)_junk += \

--- a/vendor/riscv/riscv-isa-sim/Makefile.in
+++ b/vendor/riscv/riscv-isa-sim/Makefile.in
@@ -161,7 +161,7 @@ comma := ,
 LD            := $(CXX)
 LIBS          := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@
 LIBS_EXE      := @LIBS@ @BOOST_ASIO_LIB@ @BOOST_REGEX_LIB@ $(install_libs_dir)/libyaml-cpp.a
-LINK          := $(LD) -L. -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
+LINK          := $(LD) -L. $(all-link-flags) -Wl,-rpath,$(install_libs_dir) $(patsubst -L%,-Wl$(comma)-rpath$(comma)%,$(filter -L%,$(LDFLAGS)))
 
 # Library creation
 


### PR DESCRIPTION
Do not link shared libraries of Spike against libyaml-cpp to avoid unnecessary library dependencies.