### PR TITLE
ISACOV: remove unsupported_with workaround (fix #2404)

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -544,12 +544,7 @@ covergroup cg_div_special_results(
   }
 
   cp_div_arithmetic_overflow : coverpoint instr.rs1_value {
-    `ifdef UNSUPPORTED_WITH
-     ignore_bins IGN_OVERFLOW = cp_div_arithmetic_overflow iff (!check_overflow);
-     bins OFLOW = {32'h8000_0000} iff (instr.rs2_value == 32'hffff_ffff); //TODO
-    `else
      bins OFLOW = {32'h8000_0000} with (check_overflow) iff (instr.rs2_value == 32'hffff_ffff);
-    `endif
   }
 
 endgroup : cg_div_special_results


### PR DESCRIPTION
remove unsupported with workaround as it's been resolved in V-2023.12.1