### PR TITLE
Add mscratch test covering stuck-at faults and atomic bit manipulation

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_rw_test/mscratch_rw_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_rw_test/mscratch_rw_test.c
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Preetham
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
 /**
  * mscratch CSR Essential Test Program
  * 

--- a/cv32e40p/tests/programs/custom/mscratch_rw_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_rw_test/test.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Preetham
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
 name: mscratch_rw_test
 uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
 description: >


### PR DESCRIPTION
<html>
<body>
<h2>Summary</h2>
<p>Adds a comprehensive C-based test (<code>mscratch_rw_test.c</code>) that validates the Machine Scratch Register beyond basic read/write checks, targeting bit-level faults and atomic operation correctness.</p>
<h2>Test Coverage</h2>

Stage | Test | Purpose
-- | -- | --
1 | Boundary & Alternating Patterns | 0x00000000, 0xFFFFFFFF, 0xAAAAAAAA, 0x55555555
2 | Walking-1 | Detects stuck-at-0 faults (single bit shifted 0→31)
3 | Walking-0 | Detects stuck-at-1 faults (single zero across all ones)
4 | Atomic RMW | Validates csrrs/csrrc bit-level atomicity

Verification
Simulator: Verilator v5.044
Toolchain: GNU RISC-V Embedded GCC 13.2.0 (Newlib support enabled)
Local CI Check: PASSED (./bin/ci_check --core cv32e40p --verilator --no_uvm)
Trace: GTKWave v3.3.116
Test Result: PASSED

Eclipse CLA: Signed ✓

<h2>How to Run</h2>
<pre><code class="language-bash"># Set toolchain paths
export CV_SW_TOOLCHAIN=$HOME/riscv-toolchain
export RISCV_PREFIX=riscv-none-elf-
export PATH=$CV_SW_TOOLCHAIN/bin:$PATH
export CV_SW_MARCH=rv32imac_zicsr

# Run test (from cv32e40p/sim/core)

`make veri-test TEST=mscratch_rw_test CV_SIMULATOR=verilator
`

<img width="1902" height="895" alt="Screenshot 2026-01-27 222834" src="https://github.com/user-attachments/assets/d8d06472-6dfd-4444-a1d2-2c587c3cd97e" />

<img width="1133" height="730" alt="Screenshot 2026-01-27 222504" src="https://github.com/user-attachments/assets/7ff8ab62-9783-4dda-b33a-198da741baf4" />

</code></pre></body></html><!--EndFragment-->
</body>
</html>