### PR TITLE
[Core cntrl agent] Do not pass 'xcvxif' to Spike if CV-X-IF is present.

### DIFF
--- a/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_utils.sv
+++ b/lib/uvm_agents/uvma_core_cntrl/uvma_core_cntrl_utils.sv
@@ -37,7 +37,6 @@ function automatic string get_isa_str(st_core_cntrl_cfg cfg);
     if (cfg.ext_zicsr_supported)   rtl_isa_plus = {rtl_isa_plus, "_zicsr"};
     if (cfg.ext_zicntr_supported)  rtl_isa_plus = {rtl_isa_plus, "_zicntr"};
     if (cfg.ext_zifencei_supported) rtl_isa_plus = {rtl_isa_plus, "_zifencei"};
-    if (cfg.ext_xcvxif_supported)  rtl_isa_plus = {rtl_isa_plus, "_xcvxif"};
 
     return {rtl_isa, rtl_isa_plus};
 


### PR DESCRIPTION
Remove the systematic activation of `Xcvxif` ISA extension when the RTL instantiates CV-X-IF. The activation of the extension shall now be done **exclusively** through the Spike ISA string.