### PR TITLE
[Spike] Fix #2576: Ensure bit 25 is clear for RV32 extB 32b insns (+ patch)

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0036-add-missing-shamt-checks-in-rv32-extB-32b.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0036-add-missing-shamt-checks-in-rv32-extB-32b.patch
@@ -1,0 +1,36 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h b/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h
+index 8df6a5f4e..7ab42508a 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h
+@@ -1,3 +1,4 @@
+ require_extension(EXT_ZBS);
++require(SHAMT < xlen);
+ int shamt = SHAMT & (xlen-1);
+ WRITE_RD(sext_xlen(RS1 & ~(1LL << shamt)));
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h b/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h
+index 31d231668..bf86ab434 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h
+@@ -1,3 +1,4 @@
+ require_extension(EXT_ZBS);
++require(SHAMT < xlen);
+ int shamt = SHAMT & (xlen-1);
+ WRITE_RD(sext_xlen(1 & (RS1 >> shamt)));
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h b/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h
+index 3272d3931..7f6723ce9 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h
+@@ -1,3 +1,4 @@
+ require_extension(EXT_ZBS);
++require(SHAMT < xlen);
+ int shamt = SHAMT & (xlen-1);
+ WRITE_RD(sext_xlen(RS1 ^ (1LL << shamt)));
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h b/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h
+index 495237863..8ef4b3776 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h
+@@ -1,3 +1,4 @@
+ require_extension(EXT_ZBS);
++require(SHAMT < xlen);
+ int shamt = SHAMT & (xlen-1);
+ WRITE_RD(sext_xlen(RS1 | (1LL << shamt)));

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bclri.h
@@ -1,3 +1,4 @@
 require_extension(EXT_ZBS);
+require(SHAMT < xlen);
 int shamt = SHAMT & (xlen-1);
 WRITE_RD(sext_xlen(RS1 & ~(1LL << shamt)));

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bexti.h
@@ -1,3 +1,4 @@
 require_extension(EXT_ZBS);
+require(SHAMT < xlen);
 int shamt = SHAMT & (xlen-1);
 WRITE_RD(sext_xlen(1 & (RS1 >> shamt)));

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/binvi.h
@@ -1,3 +1,4 @@
 require_extension(EXT_ZBS);
+require(SHAMT < xlen);
 int shamt = SHAMT & (xlen-1);
 WRITE_RD(sext_xlen(RS1 ^ (1LL << shamt)));

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/bseti.h
@@ -1,3 +1,4 @@
 require_extension(EXT_ZBS);
+require(SHAMT < xlen);
 int shamt = SHAMT & (xlen-1);
 WRITE_RD(sext_xlen(RS1 | (1LL << shamt)));


### PR DESCRIPTION
Add standard legality check for `shamt` value where missing (`bclr.i`, `bext.i`, `binv.i`, `bset.i`). Use the same clause as in `ror.i` which was correctly implemented in the first place.