### PR TITLE
Generic PMA agent for multiple memory interfaces (AXI / OBI)

### DIFF
--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
@@ -154,7 +154,6 @@ function void uvma_pma_agent_c::create_components();
 
    scoreboard      = uvma_pma_sb_c#(ILEN,XLEN)            ::type_id::create("scoreboard"     , this);
    cov_model       = uvma_pma_cov_model_c                 ::type_id::create("cov_model"      , this);
-  // region_cov_model       = uvma_pma_region_cov_model_c                 ::type_id::create("region_cov_model"      , this);
    region_cov_model = new[cfg.regions.size()];
    foreach (region_cov_model[i]) begin
       region_cov_model[i] = uvma_pma_region_cov_model_c   ::type_id::create($sformatf("region_cov_model%0d", i), this);
@@ -182,7 +181,7 @@ function void uvma_pma_agent_c::connect_analysis_ports();
    end else begin
       mon_ap =  monitor_axi.ap;
    end
-   //Establishing connections between monitor ports and sequencer
+   //Establishing connections between monitor ports and scoreboard
    this.mon_ap.connect(scoreboard.pma_export);
 
 endfunction : connect_analysis_ports

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
@@ -25,7 +25,8 @@ class uvma_pma_agent_c#(int ILEN=DEFAULT_ILEN,
    uvma_pma_cntxt_c            cntxt;
 
    // Components
-   uvma_pma_mon_c#(ILEN,XLEN)  monitor;
+   uvma_pma_axi_mon_c#(ILEN,XLEN)  monitor_axi;
+   uvma_pma_obi_mon_c#(ILEN,XLEN)  monitor_obi;
    uvma_pma_sb_c               scoreboard;
    uvma_pma_cov_model_c        cov_model;
    uvma_pma_region_cov_model_c region_cov_model[];
@@ -151,9 +152,9 @@ endfunction : get_and_set_cntxt
 
 function void uvma_pma_agent_c::create_components();
 
-   monitor         = uvma_pma_mon_c#(ILEN,XLEN)           ::type_id::create("monitor"        , this);
    scoreboard      = uvma_pma_sb_c#(ILEN,XLEN)            ::type_id::create("scoreboard"     , this);
    cov_model       = uvma_pma_cov_model_c                 ::type_id::create("cov_model"      , this);
+  // region_cov_model       = uvma_pma_region_cov_model_c                 ::type_id::create("region_cov_model"      , this);
    region_cov_model = new[cfg.regions.size()];
    foreach (region_cov_model[i]) begin
       region_cov_model[i] = uvma_pma_region_cov_model_c   ::type_id::create($sformatf("region_cov_model%0d", i), this);
@@ -161,12 +162,28 @@ function void uvma_pma_agent_c::create_components();
    end
    mon_trn_logger  = uvma_pma_mon_trn_logger_c#(ILEN,XLEN)::type_id::create("mon_trn_logger" , this);
 
+   if(cfg.memory_intf == UVMA_PMA_OBI_INTF) begin
+      monitor_obi  = uvma_pma_obi_mon_c#(ILEN,XLEN)::type_id::create("monitor_obi" , this);
+   end
+   else if(cfg.memory_intf == UVMA_PMA_AXI_INTF) begin
+      monitor_axi  = uvma_pma_axi_mon_c#(ILEN,XLEN)::type_id::create("monitor_axi" , this );
+   end
+   else begin
+      `uvm_fatal("CFG", "Configuration does not contain valid memory interface")
+   end
+   mon_ap = new("mon_ap", this);
 endfunction : create_components
 
 
 function void uvma_pma_agent_c::connect_analysis_ports();
 
-   mon_ap = monitor.ap;
+   if(cfg.memory_intf == UVMA_PMA_OBI_INTF) begin
+      mon_ap =  monitor_obi.ap;
+   end else begin
+      mon_ap =  monitor_axi.ap;
+   end
+   //Establishing connections between monitor ports and sequencer
+   this.mon_ap.connect(scoreboard.pma_export);
 
 endfunction : connect_analysis_ports
 

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_agent.sv
@@ -171,6 +171,7 @@ function void uvma_pma_agent_c::create_components();
       `uvm_fatal("CFG", "Configuration does not contain valid memory interface")
    end
    mon_ap = new("mon_ap", this);
+
 endfunction : create_components
 
 

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_axi_mon.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_axi_mon.sv
@@ -1,0 +1,206 @@
+// Copyright 2021 OpenHW Group
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+// Licensed under the Solderpad Hardware License v 2.1 (the "License"); you may not use this file except in compliance
+// with the License, or, at your option, the Apache License version 2.0.  You may obtain a copy of the License at
+//                                        https://solderpad.org/licenses/SHL-2.1/
+// Unless required by applicable law or agreed to in writing, any work distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
+
+
+`ifndef __UVMA_PMA_AXI_MON_SV__
+`define __UVMA_PMA_AXI_MON_SV__
+
+/**
+ * Component sampling transactions from a Memory attribution agent for OpenHW Group CORE-V verification testbenches virtual interface (uvma_pma_if).
+ */
+ class  uvma_pma_axi_mon_c#(int ILEN=DEFAULT_ILEN, int XLEN=DEFAULT_XLEN) extends uvm_monitor;
+
+   // Objects
+   uvma_pma_cfg_c    cfg;
+
+    // TLM ports
+   uvm_analysis_port#(uvma_pma_mon_trn_c)  ap;
+
+    // TLM exports
+    uvm_analysis_export#(uvma_axi_transaction_c)                   read_axi_export;
+    uvm_tlm_analysis_fifo #(uvma_axi_transaction_c)                read_axi_fifo;
+    uvm_analysis_export#(uvma_axi_transaction_c)                   write_axi_export;
+    uvm_tlm_analysis_fifo #(uvma_axi_transaction_c)                write_axi_fifo;
+
+    uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_pma_axi_mon_c) rvfi_instr_export;
+
+    `uvm_component_param_utils_begin(uvma_pma_axi_mon_c#(ILEN,XLEN))
+      `uvm_field_object(cfg  , UVM_DEFAULT)
+    `uvm_component_utils_end
+
+   /**
+     * Default constructor.
+   */
+   extern function new(string name="uvma_pma_axi_mon_c", uvm_component parent=null);
+
+   /**
+     * 1. Ensures cfg handle is not null.
+     * 2. Builds ap.
+   */
+   extern virtual function void build_phase(uvm_phase phase);
+
+    /**
+     * Oversees monitoring, depending on the reset state, by calling mon_<pre|in|post>_reset() tasks.
+     */
+    extern virtual task run_phase(uvm_phase phase);
+
+     /**
+    * RVFI instructions
+    */
+    extern function void write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+   /**
+    * axi data
+    */
+    extern virtual function void write_axi_d(uvma_axi_transaction_c axi);
+
+    /**
+    * Appends cfg, prints out trn and issues heartbeat.
+     */
+   extern virtual function void process_trn(ref uvma_pma_mon_trn_c trn);
+
+
+ endclass : uvma_pma_axi_mon_c
+
+
+function uvma_pma_axi_mon_c::new(string name="uvma_pma_axi_mon_c", uvm_component parent=null);
+
+   super.new(name, parent);
+
+endfunction : new
+
+
+function void uvma_pma_axi_mon_c::build_phase(uvm_phase phase);
+
+   super.build_phase(phase);
+
+   void'(uvm_config_db#(uvma_pma_cfg_c)::get(this, "", "cfg", cfg));
+   if (!cfg) begin
+      `uvm_fatal("CFG", "Configuration handle is null")
+   end
+
+   ap = new("ap", this);
+
+   read_axi_export      = new("read_axi_export", this);
+   read_axi_fifo      = new("read_axi_fifo", this);
+   write_axi_export      = new("write_axi_export", this);
+   write_axi_fifo      = new("write_axi_fifo", this);
+   rvfi_instr_export = new("rvfi_instr_export", this);
+
+   this.write_axi_export.connect(this.write_axi_fifo.analysis_export);
+   this.read_axi_export.connect(this.read_axi_fifo.analysis_export);
+
+endfunction : build_phase
+
+task uvma_pma_axi_mon_c::run_phase(uvm_phase phase);
+
+   super.run_phase(phase);
+   forever begin
+      uvma_axi_transaction_c ar_axi_item;
+      uvma_axi_transaction_c aw_axi_item;
+
+      fork
+         read_axi_fifo.get(ar_axi_item);
+         write_axi_fifo.get(aw_axi_item);
+      join_any
+      disable fork;
+
+      if(ar_axi_item != null)
+         write_axi_d(ar_axi_item);
+      else
+         write_axi_d(aw_axi_item);
+   end
+
+endtask : run_phase
+
+function void uvma_pma_axi_mon_c::process_trn(ref uvma_pma_mon_trn_c trn);
+
+   trn.cfg = cfg;
+   trn.__originator = get_full_name();
+
+   `uvm_info("${name_uppecase}_MON", $sformatf("Sampled transaction from the virtual interface:\n%s", trn.sprint()), UVM_HIGH)
+   `uvml_hrtbt()
+
+endfunction : process_trn
+
+function void uvma_pma_axi_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+
+   // Create a new monitor transaction with mapped index region
+   uvma_pma_mon_trn_c mon_trn;
+
+   mon_trn              = uvma_pma_mon_trn_c#(ILEN,XLEN)::type_id::create("mon_trn");
+   process_trn(mon_trn);
+   mon_trn.access       = UVMA_PMA_ACCESS_INSTR;
+   mon_trn.rw           = UVMA_PMA_RW_READ;
+   mon_trn.region_index = cfg.get_pma_region_for_addr(instr.pc_rdata);
+   if (mon_trn.region_index != -1) begin
+      mon_trn.is_first_word = ((instr.pc_rdata >> 2) == (cfg.regions[mon_trn.region_index].word_addr_low)) ? 1 : 0;
+      mon_trn.is_last_word  = ((instr.pc_rdata >> 2) == (cfg.regions[mon_trn.region_index].word_addr_high - 1)) ? 1 : 0;
+   end
+
+   if (mon_trn.region_index == -1 && cfg.regions.size() == 0) begin
+      mon_trn.is_default = 1;
+   end
+
+      ap.write(mon_trn);
+
+endfunction : write_rvfi_instr
+
+function void uvma_pma_axi_mon_c::write_axi_d(uvma_axi_transaction_c axi);
+
+   logic [3:0] cache_value ;
+   logic id ;
+
+   // Create a new monitor transaction with mapped index region
+   uvma_pma_mon_trn_c mon_trn;
+
+   mon_trn               = uvma_pma_mon_trn_c#(ILEN,XLEN)::type_id::create("mon_trn");
+   process_trn(mon_trn);
+   mon_trn.access        = (axi.m_id == 0)? UVMA_PMA_ACCESS_INSTR : UVMA_PMA_ACCESS_DATA;
+   mon_trn.address       =  axi.m_addr;
+   mon_trn.rw            = (axi.m_txn_type == UVMA_AXI_WRITE_REQ) ?  UVMA_PMA_RW_WRITE : UVMA_PMA_RW_READ ;
+   mon_trn.region_index  = cfg.get_pma_region_for_addr(mon_trn.address);
+
+   cache_value = 2;
+
+   case (axi.m_cache)
+      0000 : mon_trn.memtype = UVMA_PMA_MEM_C_NB;
+      0001, 0011 : mon_trn.memtype = UVMA_PMA_MEM_NC_B;
+      1010, 0110, 1110, 1011, 0111, 1111 : mon_trn.memtype = UVMA_PMA_MEM_C_B;
+      0010 : mon_trn.memtype = UVMA_PMA_MEM_NC_NB;
+   endcase
+
+   if ((axi.m_atop != 0) || (axi.m_lock)) begin
+      mon_trn.atomic        = 1;
+   end
+   else begin
+      mon_trn.atomic        = 0;
+   end
+
+   if (mon_trn.region_index != -1) begin
+      mon_trn.is_first_word = (mon_trn.address == cfg.regions[mon_trn.region_index].word_addr_low) ? 1 : 0;
+      mon_trn.is_last_word  = (mon_trn.address  == cfg.regions[mon_trn.region_index].word_addr_high - 1) ? 1 : 0;
+   end
+
+   if (mon_trn.region_index == -1) begin
+      mon_trn.is_default = 1;
+   end
+
+   ap.write(mon_trn);
+
+   `uvm_info("PMAXIMON", $sformatf("axi monitor send trn access %s", mon_trn.access ), UVM_NONE)
+   `uvm_info("PMAXIMON", $sformatf("axi monitor send trn rw %s",  mon_trn.rw   ), UVM_NONE)
+   `uvm_info("PMAXIMON", $sformatf("axi monitor send trn rw %x",  mon_trn.address  ), UVM_NONE)
+   `uvm_info("PMAXIMON", $sformatf("axi monitor send transaction"), UVM_NONE)
+
+endfunction : write_axi_d
+
+`endif // __UVMA_PMA_MON_SV__
+

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_obi_mon.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_obi_mon.sv
@@ -9,14 +9,14 @@
 // specific language governing permissions and limitations under the License.
 
 
-`ifndef __UVMA_PMA_MON_SV__
-`define __UVMA_PMA_MON_SV__
+`ifndef __UVMA_PMA_OBI_MON_SV__
+`define __UVMA_PMA_OBI_MON_SV__
 
 /**
  * Component sampling transactions from a Memory attribution agent for OpenHW Group CORE-V verification testbenches virtual interface (uvma_pma_if).
  */
-class uvma_pma_mon_c#(int ILEN=DEFAULT_ILEN,
-                      int XLEN=DEFAULT_XLEN) extends uvm_monitor;
+
+class uvma_pma_obi_mon_c#(int ILEN=DEFAULT_ILEN,int XLEN=DEFAULT_XLEN) extends uvm_monitor;
 
    // Objects
    uvma_pma_cfg_c    cfg;
@@ -25,21 +25,23 @@ class uvma_pma_mon_c#(int ILEN=DEFAULT_ILEN,
    uvm_analysis_port#(uvma_pma_mon_trn_c)  ap;
 
    // TLM exports
-   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_pma_mon_c) rvfi_instr_export;
-   uvm_analysis_imp_obi_d#(uvma_obi_memory_mon_trn_c, uvma_pma_mon_c)                   obi_d_export;
+   uvm_analysis_export#(uvma_obi_memory_mon_trn_c)                   obi_export;
+   uvm_tlm_analysis_fifo #(uvma_obi_memory_mon_trn_c)                 obi_fifo;
 
-   `uvm_component_param_utils_begin(uvma_pma_mon_c#(ILEN,XLEN))
+   uvm_analysis_imp_rvfi_instr#(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN), uvma_pma_obi_mon_c) rvfi_instr_export;
+
+   `uvm_component_param_utils_begin(uvma_pma_obi_mon_c#(ILEN,XLEN))
       `uvm_field_object(cfg  , UVM_DEFAULT)
    `uvm_component_utils_end
 
    /**
     * Default constructor.
     */
-   extern function new(string name="uvma_pma_mon", uvm_component parent=null);
+   extern function new(string name="uvma_pma_obi_mon_c", uvm_component parent=null);
 
-   /**
-    * 1. Ensures cfg handle is not null.
-    * 2. Builds ap.
+   /*
+    1. Ensures cfg handle is not null.
+    2. Builds ap.
     */
    extern virtual function void build_phase(uvm_phase phase);
 
@@ -63,17 +65,17 @@ class uvma_pma_mon_c#(int ILEN=DEFAULT_ILEN,
     */
    extern virtual function void process_trn(ref uvma_pma_mon_trn_c trn);
 
-endclass : uvma_pma_mon_c
+endclass :uvma_pma_obi_mon_c
 
 
-function uvma_pma_mon_c::new(string name="uvma_pma_mon", uvm_component parent=null);
+ function uvma_pma_obi_mon_c::new(string name="uvma_pma_obi_mon_c", uvm_component parent=null);
 
    super.new(name, parent);
 
-endfunction : new
+ endfunction : new
 
 
-function void uvma_pma_mon_c::build_phase(uvm_phase phase);
+function void uvma_pma_obi_mon_c::build_phase(uvm_phase phase);
 
    super.build_phase(phase);
 
@@ -83,19 +85,28 @@ function void uvma_pma_mon_c::build_phase(uvm_phase phase);
    end
 
    ap = new("ap", this);
-
+   obi_export      = new("obi_export", this);
+   obi_fifo      = new("obi_fifo", this);
    rvfi_instr_export = new("rvfi_instr_export", this);
-   obi_d_export      = new("obi_d_export", this);
+
+   this.obi_export.connect(this.obi_fifo.analysis_export);
 
 endfunction : build_phase
 
-task uvma_pma_mon_c::run_phase(uvm_phase phase);
+task uvma_pma_obi_mon_c::run_phase(uvm_phase phase);
+   uvma_obi_memory_mon_trn_c obi_trn;
 
-   super.run_phase(phase);
+   forever begin
+
+      super.run_phase(phase);
+
+      obi_fifo.get(obi_trn);
+      write_obi_d(obi_trn);
+   end
 
 endtask : run_phase
 
-function void uvma_pma_mon_c::process_trn(ref uvma_pma_mon_trn_c trn);
+function void uvma_pma_obi_mon_c::process_trn(ref uvma_pma_mon_trn_c trn);
 
    trn.cfg = cfg;
    trn.__originator = get_full_name();
@@ -104,7 +115,7 @@ function void uvma_pma_mon_c::process_trn(ref uvma_pma_mon_trn_c trn);
 
 endfunction : process_trn
 
-function void uvma_pma_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
+function void uvma_pma_obi_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,XLEN) instr);
 
    // Create a new monitor transaction with mapped index region
    uvma_pma_mon_trn_c mon_trn;
@@ -115,8 +126,10 @@ function void uvma_pma_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,
    mon_trn.rw           = UVMA_PMA_RW_READ;
    mon_trn.region_index = cfg.get_pma_region_for_addr(instr.pc_rdata);
    if (mon_trn.region_index != -1) begin
+
       mon_trn.is_first_word = ((instr.pc_rdata >> 2) == (cfg.regions[mon_trn.region_index].word_addr_low)) ? 1 : 0;
       mon_trn.is_last_word  = ((instr.pc_rdata >> 2) == (cfg.regions[mon_trn.region_index].word_addr_high - 1)) ? 1 : 0;
+
    end
 
    if (mon_trn.region_index == -1 && cfg.regions.size() == 0) begin
@@ -127,16 +140,27 @@ function void uvma_pma_mon_c::write_rvfi_instr(uvma_rvfi_instr_seq_item_c#(ILEN,
 
 endfunction : write_rvfi_instr
 
-function void uvma_pma_mon_c::write_obi_d(uvma_obi_memory_mon_trn_c obi);
+function void uvma_pma_obi_mon_c::write_obi_d(uvma_obi_memory_mon_trn_c obi);
 
    // Create a new monitor transaction with mapped index region
    uvma_pma_mon_trn_c mon_trn;
 
    mon_trn               = uvma_pma_mon_trn_c#(ILEN,XLEN)::type_id::create("mon_trn");
    process_trn(mon_trn);
-   mon_trn.access        = UVMA_PMA_ACCESS_DATA;
+
+   mon_trn.access        = (obi.aid == 0)? UVMA_PMA_ACCESS_INSTR : UVMA_PMA_ACCESS_DATA;
    mon_trn.rw            = (obi.access_type == UVMA_OBI_MEMORY_ACCESS_READ) ? UVMA_PMA_RW_READ : UVMA_PMA_RW_WRITE;
+   mon_trn.atomic        = obi.atop;
+   mon_trn.address       = obi.address;
    mon_trn.region_index  = cfg.get_pma_region_for_addr(obi.address);
+
+   case (obi.memtype)
+     00 : mon_trn.memtype       = UVMA_PMA_MEM_NC_NB;
+     01 : mon_trn.memtype       = UVMA_PMA_MEM_NC_B;
+     10 : mon_trn.memtype       = UVMA_PMA_MEM_C_NB;
+     11 : mon_trn.memtype       = UVMA_PMA_MEM_C_B;
+   endcase
+
    if (mon_trn.region_index != -1) begin
       mon_trn.is_first_word = ((obi.address >> 2) == (cfg.regions[mon_trn.region_index].word_addr_low)) ? 1 : 0;
       mon_trn.is_last_word  = ((obi.address >> 2) == (cfg.regions[mon_trn.region_index].word_addr_high - 1)) ? 1 : 0;

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_region_cov_model.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_region_cov_model.sv
@@ -153,7 +153,6 @@ task uvma_pma_region_cov_model_c::run_phase(uvm_phase phase);
    fork
       // Monitor transactions
       forever begin
-         `uvm_info("PMA REGIONS COV MODEL", $sformatf("waitong axi transaction"), UVM_LOW)
          mon_trn_fifo.get(mon_trn);
          if (cfg.enabled && cfg.cov_model_enabled) begin
             sample_mon_trn();
@@ -170,7 +169,6 @@ function void uvma_pma_region_cov_model_c::sample_mon_trn();
    if (!mon_trn.is_default && mon_trn.region_index == this.region_index) begin
       pma_access_covg.sample(mon_trn);
    end
-   `uvm_info("PMA REGIONS COV MODEL ", $sformatf("sample coverage model"), UVM_LOW)
 
 
 endfunction : sample_mon_trn

--- a/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_sb.sv
+++ b/lib/uvm_agents/uvma_pma/src/comps/uvma_pma_sb.sv
@@ -146,6 +146,7 @@ task uvma_pma_sb_c::run_phase(uvm_phase phase);
       uvma_pma_mon_trn_c pma_trn;
 
       pma_fifo.get(pma_trn);
+
       if(pma_trn.access == UVMA_PMA_ACCESS_INSTR) begin
 
          write_pma_trn_i(pma_trn);
@@ -228,13 +229,13 @@ endfunction : write_pma_trn_d
 
 function void uvma_pma_sb_c::report_phase(uvm_phase phase);
 
-  // print_checked_stats();
+   print_checked_stats();
 
 endfunction : report_phase
 
 function void uvma_pma_sb_c::pre_abort();
 
-   //print_checked_stats();
+   print_checked_stats();
 
 endfunction : pre_abort
 
@@ -249,19 +250,19 @@ function void uvma_pma_sb_c::check_pma_trn_i_deconfigured(uvma_pma_mon_trn_c pma
 
    // Check: Bufferable bit must be 0 in pma_trn for instruction fetches
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype ==UVMA_PMA_MEM_C_NB )) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for deconfigured PMA",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for deconfigured PMA",
                                        pma_trn.access, pma_trn.address));
    end
 
    // Check: Cacheable bit must be 0 in pma_trn
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype ==UVMA_PMA_MEM_NC_B)) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x cacheable bit set for deconfigured PMA",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x cacheable bit set for deconfigured PMA",
                                        pma_trn.access, pma_trn.address));
    end
 
    // Check: atomic attributes should be 0
    if (pma_trn.atomic) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x atomic is not zero, pma_trn: 0x%0x",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x atomic is not zero, pma_trn: 0x%0x",
                                        pma_trn.access.name(), pma_trn.address,
                                        pma_trn.atomic));
    end
@@ -273,7 +274,7 @@ endfunction : check_pma_trn_i_deconfigured
 
    // Check: Bufferable bit must be 0 in pma_trn for instruction fetches
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_B ) || (pma_trn.memtype == UVMA_PMA_MEM_C_B )) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for PMA default region",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for PMA default region",
                                        pma_trn.access.name(), pma_trn.address));
    end
 
@@ -296,19 +297,19 @@ endfunction : check_pma_trn_i_default_region
 function void uvma_pma_sb_c::check_pma_trn_i_mapped_region(uvma_pma_mon_trn_c pma_trn, int index);
    // Check: Must be main memory
    if (!cfg.regions[index].main) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x, region: %0d instruction fetch from I/O memory",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x, region: %0d instruction fetch from I/O memory",
                                        pma_trn.access.name(), pma_trn.address, index));
    end
 
    // Check: Bufferable bit must be 0 in pma_trn for instruction fetches
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_B ) || (pma_trn.memtype ==UVMA_PMA_MEM_C_B )) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for PMA default region",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x bufferable bit set for PMA default region",
                                        pma_trn.access.name(), pma_trn.address));
    end
 
    // Check: Cacheable bit must match memtype[0] in pma_trn
    if ((((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype == UVMA_PMA_MEM_NC_B)) && cfg.regions[index].cacheable ==1) || (((pma_trn.memtype == UVMA_PMA_MEM_C_NB) || (pma_trn.memtype == UVMA_PMA_MEM_C_B)) && cfg.regions[index].cacheable ==0)) begin
-      `uvm_error("PMApma_trnI", $sformatf("pma_trn I %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
+      `uvm_error("PMA_trnI", $sformatf("pma_trn I %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
                                        pma_trn.access.name(), pma_trn.address, index,
                                        pma_trn.memtype.name(), cfg.regions[index].cacheable));
    end
@@ -326,13 +327,13 @@ function void uvma_pma_sb_c::check_pma_trn_d_deconfigured(uvma_pma_mon_trn_c pma
 
    // Check: Bufferable bit must be 0 in pma_trn
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype ==UVMA_PMA_MEM_C_NB) ) begin
-      `uvm_error("PMApma_trnD", $sformatf("pma_trn D %s address: 0x%08x bufferable bit set for PMA default region",
+      `uvm_error("PMA_trnD", $sformatf("pma_trn D %s address: 0x%08x bufferable bit set for PMA default region",
                                        pma_trn.access.name(), pma_trn.address));
    end
 
-   /// Check: Cacheable bit must match cacheable flag in pma_trn
+   // Check: Cacheable bit must match cacheable flag in pma_trn
    if (((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype == UVMA_PMA_MEM_NC_B) && cfg.regions[index].cacheable ==1) || ((pma_trn.memtype == UVMA_PMA_MEM_C_NB) || (pma_trn.memtype == UVMA_PMA_MEM_C_B) && cfg.regions[index].cacheable ==0)  ) begin
-      `uvm_error("PMApma_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
+      `uvm_error("PMA_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
                                        pma_trn.access.name(), pma_trn.address, index,
                                        pma_trn.memtype.name(), cfg.regions[index].cacheable));
    end
@@ -343,7 +344,7 @@ function void uvma_pma_sb_c::check_pma_trn_d_default_region(uvma_pma_mon_trn_c p
 
    // Check: Bufferable bit must be 0 in pma_trn for data loads
    if ((pma_trn.memtype == UVMA_PMA_MEM_NC_NB ) || (pma_trn.memtype == UVMA_PMA_MEM_C_NB )) begin
-      `uvm_error("PMApma_trnD", $sformatf("pma_trn D %s address: 0x%08x bufferable bit set for PMA default region",
+      `uvm_error("PMA_trnD", $sformatf("pma_trn D %s address: 0x%08x bufferable bit set for PMA default region",
                                        pma_trn.access.name(), pma_trn.address));
    end
 
@@ -361,7 +362,6 @@ function void uvma_pma_sb_c::check_pma_trn_d_default_region(uvma_pma_mon_trn_c p
    end
 
 endfunction : check_pma_trn_d_default_region
-
 
 
 function void uvma_pma_sb_c::check_pma_trn_d_mapped_region(uvma_pma_mon_trn_c pma_trn, int index);
@@ -384,14 +384,14 @@ function void uvma_pma_sb_c::check_pma_trn_d_mapped_region(uvma_pma_mon_trn_c pm
 
    // Check: Cacheable bit must match memtype in pma_trn
    if ((((pma_trn.memtype == UVMA_PMA_MEM_NC_NB) || (pma_trn.memtype == UVMA_PMA_MEM_NC_B)) && cfg.regions[index].cacheable ==1) || (((pma_trn.memtype == UVMA_PMA_MEM_C_NB) || (pma_trn.memtype == UVMA_PMA_MEM_C_B)) && cfg.regions[index].cacheable ==0)  ) begin
-     `uvm_error("PMApma_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
+     `uvm_error("PMA_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d cacheable bit mismatch, pma_trn: %s, PMA: %0d",
                                        pma_trn.access.name(), pma_trn.address, index,
                                        pma_trn.memtype.name(), cfg.regions[index].cacheable));
    end
 
    // Check: atomic attributes should be 0
    if (pma_trn.atomic) begin
-      `uvm_error("PMApma_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d atomic is not zero, pma_trn: 0x%0x",
+      `uvm_error("PMA_trnD", $sformatf("pma_trn D %s address: 0x%08x, region: %0d atomic is not zero, pma_trn: 0x%0x",
                                        pma_trn.access.name(), pma_trn.address, index,
                                        pma_trn.atomic));
    end

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
@@ -85,6 +85,20 @@ endfunction : new
 
 function int uvma_pma_cfg_c::get_pma_region_for_addr(bit[XLEN-1:0] addr);
 
+   // In default PMA configurations overlapping regions map from low index to high
+   for (int i = 0; i < regions.size(); i++) begin
+      if (memory_intf == UVMA_PMA_AXI_INTF) begin
+         if (addr_in_region(addr, regions[i]))
+            return i;
+      end
+      else if (memory_intf == UVMA_PMA_OBI_INTF) begin
+         if (regions[i].is_addr_in_region(addr))
+            return i;
+      end
+     else begin
+     `uvm_fatal("CFG", "Configuration does not contain valid memory interface")
+     end
+   end
    for (int i = 0; i < regions.size(); i++) begin
       if (addr_in_region(addr, regions[i]))
          return i;

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_cfg.sv
@@ -33,6 +33,7 @@ class uvma_pma_cfg_c#(int ILEN=DEFAULT_ILEN,
    // PMA regions
    uvma_core_cntrl_pma_region_c  regions[];
 
+
    `uvm_object_param_utils_begin(uvma_pma_cfg_c#(ILEN,XLEN))
       `uvm_field_int (                         enabled           , UVM_DEFAULT)
       `uvm_field_enum(uvm_active_passive_enum, is_active         , UVM_DEFAULT)
@@ -84,19 +85,9 @@ endfunction : new
 
 function int uvma_pma_cfg_c::get_pma_region_for_addr(bit[XLEN-1:0] addr);
 
-   // In default PMA configurations overlapping regions map from low index to high
    for (int i = 0; i < regions.size(); i++) begin
-      if (memory_intf == UVMA_PMA_AXI_INTF) begin
-         if (addr_in_region(addr, regions[i]))
-            return i;
-      end
-      else if (memory_intf == UVMA_PMA_OBI_INTF) begin
-         if (regions[i].is_addr_in_region(addr))
-            return i;
-      end
-     else begin
-     `uvm_fatal("CFG", "Configuration does not contain valid memory interface")
-     end
+      if (addr_in_region(addr, regions[i]))
+         return i;
    end
 
    return -1;

--- a/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_mon_trn.sv
+++ b/lib/uvm_agents/uvma_pma/src/obj/uvma_pma_mon_trn.sv
@@ -34,6 +34,12 @@ class uvma_pma_mon_trn_c#(int ILEN=DEFAULT_ILEN,
    // Access type (instruction or data)
    uvma_pma_access_enum access;
 
+   // Read/Write Address
+   longint address;
+
+   //Atomic attributes of transaction
+   bit atomic;
+
    // Set if the first word of the PMA region (for fucntional coverage)
    bit is_first_word;
 
@@ -43,11 +49,17 @@ class uvma_pma_mon_trn_c#(int ILEN=DEFAULT_ILEN,
    // Read or write
    uvma_pma_rw_enum rw;
 
+   // Bufferable and cacheable attributes of transactions
+   uvma_pma_memtype_enum memtype;
+
    `uvm_object_param_utils_begin(uvma_pma_mon_trn_c#(ILEN,XLEN))
       `uvm_field_int(                       region_index,  UVM_DEFAULT)
       `uvm_field_int(                       is_default,    UVM_DEFAULT)
+      `uvm_field_int(                       address,       UVM_DEFAULT)
+      `uvm_field_int(                       atomic,        UVM_DEFAULT)
       `uvm_field_enum(uvma_pma_access_enum, access,        UVM_DEFAULT)
       `uvm_field_enum(uvma_pma_rw_enum,     rw,            UVM_DEFAULT)
+      `uvm_field_enum(uvma_pma_memtype_enum,memtype,       UVM_DEFAULT)
       `uvm_field_int(                       is_first_word, UVM_DEFAULT)
       `uvm_field_int(                       is_last_word,  UVM_DEFAULT)
    `uvm_object_utils_end

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_pkg.sv
@@ -30,11 +30,12 @@ package uvma_pma_pkg;
    import uvml_logs_pkg      ::*;
    import uvma_core_cntrl_pkg::*;
    import uvma_obi_memory_pkg::*;
+   import uvma_axi_pkg::*;
    import uvma_rvfi_pkg      ::*;
 
    `uvm_analysis_imp_decl(_rvfi_instr)
-   `uvm_analysis_imp_decl(_obi_i)
-   `uvm_analysis_imp_decl(_obi_d)
+   `uvm_analysis_imp_decl(_bus_i)
+   `uvm_analysis_imp_decl(_bus_d)
 
    // Constants / Structs / Enums
    `include "uvma_pma_constants.sv"
@@ -52,7 +53,8 @@ package uvma_pma_pkg;
    `include "uvma_pma_cov_model.sv"
    `include "uvma_pma_region_cov_model.sv"
    `include "uvma_pma_sb.sv"
-   `include "uvma_pma_mon.sv"
+   `include "uvma_pma_obi_mon.sv"
+   `include "uvma_pma_axi_mon.sv"
    `include "uvma_pma_agent.sv"
 
 endpackage : uvma_pma_pkg

--- a/lib/uvm_agents/uvma_pma/src/uvma_pma_tdefs.sv
+++ b/lib/uvm_agents/uvma_pma/src/uvma_pma_tdefs.sv
@@ -22,4 +22,17 @@ typedef enum {
    UVMA_PMA_RW_READ
 } uvma_pma_rw_enum;
 
+typedef enum {
+   UVM_PMA_DEFAULT,
+   UVMA_PMA_AXI_INTF,
+   UVMA_PMA_OBI_INTF
+} uvma_pma_intf_enum ;
+
+typedef enum {
+   UVMA_PMA_MEM_NC_NB,
+   UVMA_PMA_MEM_NC_B,
+   UVMA_PMA_MEM_C_NB,
+   UVMA_PMA_MEM_C_B
+} uvma_pma_memtype_enum;
+
 `endif // __UVMA_PMA_TDEFS_SV__


### PR DESCRIPTION
Modified CV32E40 PMA agent to be generic for multiple memory interfaces such as AXI and OBI
  - add monitor for AXI transactions 
  - add monitor for OBI transactions
  - Update scoreboard checks to be based on PMA transaction