### PR TITLE
Remove inline comments from uvm_info calls, as they are not supported…

### DIFF
--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_slv_seq.sv
@@ -108,7 +108,7 @@ task uvma_obi_memory_slv_seq_c::do_response(ref uvma_obi_memory_mon_trn_c mon_re
    bit  err_req;
    bit  err_siz;
 
-   `uvm_info("SLV_SEQ", $sformatf("mon_req.address before data_addr_dec remap: x%h", mon_req.address), UVM_HIGH/*NONE*/)
+   `uvm_info("SLV_SEQ", $sformatf("mon_req.address before data_addr_dec remap: x%h", mon_req.address), UVM_HIGH)
 
    // Check the virtual peripheral address hash table to see if transaction should be sent to a virtual peripheral
    if (vp_seq_table.exists(mon_req.address)) begin
@@ -119,9 +119,9 @@ task uvma_obi_memory_slv_seq_c::do_response(ref uvma_obi_memory_mon_trn_c mon_re
    // If we fell through, then handle the transaction locally
    `uvm_info("SLV_SEQ", $sformatf("VP not handled: x%h", mon_req.address), UVM_HIGH)
    err_req  = mon_req.err;
-   if (err_req) `uvm_info("SLV_SEQ", $sformatf("ERROR1: mon_req.err=%0b", mon_req.err), UVM_HIGH/*NONE*/)
+   if (err_req) `uvm_info("SLV_SEQ", $sformatf("ERROR1: mon_req.err=%0b", mon_req.err), UVM_HIGH)
    err_siz = 0;
-   if (err_siz) `uvm_info("SLV_SEQ", $sformatf("ERROR2: mon_req.address=%0h", mon_req.address), UVM_HIGH/*NONE*/)
+   if (err_siz) `uvm_info("SLV_SEQ", $sformatf("ERROR2: mon_req.address=%0h", mon_req.address), UVM_HIGH)
 
    if (!(err_req | err_siz)) begin
       do_mem_operation(mon_req);

--- a/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_sig_writer_seq.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/seq/uvma_obi_memory_vp_sig_writer_seq.sv
@@ -101,7 +101,7 @@ task uvma_obi_memory_vp_sig_writer_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
 
          2: begin
             for (int unsigned ii=signature_start_address; ii<signature_end_address; ii += 4) begin
-               `uvm_info("VP_SIG_WRITER", "Dumping signature", UVM_HIGH/*NONE*/)
+               `uvm_info("VP_SIG_WRITER", "Dumping signature", UVM_HIGH)
                if (use_sig_file) begin
                   $fdisplay(sig_fd, "%x%x%x%x", cntxt.mem.read(ii+3),
                                                 cntxt.mem.read(ii+2),
@@ -112,7 +112,7 @@ task uvma_obi_memory_vp_sig_writer_seq_c::vp_body(uvma_obi_memory_mon_trn_c mon_
                   `uvm_info("VP_VSEQ", $sformatf("%x%x%x%x", cntxt.mem.read(ii+3),
                                                             cntxt.mem.read(ii+2),
                                                             cntxt.mem.read(ii+1),
-                                                            cntxt.mem.read(ii+0)), UVM_HIGH/*NONE*/)
+                                                            cntxt.mem.read(ii+0)), UVM_HIGH)
                end
             end
 


### PR DESCRIPTION
Remove inline comments from uvm_info calls, as they are not supported by DSIM latest versions (checked against 20240923.9.0  and 20240923.8.0).