### PR TITLE
[cv_dv_utils verif] added api set_is_passive in generic agent and correct an issue with axi2mem

### DIFF
--- a/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
@@ -87,7 +87,7 @@ class generic_agent #(type req_t, type rsp_t) extends uvm_agent;
     is_active = UVM_ACTIVE;
   endfunction: set_is_active
   function void set_is_passive();
-    is_passive = UVM_PASSIVE;
+    is_active = UVM_PASSIVE;
   endfunction: set_is_passive
  
   virtual task reset_phase( uvm_phase phase );

--- a/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
+++ b/lib/cv_dv_utils/uvm/generic_agent/generic_agent.svh
@@ -86,6 +86,9 @@ class generic_agent #(type req_t, type rsp_t) extends uvm_agent;
   function void set_is_active();
     is_active = UVM_ACTIVE;
   endfunction: set_is_active
+  function void set_is_passive();
+    is_passive = UVM_PASSIVE;
+  endfunction: set_is_passive
  
   virtual task reset_phase( uvm_phase phase );
       if ( is_active == UVM_ACTIVE ) begin

--- a/lib/cv_dv_utils/uvm/memory_rsp_model/axi2mem/axi2mem.svh
+++ b/lib/cv_dv_utils/uvm/memory_rsp_model/axi2mem/axi2mem.svh
@@ -283,6 +283,10 @@ class axi2mem#(int unsigned w_addr = 0,  int unsigned w_data = 0, int unsigned w
              default     : aw_req.addr  = start_addr; // FIXME: Add other options 
             endcase
 
+            // -------------------------------------
+            // To reconstruct the response
+            // -------------------------------------
+            if(cnt == 0) q_num_aw_chan_req[aw_req.id].push_back(aw_req); 
             cnt++;
             aw_w_req.aw_chan = aw_req; 
             aw_w_req.w_chan  = w_req;
@@ -290,10 +294,6 @@ class axi2mem#(int unsigned w_addr = 0,  int unsigned w_data = 0, int unsigned w
 
          end while(w_req.last == 0);
 
-         // -------------------------------------
-         // To reconstruct the response
-         // -------------------------------------
-         q_num_aw_chan_req[aw_req.id].push_back(aw_req); 
        end
     endtask
 


### PR DESCRIPTION
Hi 

This PR contains couple of fixes. 

1. Added function set_is_passive for generic uvm agent. 
2. fixed an issue with AXI2MEM. It was causing issues in the case where response starts arriving before the req LAST is inserted. 