### PR TITLE
cv32e40p: add mscratch CSR 32-bit read/write functional test

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_test/mscratch_test.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#define MSCRATCH_CSR 0x340
+
+static inline void write_mscratch(uint32_t value)
+{
+    asm volatile ("csrw %0, %1" :: "i"(MSCRATCH_CSR), "r"(value));
+}
+
+static inline uint32_t read_mscratch(void)
+{
+    uint32_t value;
+    asm volatile ("csrr %0, %1" : "=r"(value) : "i"(MSCRATCH_CSR));
+    return value;
+}
+
+static inline int check(uint32_t value)
+{
+    write_mscratch(value);
+    return (read_mscratch() == value);
+}
+
+int main(void)
+{
+    if (!check(0x00000000)) return EXIT_FAILURE;
+    if (!check(0xFFFFFFFF)) return EXIT_FAILURE;
+    if (!check(0xAAAAAAAA)) return EXIT_FAILURE;
+    if (!check(0x55555555)) return EXIT_FAILURE;
+    if (!check(0x80000000)) return EXIT_FAILURE;
+    if (!check(0x00000001)) return EXIT_FAILURE;
+
+    return EXIT_SUCCESS;
+}
+

--- a/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_test/test.yaml
@@ -1,0 +1,5 @@
+name: mscratch_test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Functional test verifying full 32-bit read/write access to the mscratch CSR.
+


### PR DESCRIPTION
### Summary
This pull request adds a directed test program for the CV32E40P core to
verify full 32-bit read and write access to the `mscratch` CSR.

The test writes multiple bit patterns to `mscratch` and immediately reads
them back, ensuring that no bit masking, truncation, or partial-write
behavior exists in the CSR datapath.

New files : `mscratch_test.c` and `test.yaml`, inside new directory `/cv32e40p/tests/programs/custom/mscratch_test` .

---


### Test Details
The test performs the following checks:
- Write/read of all-zero value
- Write/read of all-one value
- Write/read of alternating bit patterns (0xAAAAAAAA, 0x55555555)
- Write/read of MSB-only value
- Write/read of LSB-only value

The test exits with `EXIT_SUCCESS` only if all checks pass, making it
suitable for automated regression.

---

### Verification
- Tested locally using Verilator
- Simulation completes successfully with PASS result
- Waveforms confirm correct CSR write enable and update behavior

Expected Output

<img width="1433" height="812" alt="Screenshot from 2026-02-05 19-51-48" src="https://github.com/user-attachments/assets/de8c4041-1cc7-4e35-9c26-f134992f25aa" />


Expected GTKwave Output

<img width="1747" height="588" alt="Screenshot from 2026-02-05 19-52-11" src="https://github.com/user-attachments/assets/ec3a9a5c-8d95-4ece-9bc7-327261e0b8c8" />
