### PR TITLE
[Spike] Reset non-ISA extensions when registering them (as per comment!)

### DIFF
--- a/vendor/patches/riscv/riscv-isa-sim/0042-fix-extension-reset.patch
+++ b/vendor/patches/riscv/riscv-isa-sim/0042-fix-extension-reset.patch
@@ -1,0 +1,12 @@
+diff --git a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+index 5118e2887..ac3842e64 100644
+--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
++++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+@@ -308,6 +308,7 @@ Processor::Processor(
+       std::cerr << "### [SPIKE] Registering Yaml-specified extension '" << extension->name() << "'..." << std::endl;
+       extension->set_Proc(this);
+       register_extension(extension);
++      extension->reset();
+     }
+   }
+ 

--- a/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
+++ b/vendor/riscv/riscv-isa-sim/riscv/Proc.cc
@@ -308,6 +308,7 @@ Processor::Processor(
       std::cerr << "### [SPIKE] Registering Yaml-specified extension '" << extension->name() << "'..." << std::endl;
       extension->set_Proc(this);
       register_extension(extension);
+      extension->reset();
     }
   }
 


### PR DESCRIPTION
Explicitly reset non-ISA Spike extensions such as `cv32a60x` in the `Proc` constructor.

Such extensions contain no instruction definitions, only CSR definitions and hence, were not reset correctly. As a result, the CSRs provided by the `cv32a60x`extension were instantiated.