### PR TITLE
[Spike] Set default PMP granularity to 8.  Add support for corresponding Yaml parameter.

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0035-increase-pmp-granularity-to-8.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0035-increase-pmp-granularity-to-8.patch
@@ -1,0 +1,45 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+index cba92b2e..3fcc1f58 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+@@ -234,6 +234,16 @@ Processor::Processor(
+   std::cout << "[SPIKE]                 PMP Regions " << std::hex << pmpregions_max << std::endl;
+   processor_t::set_pmp_num(pmpregions_max);
+ 
++  uint64_t pmp_granularity = this->params[base + "pmp_granularity"].a_uint64_t;
++  std::cout << "[SPIKE]                 PMP Granularity " << pmp_granularity;
++  // PMP granularity must be at least 4 and a power of two.
++  if (pmp_granularity < 4 || (pmp_granularity & (pmp_granularity - 1)) != 0)
++    std::cout << " is INVALID, will be IGNORED." << std::endl;
++  else {
++    std::cout << std::endl;
++    processor_t::set_pmp_granularity(pmp_granularity);
++  }
++
+   ((cfg_t *)cfg)->priv = priv_str.c_str();
+ 
+   uint64_t trigger_count = this->params[base + "trigger_count"].a_uint64_t;
+@@ -333,6 +343,9 @@ void Processor::default_params(string base, openhw::Params &params, Processor *p
+   if (!params.exist(base, "pmpregions_writable"))
+     params.set_uint64_t(base, "pmpregions_writable", 0x0UL, "0x0",
+                         "Number of PMP regions");
++  if (!params.exist(base, "pmp_granularity"))
++    params.set_uint64_t(base, "pmp_granularity", 0x8UL, "0x8",
++                        "Granularity of PMP addresses in bytes");
+   if (!params.exist(base, "pmpaddr0"))
+     params.set_uint64_t(base, "pmpaddr0", 0x0UL, "0x0",
+ 			"Default PMPADDR0 value");
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/processor.cc b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+index b6139b94..14082cc7 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/processor.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+@@ -60,7 +60,8 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
+   for (auto e : isa->get_extensions())
+     register_extension(e.second);
+ 
+-  set_pmp_granularity(1 << PMP_SHIFT);
++  // Assume G=1, i.e., PMP granularity 8.
++  set_pmp_granularity(1 << (1 + PMP_SHIFT));
+   set_pmp_num(cfg->pmpregions);
+ 
+   if (isa->get_max_xlen() == 32)

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -234,6 +234,16 @@ Processor::Processor(
   std::cout << "[SPIKE]                 PMP Regions " << std::hex << pmpregions_max << std::endl;
   processor_t::set_pmp_num(pmpregions_max);
 
+  uint64_t pmp_granularity = this->params[base + "pmp_granularity"].a_uint64_t;
+  std::cout << "[SPIKE]                 PMP Granularity " << pmp_granularity;
+  // PMP granularity must be at least 4 and a power of two.
+  if (pmp_granularity < 4 || (pmp_granularity & (pmp_granularity - 1)) != 0)
+    std::cout << " is INVALID, will be IGNORED." << std::endl;
+  else {
+    std::cout << std::endl;
+    processor_t::set_pmp_granularity(pmp_granularity);
+  }
+
   ((cfg_t *)cfg)->priv = priv_str.c_str();
 
   uint64_t trigger_count = this->params[base + "trigger_count"].a_uint64_t;
@@ -333,6 +343,9 @@ void Processor::default_params(string base, openhw::Params &params, Processor *p
   if (!params.exist(base, "pmpregions_writable"))
     params.set_uint64_t(base, "pmpregions_writable", 0x0UL, "0x0",
                         "Number of PMP regions");
+  if (!params.exist(base, "pmp_granularity"))
+    params.set_uint64_t(base, "pmp_granularity", 0x8UL, "0x8",
+                        "Granularity of PMP addresses in bytes");
   if (!params.exist(base, "pmpaddr0"))
     params.set_uint64_t(base, "pmpaddr0", 0x0UL, "0x0",
 			"Default PMPADDR0 value");

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
@@ -60,7 +60,8 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   for (auto e : isa->get_extensions())
     register_extension(e.second);
 
-  set_pmp_granularity(1 << PMP_SHIFT);
+  // Assume G=1, i.e., PMP granularity 8.
+  set_pmp_granularity(1 << (1 + PMP_SHIFT));
   set_pmp_num(cfg->pmpregions);
 
   if (isa->get_max_xlen() == 32)


### PR DESCRIPTION
Increase default PMP granularity from 4 to 8.  Add support for corresponding core-level parameter `pmp_granularity`.