### PR TITLE
ISACOV : no rd toggle for bext & bexti

### DIFF
--- a/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
+++ b/lib/uvm_agents/uvma_isacov/cov/uvma_isacov_cov_model.sv
@@ -173,7 +173,6 @@ covergroup cg_zb_rstype_ext(
     bins ONE  = {1};
   }
 
-  `ISACOV_CP_BITWISE(cp_rd_toggle,   instr.rd_value, 1)
   `ISACOV_CP_BITWISE(cp_rs1_toggle,  instr.rs1_value, 1)
   `ISACOV_CP_BITWISE(cp_rs2_toggle,  instr.rs2_value, 1)
 
@@ -218,7 +217,6 @@ covergroup cg_zb_itype_ext(
     bins ONE  = {1};
   }
 
-  `ISACOV_CP_BITWISE(cp_rd_toggle,  instr.rd_value, 1)
   `ISACOV_CP_BITWISE(cp_rs_toggle,  instr.rs1_value, 1)
 
 endgroup : cg_zb_itype_ext


### PR DESCRIPTION
bext & bexti instructions extract only 1 bit from an index (rs2 or imm) and store it in RD, so we can't toggle all rd bits (with 1), so I don't think it's useful to keep this cover-point because doesn't make sense.