### PR TITLE
[Spike] Add support of CV-X-IF instructions (32b with 2/3 source regs and 16b).  Refactor associated code.

### DIFF
--- a/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
+++ b/vendor/riscv/riscv-isa-sim/customext/cvxif.cc
@@ -19,22 +19,84 @@
 // is 'custom##n': illegal instruction, return 0.
 // The writeback controller 'cvxif_extn_t::do_writeback_p'
 // is in charge of determining if writeback is required or not.
-// Expected instruction encoding is 4 bytes.
+// After executing the instruction the PC is avanced by 4 bytes.
 #define customX(n) \
 static reg_t c##n(processor_t* p, insn_t insn, reg_t pc) \
   { \
     cvxif_t* cvxif = static_cast<cvxif_t*>(p->get_extension(EXTENSION_NAME)); \
-    cvxif_insn_t custom_insn; \
-    custom_insn.i = insn; \
-    reg_t xd = cvxif->default_custom##n(custom_insn); \
-    if (cvxif->do_writeback_p(custom_insn)) \
+    reg_t xd = cvxif->default_custom##n(insn); \
+    if (cvxif->do_writeback_p(insn)) \
       WRITE_RD(xd); \
     return pc+4; \
   } \
   \
-  reg_t default_custom##n(cvxif_insn_t insn) \
+  reg_t default_custom##n(insn_t insn) \
   { \
     return custom##n(insn); \
+  }
+
+// Define 32-bit insn template with explicit RD.
+// The insn-level wrapper is 'cvxif_32_##<name>',
+// the default implementation is 'default_cvxif_32_##<name>'
+// and the register semantics is expected in function 'compute_cvxif_32_##<name>'.
+// After executing the instruction the PC is advanced by 4 bytes.
+#define cvxif_insn_32(name) \
+  static reg_t cvxif_32_##name(processor_t* p, insn_t insn, reg_t pc) { \
+    cvxif_t* cvxif = static_cast<cvxif_t*>(p->get_extension(EXTENSION_NAME)); \
+    reg_t xd = cvxif->default_cvxif_32_##name(insn); \
+    if (cvxif->do_writeback_p(insn)) \
+      WRITE_RD(xd); \
+    return pc+4; \
+  } \
+  \
+  reg_t default_cvxif_32_##name(insn_t insn) { \
+    return cvxif_##name(insn); \
+  }
+
+// Define 32-bit insn template with implicit RD == a0.
+// Like 'cvxif_insn_32' but the destination register is hardcoded.
+// After executing the instruction the PC is advanced by 4 bytes.
+#define cvxif_insn_32_rd_implicit_a0(name) \
+  static reg_t cvxif_32_##name(processor_t* p, insn_t insn, reg_t pc) { \
+    cvxif_t* cvxif = static_cast<cvxif_t*>(p->get_extension(EXTENSION_NAME)); \
+    reg_t xd = cvxif->default_cvxif_32_##name(insn); \
+    if (cvxif->do_writeback_p(insn)) \
+      WRITE_REG(10, xd); \
+    return pc+4; \
+  } \
+  \
+  reg_t default_cvxif_32_##name(insn_t insn) { \
+    return cvxif_##name(insn); \
+  }
+
+// Like the 32-bit explicit RD version 'cvxif_insn_32', but uses 16-bit
+// opcodes. PC is advanced by 16 bits instead of 32.
+#define cvxif_insn_16(name) \
+  static reg_t cvxif_16_##name(processor_t* p, insn_t insn, reg_t pc) { \
+    cvxif_t* cvxif = static_cast<cvxif_t*>(p->get_extension(EXTENSION_NAME)); \
+    reg_t xd = cvxif->default_cvxif_16_##name(insn); \
+    if (cvxif->do_writeback_p(insn)) \
+      WRITE_RD(xd); \
+    return pc+2 ; \
+  } \
+  \
+  reg_t default_cvxif_16_##name(insn_t insn) { \
+    return cvxif_##name(insn); \
+  }
+
+// Like 'cvxif_insn_16', but RD is implicitly x10 (a0).
+// PC is advanced by 16 bits.
+#define cvxif_insn_16_rd_implicit_a0(name) \
+  static reg_t cvxif_16_##name(processor_t* p, insn_t insn, reg_t pc) { \
+    cvxif_t* cvxif = static_cast<cvxif_t*>(p->get_extension(EXTENSION_NAME)); \
+    reg_t xd = cvxif->default_cvxif_16_##name(insn); \
+    if (cvxif->do_writeback_p(insn)) \
+      WRITE_REG(10, xd); \
+    return pc+2 ; \
+  } \
+  \
+  reg_t default_cvxif_16_##name(insn_t insn) { \
+    return cvxif_##name(insn); \
   }
 
 // This class instantiates the CV-X-IF interface.
@@ -43,68 +105,97 @@ class cvxif_t : public cvxif_extn_t
  public:
   const char* name() { return EXTENSION_NAME; }
 
-  bool do_writeback_p(cvxif_insn_t copro_insn)
+  bool do_writeback_p(insn_t insn)
   {
+    // Convert the RISC-V insn to a more generic type 'cvxif_insn_t'.
     // INSN_R personality serves to simplify access to standard encoding fields.
+    cvxif_insn_t copro_insn = { .i = insn };
     cvxif_r_insn_t insn_r = copro_insn.r_type;
 
-   if (insn_r.opcode != 0x7b /* MATCH_CUSTOM3 */)
+    if ((insn_r.opcode & 0x3) != (unsigned) Cop::NOT_COMPRESSED) {
+      // Instruction is compressed.  Only CUS_CADD writes back something.
+      if (copro_insn.cr_type.opcode == Cop::C0) {
+        // Compressed insns with opcode C0 (2'b10) used in CV-X-IF:
+        // - CUS_CNOP: no WB
+        // - CUS_CADD: writes back into x10.
+        if (copro_insn.cr_type.funct4 == Func4::FUNC4_CADD)
+          return true;
+      }
+      // All other compressed insns.
       return false;
-    else switch (insn_r.funct3)
-    {
-      case Func3::FUNC3_0:
-        //CUS_NOP have rd equal to zero
-        return (insn_r.rd != 0x0);
-      case Func3::FUNC3_1:
-        switch (insn_r.funct7)
-        {
-          case Func7::CUS_ADD:
-            return true;
-          case Func7::CUS_DOUBLE_RS1:
-            return true;
-          case Func7::CUS_DOUBLE_RS2:
-            return true;
-          case Func7::CUS_ADD_MULTICYCLE:
-            return true;
-          default:
-            return false;
-        }
-      case Func3::FUNC3_2:
-      case Func3::FUNC3_3:
-        return false;
-      default:
-        return false;
-    }
+    } else if (insn_r.opcode == 0x7b /* MATCH_CUSTOM3 */) {
+      switch (insn_r.funct3) {
+        case Func3::FUNC3_0:
+          //CUS_NOP have rd equal to zero
+          return (insn_r.rd != 0x0);
+        case Func3::FUNC3_1:
+          switch (insn_r.funct7) {
+            case Func7::CUS_ADD:
+              return true;
+            case Func7::CUS_DOUBLE_RS1:
+              return true;
+            case Func7::CUS_DOUBLE_RS2:
+             return true;
+            case Func7::CUS_ADD_MULTI:
+              return true;
+            default:
+              return false;
+          }
+        default:
+          // All other values of Func3
+          return false;
+      }
+    } else if (insn_r.funct3 == 0x0
+               && (insn_r.funct7 & 0x3) == 0x0) {
+      // Potential CVXIF opcodes
+#if 1
+      switch (insn_r.opcode) {
+        case CustomOpcode::CUS_ADD_RS3_MADDRTYPE:
+        case CustomOpcode::CUS_ADD_RS3_MSUB:
+        case CustomOpcode::CUS_ADD_RS3_NMADD:
+        case CustomOpcode::CUS_ADD_RS3_NMSUB:
+          return true;
+        default:
+          return false;
+      }
+#endif
+    } else if (insn_r.opcode == CustomOpcode::CUS_ADD_RS3_MADDRTYPE
+               && insn_r.funct3 == 0x1
+               && insn_r.funct7 == Func7::CUS_ADD_RS3_RTYPE)
+      return true;
+
+    // Catch-all clause
+    return false;
   }
 
   // Custom0 instructions: default behaviour.
-  reg_t custom0(cvxif_insn_t incoming_insn)
+  reg_t custom0(insn_t incoming_insn)
   {
     illegal_instruction();
     return -1;
   }
 
   // Custom1 instructions: default behaviour.
-  reg_t custom1(cvxif_insn_t incoming_insn)
+  reg_t custom1(insn_t incoming_insn)
   {
     illegal_instruction();
     return -1;
   }
 
   // Custom2 instructions: default behaviour.
-  reg_t custom2(cvxif_insn_t incoming_insn)
+  reg_t custom2(insn_t incoming_insn)
   {
     illegal_instruction();
     return -1;
   }
 
   // Custom3 instructions: provide an explicit implementation of decode+exec.
-  reg_t custom3(cvxif_insn_t incoming_insn)
+  reg_t custom3(insn_t insn)
   {
+    // Convert insn to a more general type 'cvxif_insn_t'.
+    cvxif_insn_t incoming_insn = { .i = insn };
     // Assume R-type insn: it shares opcode and funct3 fields with other CVXIF insn formats.
     cvxif_r_insn_t r_insn = incoming_insn.r_type;
-    // INSN_T simplifies access to register values.
-    insn_t insn = incoming_insn.i;
 
     switch (r_insn.funct3)
     {
@@ -125,7 +216,7 @@ class cvxif_t : public cvxif_extn_t
             return (reg_t) ((reg_t) RS1 + (reg_t) RS1);
           case Func7::CUS_DOUBLE_RS2:
             return (reg_t) ((reg_t) RS2 + (reg_t) RS2);
-          case Func7::CUS_ADD_MULTICYCLE:
+          case Func7::CUS_ADD_MULTI:
             return (reg_t) ((reg_t) RS1 + (reg_t) RS2);
           default:
             illegal_instruction();
@@ -136,8 +227,74 @@ class cvxif_t : public cvxif_extn_t
 
     // FORNOW: Return 0xf......f to simplify debugging.
     return (reg_t) -1;
+  };
+
+  // 32-bit insns 
+  #define CVXIF_CUS_ADD_RS3_ADDSUB_MASK 0x0600707f
+  #define CVXIF_CUS_ADD_RS3_MADD_MATCH  0x00000043
+  #define CVXIF_CUS_ADD_RS3_MSUB_MATCH  0x00000047
+  #define CVXIF_CUS_ADD_RS3_NMADD_MATCH 0x0000004f
+  #define CVXIF_CUS_ADD_RS3_NMSUB_MATCH 0x0000004b
+
+  #define CVXIF_CUS_ADD_RS3_RTYPE_MASK  0x0600707f
+  #define CVXIF_CUS_ADD_RS3_RTYPE_MATCH 0x08001043
+
+  // Computation semantics of CUS_ADD_RS3_MADD: Custom Add with RS3, opcode == MADD.
+  // Add RS2 and RS3 to RS1.
+  reg_t cvxif_cus_add_rs3_madd(insn_t insn)
+  {
+    return (reg_t) ((reg_t) RS1 + (reg_t) RS2 + (reg_t) RS3);
+  };
+
+  // Computation semantics of CUS_ADD_RS3_MSUB: Custom Add with RS3, opcode == MSUB.
+  // Subtract RS2 and RS3 from RS1.
+  reg_t cvxif_cus_add_rs3_msub(insn_t insn)
+  {
+    return (reg_t) ((reg_t) RS1 - (reg_t) RS2 - (reg_t) RS3);
+  };
+
+  // Computation semantics of CUS_ADD_RS3_NMADD: Custom Add with RS3, opcode == NMADD.
+  // Add RS2 and RS3 to RS1, then negate result bitwise.
+  reg_t cvxif_cus_add_rs3_nmadd(insn_t insn)
+  {
+    return (reg_t) ~((reg_t) RS1 + (reg_t) RS2 + (reg_t) RS3);
+  };
+
+  // Semantics of CUS_ADD_RS3_NMSUB: Custom Add with RS3, opcode == NMSUB.
+  // Subtract RS2 and RS3 from RS1, then negate result bitwise.
+  reg_t cvxif_cus_add_rs3_nmsub(insn_t insn)
+  {
+    return (reg_t) ~((reg_t) RS1 - (reg_t) RS2 - (reg_t) RS3);
+  };
+
+  // Semantics of CUS_ADD_RS3_RTYPE: Custom Add with RS3, opcode == RTYPE (rd is implicitly a0).
+  // Add RS2 and RS3 to RS1.
+  reg_t cvxif_cus_add_rs3_rtype(insn_t insn)
+  {
+    return (reg_t) ((reg_t) RS1 + (reg_t) RS2 + (reg_t) RS3);
+  };
+
+  // Compressed (16-bit) insns
+  #define CVXIF_CUS_CNOP_MASK  0xfffff003
+  #define CVXIF_CUS_CNOP_MATCH 0x0000e000
+  #define CVXIF_CUS_CADD_MASK  0xfffff003
+  #define CVXIF_CUS_CADD_MATCH 0xffffe003
+
+  // Semantics of CUS_CNOP: Compressed CV-X-IF NOP.
+  reg_t cvxif_cus_cnop(insn_t insn)
+  {
+    // Value will be ignored by writeback checker.
+    return (reg_t) -1;
+  };
+
+  // Semantics of CUS_CADD: Compressed CV-X-IF ADD.
+  reg_t cvxif_cus_cadd(insn_t insn)
+  {
+    return (reg_t) ((reg_t) RS1 + (reg_t) RS2);
   }
 
+  // Extension constructor
+  //TODO FIXME: May need checking of active ISA extensions since CV-X-IF extension conflicts with 'F' opcodes,
   cvxif_t()
   {
   }
@@ -198,16 +355,44 @@ class cvxif_t : public cvxif_extn_t
   customX(2)
   customX(3)
 
+  // CV-X-IF non-custom3 32-bit insns
+  cvxif_insn_32(cus_add_rs3_madd)
+  cvxif_insn_32(cus_add_rs3_msub)
+  cvxif_insn_32(cus_add_rs3_nmadd)
+  cvxif_insn_32(cus_add_rs3_nmsub)
+  cvxif_insn_32_rd_implicit_a0(cus_add_rs3_rtype)                           
+
+  // CV-X-IF non-custom 16-bit insns
+  cvxif_insn_16(cus_cnop)
+  cvxif_insn_16_rd_implicit_a0(cus_cadd)
+
   // Set instruction handlers for customN opcode patterns.
   // NOTE: This method may need revisiting if multiple custom extensions are to be loaded
   //       simultaneously in the future.
   std::vector<insn_desc_t> get_instructions()
   {
+
+// Factor out tedious, repetitive code as all combinations of RV32/RV64 x RVI/RVE x fast/logged simulation path
+// use the same implementation of functions.  Leave a differentiating 'default' value at the 
+#define ADD_INSN_TO_DECODER(match,mask,impl, dflt) \
+    insns.push_back((insn_desc_t){(match), (mask), &impl, &impl, &impl, &impl, &impl, &impl, &impl, &dflt})
+
     std::vector<insn_desc_t> insns;
-    insns.push_back((insn_desc_t){0x0b, 0x7f, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, c0});
-    insns.push_back((insn_desc_t){0x2b, 0x7f, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, c1});
-    insns.push_back((insn_desc_t){0x5b, 0x7f, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, &::illegal_instruction, c2});
-    insns.push_back((insn_desc_t){0x7b, 0x7f, &c3, &c3, &c3, &c3, &c3, &c3, &c3, c3});
+    ADD_INSN_TO_DECODER(0x0b, 0x7f, ::illegal_instruction, c0);    
+    ADD_INSN_TO_DECODER(0x2b, 0x7f, ::illegal_instruction, c1);
+    ADD_INSN_TO_DECODER(0x5b, 0x7f, ::illegal_instruction, c2);
+    ADD_INSN_TO_DECODER(0x7b, 0x7f, c3,                    c3);
+
+    // Instructions ADD_RS3_*
+    ADD_INSN_TO_DECODER(CVXIF_CUS_ADD_RS3_MADD_MATCH,  CVXIF_CUS_ADD_RS3_ADDSUB_MASK, cvxif_32_cus_add_rs3_madd,  cvxif_32_cus_add_rs3_madd);
+    ADD_INSN_TO_DECODER(CVXIF_CUS_ADD_RS3_MSUB_MATCH,  CVXIF_CUS_ADD_RS3_ADDSUB_MASK, cvxif_32_cus_add_rs3_msub,  cvxif_32_cus_add_rs3_msub);
+    ADD_INSN_TO_DECODER(CVXIF_CUS_ADD_RS3_NMADD_MATCH, CVXIF_CUS_ADD_RS3_ADDSUB_MASK, cvxif_32_cus_add_rs3_nmadd, cvxif_32_cus_add_rs3_nmadd);
+    ADD_INSN_TO_DECODER(CVXIF_CUS_ADD_RS3_NMSUB_MATCH, CVXIF_CUS_ADD_RS3_ADDSUB_MASK, cvxif_32_cus_add_rs3_nmsub, cvxif_32_cus_add_rs3_nmsub);
+    ADD_INSN_TO_DECODER(CVXIF_CUS_ADD_RS3_RTYPE_MATCH, CVXIF_CUS_ADD_RS3_RTYPE_MASK,  cvxif_32_cus_add_rs3_rtype, cvxif_32_cus_add_rs3_rtype);
+
+    // Compressed insns CNOP/CADD.
+    ADD_INSN_TO_DECODER(CVXIF_CUS_CNOP_MATCH,          CVXIF_CUS_CNOP_MASK,           cvxif_16_cus_cnop,          cvxif_16_cus_cnop);
+    ADD_INSN_TO_DECODER(CVXIF_CUS_CNOP_MATCH,          CVXIF_CUS_CNOP_MASK,           cvxif_16_cus_cadd,          cvxif_16_cus_cadd);
     return insns;
   }
 

--- a/vendor/riscv/riscv-isa-sim/fesvr/SimDTM.cc
+++ b/vendor/riscv/riscv-isa-sim/fesvr/SimDTM.cc
@@ -27,7 +27,7 @@ std::vector<std::string> sanitize_args() {
 
       // remove any two double pluses at the beginning (those are target arguments)
       if (info.argv[i][0] == '+' && info.argv[i][1] == '+' && strlen(info.argv[i]) > 3) {
-          for (int j = 0; j < strlen(info.argv[i]) - 1; j++) {
+          for (size_t j = 0; j < strlen(info.argv[i]) - 1; j++) {
             info.argv[i][j] = info.argv[i][j + 2];
           }
       }

--- a/vendor/riscv/riscv-isa-sim/fesvr/fesvr_dpi.cc
+++ b/vendor/riscv/riscv-isa-sim/fesvr/fesvr_dpi.cc
@@ -44,7 +44,7 @@ public:
         uint64_t datum;
         uint8_t* buf = (uint8_t*) src;
         std::vector<uint8_t> mem;
-        for (int i = 0; i < len; i++) {
+        for (size_t i = 0; i < len; i++) {
             mem.push_back(buf[i]);
         }
         mems.insert(std::make_pair(taddr, mem));
@@ -63,7 +63,7 @@ private:
 // 0 if there are no more sections
 // 1 if there are more sections to load
 extern "C" char get_section (long long* address, long long* len) {
-    if (section_index < sections.size()) {
+    if (section_index < (int) sections.size()) {
       auto it = sections.begin();
       for( int i = 0; i < section_index; i++ , it++);
       *address = it->first;

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -569,7 +569,7 @@ void Processor::reset()
     uint64_t pmpregions_writable = this->params[base + "pmpregions_writable"].a_uint64_t;
     uint64_t pmpregions_max = this->params[base + "pmpregions_max"].a_uint64_t;
 
-    for (int i = pmpregions_writable; i < pmpregions_max; i++) {
+    for (uint64_t i = pmpregions_writable; i < pmpregions_max; i++) {
         uint64_t csr_pmpaddr = CSR_PMPADDR0 + i;
         uint64_t csr_pmpcfg = CSR_PMPCFG0 + (i/4);
 

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -296,8 +296,9 @@ Processor::Processor(
   for (auto ext : registered_extensions_v) {
     if (ext.second) {
       extension_t *extension = find_extension(ext.first.c_str())();
+      extension->set_Proc(this);
+      // 'register_extension' internally calls 'reset()' on the extension.
       this->register_extension(extension);
-      extension->reset();
     }
   }
 

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.h
@@ -1,3 +1,7 @@
+// See LICENSE for license details.
+
+#ifndef _RISCV_PROC_H
+#define _RISCV_PROC_H
 
 #include "Types.h"
 #include "processor.h"
@@ -77,3 +81,5 @@ protected:
 };
 
 } // namespace openhw
+
+#endif

--- a/vendor/riscv/riscv-isa-sim/riscv/cvxif.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/cvxif.h
@@ -53,26 +53,53 @@ struct cvxif_s_insn_t
   unsigned imm_high : 7;
 };
 
+// CR (compressed R-type) instruction format
+struct cvxif_cr_insn_t
+{
+  unsigned opcode: 2;
+  unsigned rs2: 5;
+  unsigned rd_rs1: 5;
+  unsigned funct4: 4;
+  unsigned ignored: 16;
+};
+
 union cvxif_insn_t
 {
   cvxif_r_insn_t r_type;
   cvxif_r4_insn_t r4_type;
   cvxif_i_insn_t i_type;
   cvxif_s_insn_t s_type;
+  cvxif_cr_insn_t cr_type;
   insn_t i;
 };
 
-enum Func3 {FUNC3_0, FUNC3_1, FUNC3_2, FUNC3_3};
-enum Func7 {CUS_ADD = 0, CUS_DOUBLE_RS1 = 1, CUS_DOUBLE_RS2 = 2, CUS_ADD_MULTICYCLE = 3};
+enum Cop { C0 = 0, C1, C2, NOT_COMPRESSED };
+enum Func2 {FUNC2_0 = 0};
+enum Func3 {FUNC3_0 = 0, FUNC3_1, FUNC3_2, FUNC3_3};
+enum Func4 {FUNC4_CNOP = 0xe, FUNC4_CADD = 0xf };
+enum Func7 {CUS_ADD = 0, CUS_DOUBLE_RS1 = 1, CUS_DOUBLE_RS2 = 2, CUS_ADD_MULTI = 3, CUS_ADD_RS3_RTYPE = 4};
+enum CustomOpcode {
+  CUS_ADD_RS3_MADDRTYPE = 0x43,
+  CUS_ADD_RS3_MSUB = 0x47,
+  CUS_ADD_RS3_NMADD = 0x4f,
+  CUS_ADD_RS3_NMSUB = 0x4b,
+};
 
 class cvxif_extn_t : public extension_t
 {
  public:
-  virtual bool do_writeback_p(cvxif_insn_t insn);
-  virtual reg_t custom0(cvxif_insn_t insn);
-  virtual reg_t custom1(cvxif_insn_t insn);
-  virtual reg_t custom2(cvxif_insn_t insn);
-  virtual reg_t custom3(cvxif_insn_t insn);
+  virtual bool do_writeback_p(insn_t insn);
+  virtual reg_t custom0(insn_t insn);
+  virtual reg_t custom1(insn_t insn);
+  virtual reg_t custom2(insn_t insn);
+  virtual reg_t custom3(insn_t insn);
+  virtual reg_t cvxif_cus_add_rs3_madd(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_add_rs3_msub(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_add_rs3_nmadd(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_add_rs3_nmsub(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_add_rs3_rtype(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_cnop(insn_t insn) = 0;
+  virtual reg_t cvxif_cus_cadd(insn_t insn) = 0;
   std::vector<insn_desc_t> get_instructions();
   std::vector<disasm_insn_t*> get_disasms();
 };

--- a/vendor/riscv/riscv-isa-sim/riscv/cvxif_base.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/cvxif_base.cc
@@ -14,7 +14,7 @@
 
 // Return true if writeback is required.
 // Be on the safe side, disable writeback.
-bool cvxif_extn_t::do_writeback_p(cvxif_insn_t insn)
+bool cvxif_extn_t::do_writeback_p(insn_t insn)
 {
   return false;
 }
@@ -30,15 +30,13 @@ bool cvxif_extn_t::do_writeback_p(cvxif_insn_t insn)
 static reg_t c##n(processor_t* p, insn_t insn, reg_t pc) \
   { \
     cvxif_extn_t* cvxif = static_cast<cvxif_extn_t*>(p->get_extension()); \
-    cvxif_insn_t custom_insn; \
-    custom_insn.i = insn; \
-    reg_t xd = cvxif->custom##n(custom_insn); \
-    if (cvxif->do_writeback_p(custom_insn)) \
+    reg_t xd = cvxif->custom##n(insn); \
+    if (cvxif->do_writeback_p(insn)) \
       WRITE_RD(xd); \
     return pc+4; \
   } \
   \
-  reg_t cvxif_extn_t::custom##n(cvxif_insn_t insn) \
+  reg_t cvxif_extn_t::custom##n(insn_t insn) \
   { \
     illegal_instruction(); \
     return -1; \

--- a/vendor/riscv/riscv-isa-sim/riscv/extension.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/extension.h
@@ -19,8 +19,10 @@ class extension_t
   virtual ~extension_t();
 
   void set_processor(processor_t* _p) { p = _p; }
+  void set_Proc(openhw::Processor* _proc) { proc = _proc; }
  protected:
   processor_t* p;
+  openhw::Processor* proc = 0;  // Require explicit initialization.
 
   void illegal_instruction();
   void raise_interrupt();

--- a/vendor/riscv/riscv-isa-sim/riscv/processor.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/processor.cc
@@ -37,7 +37,7 @@ processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
   log_file(log_file), sout_(sout_.rdbuf()), halt_on_reset(halt_on_reset),
   in_wfi(false), check_triggers_icount(false),
   impl_table(256, false), extension_enable_table(isa->get_extension_table()),
-  last_pc(1), executions(1), TM(cfg->trigger_count), disassembler(nullptr)
+  last_pc(1), executions(1), disassembler(nullptr), TM(cfg->trigger_count)
 {
 
   VU.p = this;


### PR DESCRIPTION
Implemented according to spec available at https://github.com/openhwgroup/cva6/blob/a12d51143217742fe42058e4dceb4baa33edf5e6/verif/env/uvme/cvxif_vseq/custom_instructions_cvxif_1_0_0.rst.

Still to do:

* testing
* vendorized Spike patch.