### PR TITLE
fix(obi-memory): stop R channel monitor when reset state changes

### DIFF
--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
@@ -175,6 +175,7 @@ task uvma_obi_memory_mon_c::observe_reset();
    forever begin
       wait (cntxt.vif.reset_n === 0);
       cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_IN_RESET;
+      cntxt.reset();
       `uvm_info("OBI_MEMORY_MON", $sformatf("RESET_STATE_IN_RESET"), UVM_NONE)
       wait (cntxt.vif.reset_n === 1);
       cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_POST_RESET;
@@ -240,14 +241,24 @@ task uvma_obi_memory_mon_c::mon_chan_r_post_reset();
    wait (cntxt.mon_outstanding_reads_q.size());
    trn = cntxt.mon_outstanding_reads_q.pop_front();
 
-   mon_chan_r_trn(trn);
-   trn.cfg = cfg;
-   `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel R:\n%s", trn.sprint()), UVM_HIGH)
-   process_r_trn(trn);
-   `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel R after process_r_trn():\n%s", trn.sprint()), UVM_HIGH)
-   ap.write(trn);
-   `uvml_hrtbt()
-   @(passive_mp.mon_cb);
+   fork
+      begin
+         fork
+            begin
+               mon_chan_r_trn(trn);
+               trn.cfg = cfg;
+               `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel R:\n%s", trn.sprint()), UVM_HIGH)
+               process_r_trn(trn);
+               `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel R after process_r_trn():\n%s", trn.sprint()), UVM_HIGH)
+               ap.write(trn);
+               `uvml_hrtbt()
+               @(passive_mp.mon_cb);
+            end
+            @(cntxt.reset_state != UVMA_OBI_MEMORY_RESET_STATE_POST_RESET);
+         join_any
+         disable fork;
+      end
+   join
 
 endtask : mon_chan_r_post_reset
 

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_sqr.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_sqr.sv
@@ -53,6 +53,8 @@ class uvma_obi_memory_sqr_c extends uvm_sequencer#(
     * Ensures cfg & cntxt handles are not null
     */
    extern virtual function void build_phase(uvm_phase phase);
+
+   extern virtual task run_phase(uvm_phase phase);
    
 endclass : uvma_obi_memory_sqr_c
 
@@ -82,5 +84,14 @@ function void uvma_obi_memory_sqr_c::build_phase(uvm_phase phase);
    
 endfunction : build_phase
 
+task uvma_obi_memory_sqr_c::run_phase(uvm_phase phase);
+    super.run_phase(phase);
+
+    forever begin
+        @(cntxt.reset_state == UVMA_OBI_MEMORY_RESET_STATE_IN_RESET);
+        mon_trn_fifo.flush();
+    end
+
+endtask
 
 `endif // __UVMA_OBI_MEMORY_SQR_SV__


### PR DESCRIPTION
It follows [AXI5 methodology](https://github.com/openhwgroup/core-v-verif/blob/298a5f6d066fe15cceb761cdf434b8487561faae/lib/uvm_agents/uvma_axi5/src/comps/uvma_axi_mon.sv#L229).

- Run R channel transaction handling in a forked block
- Exit early if reset_state leaves POST_RESET to avoid blocking waits

Fixes: openhwgroup/core-v-verif#2735