### PR TITLE
Add mscratch CSR full 32-bit R/W access test part of the coding challenge required for the RISC-V Certification Mentorship

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch-32bit-test/mscratch-32bit-test.c
+++ b/cv32e40p/tests/programs/custom/mscratch-32bit-test/mscratch-32bit-test.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdint.h>
+
+int main(void)
+{
+    static const uint32_t patterns[] = {
+        0x00000000, 0xFFFFFFFF,
+        0xAAAAAAAA, 0x55555555,
+        0xDEADBEEF, 0xCAFEBABE,
+        0x12345678, 0x87654321
+    };
+
+    uint32_t read_val;
+    int i, errors = 0;
+
+    printf("\n=== Full 32-bit mscratch CSR (0x340) write/read test ===\n");
+
+    for (i = 0; i < (int)(sizeof(patterns)/sizeof(patterns[0])); i++) {
+        uint32_t val = patterns[i];
+        asm volatile ("csrw mscratch, %0" : : "r"(val));
+        asm volatile ("csrr %0, mscratch" : "=r"(read_val));
+        if (read_val == val) {
+            printf("PASS 0x%08x -> 0x%08x\n", val, read_val);
+        } else {
+            printf("FAIL 0x%08x -> 0x%08x\n", val, read_val);
+            errors++;
+        }
+    }
+
+    if (errors == 0) {
+        printf("\nSUCCESS: All 32-bit patterns verified!\n");
+        return 0;
+    } else {
+        printf("\nFAILED: %d errors\n", errors);
+        return 1;
+    }
+}

--- a/cv32e40p/tests/programs/custom/mscratch-32bit-test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch-32bit-test/test.yaml
@@ -1,0 +1,4 @@
+name: hello-world
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Simple hello-world sanity test


### PR DESCRIPTION
**Title**: Add mscratch CSR full 32-bit read/write access test

**Description**:

This PR adds a new custom test program in `cv32e40p/tests/programs/custom/mscratch-32bit-test` that verifies full 32-bit write and read access to the mscratch CSR (0x340).

**Motivation**:
mscratch is a key machine-mode scratch register. This test ensures no bit-stuck issues by checking all 32 bits with complementary patterns. It's useful for regression and coverage.

**Details**:
- Writes and reads back 8 patterns (zeros, ones, alternating, random)
- Prints PASS/FAIL for each + final SUCCESS
- Runs successfully locally on CV32E40P with Verilator
- No changes to existing files or core RTL
- No new dependencies

**Tested**:
- Local Verilator simulation passes with "SUCCESS: All 32-bit patterns verified!" and "EXIT SUCCESS"

This test was created as part of a RISC-V certification mentorship application (stretch goal).

Signed-off-by: Mohamed Mostafa <mohamedmostafaabdelrahman1@gmail.com>