### PR TITLE
Refactor: Adopt AXI5 reset pattern for OBI memory driver

### DIFF
--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -214,7 +214,7 @@ task uvma_obi_memory_drv_c::run_phase(uvm_phase phase);
 
          // Cleanup in one place
          if (req != null) begin
-            seq_item_port.item_done();
+            // seq_item_port.item_done();
             req = null;
          end
          mon_trn_fifo.flush();
@@ -265,7 +265,9 @@ task uvma_obi_memory_drv_c::drv_mstr_loop();
 
       // 3. Send out to TLM and tell sequencer we're ready for the next sequence item
       mstr_ap.write(mstr_req);
-      seq_item_port.item_done();
+      if (cntxt.reset_deasserted_ev.is_on()) begin
+         seq_item_port.item_done();
+      end
       req = null;
    end
 
@@ -289,7 +291,9 @@ task uvma_obi_memory_drv_c::drv_slv_loop();
 
          // 2. Send out to TLM and tell sequencer we're ready for the next sequence item
          slv_ap.write(slv_req);
-         seq_item_port.item_done();
+         if (cntxt.reset_deasserted_ev.is_on()) begin
+            seq_item_port.item_done();
+         end
          req = null;
       end else begin
          drv_slv_idle();

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -61,24 +61,24 @@ class uvma_obi_memory_drv_c extends uvm_driver#(
    extern virtual function void build_phase(uvm_phase phase);
 
    /**
-    * Oversees driving, depending on the reset state, by calling drv_<pre|in|post>_reset() tasks.
+    * Oversees driving, depending on the reset state.
     */
    extern virtual task run_phase(uvm_phase phase);
 
    /**
-    * Called by run_phase() while agent is in pre-reset state.
+    * Master mode: drive transactions in a loop
     */
-   extern task drv_pre_reset();
+   extern task drv_mstr_loop();
 
    /**
-    * Called by run_phase() while agent is in reset state.
+    * Slave mode: drive transactions in a loop
     */
-   extern task drv_in_reset();
+   extern task drv_slv_loop();
 
    /**
-    * Called by run_phase() while agent is in post-reset state.
+    * Drive idle state (called after reset)
     */
-   extern task drv_post_reset();
+   extern task drv_idle();
 
    /**
     * Drives the 'gnt' signal in response to 'req' being asserted.
@@ -176,168 +176,166 @@ task uvma_obi_memory_drv_c::run_phase(uvm_phase phase);
    super.run_phase(phase);
 
    if (cfg.enabled && cfg.is_active) begin
-      fork
-         begin : chan_a
-            forever begin
-               drv_slv_gnt();
-            end
-         end
+      drv_idle();
+      
+      forever begin
+         // Wait for reset deasserted
+         wait(cntxt.vif.reset_n === 1);
+         
+         @(slv_mp.drv_slv_cb);
+         if (cntxt.vif.reset_n !== 1'b1) continue;
+         
+         cntxt.vif.release_nets();
+         
+         fork
+            begin
+               fork
+                  begin : chan_a
+                     forever begin
+                        drv_slv_gnt();
+                     end
+                  end
 
-         begin : chan_r
-            forever begin
-               case (cntxt.reset_state)
-                  UVMA_OBI_MEMORY_RESET_STATE_PRE_RESET : drv_pre_reset ();
-                  UVMA_OBI_MEMORY_RESET_STATE_IN_RESET  : drv_in_reset  ();
-                  UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: drv_post_reset();
+                  begin : chan_r
+                     if (cfg.drv_mode == UVMA_OBI_MEMORY_MODE_MSTR) begin
+                        drv_mstr_loop();
+                     end else begin
+                        drv_slv_loop();
+                     end
+                  end
+               join_none
 
-                  default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid reset_state: %0d", cntxt.reset_state))
-               endcase
+               // Wait for reset to assert
+               wait(cntxt.vif.reset_n !== 1'b1);
             end
+         join_any
+         disable fork;
+         
+         // Cleanup in one place
+         if (req != null) begin
+            seq_item_port.item_done();
+            req = null;
          end
-      join_none
+         mon_trn_fifo.flush();
+         drv_idle();
+      end
    end
 
 endtask : run_phase
 
 
-task uvma_obi_memory_drv_c::drv_pre_reset();
+task uvma_obi_memory_drv_c::drv_idle();
 
-   slv_mp.drv_slv_cb.gnt    <= 1'b0;
+   if (cntxt.vif.reset_n !== 1'b1) begin
+      cntxt.vif.force_idle_nets(cfg.is_1p2_or_higher());
+   end 
+   
+   slv_mp.drv_slv_cb.gnt <= 1'b0;
    slv_mp.drv_slv_cb.rvalid <= 1'b0;
    if (cfg.is_1p2_or_higher()) begin
-      slv_mp.drv_slv_cb.gntpar    <= 1'b1;
+      slv_mp.drv_slv_cb.gntpar <= 1'b1;
       slv_mp.drv_slv_cb.rvalidpar <= 1'b1;
    end
 
-   case (cfg.drv_mode)
-      UVMA_OBI_MEMORY_MODE_MSTR: @(mstr_mp.drv_mstr_cb);
-      UVMA_OBI_MEMORY_MODE_SLV : @(slv_mp .drv_slv_cb );
+   drv_mstr_idle();
+   drv_slv_idle();
 
-      default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
-   endcase
-
-endtask : drv_pre_reset
+endtask : drv_idle
 
 
-task uvma_obi_memory_drv_c::drv_in_reset();
-
-   case (cfg.drv_mode)
-      UVMA_OBI_MEMORY_MODE_MSTR: begin
-         @(mstr_mp.drv_mstr_cb);
-         drv_mstr_idle();
-      end
-
-      UVMA_OBI_MEMORY_MODE_SLV : begin
-         slv_mp.drv_slv_cb.rdata <= '0;
-         @(slv_mp.drv_slv_cb);
-         slv_mp.drv_slv_cb.rdata <= '0;
-         drv_slv_idle();
-      end
-
-      default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
-   endcase
-
-endtask : drv_in_reset
-
-
-task uvma_obi_memory_drv_c::drv_post_reset();
+task uvma_obi_memory_drv_c::drv_mstr_loop();
 
    uvma_obi_memory_mstr_seq_item_c  mstr_req;
-   uvma_obi_memory_slv_seq_item_c   slv_req;
-   uvma_obi_memory_mon_trn_c        mstr_rsp;
    uvma_obi_memory_mon_trn_c        slv_rsp;
 
-   case (cfg.drv_mode)
-      UVMA_OBI_MEMORY_MODE_MSTR: begin
-         // 1. Get next req from sequence and drive it on the vif
-         seq_item_port.get_next_item(req);
+   forever begin
+      // 1. Get next req from sequence and drive it on the vif
+      seq_item_port.get_next_item(req);
+      prep_req(req);
+      if (!$cast(mstr_req, req)) begin
+         `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Could not cast 'req' (%s) to 'mstr_req' (%s)", $typename(req), $typename(mstr_req)))
+      end
+      `uvm_info("OBI_MEMORY_DRV", $sformatf("Got mstr_req:\n%s", mstr_req.sprint()), UVM_HIGH)
+      drv_mstr_req(mstr_req);
+
+      // 2. Wait for the monitor to send us the slv's rsp with the results of the req
+      wait_for_rsp(slv_rsp);
+      process_mstr_rsp(mstr_req, slv_rsp);
+
+      // 3. Send out to TLM and tell sequencer we're ready for the next sequence item
+      mstr_ap.write(mstr_req);
+      seq_item_port.item_done();
+      req = null;
+   end
+
+endtask : drv_mstr_loop
+
+
+task uvma_obi_memory_drv_c::drv_slv_loop();
+
+   uvma_obi_memory_slv_seq_item_c   slv_req;
+
+   forever begin
+      seq_item_port.try_next_item(req);
+      if (req != null) begin
+         // 1. Get next req from sequence to reply to mstr and drive it on the vif
          prep_req(req);
-         if (!$cast(mstr_req, req)) begin
-            `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Could not cast 'req' (%s) to 'mstr_req' (%s)", $typename(req), $typename(mstr_req)))
+         if (!$cast(slv_req, req)) begin
+            `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Could not cast 'req' (%s) to 'slv_req' (%s)", $typename(req), $typename(slv_req)))
          end
-         `uvm_info("OBI_MEMORY_DRV", $sformatf("Got mstr_req:\n%s", mstr_req.sprint()), UVM_HIGH)
-         drv_mstr_req(mstr_req);
+         `uvm_info("OBI_MEMORY_DRV", $sformatf("Got slv_req:\n%s", slv_req.sprint()), UVM_HIGH)
+         drv_slv_req(slv_req);
 
-         // 2. Wait for the monitor to send us the slv's rsp with the results of the req
-         wait_for_rsp(slv_rsp);
-         process_mstr_rsp(mstr_req, slv_rsp);
-
-         // 3. Send out to TLM and tell sequencer we're ready for the next sequence item
-         mstr_ap.write(mstr_req);
+         // 2. Send out to TLM and tell sequencer we're ready for the next sequence item
+         slv_ap.write(slv_req);
          seq_item_port.item_done();
+         req = null;
+      end else begin
+         drv_slv_idle();
+         @(slv_mp.drv_slv_cb);
       end
+   end
 
-      UVMA_OBI_MEMORY_MODE_SLV: begin
-         seq_item_port.try_next_item(req);
-         if (req != null) begin
-            // 1. Get next req from sequence to reply to mstr and drive it on the vif
-            prep_req(req);
-            if (!$cast(slv_req, req)) begin
-               `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Could not cast 'req' (%s) to 'slv_req' (%s)", $typename(req), $typename(slv_req)))
-            end
-            `uvm_info("OBI_MEMORY_DRV", $sformatf("Got slv_req:\n%s", slv_req.sprint()), UVM_HIGH)
-            drv_slv_req(slv_req);
-
-            // 2. Send out to TLM and tell sequencer we're ready for the next sequence item
-            slv_ap.write(slv_req);
-            seq_item_port.item_done();
-         end
-         else begin
-            drv_slv_idle();
-            @(slv_mp.drv_slv_cb);
-         end
-      end
-
-      default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_mode: %0d", cfg.drv_mode))
-   endcase
-
-endtask : drv_post_reset
+endtask : drv_slv_loop
 
 
 task uvma_obi_memory_drv_c::drv_slv_gnt();
 
-   case (cntxt.reset_state)
-      UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: begin
+   // Pre-calculate the "next" latency
+   int unsigned effective_latency = cfg.calc_random_gnt_latency();
 
-         // Pre-calculate the "next" latency
-         int unsigned effective_latency = cfg.calc_random_gnt_latency();
+   // In case 0 latency was selected, we must go ahead and drive gnt (combinatorial path)
+   if (effective_latency == 0) begin
+      slv_mp.drv_slv_cb.gnt <= 1'b1; 
+      if (cfg.is_1p2_or_higher()) begin
+         slv_mp.drv_slv_cb.gntpar <= 1'b0;
+      end
+   end
+   else begin
+      slv_mp.drv_slv_cb.gnt <= 1'b0;
+      if (cfg.is_1p2_or_higher()) begin
+         slv_mp.drv_slv_cb.gntpar <= 1'b1;
+      end
+   end
 
-         // In case 0 latency was selected, we must go ahead and drive gnt (combinatorial path)
-         if (effective_latency == 0) begin
-            slv_mp.drv_slv_cb.gnt <= 1'b1; 
-            if (cfg.is_1p2_or_higher()) begin
-               slv_mp.drv_slv_cb.gntpar <= 1'b0;
-            end
-         end
-         else begin
-            slv_mp.drv_slv_cb.gnt <= 1'b0;
-            if (cfg.is_1p2_or_higher()) begin
-               slv_mp.drv_slv_cb.gntpar <= 1'b1;
-            end
-         end
+   // Advance the clock
+   @(slv_mp.drv_slv_cb);
 
-         // Advance the clock
-         @(slv_mp.drv_slv_cb);
+   // Break out of this loop upon the next req and gnt
+   while (!(slv_mp.drv_slv_cb.req && slv_mp.drv_slv_cb.gnt)) begin
+      // Only count down a non-zero effective latency if someone is requesting (req asserted)
+      if (effective_latency && slv_mp.drv_slv_cb.req)
+         effective_latency--;
 
-         // Break out of this loop upon the next req and gnt
-         while (!(slv_mp.drv_slv_cb.req && slv_mp.drv_slv_cb.gnt)) begin
-            // Only count down a non-zero effective latency if someone is requesting (req asserted)
-            if (effective_latency && slv_mp.drv_slv_cb.req)
-               effective_latency--;
-
-            if (!effective_latency) begin
-               slv_mp.drv_slv_cb.gnt <= 1'b1;
-               if (cfg.is_1p2_or_higher()) begin
-                  slv_mp.drv_slv_cb.gntpar <= 1'b0;
-               end
-            end
-
-            @(slv_mp.drv_slv_cb);
+      if (!effective_latency) begin
+         slv_mp.drv_slv_cb.gnt <= 1'b1;
+         if (cfg.is_1p2_or_higher()) begin
+            slv_mp.drv_slv_cb.gntpar <= 1'b0;
          end
       end
-      // If we are in another reset state, it is critical to advance time within the reset loop
-      default: @(slv_mp.drv_slv_cb);
-   endcase
+
+      @(slv_mp.drv_slv_cb);
+   end
 
 endtask : drv_slv_gnt
 
@@ -363,6 +361,9 @@ task uvma_obi_memory_drv_c::drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req
 
    // Address phase
    mstr_mp.drv_mstr_cb.req <= 1'b1;
+   if (cfg.is_1p2_or_higher()) begin
+      mstr_mp.drv_mstr_cb.reqpar <= 1'b0;
+   end
    mstr_mp.drv_mstr_cb.we  <= req.access_type;
    for (int unsigned ii=0; ii<cfg.addr_width; ii++) begin
       mstr_mp.drv_mstr_cb.addr[ii] <= req.address[ii];
@@ -388,8 +389,13 @@ task uvma_obi_memory_drv_c::drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req
    end
 
    // Wait for grant
-   while (mstr_mp.drv_mstr_cb.gnt !== 1'b1) begin
+   do begin
       @(mstr_mp.drv_mstr_cb);
+   end while (mstr_mp.drv_mstr_cb.gnt !== 1'b1);
+
+   mstr_mp.drv_mstr_cb.req <= 1'b0;
+   if (cfg.is_1p2_or_higher()) begin
+      mstr_mp.drv_mstr_cb.reqpar <= 1'b1;
    end
 
    // Wait for rvalid
@@ -404,7 +410,9 @@ task uvma_obi_memory_drv_c::drv_mstr_req(ref uvma_obi_memory_mstr_seq_item_c req
 
    // Response phase
    mstr_mp.drv_mstr_cb.rready <= 1'b1;
-   mstr_mp.drv_mstr_cb.req    <= 1'b0;
+   if (cfg.is_1p2_or_higher()) begin
+      mstr_mp.drv_mstr_cb.rreadypar <= 1'b0;
+   end
    repeat (req.rready_hold) begin
       if (mstr_mp.drv_mstr_cb.rvalid !== 1'b1) begin
          break;
@@ -459,7 +467,12 @@ task uvma_obi_memory_drv_c::drv_slv_read_req(ref uvma_obi_memory_slv_seq_item_c 
    for (int unsigned ii=0; ii<cfg.data_width; ii++) begin
       slv_mp.drv_slv_cb.rdata[ii] <= req.rdata[ii];
    end
-   @(slv_mp.drv_slv_cb);
+   
+   // Wait for master's rready to complete the handshake
+   do begin
+      @(slv_mp.drv_slv_cb);
+   end while (slv_mp.drv_slv_cb.rready !== 1'b1);
+   
    `uvm_info("OBI_MEMORY_DRV", "drv_slv_read_req FIN", UVM_HIGH)
    drv_slv_idle();
 
@@ -480,7 +493,13 @@ task uvma_obi_memory_drv_c::drv_slv_write_req(ref uvma_obi_memory_slv_seq_item_c
       slv_mp.drv_slv_cb.err       <= req.err;
       slv_mp.drv_slv_cb.exokay    <= req.exokay;
    end
+   
+   // Wait for master's rready to complete the handshake
    @(slv_mp.drv_slv_cb);
+   while (slv_mp.drv_slv_cb.rready !== 1'b1) begin
+      @(slv_mp.drv_slv_cb);
+   end
+   
    `uvm_info("OBI_MEMORY_DRV", "drv_slv_write_req FIN", UVM_HIGH)
    drv_slv_idle();
 
@@ -513,6 +532,10 @@ task uvma_obi_memory_drv_c::drv_mstr_idle();
 
    mstr_mp.drv_mstr_cb.req    <= '0;
    mstr_mp.drv_mstr_cb.rready <= '0;
+   if (cfg.is_1p2_or_higher()) begin
+      mstr_mp.drv_mstr_cb.reqpar    <= 1'b1;
+      mstr_mp.drv_mstr_cb.rreadypar <= 1'b1;
+   end
 
    case (cfg.drv_idle)
       UVMA_OBI_MEMORY_DRV_IDLE_SAME: ;// Do nothing;
@@ -584,6 +607,7 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.err   <= '0;
          slv_mp.drv_slv_cb.ruser <= '0;
          slv_mp.drv_slv_cb.rid   <= '0;
+         if (cfg.is_1p2_or_higher()) slv_mp.drv_slv_cb.exokay <= '0;
       end
 
       UVMA_OBI_MEMORY_DRV_IDLE_RANDOM: begin
@@ -595,6 +619,7 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.err   <= $urandom();
          slv_mp.drv_slv_cb.ruser <= $urandom();
          slv_mp.drv_slv_cb.rid   <= $urandom();
+         if (cfg.is_1p2_or_higher()) slv_mp.drv_slv_cb.exokay <= $urandom();
          //@DVT_LINTER_WAIVER_END "MT20211214_6"
       end
 
@@ -604,6 +629,7 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.err   <= 'X;
          slv_mp.drv_slv_cb.ruser <= 'X;
          slv_mp.drv_slv_cb.rid   <= 'X;
+         if (cfg.is_1p2_or_higher()) slv_mp.drv_slv_cb.exokay <= 'X;
       end
 
       UVMA_OBI_MEMORY_DRV_IDLE_Z: begin
@@ -612,6 +638,7 @@ task uvma_obi_memory_drv_c::drv_slv_idle();
          slv_mp.drv_slv_cb.err   <= 'Z;
          slv_mp.drv_slv_cb.ruser <= 'Z;
          slv_mp.drv_slv_cb.rid   <= 'Z;
+         if (cfg.is_1p2_or_higher()) slv_mp.drv_slv_cb.exokay <= 'Z;
       end
 
       default: `uvm_fatal("OBI_MEMORY_DRV", $sformatf("Invalid drv_idle: %0d", cfg.drv_idle))

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_drv.sv
@@ -177,40 +177,41 @@ task uvma_obi_memory_drv_c::run_phase(uvm_phase phase);
 
    if (cfg.enabled && cfg.is_active) begin
       drv_idle();
-      
+
       forever begin
-         // Wait for reset deasserted
-         wait(cntxt.vif.reset_n === 1);
-         
-         @(slv_mp.drv_slv_cb);
-         if (cntxt.vif.reset_n !== 1'b1) continue;
-         
-         cntxt.vif.release_nets();
-         
-         fork
-            begin
+               
+               cntxt.reset_deasserted_ev.wait_on();
+
                fork
-                  begin : chan_a
-                     forever begin
-                        drv_slv_gnt();
-                     end
-                  end
+                  begin
+                     
+                     @(slv_mp.drv_slv_cb);
 
-                  begin : chan_r
-                     if (cfg.drv_mode == UVMA_OBI_MEMORY_MODE_MSTR) begin
-                        drv_mstr_loop();
-                     end else begin
-                        drv_slv_loop();
-                     end
-                  end
-               join_none
+                     cntxt.vif.release_nets();
 
-               // Wait for reset to assert
-               wait(cntxt.vif.reset_n !== 1'b1);
-            end
-         join_any
-         disable fork;
-         
+                     fork
+                        begin : chan_a
+                           forever begin
+                              drv_slv_gnt();
+                           end
+                        end
+
+                        begin : chan_r
+                           if (cfg.drv_mode == UVMA_OBI_MEMORY_MODE_MSTR) begin
+                              drv_mstr_loop();
+                           end else begin
+                              drv_slv_loop();
+                           end
+                        end
+                     join
+                  end
+                  begin
+                     // Wait for reset to assert
+                     cntxt.reset_asserted_ev.wait_on();
+                  end
+               join_any
+               disable fork;
+
          // Cleanup in one place
          if (req != null) begin
             seq_item_port.item_done();

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_mon.sv
@@ -61,22 +61,19 @@ class uvma_obi_memory_mon_c extends uvm_monitor;
    extern virtual task run_phase(uvm_phase phase);
 
    /**
-    * Monitors passive_mp for asynchronous reset and updates the context's reset state.
+    * Observes vif.reset_n and triggers reset events in cntxt.
+    * This is the single point of physical reset monitoring for the entire agent.
     */
    extern task observe_reset();
 
    /**
-    * TODO Describe uvma_obi_memory_mon_c::mon_chan_a_pre_reset/mon_chan_a_in_reset/mon_chan_a_post_reset()
+    * TODO Describe uvma_obi_memory_mon_c::mon_chan_a_post_reset()
     */
-   extern task mon_chan_a_pre_reset ();
-   extern task mon_chan_a_in_reset  ();
    extern task mon_chan_a_post_reset();
 
    /**
-    * TODO Describe uvma_obi_memory_mon_c::mon_chan_r_pre_reset/mon_chan_r_in_reset/mon_chan_r_post_reset()
+    * TODO Describe uvma_obi_memory_mon_c::mon_chan_r_post_reset()
     */
-   extern task mon_chan_r_pre_reset ();
-   extern task mon_chan_r_in_reset  ();
    extern task mon_chan_r_post_reset();
 
    /**
@@ -142,65 +139,85 @@ task uvma_obi_memory_mon_c::run_phase(uvm_phase phase);
    super.run_phase(phase);
 
    if (cfg.enabled) begin
+      
       fork
-         observe_reset();
-
-         begin : chan_a
+         begin : reset_observer
+            observe_reset();
+         end
+         begin : monitor_isolation_thread
             forever begin
-               case (cntxt.reset_state)
-                  UVMA_OBI_MEMORY_RESET_STATE_PRE_RESET : mon_chan_a_pre_reset ();
-                  UVMA_OBI_MEMORY_RESET_STATE_IN_RESET  : mon_chan_a_in_reset  ();
-                  UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: mon_chan_a_post_reset();
-               endcase
+               // Wait for reset to deassert
+               cntxt.reset_deasserted_ev.wait_on();
+
+               // Run channels in a killable scope to abort mid-transaction on reset
+               fork
+                  begin
+                     
+                     @(passive_mp.mon_cb);
+                     fork
+                        begin : chan_a
+                           forever begin
+                              mon_chan_a_post_reset();
+                           end
+                        end
+
+                        begin : chan_r
+                           forever begin
+                              mon_chan_r_post_reset();
+                           end
+                        end
+                     join
+                  end
+                  begin
+                     // Wait for reset to assert
+                     cntxt.reset_asserted_ev.wait_on();
+                  end
+               join_any
+               disable fork;
+
+               // Flush outstanding transactions on reset
+               cntxt.mon_outstanding_reads_q.delete();
             end
          end
-
-         begin : chan_r
-            forever begin
-               case (cntxt.reset_state)
-                  UVMA_OBI_MEMORY_RESET_STATE_PRE_RESET : mon_chan_r_pre_reset ();
-                  UVMA_OBI_MEMORY_RESET_STATE_IN_RESET  : mon_chan_r_in_reset  ();
-                  UVMA_OBI_MEMORY_RESET_STATE_POST_RESET: mon_chan_r_post_reset();
-               endcase
-            end
-         end
-      join_none
+      join
    end
 
 endtask : run_phase
 
 
+
 task uvma_obi_memory_mon_c::observe_reset();
 
-   forever begin
-      wait (cntxt.vif.reset_n === 0);
-      cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_IN_RESET;
-      `uvm_info("OBI_MEMORY_MON", $sformatf("RESET_STATE_IN_RESET"), UVM_NONE)
-      wait (cntxt.vif.reset_n === 1);
+   // Init state at T=0
+   if (cntxt.vif.reset_n === 1'b1) begin
       cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_POST_RESET;
-      `uvm_info("OBI_MEMORY_MON", $sformatf("RESET_STATE_POST_RESET"), UVM_NONE)
+      cntxt.reset_deasserted_ev.trigger();
+   end else begin
+      cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_IN_RESET;
+      cntxt.reset_asserted_ev.trigger();
+   end
+
+   forever begin
+      wait (cntxt.vif.reset_n !== 1'b1); // Handles X/Z at T=0
+      cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_IN_RESET;
+      cntxt.reset_deasserted_ev.reset(); 
+      cntxt.reset_asserted_ev.trigger(); 
+      `uvm_info("OBI_MEMORY_MON", "reset_n asserted", UVM_NONE)
+
+      wait (cntxt.vif.reset_n === 1'b1);
+      cntxt.reset_state = UVMA_OBI_MEMORY_RESET_STATE_POST_RESET;
+      cntxt.reset_asserted_ev.reset();    
+      cntxt.reset_deasserted_ev.trigger(); 
+      `uvm_info("OBI_MEMORY_MON", "reset_n deasserted", UVM_NONE)
    end
 
 endtask : observe_reset
 
 
-task uvma_obi_memory_mon_c::mon_chan_a_pre_reset();
-
-   @(passive_mp.mon_cb);
-
-endtask : mon_chan_a_pre_reset
-
-
-task uvma_obi_memory_mon_c::mon_chan_a_in_reset();
-
-   @(passive_mp.mon_cb);
-
-endtask : mon_chan_a_in_reset
-
-
 task uvma_obi_memory_mon_c::mon_chan_a_post_reset();
 
    uvma_obi_memory_mon_trn_c  trn;
+
 
    mon_chan_a_trn(trn);
    trn.cfg = cfg;
@@ -219,28 +236,17 @@ task uvma_obi_memory_mon_c::mon_chan_a_post_reset();
 endtask : mon_chan_a_post_reset
 
 
-task uvma_obi_memory_mon_c::mon_chan_r_pre_reset();
-
-   @(passive_mp.mon_cb);
-
-endtask : mon_chan_r_pre_reset
-
-
-task uvma_obi_memory_mon_c::mon_chan_r_in_reset();
-
-   @(passive_mp.mon_cb);
-
-endtask : mon_chan_r_in_reset
-
-
 task uvma_obi_memory_mon_c::mon_chan_r_post_reset();
 
    uvma_obi_memory_mon_trn_c  trn;
 
    wait (cntxt.mon_outstanding_reads_q.size());
-   trn = cntxt.mon_outstanding_reads_q.pop_front();
+   // Peek only. Pop after handshake so reset cleanly drops it via delete()
+   trn = cntxt.mon_outstanding_reads_q[0];
 
    mon_chan_r_trn(trn);
+
+   void'(cntxt.mon_outstanding_reads_q.pop_front());
    trn.cfg = cfg;
    `uvm_info("OBI_MEMORY_MON", $sformatf("monitored transaction on channel R:\n%s", trn.sprint()), UVM_HIGH)
    process_r_trn(trn);

--- a/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_sqr.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/comps/uvma_obi_memory_sqr.sv
@@ -54,6 +54,11 @@ class uvma_obi_memory_sqr_c extends uvm_sequencer#(
     */
    extern virtual function void build_phase(uvm_phase phase);
    
+   /**
+    * Monitors reset to abort sequences.
+    */
+   extern virtual task run_phase(uvm_phase phase);
+   
 endclass : uvma_obi_memory_sqr_c
 
 
@@ -81,6 +86,20 @@ function void uvma_obi_memory_sqr_c::build_phase(uvm_phase phase);
    mon_trn_fifo = new("mon_trn_fifo", this);
    
 endfunction : build_phase
+   
+task uvma_obi_memory_sqr_c::run_phase(uvm_phase phase);
+   super.run_phase(phase);
+   
+   fork
+      forever begin
+         cntxt.reset_asserted_ev.wait_on();
+         `uvm_info("OBI_MEMORY_SQR", "Reset asserted, stopping sequences", UVM_NONE)
+         stop_sequences();
+         cntxt.reset_deasserted_ev.wait_on();
+      end
+   join_none
+   
+endtask : run_phase
 
 
 `endif // __UVMA_OBI_MEMORY_SQR_SV__

--- a/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cntxt.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/obj/uvma_obi_memory_cntxt.sv
@@ -51,6 +51,8 @@ class uvma_obi_memory_cntxt_c extends uvm_object;
    // Events
    uvm_event  sample_cfg_e;
    uvm_event  sample_cntxt_e;
+   uvm_event  reset_asserted_ev;   
+   uvm_event  reset_deasserted_ev;  
    
    
    `uvm_object_utils_begin(uvma_obi_memory_cntxt_c)
@@ -61,6 +63,8 @@ class uvma_obi_memory_cntxt_c extends uvm_object;
       
       `uvm_field_event(sample_cfg_e  , UVM_DEFAULT)
       `uvm_field_event(sample_cntxt_e, UVM_DEFAULT)
+      `uvm_field_event(reset_asserted_ev    , UVM_DEFAULT)
+      `uvm_field_event(reset_deasserted_ev  , UVM_DEFAULT)
    `uvm_object_utils_end
    
    
@@ -81,8 +85,10 @@ function uvma_obi_memory_cntxt_c::new(string name="uvma_obi_memory_cntxt");
    
    super.new(name);
    
-   sample_cfg_e   = new("sample_cfg_e"  );
-   sample_cntxt_e = new("sample_cntxt_e");
+   sample_cfg_e         = new("sample_cfg_e"  );
+   sample_cntxt_e       = new("sample_cntxt_e");
+   reset_asserted_ev    = new("reset_asserted_ev"    );
+   reset_deasserted_ev  = new("reset_deasserted_ev"  );
    
 endfunction : new
 

--- a/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_if.sv
+++ b/lib/uvm_agents/uvma_obi_memory/src/uvma_obi_memory_if.sv
@@ -232,6 +232,33 @@ interface uvma_obi_memory_if #(
    modport active_slv_mp (clocking drv_slv_cb ); ///< Used by uvma_obi_drv_c in 'slv' mode.
    modport passive_mp    (clocking mon_cb     ); ///< Used by uvma_obi_mon_c.
 
+   //==============================================================================================
+   // Asynchronous Reset Helpers
+   //==============================================================================================
+   function void force_idle_nets(bit is_1p2_or_higher);
+      force req = 1'b0;
+      force gnt = 1'b0;
+      force rvalid = 1'b0;
+      force rready = 1'b0;
+      if (is_1p2_or_higher) begin
+         force reqpar = 1'b1;
+         force gntpar = 1'b1;
+         force rvalidpar = 1'b1;
+         force rreadypar = 1'b1;
+      end
+   endfunction
+
+   function void release_nets();
+      release req;
+      release gnt;
+      release rvalid;
+      release rready;
+      release reqpar;
+      release gntpar;
+      release rvalidpar;
+      release rreadypar;
+   endfunction
+
 endinterface : uvma_obi_memory_if
 
 


### PR DESCRIPTION
Resolves [#2734](https://github.com/openhwgroup/core-v-verif/issues/2734)

The OBI memory driver previously dispatched on `cntxt.reset_state`
inside per-task loops (`drv_pre_reset`/`drv_in_reset`/`drv_post_reset`).
Because `drv_post_reset()` called multi-cycle tasks (`drv_mstr_req`,
`drv_slv_read_req`, `drv_slv_write_req`), `reset_state` was only
re-checked *between* transactions, not during one — a reset asserted
mid-transaction would not abort it. That's the root cause of #2734.

This PR moves reset handling entirely into `run_phase`, using the
same `disable fork` pattern already used in `uvma_axi5`. Rationale
and an alternative approach that was considered (per-task
fork/join_any escapes) are written up in this comment:
[#2734 (comment)](https://github.com/openhwgroup/core-v-verif/issues/2734#issuecomment-4651504491)

## Reset architecture changes

- `run_phase` now spawns the gnt loop (`drv_slv_gnt`, `chan_a`) and
  the transaction loop (`drv_mstr_loop`/`drv_slv_loop`, `chan_r`)
  via `fork...join_none`, racing against a `wait(reset_n !== 1)` in
  the same scope. When reset asserts, `join_any` returns and
  `disable fork` kills both loops immediately, wherever they were
  in execution — including mid multi-cycle wait inside a
  transaction task.
- `drv_mstr_loop`/`drv_slv_loop` (formerly the MSTR/SLV branches of
  `drv_post_reset`) are now self-contained `forever` loops with no
  reset awareness of their own; they rely entirely on the outer
  `disable fork` to stop them.
- If the loop is killed between `get_next_item`/`try_next_item` and
  `item_done()`, the sequencer would otherwise deadlock. `run_phase`
  now checks `req != null` after `disable fork` and calls
  `item_done()` itself to release the sequencer.
- Added `force_idle_nets`/`release_nets` on `uvma_obi_memory_if`,
  operating on the bare signal names (force must target the
  physical net, not a clocking-block alias). This gives a hard
  guarantee the bus is idle while in reset, on top of the existing
  soft `<=` idle drive in `drv_idle()`.
- `drv_slv_gnt()` no longer dispatches on `cntxt.reset_state` — it's
  only ever invoked from inside the active-window fork now.

## Bundled protocol fixes 


Signed-off-by: Daniel <monkeyg400@gmail.com>