### PR TITLE
Use C++14 required by Verilator V5+

### DIFF
--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -496,7 +496,7 @@ testbench_verilator: CV_CORE_pkg $(TBSRC_VERI) $(TBSRC_PKG)
 		-f $(CV_CORE_MANIFEST) \
 		$(CV_CORE_PKG)/bhv/$(CV_CORE_LC)_core_log.sv \
 		$(TBSRC_CORE)/tb_top_verilator.cpp --Mdir $(VERI_OBJ_DIR) \
-		-CFLAGS "-std=gnu++11 $(VERI_CFLAGS)" \
+		-CFLAGS "-std=gnu++14 $(VERI_CFLAGS)" \
 		$(VERI_COMPILE_FLAGS)
 	$(MAKE) -C $(VERI_OBJ_DIR) -f Vtb_top_verilator.mk
 	mkdir -p $(SIM_RESULTS)


### PR DESCRIPTION
Found this as we were looking at the CV32E40P core, and been struggling with the verilating process.
Turns out this was raised earlier in October, but no pull-requests came: https://github.com/openhwgroup/core-v-verif/issues/2641

After making the suggested change, `make` under `cv32e40p/sim/core/` worked.

<img width="1325" height="480" alt="cv32e40p_hello_world" src="https://github.com/user-attachments/assets/83893a2d-6568-47b6-b608-5e71d16bcecd" />