### PR TITLE
CVXIF UVM agent : remove wrong assertion

### DIFF
--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_drv.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_drv.sv
@@ -249,8 +249,13 @@ task uvma_cvxif_drv_c::drv_slv_resp(input uvma_cvxif_resp_item_c item);
    fork begin
       if (item.issue_valid) begin
          wait (cntxt.vif.issue_ready);
-         drv_issue_resp(item);
-         `uvm_info(info_tag, $sformatf("drive issue done !"), UVM_NONE);
+         if (cntxt.vif.issue_valid) begin
+            drv_issue_resp(item);
+            `uvm_info(info_tag, $sformatf("drive issue done !"), UVM_NONE);
+         end
+         else begin
+            `uvm_info(info_tag, $sformatf("CPU retract issue req !"), UVM_NONE);
+         end
          @(posedge cntxt.vif.clk);
          if (item.result_valid) begin
            resp_item_queue.push_back(item);
@@ -262,8 +267,13 @@ task uvma_cvxif_drv_c::drv_slv_resp(input uvma_cvxif_resp_item_c item);
    begin
      if (item.compressed_valid) begin
         wait (cntxt.vif.compressed_ready);
-        drv_compressed_resp(item);
-        `uvm_info(info_tag, $sformatf("drive compressed done !"), UVM_NONE);
+        if (cntxt.vif.compressed_valid) begin
+           drv_compressed_resp(item);
+           `uvm_info(info_tag, $sformatf("drive compressed done !"), UVM_NONE);
+        end
+        else begin
+           `uvm_info(info_tag, $sformatf("CPU retract compressed req !"), UVM_NONE);
+        end
          @(posedge cntxt.vif.clk);
         deassert_compressed_resp();
      end

--- a/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_drv.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/comps/uvma_cvxif_drv.sv
@@ -251,10 +251,10 @@ task uvma_cvxif_drv_c::drv_slv_resp(input uvma_cvxif_resp_item_c item);
          wait (cntxt.vif.issue_ready);
          if (cntxt.vif.issue_valid) begin
             drv_issue_resp(item);
-            `uvm_info(info_tag, $sformatf("drive issue done !"), UVM_NONE);
+            `uvm_info(info_tag, $sformatf("drive issue done!"), UVM_NONE);
          end
          else begin
-            `uvm_info(info_tag, $sformatf("CPU retract issue req !"), UVM_NONE);
+            `uvm_info(info_tag, $sformatf("CPU retracts issue req!"), UVM_NONE);
          end
          @(posedge cntxt.vif.clk);
          if (item.result_valid) begin
@@ -269,10 +269,10 @@ task uvma_cvxif_drv_c::drv_slv_resp(input uvma_cvxif_resp_item_c item);
         wait (cntxt.vif.compressed_ready);
         if (cntxt.vif.compressed_valid) begin
            drv_compressed_resp(item);
-           `uvm_info(info_tag, $sformatf("drive compressed done !"), UVM_NONE);
+           `uvm_info(info_tag, $sformatf("drive compressed done!"), UVM_NONE);
         end
         else begin
-           `uvm_info(info_tag, $sformatf("CPU retract compressed req !"), UVM_NONE);
+           `uvm_info(info_tag, $sformatf("CPU retracts compressed req!"), UVM_NONE);
         end
          @(posedge cntxt.vif.clk);
         deassert_compressed_resp();

--- a/lib/uvm_agents/uvma_cvxif/src/obj/uvma_cvxif_cfg.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/obj/uvma_cvxif_cfg.sv
@@ -31,10 +31,10 @@ class uvma_cvxif_cfg_c extends uvm_object;
    rand uvma_cvxif_compressed_ready_mode_enum     compressed_ready_mode;
 
    constraint reasonable_values {
-      soft hold_issue_ready          inside {[1:2]};
-      soft hold_issue_not_ready      inside {[1:2]};
-      soft hold_compressed_ready     inside {[1:2]};
-      soft hold_compressed_not_ready inside {[1:2]};
+      soft hold_issue_ready          inside {[1:3]};
+      soft hold_issue_not_ready      inside {[1:3]};
+      soft hold_compressed_ready     inside {[1:3]};
+      soft hold_compressed_not_ready inside {[1:3]};
       if (zero_delay_mode) {
         instr_delayed == 0;
       }
@@ -50,7 +50,7 @@ class uvma_cvxif_cfg_c extends uvm_object;
 
    constraint defaults_val {
       soft issue_ready_mode       == UVMA_CVXIF_ISSUE_READY_RANDOMIZED;
-      soft compressed_ready_mode  == UVMA_CVXIF_COMPRESSED_READY_FIX;
+      soft compressed_ready_mode  == UVMA_CVXIF_COMPRESSED_READY_RANDOMIZED;
       soft ordering_mode          == UVMA_CVXIF_ORDERING_MODE_IN_ORDER;
       soft zero_delay_mode        == 1;
       soft cov_model_enabled      == 1;

--- a/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
@@ -38,12 +38,6 @@ module uvma_cvxif_assert #(int unsigned X_HARTID_WIDTH = 32, int unsigned X_ID_W
       (cvxif_assert.compressed_valid && cvxif_assert.compressed_ready && cvxif_assert.compressed_req.instr[1:0] == 2'b11) |-> !cvxif_assert.compressed_resp.accept;
    endproperty
 
-   // Check that during an compressed request transaction, "instr", "hartid" signal should remain stable
-   property CVXIF_STABLE_COMPRESSED_REQ;
-      @(posedge cvxif_assert.clk) disable iff (!cvxif_assert.reset_n)
-      (cvxif_assert.compressed_valid && !cvxif_assert.compressed_ready) |=> ($stable(cvxif_assert.compressed_req.instr) && $stable(cvxif_assert.compressed_req.hartid));
-   endproperty
-
    // Check that compressed interface respond with an uncompressed instruction
    property CVXIF_UNCOMPRESSED_RESP;
       @(posedge cvxif_assert.clk) disable iff (!cvxif_assert.reset_n)
@@ -58,17 +52,12 @@ module uvma_cvxif_assert #(int unsigned X_HARTID_WIDTH = 32, int unsigned X_ID_W
    compressed_req_rejected        : assert property (CVXIF_REJECT_COMPRESSED_REQ)
                                        else `uvm_error (info_tag , "Violation: UNVALID 16-BIT INSTRUCTION");
 
-   compressed_req_stable          : assert property (CVXIF_STABLE_COMPRESSED_REQ)
-                                       else `uvm_error (info_tag , "Violation: COMPRESSED REQUEST PACKET IS NOT STABLE DURING A COMPRESSED TRANSACTION");
-
    uncompressed_resp              : assert property (CVXIF_UNCOMPRESSED_RESP)
                                        else `uvm_error (info_tag , "Violation: UNVALID 32-BIT INSTRUCTION IN RESPONSE");
 
 /********************************************** Cover Property ******************************************************/
 
    cov_compressed_instr           : cover property(CVXIF_COMPRESSED_INSTR);
-
-   cov_reject_uncompressed        : cover property(CVXIF_REJECT_COMPRESSED_REQ);
 
    cov_compressed_stable          : cover property(CVXIF_STABLE_COMPRESSED_REQ);
 

--- a/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
+++ b/lib/uvm_agents/uvma_cvxif/src/uvma_cvxif_assert.sv
@@ -59,8 +59,6 @@ module uvma_cvxif_assert #(int unsigned X_HARTID_WIDTH = 32, int unsigned X_ID_W
 
    cov_compressed_instr           : cover property(CVXIF_COMPRESSED_INSTR);
 
-   cov_compressed_stable          : cover property(CVXIF_STABLE_COMPRESSED_REQ);
-
    cov_uncompressed_resp          : cover property(CVXIF_UNCOMPRESSED_RESP);
 
    /**


### PR DESCRIPTION
This is some changes on cvxif uvm agent :
remove wrong assertion
add support to the agent to see that the cpu is retracting transaction