### PR TITLE
RVFI INSTR IF - Heed `clicptr` in `is_instr_bus_valid`

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_instr_if.sv
@@ -197,8 +197,9 @@ interface uvma_rvfi_instr_if_t
 
 
   // -------------------------------------------------------------------
-  // Local variables
+  // Signals
   // -------------------------------------------------------------------
+
   int unsigned                      irq_cnt;         // number of taken interrupts
   int unsigned                      nmi_instr_cnt;   // number of instructions after nmi
   int unsigned                      single_step_cnt; // number of instructions stepped
@@ -275,6 +276,10 @@ interface uvma_rvfi_instr_if_t
 
   asm_t instr_asm;
 
+  wire is_exception_cause_instr_acc_fault = (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_ACC_FAULT);
+  wire is_exception_cause_integrity_fault = (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_INTEGRITY_FAULT);
+  wire is_exception_cause_bus_fault       = (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_BUS_FAULT);
+
   // -------------------------------------------------------------------
   // Begin module code
   // -------------------------------------------------------------------
@@ -335,7 +340,7 @@ interface uvma_rvfi_instr_if_t
   end
 
   always_comb begin
-    is_mret                          = is_mret_f();
+    is_mret                          = match_instr(INSTR_OPCODE_MRET, INSTR_MASK_FULL);
   end
 
   always_comb begin
@@ -437,7 +442,14 @@ interface uvma_rvfi_instr_if_t
   end
 
   always_comb begin
-    is_instr_bus_valid               = is_instr_bus_valid_f();
+    is_instr_bus_valid = (
+      (
+        !is_exception_cause_bus_fault &&
+        !is_exception_cause_integrity_fault &&
+        !is_exception_cause_instr_acc_fault
+      ) ||
+      rvfi_trap.clicptr
+    );
   end
 
   always_comb begin
@@ -623,6 +635,7 @@ interface uvma_rvfi_instr_if_t
 
   modport passive_mp    (clocking mon_cb);
 
+
   // -------------------------------------------------------------------
   // Functions
   // -------------------------------------------------------------------
@@ -637,9 +650,11 @@ interface uvma_rvfi_instr_if_t
     logic [ XLEN-1:0] instr_ref,
     logic [ XLEN-1:0] instr_mask
   );
-
-  return rvfi_valid && is_instr_bus_valid && ((rvfi_insn & instr_mask) == instr_ref);
-
+    return (
+      rvfi_valid &&
+      is_instr_bus_valid &&
+      ((rvfi_insn & instr_mask) == instr_ref)
+    );
   endfunction : match_instr
 
   // Check if instruction is of a certain type, without verifying the instr word is valid
@@ -841,10 +856,6 @@ function automatic logic is_dret_f();
   return match_instr(INSTR_OPCODE_DRET, INSTR_MASK_FULL);
 endfunction : is_dret_f
 
-function automatic logic is_mret_f();
-  return match_instr(INSTR_OPCODE_MRET, INSTR_MASK_FULL);
-endfunction : is_mret_f
-
 function automatic logic is_uret_f();
   return match_instr(INSTR_OPCODE_URET, INSTR_MASK_FULL);
 endfunction : is_uret_f
@@ -966,13 +977,6 @@ function automatic logic is_pma_fault_f();
           })  &&
           (rvfi_trap.cause_type == 'h 0);
 endfunction : is_pma_fault_f
-
-function automatic logic is_instr_bus_valid_f();
-  return !( (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_ACC_FAULT) ||
-            (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_INTEGRITY_FAULT) ||
-            (rvfi_trap.exception_cause == EXC_CAUSE_INSTR_BUS_FAULT)
-    );
-endfunction : is_instr_bus_valid_f
 
 function automatic logic [31:0] rvfi_mem_addr_word0highbyte_f();
   logic [31:0] addr = rvfi_mem_addr[31:0];


### PR DESCRIPTION
This PR amends `uvma_rvfi_instr_if`, making sure `is_instr_bus_valid` considers `rvfi_trap.clicptr`.

Relevant `clicptr` spec:
https://docs.openhwgroup.org/projects/cv32e40x-user-manual/en/latest/rvfi.html#compatibility
_"rvfi_trap.clicptr is set for CLIC pointers. CLIC pointers are only reported on RVFI when they get an exception during fetch."_

Test status:
* Formal - Compiles and runs.
* `ci_check` - TODO

Background:
Here is the assert that failed before: [a_mintstatus_mil_decrease_intended](https://github.com/openhwgroup/cv32e40x-dv/blob/main/tb/uvmt/uvmt_cv32e40x_clic_interrupt_assert.sv#L3079).
It required an `mret` in a certain situation, but the RVFI instr if claimed that there was no `mret` because of an "instruction access fault". (The fault was on the pointer fetch, but the mret itself was fine.)