### PR TITLE
removed use_response_handler: not possible in a generic agent

### DIFF
--- a/lib/cv_dv_utils/python/sim_cmd/get_cmd.py
+++ b/lib/cv_dv_utils/python/sim_cmd/get_cmd.py
@@ -63,6 +63,11 @@ def cmp_cmd(yaml_file, outdir, opt, vopt_option, work):
       if 'svlog_source' in comp:
         src_list  = comp["svlog_source"]
         srcs      = src_list.split()
+        cmd       = "vlog -sv"
+      elif 'vlog_source' in comp:
+        cmd       = "vlog"
+        src_list  = comp["vlog_source"]
+        srcs      = src_list.split()
       else: 
         src_list  = ""
         srcs      = ""

--- a/lib/cv_dv_utils/python/sim_cmd/get_cmd.py
+++ b/lib/cv_dv_utils/python/sim_cmd/get_cmd.py
@@ -156,7 +156,7 @@ def get_cmd_opt(yaml_file):
     sim_cmd_opt = "{} {}".format(cmd, sim_opt)
     return sim_cmd_opt
 
-def run_test(test_name, seed, debug, batch, dump, coverage, stdout, outdir, vsim_opt):
+def run_test(test_name, seed, debug, batch, dump, stdout, outdir, vsim_opt):
 
    if outdir == None: 
       outdir = "output"
@@ -197,12 +197,4 @@ def run_test(test_name, seed, debug, batch, dump, coverage, stdout, outdir, vsim
    if os.path.isdir("{}".format(outdir)) == False:
      os.system("mkdir {}".format(outdir))
    
-   if coverage == 1:
-     ucdbfile    = "\"coverage save -onexit {}/{}_{}.ucdb\"".format(outdir, test_name, seed)
-     coveragestr = "-do {}".format(ucdbfile)
-     coverageopt = "-coverage -assertdebug"
-   else:
-     coveragestr = ""
-     coverageopt = ""
-
-   os.system("{} {} {} {} -sv_seed {} +UVM_VERBOSITY={} +UVM_TESTNAME={} {} {}/{}_{}.log {}".format(vsim_opt,  batchstr, dumpstr, coverageopt, seed, debug, test_name, stdoutstr, outdir, test_name, seed, wlfstr))
+   os.system("{} {} {} -sv_seed {} +UVM_VERBOSITY={} +UVM_TESTNAME={} {} {}/{}_{}.log {}".format(vsim_opt,  batchstr, dumpstr, seed, debug, test_name, stdoutstr, outdir, test_name, seed, wlfstr))

--- a/lib/cv_dv_utils/python/sim_cmd/run_reg.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_reg.py
@@ -33,9 +33,6 @@ parser = argparse.ArgumentParser(description='Run Regression')
 parser.add_argument('--yaml'       ,dest='yaml_file', type=str, help='Top YAML with compile and simulation options')
 parser.add_argument('--reg_list'   ,dest='reglist'   , type=str, help='file that contains the regression list, the number of seeds and a default seed')
 parser.add_argument('--nthreads'   ,dest='nthreads'  , type=int, help='Number of test run at the same time: default 2')
-parser.add_argument('--coverage'   ,dest='coverage'   , type=int, help='If 1, a ucdb(questasim) file will be generated')
-parser.add_argument('--cc'         ,dest='cc'         , type=int, help='If 1, code coverage is activated')
-parser.add_argument('--cc_opt'     ,dest='cc_opt'     , type=int, help='If 1, option for code coverage')
 parser.add_argument('--outdir'     , dest='outdir'    , type=str, help='output directory: default regression')
 args = parser.parse_args()
 
@@ -46,14 +43,10 @@ if args.outdir == None:
     outdir = "regression"
 if args.nthreads == None:
     args.nthreads = 2
-if args.cc == None:
-    args.cc = 0
-if args.coverage == None:
-    args.coverage = 0
 
 
 def rtest(test, seed, cmd_opt):
-    get_cmd.run_test(test, seed,  "UVM_NONE", 1, 0, args.coverage, 0, outdir, cmd_opt )
+    get_cmd.run_test(test, seed,  "UVM_NONE", 1, 0, 0, outdir, cmd_opt )
     log = "{}/{}_{}.log".format(outdir, test, seed) 
     pattern = "{}/scripts/patterns/sim_patterns.pat".format(project_dir)
     cmd = "scan_logs.pl -silent -nopreresetwarn {}  -pat {} ".format(log, pattern)

--- a/lib/cv_dv_utils/python/sim_cmd/run_test.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_test.py
@@ -30,7 +30,6 @@ parser.add_argument('--seed'     , dest='seed',      type=int, help='random seed
 parser.add_argument('--debug'    , dest='debug',     type=str, help='UVM_LOW/MEDIUM/HIGH/FULL/DEBUG, default LOW')
 parser.add_argument('--batch'    , dest='batch',     type=int, help='1: batch mode, 0:gui default, 1')
 parser.add_argument('--dump'     , dest='dump',      type=int, help='1: all signals are logged, 0: nothing is looged, default 1') #FIXME
-parser.add_argument('--coverage' , dest='coverage',   type=int, help='Activate coverage')
 parser.add_argument('--stdout'   , dest='stdout', type=int, help='1: stdout 0: nostdout')
 parser.add_argument('--outdir'   , dest='outdir', type=str, help='output dirctory de fault "output"')
 
@@ -48,5 +47,5 @@ if args.test_name == None:
    option_ok = 0
 
 if option_ok == 1:
-  sim.run_test(args.test_name, args.seed, args.debug, args.batch, args.dump, args.coverage, args.stdout, args.outdir, cmd_opt )
+  sim.run_test(args.test_name, args.seed, args.debug, args.batch, args.dump, args.stdout, args.outdir, cmd_opt )
 

--- a/lib/cv_dv_utils/uvm/generic_agent/README.md
+++ b/lib/cv_dv_utils/uvm/generic_agent/README.md
@@ -64,6 +64,12 @@ Following signals need to be connected to the write/read response interface
 ### Ready Signal 
 User should connect his/her own ready signal directly to req_ready.
 
+## Response Handler 
+
+By default response handler is deactivated. Following setup needs to be done to enable the response handle
+
+      uvm_config_db #( bit )::set(uvm_root::get(), "*", "generic_sequencer" , 1);
+
 ## APIs
 The class generic_sequences provide following API to generate and drive a sequences. 
 ```

--- a/lib/cv_dv_utils/uvm/generic_agent/README.md
+++ b/lib/cv_dv_utils/uvm/generic_agent/README.md
@@ -68,7 +68,18 @@ User should connect his/her own ready signal directly to req_ready.
 
 By default response handler is deactivated. Following setup needs to be done to enable the response handle
 
-      uvm_config_db #( bit )::set(uvm_root::get(), "*", "generic_sequencer" , 1);
+ ```
+ uvm_config_db #( bit )::set(uvm_root::get(), "*", "generic_sequencer" , 1);
+
+ over write the following task of generic_driver, otherwise it gives an uvm_warning 
+ virtual task spy_and_drive_rsp(); 
+
+ over write following function if generic_sequences
+ virtual function void response_handler(uvm_sequence_item response);
+ 
+ ```
+
+
 
 ## APIs
 The class generic_sequences provide following API to generate and drive a sequences. 

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
@@ -39,7 +39,6 @@ class generic_agent #(type req_t, type rsp_t) extends uvm_agent;
 
   virtual generic_if #(req_t, rsp_t)generic_vif; 
   generic_monitor    #(req_t, rsp_t)m_monitor;
-  
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -53,15 +52,16 @@ class generic_agent #(type req_t, type rsp_t) extends uvm_agent;
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    m_monitor = generic_monitor#(req_t, rsp_t)::type_id::create("monitor", this);
+    m_monitor = generic_monitor#(req_t, rsp_t)::type_id::create("generic_monitor", this);
     if(is_active == UVM_ACTIVE) begin
-      m_sequencer = generic_sequencer#(req_t, rsp_t)::type_id::create("sequencer", this);
-      m_driver    = generic_driver#(req_t, rsp_t)::type_id::create("driver", this);
+      m_sequencer = generic_sequencer#(req_t, rsp_t)::type_id::create("generic_sequencer", this);
+      m_driver    = generic_driver#(req_t, rsp_t)::type_id::create("generic_driver", this);
     end
 
     if (!uvm_config_db #( virtual generic_if#(req_t, rsp_t))::get(this, "", get_name(), generic_vif )) begin
         `uvm_fatal("BUILD_PHASE", $sformatf("Unable to get generic_vif_config for %s from configuration database", get_name() ) );
     end // if
+
 
     `uvm_info(get_full_name( ), "Build stage complete.", UVM_LOW)
   endfunction: build_phase
@@ -73,8 +73,10 @@ class generic_agent #(type req_t, type rsp_t) extends uvm_agent;
       if(is_active == UVM_ACTIVE) begin
         m_driver.seq_item_port.connect(m_sequencer.seq_item_export);
         m_driver.set_generic_vif(generic_vif);
+        m_driver.use_response_handler = m_sequencer.use_response_handler;
       end
       m_monitor.set_generic_vif(generic_vif);
+
       `uvm_info(get_full_name( ), "Connect stage complete.", UVM_LOW)
   endfunction: connect_phase
 

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
@@ -90,7 +90,7 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
            // ----------------------------------------------------------------------------
            fork 
              get_and_drive_req(); 
-             spy_and_drive_rsp(); 
+ //            spy_and_drive_rsp(); 
            join_none
           // In case of a reset on the fly, kill all processes
           @(reset_asserted);

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
@@ -90,7 +90,6 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
            // ----------------------------------------------------------------------------
            fork 
              get_and_drive_req(); 
- //            spy_and_drive_rsp(); 
            join_none
           // In case of a reset on the fly, kill all processes
           @(reset_asserted);
@@ -108,8 +107,6 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
            seq_item_port.get_next_item(req);
            `uvm_info("REQ ACK DRIVER", "New Request Recieved", UVM_HIGH);
 
-//           @ (posedge generic_vif.clk_i);
-
            if(req.m_txn_idle_cycles > 0)
              generic_vif.wait_n_clocks(req.m_txn_idle_cycles);
 
@@ -126,9 +123,6 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
            // ------------------------------------------------------
            // This is to be used by respose handler
            // ------------------------------------------------------
-          // if(req.m_req_need_rsp) begin 
-          //   rsp_list[req.m_req_tid].push_back(req);
-          // end
            seq_item_port.item_done();
        end
     endtask

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_driver.svh
@@ -30,6 +30,7 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
     // Local variable
     // ------------------------------------------------------------------------
     protected string name ;
+    bit use_response_handler;
 //    generic_txn rsp_list[integer][$]; 
 
     // ------------------------------------------------------------------------
@@ -131,19 +132,9 @@ class generic_driver #(type req_t, type rsp_t) extends uvm_driver #(generic_txn 
     // get and drive 
     // ----------------------------------
     virtual task spy_and_drive_rsp( );
-       generic_txn #(req_t, rsp_t)rsp;
-       // Drive generic iterface
-       forever begin
-           @ (posedge generic_vif.clk_i);
-           
-           if(generic_vif.rsp_valid & generic_vif.rsp_ready) begin
-             rsp       = generic_txn#(req_t, rsp_t)::type_id::create("new rsp");
-             rsp.m_rsp <= generic_vif.rsp;
-
-             seq_item_port.put(rsp);
-             `uvm_info("RES ACK DRIVER", "New Response Sent", UVM_HIGH);
-           end
-       end
+      if(use_response_handler) begin
+        `uvm_warning(this.name, "use_response_handler is enabled: Please over write virtual task spy_and_drive_rsp in generic driver");
+      end
     endtask
     // ------------------------------------------------------
     // API to set the interface 

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_sequencer.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_sequencer.svh
@@ -25,7 +25,7 @@
 class generic_sequencer#(type req_t, type rsp_t) extends uvm_sequencer #(generic_txn#(req_t, rsp_t), generic_txn#(req_t, rsp_t));
 
   `uvm_sequencer_param_utils(generic_sequencer#(req_t, rsp_t))
-
+  bit     use_response_handler;
   // -------------------------------------------------------------------------
   // Constructor
   // -------------------------------------------------------------------------
@@ -33,5 +33,13 @@ class generic_sequencer#(type req_t, type rsp_t) extends uvm_sequencer #(generic
       super.new(name, parent);
       
   endfunction: new
-  
+ 
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase); 
+
+
+    if (!uvm_config_db #( bit )::get(this, "", get_name(), use_response_handler )) begin
+      `uvm_info("BUILD_PHASE", $sformatf("Reponse Handler Is Set"), UVM_LOW);
+    end // if
+  endfunction 
 endclass: generic_sequencer

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
@@ -38,7 +38,7 @@ class generic_base_sequence#(type req_t, type rsp_t) extends uvm_sequence #(gene
     end // if
     `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );
 
-    use_response_handler(1);
+    //use_response_handler(1);
   endfunction: new
 
   task pre_body();

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
@@ -37,11 +37,17 @@ class generic_base_sequence#(type req_t, type rsp_t) extends uvm_sequence #(gene
       num_txn = 10000;
     end // if
     `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );
-
   endfunction: new
+
+
 
   task pre_body();
     $cast(m_sequencer, get_sequencer());
+
+    if(m_sequencer.use_response_handler) begin
+      use_response_handler(1);
+      `uvm_info("BUILD_PHASE", $sformatf("Reponse Handler Is Set"), UVM_HIGH);
+    end
   endtask: pre_body
 
   virtual task body( );
@@ -49,7 +55,7 @@ class generic_base_sequence#(type req_t, type rsp_t) extends uvm_sequence #(gene
   endtask
 
   // The response_handler function serves to keep the sequence response FIFO empty
-  function void response_handler(uvm_sequence_item response);
+  virtual function void response_handler(uvm_sequence_item response);
     rsp_count++;
     `uvm_info("generic SEQUENCE BASE", $sformatf("Number of responses %0d(d)", rsp_count), UVM_HIGH);
   endfunction: response_handler

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_sequences.svh
@@ -38,7 +38,6 @@ class generic_base_sequence#(type req_t, type rsp_t) extends uvm_sequence #(gene
     end // if
     `uvm_info( get_full_name(), $sformatf("NUM_TXN=%0d", num_txn), UVM_HIGH );
 
-    //use_response_handler(1);
   endfunction: new
 
   task pre_body();


### PR DESCRIPTION
Hello,

In a generic agent, protocol is not known before hand. So it is not possible to correctly define the functionning of response handler. 

Hence I have removed this. 

Regards
Tanuj Khandelwal