### PR TITLE
cv_dv_utils: add coverage support, simulation controls and pulse driver observability

### DIFF
--- a/lib/cv_dv_utils/python/sim_cmd/README.md
+++ b/lib/cv_dv_utils/python/sim_cmd/README.md
@@ -35,7 +35,7 @@ python3 compile.py --yaml yaml_file.yaml [--outdir output_dir] [--cover 0/1]
 |--------|-------------|---------|
 | `--yaml` | Top YAML file with compile and simulation options | required |
 | `--outdir` | Directory for compilation logs | `output` |
-| `--cover` | `1`: To pass coverage option during elab; `0`: no coverage | `0` |
+| `--cover` | `1`: instrument for coverage during elaboration (Questasim only); `0`: no coverage | `0` |
 
 ## Running a single test
 
@@ -51,7 +51,7 @@ python3 run_test.py --yaml yaml_file.yaml --test_name name_of_the_test --seed n_
 | `--debug` | UVM verbosity: `UVM_NONE/LOW/MEDIUM/HIGH/DEBUG` | `UVM_LOW` |
 | `--batch` | `1`: batch mode; `0`: GUI mode | `1` |
 | `--dump` | `1`: log all signals to waveform database; `0`: no dump | `0` |
-| `--cover` | `1`: enable coverage collection; `0`: disabled | `0` |
+| `--cover` | `1`: enable coverage collection (Questasim only); `0`: disabled | `0` |
 | `--stdout` | `1`: print log to stdout; `0`: redirect to log file | `1` |
 | `--outdir` | Output directory for logs and databases | `output` |
 | `--run_time` | Simulation run time (e.g. `100ns`) | `-all` |
@@ -68,7 +68,7 @@ python3 run_reg.py --yaml yaml_file.yaml --reg_list reg_list_file [--nthreads n]
 | `--yaml` | Top YAML file with compile and simulation options | required |
 | `--reg_list` | File listing tests and number of seeds | required |
 | `--nthreads` | Number of parallel simulation instances | `1` |
-| `--cover` | `1`: enable coverage for all tests; `0`: disabled | `0` |
+| `--cover` | `1`: enable coverage for all tests (Questasim only); `0`: disabled | `0` |
 | `--outdir` | Output directory | `regression` |
 | `--verbose` | Print informational messages | `False` |
 

--- a/lib/cv_dv_utils/python/sim_cmd/README.md
+++ b/lib/cv_dv_utils/python/sim_cmd/README.md
@@ -20,28 +20,67 @@
 
 # SIM CMD
 ## Introduction
-These are python scripts, they allow to compile and run a test. 
+Python scripts to compile, elaborate, and run UVM tests. Supports waveform dumping and coverage collection. Compatible with Questasim, Xcelium, and VCS.
 
 # Usage
-To compile a code in system verilog:
+
+## Compilation
+
+To compile and elaborate a design:
 ```
-python3 compile.py --yaml_file.yaml
+python3 compile.py --yaml yaml_file.yaml [--outdir output_dir] [--cover 0/1]
 ```
 
-To run a UVM test:
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--yaml` | Top YAML file with compile and simulation options | required |
+| `--outdir` | Directory for compilation logs | `output` |
+| `--cover` | `1`: To pass coverage option during elab; `0`: no coverage | `0` |
+
+## Running a single test
+
 ```
-python3 run_test.py --yaml_file.yaml --test_name name_of_the_test --seed n_seed --debug UVM_verbosity --dump 0/1 --batch 0/1
+python3 run_test.py --yaml yaml_file.yaml --test_name name_of_the_test --seed n_seed [options]
 ```
 
-There is also the possibility to run a set of regression tests reported in a specified reg_list_file:
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--yaml` | Top YAML file with compile and simulation options | required |
+| `--test_name` | Name of the UVM test to run | required |
+| `--seed` | Random seed | `1` |
+| `--debug` | UVM verbosity: `UVM_NONE/LOW/MEDIUM/HIGH/DEBUG` | `UVM_LOW` |
+| `--batch` | `1`: batch mode; `0`: GUI mode | `1` |
+| `--dump` | `1`: log all signals to waveform database; `0`: no dump | `0` |
+| `--cover` | `1`: enable coverage collection; `0`: disabled | `0` |
+| `--stdout` | `1`: print log to stdout; `0`: redirect to log file | `1` |
+| `--outdir` | Output directory for logs and databases | `output` |
+| `--run_time` | Simulation run time (e.g. `100ns`) | `-all` |
+| `--verbose` | Print informational messages | `False` |
+
+## Running a regression
+
 ```
-python3 run_reg.py --yaml_file.yaml --nthreads n --reg_list reg_list_file
+python3 run_reg.py --yaml yaml_file.yaml --reg_list reg_list_file [--nthreads n] [--cover 0/1] [--outdir output_dir]
 ```
-where the nthreads option specifies the occurences of the simulation tool that run in parallel.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--yaml` | Top YAML file with compile and simulation options | required |
+| `--reg_list` | File listing tests and number of seeds | required |
+| `--nthreads` | Number of parallel simulation instances | `1` |
+| `--cover` | `1`: enable coverage for all tests; `0`: disabled | `0` |
+| `--outdir` | Output directory | `regression` |
+| `--verbose` | Print informational messages | `False` |
+
+## Coverage (Questasim only)
+
+To enable coverage, pass `--cover 1` to `compile.py` and `run_test.py` (or `run_reg.py` for regressions). Each test saves its UCDB file to `{outdir}/coverage/{test_name}_{seed}.ucdb`.
+
+## Waveform inspection
 
 The user can also use post_proc.py after batch mode simulations with dumping option enabled for inspecting the DUT waveforms:
 ```
-python3 ${SCRIPTS_DIR}/post_proc.py --tool user_tool --db_file ./path/to/db/file 
+python3 ${SCRIPTS_DIR}/post_proc.py --tool user_tool --db_file ./path/to/db/file
 ```
 
-The templates of yaml files are provided with the script, which can be used to compile and run the test with Questasim, Xcelium and VCS
+The templates of yaml files are provided with the script, which can be used to compile and run the test with Questasim, Xcelium and VCS.

--- a/lib/cv_dv_utils/python/sim_cmd/compile.py
+++ b/lib/cv_dv_utils/python/sim_cmd/compile.py
@@ -110,6 +110,9 @@ else:
         os.system(elab_cmd)
 
     elif entry['tool'] == "xcelium":
+        if cover == 1:
+            print("[ERROR]: --cover option is only supported with questa")
+            exit(1)
         print("[INFO]: Starting compilation with Xcelium...")
         comp_cmd = f"xrun -compile {comp_opt} -f {filelist} -work {work_lib} -logfile {outdir}/xcelium_compile.log"
         print("[INFO] Compilation command:\n{}".format(comp_cmd))
@@ -121,6 +124,9 @@ else:
         os.system(elab_cmd)
 
     elif entry['tool'] == "vcs":
+        if cover == 1:
+            print("[ERROR]: --cover option is only supported with questa")
+            exit(1)
         print("[INFO]: Starting compilation and elaboration with VCS...")
         #removing existing timestamp for recompilation
         if os.path.isfile("simv.daidir/.vcs.timestamp") == True:

--- a/lib/cv_dv_utils/python/sim_cmd/compile.py
+++ b/lib/cv_dv_utils/python/sim_cmd/compile.py
@@ -24,8 +24,11 @@ import re
 
 parser = argparse.ArgumentParser(description='compile options')
 parser.add_argument('--yaml'     ,dest='yaml_file', type=str, help='Top YAML with compile and simulation options')
-parser.add_argument('--outdir'   ,dest='outdir', type=str, help='Logs are directed to outdir: default output')
+parser.add_argument('--outdir'   ,dest='outdir',    type=str, help='Logs are directed to outdir: default output')
+parser.add_argument('--cover'    ,dest='cover',     type=int, help='1: instrument for coverage (adds +cover to vopt), 0: no coverage, default 0')
 args = parser.parse_args()
+
+cover = args.cover if args.cover is not None else 0
 
    
 
@@ -86,6 +89,8 @@ else:
     else:
        elab_opt = ""
 
+    cover_opt = "+cover" if cover == 1 else ""
+
     if 'top_entity' in comp:
       top  = comp['top_entity']
     else:
@@ -100,7 +105,7 @@ else:
         os.system(comp_cmd)
 
         print("[INFO]: Starting elaboration with Questasim...")
-        elab_cmd = f"vopt {elab_opt} -work {work_lib} {top} -o opt"
+        elab_cmd = f"vopt {cover_opt} {elab_opt} -work {work_lib} {top} -o opt"
         print("[INFO] Elaboration command:\n{}".format(elab_cmd))
         os.system(elab_cmd)
 

--- a/lib/cv_dv_utils/python/sim_cmd/run_reg.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_reg.py
@@ -35,7 +35,10 @@ parser.add_argument('--reg_list'   ,dest='reglist'   , type=str, help='file that
 parser.add_argument('--nthreads'   ,dest='nthreads'  , type=int, help='Number of test run at the same time: default 2')
 parser.add_argument('--cover'    , dest='cover',     type=int, help='1: generate coverage file, 0: nothing is done, cover option are passed from yaml file ') #FIXME
 parser.add_argument('--outdir'     , dest='outdir'    , type=str, help='output directory: default regression')
+parser.add_argument('--verbose'    , dest='verbose'   , action='store_true', help='print info messages, default False')
 args = parser.parse_args()
+verbose = args.verbose
+cover = args.cover if args.cover is not None else 0
 
 #save the environment variables
 project_dir = os.environ["PROJECT_DIR"]
@@ -52,8 +55,8 @@ if args.nthreads == None:
 
 
 def rtest(yaml_file, test, seed):
-    run_cmd = f"python3 {scripts_dir}/run_test.py --yaml {yaml_file} --test_name {test} --seed {seed} --debug UVM_NONE --dump 0 --stdout 0 --outdir {outdir}"
-    print("[INFO] Simulation command:\n{}".format(run_cmd))
+    run_cmd = f"python3 {scripts_dir}/run_test.py --yaml {yaml_file} --test_name {test} --seed {seed} --debug UVM_NONE --dump 0 --stdout 0 --outdir {outdir} --cover {cover}"
+    if verbose: print("[INFO] Simulation command:\n{}".format(run_cmd))
     os.system(run_cmd)
     log = "{}/{}_{}.log".format(outdir, test, seed) 
     pattern = "{}/scripts/patterns/sim_patterns.pat".format(project_dir)
@@ -63,10 +66,10 @@ def rtest(yaml_file, test, seed):
     if ret == 0: 
         print ("passing", test, "seed", seed,  "end time", et.strftime("%Y-%m-%d %H:%M:%S"))
     else:
-        print(f"RET={ret}")
+        if verbose: print(f"RET={ret}")
         print ("failing", test, "seed", seed,  "end time", et.strftime("%Y-%m-%d %H:%M:%S"))
 
-print("[INFO] Starting compilation and elaboration...")
+print("Starting compilation and elaboration...")
 #check the insertion of the top yaml file
 if args.yaml_file == None: 
    print("[ERROR] Please provide a Top YAML file")
@@ -75,15 +78,15 @@ else:
      os.system("mkdir {}".format(outdir))
 
    #call the compilation and elaboration command
-   comp_el_cmd = f"python3 {scripts_dir}/compile.py --yaml {args.yaml_file}"
-   print("[INFO] Compilation and elaboration command:\n{}".format(comp_el_cmd))
+   comp_el_cmd = f"python3 {scripts_dir}/compile.py --yaml {args.yaml_file} --cover {cover}"
+   if verbose: print("[INFO] Compilation and elaboration command:\n{}".format(comp_el_cmd))
    #vopt_cmd = get_cmd.cmp_cmd(args.yaml_file, outdir, '', '', '')
    if comp_el_cmd != "":
      os.system(comp_el_cmd)
 
 #queues for test and seed
 if args.reglist == None:
-    print("Please provide a Regression List")
+    print("[ERROR] Please provide a Regression List")
 else:
   tq = queue.Queue()
   sq = queue.Queue()

--- a/lib/cv_dv_utils/python/sim_cmd/run_reg.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_reg.py
@@ -69,11 +69,19 @@ def rtest(yaml_file, test, seed):
         if verbose: print(f"RET={ret}")
         print ("failing", test, "seed", seed,  "end time", et.strftime("%Y-%m-%d %H:%M:%S"))
 
-print("Starting compilation and elaboration...")
+print("[INFO] Starting compilation and elaboration...")
 #check the insertion of the top yaml file
 if args.yaml_file == None: 
    print("[ERROR] Please provide a Top YAML file")
 else:
+   if cover == 1:
+      with open(args.yaml_file, 'r') as yaml_top:
+         reg_yaml = yaml.safe_load(yaml_top)
+      for entry in reg_yaml:
+         if entry['tool'] != "questa":
+            print("[ERROR]: --cover option is only supported with questa")
+            exit(1)
+
    if os.path.isdir("{}".format(outdir)) == False:
      os.system("mkdir {}".format(outdir))
 

--- a/lib/cv_dv_utils/python/sim_cmd/run_test.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_test.py
@@ -32,8 +32,12 @@ parser.add_argument('--dump'     , dest='dump',      type=int, help='1: all sign
 parser.add_argument('--cover'    , dest='cover',     type=int, help='1: generate coverage file, 0: nothing is done, cover option are passed from yaml file ') #FIXME
 parser.add_argument('--stdout'   , dest='stdout', type=int, help='1: stdout 0: nostdout')
 parser.add_argument('--outdir'   , dest='outdir', type=str, help='output dirctory default "output"')
+parser.add_argument('--verbose'  , dest='verbose', action='store_true', help='print info messages, default False')
+parser.add_argument('--run_time' , dest='run_time', type=str, help='simulation run time ex: 100ns, default -all')
 
 args = parser.parse_args()
+verbose = args.verbose
+run_time = args.run_time if args.run_time is not None else "-all"
 
 
 option_ok = 1
@@ -53,37 +57,39 @@ else:
 
 #set default values if seed, debug, batch, dump, stdout and outdir are not defined
 if args.seed == None:
-   print("[INFO] Setting default seed = 1")
+   if verbose: print("[INFO] Setting default seed = 1")
    seed = 1
 else:
    seed = args.seed
 
 if args.debug == None:
-   print("[INFO] Setting default UVM debug = UVM LOW")
+   if verbose: print("[INFO] Setting default UVM debug = UVM LOW")
    debug = "UVM_LOW"
 else:
    debug = args.debug
 
 if args.batch == None:
-   print("[INFO] Setting default mode = batch mode")
+   if verbose: print("[INFO] Setting default mode = batch mode")
    batch = 1
 else:
    batch = args.batch
 
 if args.dump == None:
-   print("[INFO] Setting default dump = 0")
+   if verbose: print("[INFO] Setting default dump = 0")
    dump = 0
 else:
    dump = args.dump
 
+cover = args.cover if args.cover is not None else 0
+
 if args.stdout == None:
-   print("[INFO] Setting default output (-l)")
+   if verbose: print("[INFO] Setting default output (-l)")
    stdout = 1
 else:
    stdout = args.stdout
 
 if args.outdir == None:
-   print("[INFO] Setting default output directory = output")
+   if verbose: print("[INFO] Setting default output directory = output")
    outdir = "output"
 else:
    outdir = args.outdir
@@ -131,19 +137,26 @@ if option_ok == 1:
          dbg_dir = os.path.join(outdir, "questa_db")
          if os.path.isdir("{}".format(dbg_dir)) == False:
             os.system("mkdir {}".format(dbg_dir))
-         
+
          #Full path to output dbg
          db_file = os.path.join(dbg_dir, f"{test_name}_{seed}.db")
+
+         #directory that stores coverage UCDB files
+         if cover == 1:
+            cov_dir = os.path.join(outdir, "coverage")
+            if os.path.isdir("{}".format(cov_dir)) == False:
+               os.system("mkdir {}".format(cov_dir))
+            ucdb_file = os.path.join(cov_dir, f"{test_name}_{seed}.ucdb")
          
          #DO
          do_file = "questa_run.do"
          if os.path.isfile("{}".format(do_file)) == False:
-            print("[INFO]: creating new questa_run.do file...")
+            if verbose: print("[INFO]: creating new questa_run.do file...")
             os.system("touch {}".format(do_file))
          else:
-            print("[INFO]: removing old questa_run.do file...")
+            if verbose: print("[INFO]: removing old questa_run.do file...")
             os.system("rm {}".format(do_file))
-            print("[INFO]: creating new questa_run.do file...")
+            if verbose: print("[INFO]: creating new questa_run.do file...")
             os.system("touch {}".format(do_file))
          
          if batch == 1:
@@ -154,17 +167,21 @@ if option_ok == 1:
          if dump == 1:
             with open(do_file, "w") as do:
                if batch == 1:
-                  do.write("run -all\n")
+                  if cover == 1:
+                     do.write(f"coverage save -onexit {ucdb_file}\n")
+                  do.write(f"run {run_time}\n")
                   do.write("quit -f\n")
                else:
                   do.write("add log -r /*\n")
 
             dumpstr = f"-qwavedb=+wavefile={db_file}+signal+memory=4096+class+assertion -do {do_file}"
-            
+
          else:
             with open(do_file, "w") as do:
                if batch == 1:
-                  do.write("run -all\n")
+                  if cover == 1:
+                     do.write(f"coverage save -onexit {ucdb_file}\n")
+                  do.write(f"run {run_time}\n")
                   do.write("quit\n")
                else:
                   do.write("add log -r /*\n")
@@ -176,9 +193,11 @@ if option_ok == 1:
          else:
             stdoutstr = "-l"
 
-         print("[INFO]: Starting simulation with Questasim...")
-         sim_cmd = f"vsim -lib {worklib} {sim_opt} {batchstr} {dumpstr} -sv_seed {seed} +UVM_VERBOSITY={debug} +UVM_TESTNAME={test_name} {stdoutstr} {outdir}/{test_name}_{seed}.log"
-         print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
+         coverstr = "-coverage" if cover == 1 else ""
+
+         if verbose: print("[INFO]: Starting simulation with Questasim...")
+         sim_cmd = f"vsim -lib {worklib} {sim_opt} {batchstr} {coverstr} {dumpstr} -sv_seed {seed} +UVM_VERBOSITY={debug} +UVM_TESTNAME={test_name} {stdoutstr} {outdir}/{test_name}_{seed}.log"
+         if verbose: print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
          os.system(sim_cmd)
 
       elif entry['tool'] == "xcelium":
@@ -193,12 +212,12 @@ if option_ok == 1:
          #TCL
          tcl_file = "xlm_run.tcl"
          if os.path.isfile("{}".format(tcl_file)) == False:
-            print("[INFO]: creating new xlm_run.tcl file...")
+            if verbose: print("[INFO]: creating new xlm_run.tcl file...")
             os.system("touch {}".format(tcl_file))
          else:
-            print("[INFO]: removing old xlm_run.tcl file...")
+            if verbose: print("[INFO]: removing old xlm_run.tcl file...")
             os.system("rm {}".format(tcl_file))
-            print("[INFO]: creating new xlm_run.tcl file...")
+            if verbose: print("[INFO]: creating new xlm_run.tcl file...")
             os.system("touch {}".format(tcl_file))
          
 
@@ -232,9 +251,9 @@ if option_ok == 1:
          else:
             stdoutstr = "-l"
             
-         print("[INFO]: Starting simulation with Xcelium...")
+         if verbose: print("[INFO]: Starting simulation with Xcelium...")
          sim_cmd = f"xrun -r {sim_opt} {batchstr} {dumpstr} -seed {seed} +UVM_VERBOSITY={debug} +UVM_TESTNAME={test_name} {stdoutstr} {outdir}/{test_name}_{seed}.log"
-         print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
+         if verbose: print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
          os.system(sim_cmd)
 
 
@@ -250,12 +269,12 @@ if option_ok == 1:
          #TCL
          tcl_file = "vcs_run.tcl"
          if os.path.isfile("{}".format(tcl_file)) == False:
-            print("[INFO]: creating new vcs_run.tcl file...")
+            if verbose: print("[INFO]: creating new vcs_run.tcl file...")
             os.system("touch {}".format(tcl_file))
          else:
-            print("[INFO]: removing old vcs_run.tcl file...")
+            if verbose: print("[INFO]: removing old vcs_run.tcl file...")
             os.system("rm {}".format(tcl_file))
-            print("[INFO]: creating new vcs_run.tcl file...")
+            if verbose: print("[INFO]: creating new vcs_run.tcl file...")
             os.system("touch {}".format(tcl_file))
 
 
@@ -290,9 +309,9 @@ if option_ok == 1:
          else:
             stdoutstr = "-l"
 
-         print("[INFO]: Starting simulation with VCS...")
+         if verbose: print("[INFO]: Starting simulation with VCS...")
          sim_cmd = f"./simv {sim_opt} {batchstr} {dumpstr} +ntb_random_seed={seed} +UVM_VERBOSITY={debug} +UVM_TESTNAME={test_name} {stdoutstr} {outdir}/{test_name}_{seed}.log"
-         print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
+         if verbose: print("[INFO] Simulation command:\n{}\n".format(sim_cmd))
          os.system(sim_cmd)
       else:
          print("[ERROR]: Not supported tool")

--- a/lib/cv_dv_utils/python/sim_cmd/run_test.py
+++ b/lib/cv_dv_utils/python/sim_cmd/run_test.py
@@ -201,6 +201,9 @@ if option_ok == 1:
          os.system(sim_cmd)
 
       elif entry['tool'] == "xcelium":
+         if cover == 1:
+            print("[ERROR]: --cover option is only supported with questa")
+            exit(1)
          #directory that stores shm files
          shm_dir = os.path.join(outdir, "xlm_db")
          if os.path.isdir("{}".format(shm_dir)) == False:
@@ -258,6 +261,9 @@ if option_ok == 1:
 
 
       elif entry['tool'] == "vcs":
+         if cover == 1:
+            print("[ERROR]: --cover option is only supported with questa")
+            exit(1)
          #directory that stores fsbd files
          fsdb_dir = os.path.join(outdir, "vcs_db")
          if os.path.isdir("{}".format(fsdb_dir)) == False:

--- a/lib/cv_dv_utils/uvm/pulse_gen/README.md
+++ b/lib/cv_dv_utils/uvm/pulse_gen/README.md
@@ -2,8 +2,8 @@
 
 ## Introduction
 
-The Pulse Gererator is a SystemVerilog UVM module which is used to configure and generate pulses. Pulse Generator can be configured to generate multiple pulses. 
-A pulse can be a sysncronous pulse with respect to a clock or an asynchronous pulse. Timeunit of pico second is used to genarate an asynchronous pulse. 
+The Pulse Generator is a SystemVerilog UVM module which is used to configure and generate pulses. Pulse Generator can be configured to generate multiple pulses.
+A pulse can be a synchronous pulse with respect to a clock or an asynchronous pulse. Timeunit of pico second is used to generate an asynchronous pulse.
 
 ## Configuration
 
@@ -16,7 +16,7 @@ Here are the parameters that user should configure
     
     //////////////////////////////////////////////////////
     // if 1: Generate a pulse synchronous to a clock
-    //    0: Generate an asynchronos pulse  
+    //    0: Generate an asynchronous pulse
     /////////////////////////////////////////////////////
     rand bit unsigned                m_pulse_clock_based;
 
@@ -77,6 +77,16 @@ Pulse driver provides following APIs.
     // ------------------------------------------------------------------------
     virtual function string convert2string();
 
+    // Return the current value of the internal pulse counter
+    function int get_pulse_cnt();
+```
+
+## Synchronisation
+The pulse driver exposes a `pulse_fired` event that is triggered after each pulse deasserts. Other testbench components can wait on this event to synchronise with individual pulse occurences without directly polling DUT interface.
+
+```
+    // Block until a pulse is detected
+    @(env.m_pulse_driver.pulse_fired);
 ```
 
 ## Integration guide

--- a/lib/cv_dv_utils/uvm/pulse_gen/pulse_gen_driver.svh
+++ b/lib/cv_dv_utils/uvm/pulse_gen/pulse_gen_driver.svh
@@ -45,6 +45,7 @@ class pulse_gen_driver extends uvm_driver #( dummy_txn, dummy_txn ) ;
 
     event reset_asserted ;
     event reset_deasserted ;
+    event pulse_fired;
 
 
     //--------------------------------------------
@@ -158,8 +159,9 @@ class pulse_gen_driver extends uvm_driver #( dummy_txn, dummy_txn ) ;
         m_pulse_vif.wait_n_clocks(m_pulse_cfg.m_pulse_width);
         #(phase_shift_delay * 1ps);
         m_pulse_vif.m_pulse_out = 0;
-        if(m_pulse_cfg.m_pulse_num == m_pulse_cnt+1) break; 
-        m_pulse_cnt++; 
+        -> pulse_fired;
+        m_pulse_cnt++;
+        if(m_pulse_cfg.m_pulse_num == m_pulse_cnt) break; 
       end
     endtask
 
@@ -174,9 +176,14 @@ class pulse_gen_driver extends uvm_driver #( dummy_txn, dummy_txn ) ;
         m_pulse_vif.m_pulse_out = 1;
         #(m_pulse_cfg.m_pulse_width * 1ps);
         m_pulse_vif.m_pulse_out = 0;
-        if(m_pulse_cfg.m_pulse_num == m_pulse_cnt+1) break; 
         m_pulse_cnt++; 
+        if(m_pulse_cfg.m_pulse_num == m_pulse_cnt) break; 
       end
     endtask
+
+    // Get pulse counter
+    function int get_pulse_cnt();
+      return m_pulse_cnt;
+    endfunction
 endclass : pulse_gen_driver
 


### PR DESCRIPTION
### Description

This PR introduces several improvements to the `sim_cmd` simulation scripts, functional coverage collection, and the pulse generator driver `pulse_gen_driver.svh` in `cv_dv_utils`.

### Changes
#### sim_cmd scripts enhancements

- Added `--verbose` flag to suppress `[INFO]` messages by default, keeping only `[ERROR]` messages visible
- Added `--run_time` flag to configure simulation run-time from the command line, replacing hardcoded value (`run -all`)
- Added `--cover` flag to enable functional coverage collection for Questasim

#### Documentation (`README`)
- Added full option tables for all three scripts (`compile.py`, `run_test.py` and `run_reg.py`)
- Added coverage usage instructions describing how to enable and collect coverage results

#### Pulse generator driver

- Added `pulse_fired` event in `pulse_gen_driver` triggered after each pulse deasserts, enabling testbench components to synchronise on individual pulse events without polling
- Added `get_pulse_cnt()` getter to access to `m_pulse_cnt` field by other components