### PR TITLE
[Spike] Fix #2579: Require explicit Zifencei in ISA to enable fence.i instruction.

### DIFF
--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_utils.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_utils.sv
@@ -36,6 +36,7 @@ function automatic string get_isa_str(st_core_cntrl_cfg cfg);
     if (cfg.ext_zcb_supported)     rtl_isa_plus = {rtl_isa_plus, "_zcb"};
     if (cfg.ext_zicsr_supported)   rtl_isa_plus = {rtl_isa_plus, "_zicsr"};
     if (cfg.ext_zicntr_supported)  rtl_isa_plus = {rtl_isa_plus, "_zicntr"};
+    if (cfg.ext_zifencei_supported) rtl_isa_plus = {rtl_isa_plus, "_zifencei"};
     if (cfg.ext_xcvxif_supported)  rtl_isa_plus = {rtl_isa_plus, "_xcvxif"};
 
     return {rtl_isa, rtl_isa_plus};

--- a/vendor/patches/riscv/riscv-isa-sim/0037-make-zifencei-optional.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0037-make-zifencei-optional.patch
@@ -1,0 +1,33 @@
+diff --git a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+index ddb486a61..0449ad0d2 100644
+--- a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
++++ b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+@@ -114,8 +114,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
+       // Spike necessarily has Zicsr, because
+       // Zicsr is implied by the privileged architecture
+     } else if (ext_str == "zifencei") {
+-      // For compatibility with version 2.0 of the base ISAs, we
+-      // unconditionally include FENCE.I, so Zifencei adds nothing more.
++      extension_table[EXT_ZIFENCEI] = true;
+     } else if (ext_str == "zihintpause") {
+       // HINTs encoded in base-ISA instructions are always present.
+     } else if (ext_str == "zihintntl") {
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h b/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h
+index 38dcaf3fc..4c1a903a5 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h
+@@ -1 +1,2 @@
++require_extension(EXT_ZIFENCEI);
+ MMU.flush_icache();
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h b/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h
+index 9effd164d..73547c19e 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h
++++ b/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h
+@@ -56,6 +56,7 @@ typedef enum {
+   EXT_ZICBOZ,
+   EXT_ZICNTR,
+   EXT_ZICOND,
++  EXT_ZIFENCEI,
+   EXT_ZIHPM,
+   EXT_XZBP,
+   EXT_XZBS,

--- a/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
+++ b/vendor/riscv/riscv-isa-sim/disasm/isa_parser.cc
@@ -115,8 +115,7 @@ isa_parser_t::isa_parser_t(const char* str, const char *priv)
       // Spike necessarily has Zicsr, because
       // Zicsr is implied by the privileged architecture
     } else if (ext_str == "zifencei") {
-      // For compatibility with version 2.0 of the base ISAs, we
-      // unconditionally include FENCE.I, so Zifencei adds nothing more.
+      extension_table[EXT_ZIFENCEI] = true;
     } else if (ext_str == "zihintpause") {
       // HINTs encoded in base-ISA instructions are always present.
     } else if (ext_str == "zihintntl") {

--- a/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/insns/fence_i.h
@@ -1,1 +1,2 @@
+require_extension(EXT_ZIFENCEI);
 MMU.flush_icache();

--- a/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h
+++ b/vendor/riscv/riscv-isa-sim/riscv/isa_parser.h
@@ -56,6 +56,7 @@ typedef enum {
   EXT_ZICBOZ,
   EXT_ZICNTR,
   EXT_ZICOND,
+  EXT_ZIFENCEI,
   EXT_ZIHPM,
   EXT_XZBP,
   EXT_XZBS,


### PR DESCRIPTION
Spike part of fix to CVA6 issue https://github.com/openhwgroup/cva6/issues/2734.

Spike code explicitly assumed `Zifencei` as being present for backward compatibility, cf. the diff on `isa_parser.cc`.
This request changes the original Spike behavior to require the explicit inclusion of `Zifencei` in the ISA string to enable the `fence.i` instruction.