### PR TITLE
Add custom mscratch CSR read/write test for CV32E40P 

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+int main() {
+    //Write out all 32 bits to leave no bits behind
+    unsigned int write_val = 0xACE12345;
+    unsigned int read_val = 0;
+
+    printf("Executing mscratch CSR test...\n");
+
+    // Write to mscratch (CSR 0x340)
+    asm volatile ("csrw mscratch, %0" : : "r" (write_val));
+
+    // Read back from mscratch
+    asm volatile ("csrr %0, mscratch" : "=r" (read_val));
+
+    if (read_val == write_val) {
+        printf("SUCCESS: Written 0x%08x, Read 0x%08x\n", write_val, read_val);
+        return 0; 
+    } else {
+        printf("FAILURE: Written 0x%08x, Read 0x%08x\n", write_val, read_val);
+        return 1;
+    }
+}

--- a/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
@@ -1,0 +1,6 @@
+name: mscratch_test
+uvm_test: uvmt_cv32e40p_base_test
+description: >
+  Test read/write access to mscratch CSR.
+files:
+  - mscratch_test.c


### PR DESCRIPTION
This test verifies the 32-bit integrity of the mscratch CSR (0x340).  It performs a write-read-compare operation using a specific bit
pattern (0xACE12345) to ensure all 32 bits are functional. Included a UVM-compatible test.yaml to support the yaml2make flow.