### PR TITLE
Fix #2270: Stop orphaning yaml2make tempfiles in /tmp

### DIFF
--- a/bin/cfgyaml2make
+++ b/bin/cfgyaml2make
@@ -103,9 +103,14 @@ def read_file(file):
 
     return cfg_spec
 
-def emit_make(cfg_spec, prefix):
+def emit_make(cfg_spec, prefix, output=None):
     '''Emit a hash from the YAML test specification into a makefile that can be included'''
-    fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    if output:
+        os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
+        fh = open(output, 'w')
+    else:
+        fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
     for k,v in sorted(cfg_spec.items()):
         # Handle empty value (allowed)
         try:
@@ -115,7 +120,7 @@ def emit_make(cfg_spec, prefix):
         fh.write('{}{}={}\n'.format('' if not prefix else prefix.upper() + '_', k.upper(), v_rstrip))
     fh.close()
 
-    return fh.name
+    return os.path.abspath(output) if output else fh.name
 
 ################################################################################
 # Command-line arguments
@@ -125,6 +130,7 @@ parser.add_argument('-d', '--debug', action='store_true', help='Display debug me
 parser.add_argument('--yaml', help='Name of YAML build specification to find')
 parser.add_argument('--core', default=DEFAULT_CORE, help='Default core to test')
 parser.add_argument('--prefix', help='Prefix to add to make variables generated')
+parser.add_argument('--output', help='Output file path for generated .mk file')
 args = parser.parse_args()
 
 if args.debug:
@@ -142,7 +148,7 @@ if not args.yaml:
 CFG_PATHS = [p.replace('<CV_CORE>', args.core.lower()) for p in CFG_PATHS]
 
 cfg_spec = read_file(file=args.yaml)
-temp_file = emit_make(cfg_spec=cfg_spec, prefix=args.prefix)
+temp_file = emit_make(cfg_spec=cfg_spec, prefix=args.prefix, output=args.output)
 
 logger.debug('File written to {}'.format(temp_file))
 print(temp_file)

--- a/bin/yaml2make
+++ b/bin/yaml2make
@@ -123,14 +123,19 @@ def read_file(test, type, run_index):
 
     return test_spec
 
-def emit_make(test_spec, prefix):
+def emit_make(test_spec, prefix, output=None):
     '''Emit a hash from the YAML test specification into a makefile that can be included'''
-    fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    if output:
+        os.makedirs(os.path.dirname(os.path.abspath(output)), exist_ok=True)
+        fh = open(output, 'w')
+    else:
+        fh = tempfile.NamedTemporaryFile(mode='w', delete=False)
+
     for k,v in sorted(test_spec.items()):
         fh.write('{}{}={}\n'.format('' if not prefix else prefix.upper() + '_', k.upper(), v.rstrip()))
     fh.close()
 
-    return fh.name
+    return os.path.abspath(output) if output else fh.name
 
 ################################################################################
 # Command-line arguments
@@ -141,6 +146,7 @@ parser.add_argument('--yaml', help='Required: Name of YAML test specification to
 parser.add_argument('--core', default=DEFAULT_CORE, help='Default core to test')
 parser.add_argument('--prefix', help='Prefix to add to make variables generated')
 parser.add_argument('--run-index', default='0', help='Add a run index to append to test specifications')
+parser.add_argument('--output', help='Output file path for generated .mk file')
 parser.add_argument('-d', '--debug', action='store_true', help='Display debug messages')
 args = parser.parse_args()
 
@@ -164,7 +170,7 @@ CFG_PATH = [p.replace('<CV_CORE>', args.core.lower()) for p in CFG_PATH]
 TEST_PATHS = [p.replace('<CV_CORE>', args.core.lower()) for p in TEST_PATHS]
 
 test_spec = read_file(test=args.test, type=args.yaml, run_index=args.run_index)
-temp_file = emit_make(test_spec=test_spec, prefix=args.prefix)
+temp_file = emit_make(test_spec=test_spec, prefix=args.prefix, output=args.output)
 
 logger.debug('File written to {}'.format(temp_file))
 print(temp_file)

--- a/cv32e40p/sim/core/Makefile
+++ b/cv32e40p/sim/core/Makefile
@@ -85,7 +85,7 @@ TEST         ?= hello-world
 #       TEST_UVM_TEST=uvmt_$(CV_CORE_LC)_firmware_test_c
 
 YAML2MAKE = $(CORE_V_VERIF)/bin/yaml2make
-TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(u) --prefix=TEST --core=$(CV_CORE))
+TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(u) --prefix=TEST --core=$(CV_CORE) --output=$(SIM_RESULTS)/test_$(TEST).mk)
 ifeq ($(TEST_FLAGS_MAKE),)
 $(error ERROR Could not find test.yaml for test: $(TEST))
 endif

--- a/mk/Common.mk
+++ b/mk/Common.mk
@@ -185,13 +185,17 @@ else
 YAML2MAKE_DEBUG =
 endif
 
+# Output directory for generated .mk files (cleaned by make clean).
+# Uses SIM_CFG_RESULTS (uvmt context) with fallback to SIM_RESULTS (core context).
+YAML2MAKE_OUTPUT_DIR ?= $(if $(SIM_CFG_RESULTS),$(SIM_CFG_RESULTS),$(SIM_RESULTS))
+
 # If the gen_corev-dv target is defined then read in a test defintions file
 YAML2MAKE = $(CORE_V_VERIF)/bin/yaml2make
 ifneq ($(filter gen_corev-dv,$(MAKECMDGOALS)),)
 ifeq ($(TEST),)
 $(error ERROR must specify a TEST variable with gen_corev-dv target)
 endif
-GEN_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=corev-dv.yaml $(YAML2MAKE_DEBUG) --prefix=GEN --core=$(CV_CORE))
+GEN_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=corev-dv.yaml $(YAML2MAKE_DEBUG) --prefix=GEN --core=$(CV_CORE) --output=$(YAML2MAKE_OUTPUT_DIR)/gen_$(TEST).mk)
 ifeq ($(GEN_FLAGS_MAKE),)
 $(error ERROR Could not find corev-dv.yaml for test: $(TEST))
 endif
@@ -204,7 +208,7 @@ ifneq ($(filter $(TEST_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifeq ($(TEST),)
 $(error ERROR! must specify a TEST variable)
 endif
-TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(u) --prefix=TEST --core=$(CV_CORE))
+TEST_FLAGS_MAKE := $(shell $(YAML2MAKE) --test=$(TEST) --yaml=test.yaml  $(YAML2MAKE_DEBUG) --run-index=$(u) --prefix=TEST --core=$(CV_CORE) --output=$(YAML2MAKE_OUTPUT_DIR)/test_$(TEST).mk)
 ifeq ($(TEST_FLAGS_MAKE),)
 $(error ERROR Could not find test.yaml for test: $(TEST))
 endif
@@ -220,7 +224,7 @@ CFGYAML2MAKE = $(CORE_V_VERIF)/bin/cfgyaml2make
 CFG_YAML_PARSE_TARGETS=comp ldgen comp_corev-dv gen_corev-dv test hex clean_hex corev-dv sanity-veri-run bsp riscof_sim_run
 ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(CFG),)
-CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml $(YAML2MAKE_DEBUG) --prefix=CFG --core=$(CV_CORE))
+CFG_FLAGS_MAKE := $(shell $(CFGYAML2MAKE) --yaml=$(CFG).yaml $(YAML2MAKE_DEBUG) --prefix=CFG --core=$(CV_CORE) --output=$(YAML2MAKE_OUTPUT_DIR)/cfg_$(CFG).mk)
 ifeq ($(CFG_FLAGS_MAKE),)
 $(error ERROR Error finding or parsing configuration: $(CFG).yaml)
 endif
@@ -254,7 +258,7 @@ ifneq ($(filter $(CFG_YAML_PARSE_TARGETS),$(MAKECMDGOALS)),)
 ifneq ($(TEST_CFG_FILE_LIST),)
 
 define GET_TEST_CONFIG_LIST =
-TEST_CFG_LIST_FLAGS_MAKE_$(1) := $$(shell $(CFGYAML2MAKE) --yaml=$(1).yaml $(YAML2MAKE_DEBUG) --prefix=TEST_CFG_FILE_LIST_$(1) --core=$(CV_CORE) --debug)
+TEST_CFG_LIST_FLAGS_MAKE_$(1) := $$(shell $(CFGYAML2MAKE) --yaml=$(1).yaml $(YAML2MAKE_DEBUG) --prefix=TEST_CFG_FILE_LIST_$(1) --core=$(CV_CORE) --output=$(YAML2MAKE_OUTPUT_DIR)/test_cfg_$(1).mk)
 ifeq ($$(TEST_CFG_LIST_FLAGS_MAKE_$(1)),)
   $$(error ERROR Error finding or parsing configuration: $(1).yaml)
 endif


### PR DESCRIPTION
## Summary
- Add --output parameter to bin/yaml2make and `bin/cfgyaml2make to write generated .mk files to a specified path instead of /tmp
- Update all 5 call sites (1 in cv32e40p/sim/core/Makefile, 4 in mk/Common.mk) to use --output= pointing into  simulation_results
- Add YAML2MAKE_OUTPUT_DIR variable in mk/Common.mk with fallback from SIM_CFG_RESULTS to SIM_RESULTS
- Backward compatible: omitting --output falls back to tempfile

## Test done
- bin/yaml2make --output=<path> writes to specified path
- bin/yaml2make without --output still creates tempfile (backward compat)
- make veri-test TEST=hello-world produces simulation_results/test_hello-world.mk
- make clean removes generated .mk files
- No new orphaned files in /tmp

Fixes #2270


