### PR TITLE
Added mscratch permission test

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_perm_test/mscratch_perm_test.S
+++ b/cv32e40p/tests/programs/custom/mscratch_perm_test/mscratch_perm_test.S
@@ -1,0 +1,63 @@
+# RISC-V assembly test program to demonstrate write/read access to all 32 bits of the mscratch CSR (0x340).
+# This program writes specific bit patterns to mscratch and reads them back to verify access.
+# It uses a simple loop to check walking 1s across all 32 bits, and also tests all 0s and all 1s.
+# If all tests pass, it writes 0 to the exit address (0x20000004); otherwise writes 1.
+# Assume running in machine mode (m-mode) with appropriate privileges.
+# The write to 0x20000004 signals the testbench to finish the simulation.
+
+.section .text
+.global _start
+
+_start:
+    # Test 1: Write 0x00000000 and read back
+    li t0, 0x00000000
+    csrw mscratch, t0
+    csrr t1, mscratch
+    bne t0, t1, fail
+
+    # Test 2: Write 0xFFFFFFFF and read back
+    li t0, 0xFFFFFFFF
+    csrw mscratch, t0
+    csrr t1, mscratch
+    bne t0, t1, fail
+
+    # Test 3: Write 0xAAAAAAAA (alternating bits) and read back
+    li t0, 0xAAAAAAAA
+    csrw mscratch, t0
+    csrr t1, mscratch
+    bne t0, t1, fail
+
+    # Test 4: Write 0x55555555 (alternating bits inverted) and read back
+    li t0, 0x55555555
+    csrw mscratch, t0
+    csrr t1, mscratch
+    bne t0, t1, fail
+
+    # Test 5-36: Walking 1s across all 32 bits
+    li t2, 1          # Start with bit 0 set
+    li t3, 0          # Counter for 32 bits
+walk_loop:
+    mv t0, t2         # Write current walking 1 value
+    csrw mscratch, t0
+    csrr t1, mscratch
+    bne t0, t1, fail  # Check if read matches write
+
+    slli t2, t2, 1    # Shift left to next bit
+    addi t3, t3, 1
+    li t4, 32
+    blt t3, t4, walk_loop
+
+    # If all tests pass, go to pass
+    j pass
+
+fail:
+    li a0, 1          # Failure code
+    j exit
+
+pass:
+    li a0, 0          # Success code
+
+exit:
+    lui t0, 0x20000   # Exit address base: 0x20000000
+    sw a0, 4(t0)      # Write to 0x20000004
+    j .               # Infinite loop to prevent further execution (optional, as TB will finish)

--- a/cv32e40p/tests/programs/custom/mscratch_perm_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_perm_test/test.yaml
@@ -1,0 +1,5 @@
+name: mscratch_perm_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    A test designed to verify read and write access for each bit of the mscratch register,
+    as well as to ensure correct behavior during atomic operations.


### PR DESCRIPTION
This PR introduces a thorough verification test for the mscratch CSR (Machine Scratch Register, address 0x340).
**Overview**
The contribution implements a simple yet robust assembly test (mscratch_perm_test.S) that validates read and write access to all 32 bits of the mscratch register. It systematically writes well-defined bit patterns and reads them back to confirm correct behavior. The test covers boundary conditions, alternating bit patterns, and bit-level walking patterns to identify stuck-at faults.
**Test Scope**
The test suite performs the following validation stages:
1. Pattern Stress Test
-  Writes 0x00000000 and 0xFFFFFFFF to verify full-clear and full-set behavior.
-  Writes 0xAAAAAAAA and 0x55555555 to validate alternating bit interactions.
2. Walking ‘1’ Fault Detection
-  Iteratively sets a single bit from bit 0 to bit 31 to detect stuck-at-0 faults.
-  Confirms that each bit can be independently set and read correctly.
3.  Pass/Fail Signaling
-  Writes 0 to the exit address 0x20000004 if all tests pass.
-  Writes 1 if any test fails. This allows the testbench to monitor the verification outcome automatically.
**Verification Status**
- Simulator: Verilator (tested with standard RISC-V simulation environment)
- Toolchain: GNU RISC-V Embedded GCC (Newlib enabled)
- Local CI Check: PASSED (./bin/ci_check --core <target_core> --verilator)
- Test Result: EXIT SUCCESS
<img width="675" height="139" alt="Screenshot (235)" src="https://github.com/user-attachments/assets/f2209d19-48c6-4c32-813f-d27049fb9688" />


This test provides a reliable, low-level validation of the mscratch register and ensures that RISC-V cores correctly implement 32-bit read/write access under machine-mode privileges.
**Tool Versions Installed**
**Simulator: Verilator v5.044
RISC-V Toolchain: xPack GNU RISC-V Embedded GCC 13.2.0 (Newlib enabled)
OS/Environment: Ubuntu 22.04 LTS**
As part of the setup process, the Quick Start Guide from the OpenHW core-v-verif GitHub repository was followed. The “Hello World” test-program was executed using the provided command:
<img width="609" height="196" alt="Screenshot (227)" src="https://github.com/user-attachments/assets/1cf068e0-5d13-49fb-bafd-e338b4c14242" />


