### PR TITLE
Add test to check RW permissions of mscratch csr

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_rw_test/mscratch_rw_test.c
+++ b/cv32e40p/tests/programs/custom/mscratch_rw_test/mscratch_rw_test.c
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 danteantu5@gmail.com
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+#include <stdint.h>
+
+int main(int argc, char *argv[])
+{
+    // Simplified test that reads the current value of mscratch, flips it
+    // writes the new flipped value, and checks if the write operation was successful or not.
+    unsigned int initial_value;
+    asm volatile("csrr %0, 0x340" : "=r"(initial_value));
+    unsigned int target = ~initial_value;
+    asm volatile("csrw 0x340, %0" :: "r"(target));
+    unsigned int current_value;
+    asm volatile("csrr %0, 0x340" : "=r"(current_value));
+    if(current_value == target) {
+      printf("Successfuly read/written mscratch reg\n");
+    }
+    else {
+      printf("Error trying to read/write mscratch reg\n");
+    }
+}

--- a/cv32e40p/tests/programs/custom/mscratch_rw_test/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_rw_test/test.yaml
@@ -1,0 +1,4 @@
+name: mscratch RW test
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    Test if all 32 bits of the mscratch reg are readable and writable


### PR DESCRIPTION
Test read and write permissions for all 32 bits of the mscratch(0x340) register. 

Submitted as part of the stretch goal for LFX mentorship