### PR TITLE
Added test-program for stretch goal

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Arijit Pal
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+/*
+ * Test: mscratch_test
+ * Description: Validates full 32-bit R/W access to the mscratch CSR (0x340).
+ * Logic: Writes/Reads patterns (Zeros, Ones, Alternating) to detect stuck bits or crosstalk.
+ * Returns: 0 on Success; Non-zero index on Failure.
+ */
+#include <stdint.h>
+
+int main() {
+    // Patterns: 0, All-1s, 0x55.., 0xAA.., Random, Sanity
+    uint32_t p[] = {0, 0xFFFFFFFF, 0x55555555, 0xAAAAAAAA, 0x12345678, 0xDEADBEEF};
+    uint32_t v;
+
+    for (int i = 0; i < 6; i++) {
+        __asm__ volatile ("csrw 0x340, %0" :: "r"(p[i]));
+        __asm__ volatile ("csrr %0, 0x340" : "=r"(v));
+        if (v != p[i]) return i + 1;
+    }
+    return 0;
+}

--- a/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
@@ -1,0 +1,4 @@
+name: mscratch_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Stretch Goal: test-program to demonstrate that a test-program has write/read access to all 32-bits of the mscratch CSR


### PR DESCRIPTION
This PR adds a custom C program and YAML configuration to verify read/write access to all 32 bits of the mscratch CSR (0x340)

Environment Variables:
```bash
export CORE_V_VERIF=$(pwd)
export CV_SW_MARCH=rv32imc_zicsr
export CV_SW_PREFIX="riscv32-corev-elf-"
export CV_SW_TOOLCHAIN="/opt/corev"
```

Test:
```bash
cd $CORE_V_VERIF/cv32e40p/sim/core
make veri-test   TEST=mscratch_test
```

Reference:
1. [Control and Status Registers](https://docs.openhwgroup.org/projects/cv32e40p-user-manual/en/cv32e40p_v1.8.3/control_status_registers.html#control-and-status-registers)
2. [contribution.md](https://github.com/openhwgroup/core-v-verif/blob/master/CONTRIBUTING.md)


<img width="1160" height="691" alt="Screenshot From 2026-01-27 13-33-38" src="https://github.com/user-attachments/assets/9c8fe01d-5fa8-4c14-a2f4-046b64fdd5b7" />
<img width="1364" height="760" alt="Screenshot From 2026-01-27 13-35-36" src="https://github.com/user-attachments/assets/6edd772c-0d10-4481-88d7-7173586ecfe2" />