### PR TITLE
RVFI agent: log CSR updates in UVM logger

### DIFF
--- a/lib/uvm_agents/uvma_rvfi/uvma_rvfi_mon_trn_logger.sv
+++ b/lib/uvm_agents/uvma_rvfi/uvma_rvfi_mon_trn_logger.sv
@@ -184,6 +184,7 @@ class uvma_rvfi_mon_trn_logger_c#(int ILEN=DEFAULT_ILEN,
 
          csr_line = $sformatf(
             "    CSR[0x%0x] old=0x%0x new=0x%0x",
+            csr_trn.csr,
             csr_trn.addr,
             csr_trn.rdata,
             csr_trn.get_csr_retirement_data()


### PR DESCRIPTION
This PR adds CSR update logging to the RVFI UVM transaction logger.

CSR information (addr, rdata, wdata/wmask) is already captured in `uvma_rvfi_instr_seq_item`; this change surfaces it in `uvma_rvfi_mon_trn_logger` without requiring any RTL or RVFI changes. This is the implementation of the approach discussed and confirmed in issue #2577.