### PR TITLE
Restore verilator to CV32E40P core testbench

### DIFF
--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -134,7 +134,8 @@ SIMV                    = ./simv
 # dsim is the Metrics Technologies SystemVerilog simulator  (https://metrics.ca/)
 DSIM                    = dsim
 DSIM_HOME               = /tools/Metrics/dsim
-DSIM_CMP_FLAGS          = +define+CORE_TB -timescale 1ns/1ps $(SV_CMP_FLAGS) -suppress MultiBlockWrite +define+CV32E40P_APU_TRACE
+DSIM_CMP_FLAGS          = +define+CORE_TB +define+CV32E40P_APU_TRACE +acc+b -timescale 1ns/1ps $(SV_CMP_FLAGS)
+DSIM_SUPPRESS           = -suppress MultiBlockWrite -suppress IneffectiveDynamicCast
 DSIM_RUN_FLAGS          =
 DSIM_UVM_ARGS           = +incdir+$(UVM_HOME)/src $(UVM_HOME)/src/uvm_pkg.sv
 DSIM_RESULTS           ?= $(PWD)/dsim_results
@@ -142,7 +143,6 @@ DSIM_WORK              ?= $(DSIM_RESULTS)/dsim_work
 DSIM_IMAGE              = dsim.out
 
 ifneq (${WAVES}, 0)
-  DSIM_CMP_FLAGS += +acc
   DSIM_DMP_FILE  ?= dsim.fst
   DSIM_RUN_FLAGS += -waves $(DSIM_DMP_FILE)
 endif
@@ -155,7 +155,8 @@ XRUN_DIR          = xcelium.d
 # verilator configuration
 VERILATOR           = verilator
 VERI_FLAGS         +=
-VERI_COMPILE_FLAGS += -Wno-BLKANDNBLK $(SV_CMP_FLAGS) # hope this doesn't hurt us in the long run
+VERI_COMPILE_FLAGS += $(SV_CMP_FLAGS)
+VERI_WARN_WAIVERS  ?= --Wno-lint --Wno-UNOPTFLAT --Wno-MODDUP --Wno-MULTIDRIVEN --Wno-COMBDLY --Wno-BLKANDNBLK
 VERI_TRACE         ?=
 VERI_OBJ_DIR       ?= cobj_dir
 #VERI_LOG_DIR       ?= cobj_dir/logs
@@ -276,9 +277,13 @@ mk_results:
 
 # Metrics dsim compile targets
 dsim-comp: mk_results CV_CORE_pkg tbsrc_pkg tbsrc
+	@echo "$(BANNER)"
+	@echo "* Compiling with Metrics DSIM"
+	@echo "$(BANNER)"
 		cd $(DSIM_RESULTS) && \
 		$(DSIM) \
 		$(DSIM_CMP_FLAGS) \
+		$(DSIM_SUPPRESS) \
 		$(DSIM_UVM_ARGS) \
 		-f $(CV_CORE_MANIFEST) \
 		$(TBSRC_PKG) \
@@ -287,8 +292,12 @@ dsim-comp: mk_results CV_CORE_pkg tbsrc_pkg tbsrc
 		-genimage $(DSIM_IMAGE)
 
 dsim-comp-rtl-only: mk_results $(CV_CORE_PKG)
+	@echo "$(BANNER)"
+	@echo "* Compiling (only) with Metrics DSIM"
+	@echo "$(BANNER)"
 	$(DSIM) \
 		$(DSIM_CMP_FLAGS) \
+		$(DSIM_SUPPRESS) \
 		-f $(CV_CORE_MANIFEST) \
 		-work $(DSIM_WORK) \
 		-genimage $(DSIM_IMAGE)
@@ -313,7 +322,7 @@ dsim-test: dsim-comp $(TEST_PROGRAM_PATH)/$(TEST)/$(TEST).hex
 		-work $(DSIM_WORK) \
 		$(DSIM_RUN_FLAGS) \
 		-sv_lib $(UVM_HOME)/src/dpi/libuvm_dpi.so \
-		+firmware=$(VERI_CUSTOM)/$(TEST)/$(TEST).hex
+		+firmware=../../$(TEST_PROGRAM_RELPATH)/$(TEST)/$(TEST).hex
 
 # Metrics dsim cleanup
 .PHONY: dsim-clean
@@ -490,13 +499,13 @@ testbench_verilator: CV_CORE_pkg $(TBSRC_VERI) $(TBSRC_PKG)
 	@echo "$(BANNER)"
 	$(VERILATOR) --cc --sv --exe \
 		$(VERI_TRACE) \
-		--Wno-lint --Wno-UNOPTFLAT \
-		--Wno-MODDUP --top-module \
+		$(VERI_WARN_WAIVERS) \
+		--top-module \
 		tb_top_verilator $(TBSRC_VERI) \
 		-f $(CV_CORE_MANIFEST) \
 		$(CV_CORE_PKG)/bhv/$(CV_CORE_LC)_core_log.sv \
 		$(TBSRC_CORE)/tb_top_verilator.cpp --Mdir $(VERI_OBJ_DIR) \
-		-CFLAGS "-std=gnu++11 $(VERI_CFLAGS)" \
+		-CFLAGS "$(VERI_CFLAGS)" \
 		$(VERI_COMPILE_FLAGS)
 	$(MAKE) -C $(VERI_OBJ_DIR) -f Vtb_top_verilator.mk
 	mkdir -p $(SIM_RESULTS)

--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -186,7 +186,7 @@ TBSRC_TOP   := $(TBSRC_HOME)/core/tb_top.sv
 TBSRC_CORE  := $(TBSRC_HOME)/core
 TBSRC_PKG   := $(TBSRC_CORE)/tb_riscv/include/perturbation_defines.sv
 TBSRC       := $(TBSRC_CORE)/tb_top.sv \
-               $(TBSRC_CORE)/cv32e40p_tb_wrapper.sv \
+               $(TBSRC_CORE)/cv32e40p_core_tb_wrapper.sv \
                $(TBSRC_CORE)/mm_ram.sv \
                $(TBSRC_CORE)/dp_ram.sv \
                $(TBSRC_CORE)/tb_riscv/riscv_random_stall.sv \
@@ -200,7 +200,7 @@ RTLSRC_VLOG_TB_TOP	:= $(basename $(notdir $(TBSRC_TOP)))
 RTLSRC_VOPT_TB_TOP	:= $(addsuffix _vopt, $(RTLSRC_VLOG_TB_TOP))
 
 TBSRC_VERI  := $(TBSRC_CORE)/tb_top_verilator.sv \
-               $(TBSRC_CORE)/cv32e40p_tb_wrapper.sv \
+               $(TBSRC_CORE)/cv32e40p_core_tb_wrapper.sv \
                $(TBSRC_CORE)/tb_riscv/riscv_rvalid_stall.sv \
                $(TBSRC_CORE)/tb_riscv/riscv_gnt_stall.sv \
                $(TBSRC_CORE)/mm_ram.sv \

--- a/cv32e40p/tb/core/cv32e40p_core_tb_wrapper.sv
+++ b/cv32e40p/tb/core/cv32e40p_core_tb_wrapper.sv
@@ -179,4 +179,4 @@ module cv32e40p_core_tb_wrapper
          .exit_valid_o   ( exit_valid_o                              ),
          .exit_value_o   ( exit_value_o                              ));
 
-endmodule // cv32e40p_tb_wrapper
+endmodule // cv32e40p_core_tb_wrapper

--- a/cv32e40p/tb/core/cv32e40p_tb_wrapper.sv
+++ b/cv32e40p/tb/core/cv32e40p_tb_wrapper.sv
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-0.51
 
-module cv32e40p_tb_wrapper
+module cv32e40p_core_tb_wrapper
     #(parameter // Parameters used by TB
                 INSTR_RDATA_WIDTH = 32,
                 RAM_ADDR_WIDTH    = 20,

--- a/cv32e40p/tb/core/tb_top.sv
+++ b/cv32e40p/tb/core/tb_top.sv
@@ -70,7 +70,7 @@ module tb_top
             if($test$plusargs("verbose"))
                 $display("[TESTBENCH] @ t=%0t: loading firmware %0s",
                          $time, firmware);
-            $readmemh(firmware, cv32e40p_tb_wrapper_i.ram_i.dp_ram_i.mem);
+            $readmemh(firmware, cv32e40p_core_tb_wrapper_i.ram_i.dp_ram_i.mem);
         end else begin
             $display("No firmware specified");
             $finish;
@@ -145,13 +145,13 @@ module tb_top
     end
 
     // wrapper for CV32E40P, the memory system and stdout peripheral
-    cv32e40p_tb_wrapper
+    cv32e40p_core_tb_wrapper
         #(
           .INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
           .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
           .BOOT_ADDR         (BOOT_ADDR)
          )
-    cv32e40p_tb_wrapper_i
+    cv32e40p_core_tb_wrapper_i
         (
          .clk_i          ( core_clk     ),
          .rst_ni         ( core_rst_n   ),

--- a/cv32e40p/tb/core/tb_top_verilator.cpp
+++ b/cv32e40p/tb/core/tb_top_verilator.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv, char **env)
     top = new Vtb_top_verilator();
 
     svSetScope(svGetScopeFromName(
-        "TOP.tb_top_verilator.cv32e40p_tb_wrapper_i.ram_i.dp_ram_i"));
+        "TOP.tb_top_verilator.cv32e40p_core_tb_wrapper_i.ram_i.dp_ram_i"));
     Verilated::scopesDump();
 
 #ifdef VCD_TRACE
@@ -56,7 +56,7 @@ int main(int argc, char **argv, char **env)
 
 #ifdef MCY
     svSetScope(svGetScopeFromName(
-        "TOP.tb_top_verilator.cv32e40p_tb_wrapper_i.riscv_core_i.ex_stage_i.alu_i.int_div.div_i"));
+        "TOP.tb_top_verilator.cv32e40p_core_tb_wrapper_i.riscv_core_i.ex_stage_i.alu_i.int_div.div_i"));
     svLogicVecVal idx = {0};
     idx.aval = mutidx;
     set_mutidx(&idx);

--- a/cv32e40p/tb/core/tb_top_verilator.sv
+++ b/cv32e40p/tb/core/tb_top_verilator.sv
@@ -39,7 +39,7 @@ module tb_top_verilator
             if($test$plusargs("verbose"))
                 $display("[TESTBENCH] %t: loading firmware %0s ...",
                          $time, firmware);
-            $readmemh(firmware, cv32e40p_tb_wrapper_i.ram_i.dp_ram_i.mem);
+            $readmemh(firmware, cv32e40p_core_tb_wrapper_i.ram_i.dp_ram_i.mem);
 
         end else begin
             $display("No firmware specified");
@@ -85,7 +85,7 @@ module tb_top_verilator
     end
 
     // wrapper for cv32e40p, the memory system and stdout peripheral
-    cv32e40p_tb_wrapper
+    cv32e40p_core_tb_wrapper
         #(.INSTR_RDATA_WIDTH (INSTR_RDATA_WIDTH),
           .RAM_ADDR_WIDTH    (RAM_ADDR_WIDTH),
           .BOOT_ADDR         (BOOT_ADDR),
@@ -94,7 +94,7 @@ module tb_top_verilator
           .ZFINX             (0),
           .DM_HALTADDRESS    (32'h1A110800)
          )
-    cv32e40p_tb_wrapper_i
+    cv32e40p_core_tb_wrapper_i
         (.clk_i          ( clk_i          ),
          .rst_ni         ( rst_ni         ),
          .fetch_enable_i ( fetch_enable_i ),


### PR DESCRIPTION
Several modifications to the "core" testbench and related Makefile to restore compile and simulation of Verilator (and DSim).