### PR TITLE
Add comprehensive mscratch CSR verification with atomic RMW tests

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Amit Matth
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    unsigned int read_val;
+    unsigned int old_val;
+    int fail_count = 0;
+
+    printf("\n=== Starting Comprehensive mscratch CSR Test ===\n");
+
+    // -------------------------------------------------------------------------
+    // Test 1: Basic Patterns (Boundary values and alternating bits)
+    // -------------------------------------------------------------------------
+    printf("[1/4] Testing Basic Patterns...\n");
+    unsigned int patterns[] = {
+        0x00000000, // All Zeros
+        0xFFFFFFFF, // All Ones
+        0xAAAAAAAA, // Alternating 1010...
+        0x55555555, // Alternating 0101...
+        0xDEADBEEF, // Random pattern
+        0xCAFEBABE  // Random pattern
+    };
+
+    for (int i = 0; i < 6; i++) {
+        unsigned int pat = patterns[i];
+        
+        // Write pattern
+        asm volatile ("csrw mscratch, %0" : : "r"(pat));
+        
+        // Read back
+        asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+
+        if (read_val != pat) {
+            printf("  [FAIL] Wrote 0x%08x, Read 0x%08x\n", pat, read_val);
+            fail_count++;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2: Walking "One" (Testing Stuck-at-0 faults)
+    // -------------------------------------------------------------------------
+    printf("[2/4] Testing Walking '1' (0 -> 31)...\n");
+    for (int i = 0; i < 32; i++) {
+        unsigned int pat = (1u << i);
+        
+        asm volatile ("csrw mscratch, %0" : : "r"(pat));
+        asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+
+        if (read_val != pat) {
+            printf("  [FAIL] Bit %d: Wrote 0x%08x, Read 0x%08x\n", i, pat, read_val);
+            fail_count++;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 3: Walking "Zero" (Testing Stuck-at-1 faults)
+    // -------------------------------------------------------------------------
+    printf("[3/4] Testing Walking '0' (0 -> 31)...\n");
+    for (int i = 0; i < 32; i++) {
+        unsigned int pat = ~(1u << i);
+        
+        asm volatile ("csrw mscratch, %0" : : "r"(pat));
+        asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+
+        if (read_val != pat) {
+            printf("  [FAIL] Bit %d: Wrote 0x%08x, Read 0x%08x\n", i, pat, read_val);
+            fail_count++;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4: Atomic Read-Modify-Write Operations (CSRRS, CSRRC)
+    // -------------------------------------------------------------------------
+    printf("[4/4] Testing Atomic Operations (CSRRS/CSRRC)...\n");
+    
+    // Initial Setup: mscratch = 0x0000FFFF
+    unsigned int init_val = 0x0000FFFF;
+    asm volatile ("csrw mscratch, %0" : : "r"(init_val));
+
+    // A. Test CSRRS (Read and Set Bits)
+    // Set upper 16 bits (0xFFFF0000). Expected result: 0xFFFFFFFF.
+    // CSRRS returns the OLD value.
+    unsigned int set_mask = 0xFFFF0000;
+    asm volatile ("csrrs %0, mscratch, %1" : "=r"(old_val) : "r"(set_mask));
+    
+    // Check returned old value
+    if (old_val != 0x0000FFFF) {
+        printf("  [FAIL] CSRRS Old Value: Expected 0x0000FFFF, Got 0x%08x\n", old_val);
+        fail_count++;
+    }
+    
+    // Check new value in register
+    asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+    if (read_val != 0xFFFFFFFF) {
+        printf("  [FAIL] CSRRS New Value: Expected 0xFFFFFFFF, Got 0x%08x\n", read_val);
+        fail_count++;
+    }
+
+    // B. Test CSRRC (Read and Clear Bits)
+    // Clear lower 8 bits (0x000000FF). Current is 0xFFFFFFFF.
+    // Expected result: 0xFFFFFF00.
+    unsigned int clr_mask = 0x000000FF;
+    asm volatile ("csrrc %0, mscratch, %1" : "=r"(old_val) : "r"(clr_mask));
+
+    if (old_val != 0xFFFFFFFF) {
+         printf("  [FAIL] CSRRC Old Value: Expected 0xFFFFFFFF, Got 0x%08x\n", old_val);
+         fail_count++;
+    }
+
+    asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+    if (read_val != 0xFFFFFF00) {
+        printf("  [FAIL] CSRRC New Value: Expected 0xFFFFFF00, Got 0x%08x\n", read_val);
+        fail_count++;
+    }
+
+    // -------------------------------------------------------------------------
+    // Conclusion
+    // -------------------------------------------------------------------------
+    if (fail_count == 0) {
+        printf("\n=== SUCCESS: All mscratch CSR tests passed! ===\n");
+        return EXIT_SUCCESS;
+    } else {
+        printf("\n=== FAILURE: %d tests failed! ===\n", fail_count);
+        return EXIT_FAILURE;
+    }
+}

--- a/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 Amit Matth
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+name: mscratch_test
+uvm_test: uvmt_cv32e40p_firmware_test_c
+description: Add comprehensive mscratch CSR verification with atomic RMW tests


### PR DESCRIPTION
This PR implements a robust verification test for the `mscratch` CSR (Machine Scratch Register) targeting the `cv32e40p` core.

### Overview
This contribution goes beyond basic read/write sanity checks by implementing a comprehensive C-based test suite `mscratch_test.c` that validates the register's behavior under stress conditions, specifically focusing on atomic operations and bit-level faults.

### Test Scope
The test performs four distinct validation stages:
1.  **Pattern Stress Test**: Verifies boundary values (`0x00..`, `0xFF..`) and alternating interactions (`0xAA..`, `0x55..`).
2.  **Stuck-at-Fault Walking '1'**: Shifts a single bit from 0 to 31 to detect stuck-at-0 faults.
3.  **Stuck-at-Fault Walking '0'**: Shifts a single zero across a field of ones to detect stuck-at-1 faults.
4.  **Atomic Operations**: Explicitly validates `csrrs` (Read & Set) and `csrrc` (Read & Clear) instructions. This ensures that Read-Modify-Write (RMW) operations correctly update only the targeted bits while preserving atomicity.

### Verification Status
- Simulator: Verilator v5.044
- Toolchain: xPack GNU RISC-V Embedded GCC 13.2.0 (Newlib support enabled)
- Local CI Check: PASSED (./bin/ci_check --core cv32e40p --verilator --no_uvm)
- Test Result: PASSED

Validation Log:
<img width="1365" height="767" alt="Test_Proof" src="https://github.com/user-attachments/assets/078a1b6b-3e51-4016-967f-064fc2c145df" />

I have signed the Eclipse Contributor Agreement (ECA) and validated the test locally.

### How to Run
To execute this test with Verilator, run the following from `cv32e40p/sim/core`:

```bash
# Ensure toolchain environment variables are set
# (Adjust paths if your toolchain is in a different location)
export CV_SW_TOOLCHAIN=$HOME/riscv-toolchain
export RISCV_PREFIX=riscv-none-elf-
export PATH=$CV_SW_TOOLCHAIN/bin:$PATH

# Run the specific test
make veri-test TEST=mscratch_test \
    RISCV_MARCH=rv32imc_zicsr \
    CLONE_CV_CORE_CMD=true