### PR TITLE
OpenHW Coding Challenge : Add custom test for full 32-bit mscratch CSR access

### DIFF
--- a/cv32e40p/tests/programs/custom/mscratch_csr_readwrite_access/mscratch_csr_readwrite_access.S
+++ b/cv32e40p/tests/programs/custom/mscratch_csr_readwrite_access/mscratch_csr_readwrite_access.S
@@ -1,0 +1,99 @@
+# Copyright (c) <2026> <Ammarah_wakeel>
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+###############################################################################
+# Test: mscratch read/write access
+#
+# Purpose:
+#   Verify that the mscratch CSR (0x340) is fully readable and writable
+#   across all 32 bits on RV32 (CV32E40P).
+#
+# Method:
+#   - Write known 32-bit patterns to mscratch
+#   - Read them back
+#   - Compare expected vs actual
+#
+# Result:
+#   - PASS if all patterns match
+#   - FAIL on first mismatch
+###############################################################################
+
+.globl _start
+.globl main
+.globl exit
+.global debug
+.section .text
+
+#define MSCRATCH_CSR   0x340
+#define TEST_PASS     0x12345678
+#define TEST_FAIL     0x1
+#define STATUS_ADDR   0x20000000
+
+
+main:  # Label as main for entry point
+
+    ###########################################################################
+    # Pattern 1: all zeros
+    ###########################################################################
+    li      t0, 0x00000000
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # Pattern 2: all ones
+    ###########################################################################
+    li      t0, 0xFFFFFFFF
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # Pattern 3: alternating bits (1010...)
+    ###########################################################################
+    li      t0, 0xAAAAAAAA
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # Pattern 4: alternating bits (0101...)
+    ###########################################################################
+    li      t0, 0x55555555
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # Pattern 5: MSB only
+    ###########################################################################
+    li      t0, 0x80000000
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # Pattern 6: LSB only
+    ###########################################################################
+    li      t0, 0x00000001
+    csrw    MSCRATCH_CSR, t0
+    csrr    t1, MSCRATCH_CSR
+    bne     t0, t1, fail
+
+    ###########################################################################
+    # All tests passed
+    ###########################################################################
+pass:
+    li      t0, TEST_PASS
+    li      t1, STATUS_ADDR
+    sw      t0, 0(t1)
+    j _exit
+
+fail:
+    li      t0, TEST_FAIL
+    li      t1, STATUS_ADDR
+    sw      t0, 0(t1)
+    j _exit
+    
+end:
+    j _exit

--- a/cv32e40p/tests/programs/custom/mscratch_csr_readwrite_access/test.yaml
+++ b/cv32e40p/tests/programs/custom/mscratch_csr_readwrite_access/test.yaml
@@ -1,0 +1,4 @@
+name: mscratch_csr_readwrite_access
+uvm_test: uvmt_$(CV_CORE_LC)_firmware_test_c
+description: >
+    test full 32-bit write/read access to mscratch csr


### PR DESCRIPTION
This pull request adds an assembly test "mscratch_csr_readwrite_access" to verify full read/write access to the mscratch CSR(0x340) on CV32E40P.

**Inspiration**
The test structure and methodology are inspired by the following existing tests in the repository:
>>cv32e40p_csr_access_test
>>cv32e40p_readonly_csr_access_test
These tests helped me define the standard structure, test.yaml format, status address usage, and pass/fail signaling convention.

**Test Methodology**
To ensure complete bit-level read/write functionality, the following six canonical patterns were written to mscratch and read back for comparison:
All zeros                   0x00000000
All ones                    0xFFFFFFFF
Walking 1s (1010...)  0xAAAAAAAA
Walking 0s (0101...)  0x55555555
MSB set only            0x80000000
LSB set only              0x00000001

**Results**
All 6 test patterns passed successfully
<img width="947" height="396" alt="image" src="https://github.com/user-attachments/assets/67f079bb-cfaf-48db-84eb-042ffc4eb83a" />

<img width="946" height="437" alt="image" src="https://github.com/user-attachments/assets/e5944ede-7db5-4576-a29c-f0b820bd4a28" />
