### PR TITLE
Add interrupt and debug_request throttle for CVE2

### DIFF
--- a/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
@@ -115,7 +115,12 @@ endtask : run_phase
 
 task uvma_debug_drv_c::drv_req(uvma_debug_seq_item_c req);
 
-   @(cntxt.vif.drv_cb); // WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
+   @(cntxt.vif.drv_cb);
+   // TODO: address this properly!
+   // WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
+   // See the matching comment in uvma_interrupt_drv_c::wait_and_assert_irq_edge -- that wait can
+   // deadlock outright when the core is parked in WFI (id_in_ready_o stays low while asleep), and
+   // the hazard defends against is now fixed by probing the controller (in cve2_controller.sv).
    `uvm_info("DEBUGDRV", $sformatf("Driving debug:\n%s",req.sprint()), UVM_HIGH)
    cntxt.vif.drv_cb.debug_drv <= 1'b1;
    repeat (req.active_cycles) @(cntxt.vif.mon_cb);

--- a/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_drv.sv
@@ -116,11 +116,8 @@ endtask : run_phase
 task uvma_debug_drv_c::drv_req(uvma_debug_seq_item_c req);
 
    @(cntxt.vif.drv_cb);
-   // TODO: address this properly!
    // WARNING If no time is consumed by this task, a zero-delay oscillation loop will occur and stall simulation
-   // See the matching comment in uvma_interrupt_drv_c::wait_and_assert_irq_edge -- that wait can
-   // deadlock outright when the core is parked in WFI (id_in_ready_o stays low while asleep), and
-   // the hazard defends against is now fixed by probing the controller (in cve2_controller.sv).
+   // See the matching comment in uvma_interrupt_drv_c::wait_and_assert_irq_edge
    `uvm_info("DEBUGDRV", $sformatf("Driving debug:\n%s",req.sprint()), UVM_HIGH)
    cntxt.vif.drv_cb.debug_drv <= 1'b1;
    repeat (req.active_cycles) @(cntxt.vif.mon_cb);

--- a/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
@@ -28,8 +28,13 @@ interface uvma_debug_if(
     wire clk;
     wire reset_n;
     wire debug_req;
-  
-    bit is_active; 
+
+    // Probed from the core's controller (id_in_ready_o): true when it's safe to present a new
+    // interrupt/debug request without racing one already in flight. See uvma_interrupt_if.sv for
+    // the full rationale (same signal, same reasoning, shared by both request sources).
+    wire id_in_ready;
+
+    bit is_active;
     bit debug_drv;
 
     assign debug_req = is_active ? debug_drv : 1'b0;
@@ -52,6 +57,7 @@ interface uvma_debug_if(
       // TODO Implement uvma_debug_if::drv_cb()
       //      Ex: output  enable,
       //                  data  ;
+       input #1step id_in_ready;
        output debug_drv;
    endclocking : drv_cb
    

--- a/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
+++ b/lib/uvm_agents/uvma_debug/uvma_debug_if.sv
@@ -29,9 +29,10 @@ interface uvma_debug_if(
     wire reset_n;
     wire debug_req;
 
-    // Probed from the core's controller (id_in_ready_o): true when it's safe to present a new
-    // interrupt/debug request without racing one already in flight. See uvma_interrupt_if.sv for
-    // the full rationale (same signal, same reasoning, shared by both request sources).
+    // 'id_in_ready' is probed from the core's controller (e.g. id_in_ready_o in cve2_controller.sv).
+    // When true it is safe to present a new interrupt/debug request without racing
+    // one already in flight. See uvma_interrupt_if.sv for the full rationale.
+    // TODO: set 'id_in_ready' true for cores that do not need it.
     wire id_in_ready;
 
     bit is_active;
@@ -54,9 +55,6 @@ interface uvma_debug_if(
     * Used by uvma_debug_drv_c.
     */
    clocking drv_cb @(posedge clk or reset_n);
-      // TODO Implement uvma_debug_if::drv_cb()
-      //      Ex: output  enable,
-      //                  data  ;
        input #1step id_in_ready;
        output debug_drv;
    endclocking : drv_cb

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
@@ -33,13 +33,11 @@ class uvma_interrupt_drv_c extends uvm_driver#(
 
    semaphore               assert_until_ack_sem[32];
 
-   // Serializes the actual irq_drv[] rising edge across all 32 lines (not just same-index, unlike
-   // assert_until_ack_sem above): only one new edge is allowed at a time, and the holder keeps the
-   // lock for 2 extra cycles after driving it, so any two new rising edges are guaranteed to land
-   // on different clock edges and be at least 2 cycles apart. Deliberately does NOT gate on
-   // cntxt.vif.drv_cb.id_in_ready (the core's id_in_ready_o): id_in_ready_o stays low while the
-   // core is parked in WFI, so waiting on it here would block forever on the very interrupt meant
-   // to wake it.
+   // The 'new_irq_edge_sem' semaphore is used to serialize the actual irq_drv[]
+   // rising edge across all 32 lines (not just same-index, unlike 'assert_until_ack_sem' above)
+   // Only one new edge is allowed at a time, and the holder keeps the lock for 2
+   // extra cycles after driving it, so any two new rising edges are guaranteed to land
+   // on different clock edges and be at least 2 cycles apart.
    semaphore               new_irq_edge_sem;
 
    // TLM
@@ -194,15 +192,6 @@ endtask : drv_req
 
 task uvma_interrupt_drv_c::wait_and_assert_irq_edge(int unsigned index);
    new_irq_edge_sem.get(1);
-   // Previously also waited on cntxt.vif.drv_cb.id_in_ready here (the core's id_in_ready_o) before
-   // driving the edge, to avoid racing an in-flight exception request. Reverted: that wait can
-   // deadlock outright when the core is genuinely parked in WFI (id_in_ready_o stays low while
-   // asleep), since it then blocks forever waiting to "be ready" for the very interrupt that would
-   // wake it. The actual false-assertion hazard it was defending against
-   // (CVE2DontSkipExceptionReq/CVE2SetExceptionPCOnSpecialReqIfExpected on a withdrawn-but-still-
-   // latched request) is now fixed at its root in cve2_controller.sv (exception_req_withdrawn), so
-   // this driver-side gate is redundant as well as harmful. See
-   // E20DV/tmp/exception_req_pending_finding.md.
    cntxt.vif.drv_cb.irq_drv[index] <= 1'b1;
    repeat (2) @(cntxt.vif.drv_cb);
    new_irq_edge_sem.put(1);

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_drv.sv
@@ -33,6 +33,15 @@ class uvma_interrupt_drv_c extends uvm_driver#(
 
    semaphore               assert_until_ack_sem[32];
 
+   // Serializes the actual irq_drv[] rising edge across all 32 lines (not just same-index, unlike
+   // assert_until_ack_sem above): only one new edge is allowed at a time, and the holder keeps the
+   // lock for 2 extra cycles after driving it, so any two new rising edges are guaranteed to land
+   // on different clock edges and be at least 2 cycles apart. Deliberately does NOT gate on
+   // cntxt.vif.drv_cb.id_in_ready (the core's id_in_ready_o): id_in_ready_o stays low while the
+   // core is parked in WFI, so waiting on it here would block forever on the very interrupt meant
+   // to wake it.
+   semaphore               new_irq_edge_sem;
+
    // TLM
    uvm_analysis_port#(uvma_interrupt_seq_item_c)  ap;
 
@@ -66,6 +75,13 @@ class uvma_interrupt_drv_c extends uvm_driver#(
     * Drives the virtual interface's (cntxt.vif) signals using req's contents.
     */
    extern task drv_req(uvma_interrupt_seq_item_c req);
+
+   /**
+    * Waits for new_irq_edge_sem and cntxt.vif.drv_cb.id_in_ready, then drives irq_drv[index] high
+    * and holds the lock a couple more cycles so id_in_ready has time to respond before the next
+    * waiting caller re-checks it.
+    */
+   extern task wait_and_assert_irq_edge(int unsigned index);
 
    /**
     * Forked thread to handle interrupts
@@ -112,6 +128,8 @@ function void uvma_interrupt_drv_c::build_phase(uvm_phase phase);
    foreach (assert_until_ack_sem[i]) begin
       assert_until_ack_sem[i] = new(1);
    end
+
+   new_irq_edge_sem = new(1);
 endfunction : build_phase
 
 
@@ -174,6 +192,22 @@ task uvma_interrupt_drv_c::drv_req(uvma_interrupt_seq_item_c req);
 
 endtask : drv_req
 
+task uvma_interrupt_drv_c::wait_and_assert_irq_edge(int unsigned index);
+   new_irq_edge_sem.get(1);
+   // Previously also waited on cntxt.vif.drv_cb.id_in_ready here (the core's id_in_ready_o) before
+   // driving the edge, to avoid racing an in-flight exception request. Reverted: that wait can
+   // deadlock outright when the core is genuinely parked in WFI (id_in_ready_o stays low while
+   // asleep), since it then blocks forever waiting to "be ready" for the very interrupt that would
+   // wake it. The actual false-assertion hazard it was defending against
+   // (CVE2DontSkipExceptionReq/CVE2SetExceptionPCOnSpecialReqIfExpected on a withdrawn-but-still-
+   // latched request) is now fixed at its root in cve2_controller.sv (exception_req_withdrawn), so
+   // this driver-side gate is redundant as well as harmful. See
+   // E20DV/tmp/exception_req_pending_finding.md.
+   cntxt.vif.drv_cb.irq_drv[index] <= 1'b1;
+   repeat (2) @(cntxt.vif.drv_cb);
+   new_irq_edge_sem.put(1);
+endtask : wait_and_assert_irq_edge
+
 task uvma_interrupt_drv_c::assert_irq_until_ack(int unsigned index, int unsigned repeat_count, int unsigned skew);
    // If a thread is already running on this irq, then exit
    if (!assert_until_ack_sem[index].try_get(1))
@@ -182,7 +216,8 @@ task uvma_interrupt_drv_c::assert_irq_until_ack(int unsigned index, int unsigned
    repeat (skew) @(cntxt.vif.drv_cb);
 
    for (int loop = 0; loop < repeat_count; loop++) begin
-      repeat (skew) @(cntxt.vif.drv_cb);cntxt.vif.drv_cb.irq_drv[index] <= 1'b1;
+      repeat (skew) @(cntxt.vif.drv_cb);
+      wait_and_assert_irq_edge(index);
 
       while (1) begin
          @(cntxt.vif.mon_cb);
@@ -199,12 +234,12 @@ endtask : assert_irq_until_ack
 task uvma_interrupt_drv_c::assert_irq(int unsigned index, int unsigned skew);
    if (assert_until_ack_sem[index].try_get(1)) begin
       repeat (skew) @(cntxt.vif.drv_cb);
-      cntxt.vif.drv_cb.irq_drv[index] <= 1'b1;
+      wait_and_assert_irq_edge(index);
       assert_until_ack_sem[index].put(1);
       return;
    end
 
-   cntxt.vif.drv_cb.irq_drv[index] <= 1'b1;
+   wait_and_assert_irq_edge(index);
 endtask : assert_irq
 
 task uvma_interrupt_drv_c::deassert_irq(int unsigned index, int unsigned skew);

--- a/lib/uvm_agents/uvma_interrupt/uvma_interrupt_if.sv
+++ b/lib/uvm_agents/uvma_interrupt/uvma_interrupt_if.sv
@@ -36,6 +36,16 @@ interface uvma_interrupt_if
     wire        irq_ack;
     wire [4:0]  irq_id;
 
+    // 'id_in_ready': expected to be asserted when it's safe to assert a new interrupt/debug.
+    // In some cases, this will need to be probed from the DUT's controller.
+    // In the case of the CVE2, it does not support hardware nesting of interrupts/exceptions
+    // (cv32e20 User Manual, exception_interrupts.rst), and the "in flight" window is
+    // data-dependent (multi-cycle instructions, randomized memory-response latency),
+    // so a fixed cycle-count gap is not sufficient - see uvma_interrupt_drv_c.
+    // For DUTs that support hardware nesting, this signal can be tied high, and the driver
+    // is free to assert nested interrupts/debug-requests.
+    wire        id_in_ready;
+
     // Used to time true interrupt entry with tracer instruction retirement
     wire        deferint;
     wire        ovp_cpu_state_stepi;
@@ -70,8 +80,9 @@ interface uvma_interrupt_if
        * Used by uvma_interrupt_drv_c.
     */
     clocking drv_cb @(posedge clk or reset_n);
-        input #1step irq_ack, 
-                     irq_id;
+        input #1step irq_ack,
+                     irq_id,
+                     id_in_ready;
         output       irq_drv;
     endclocking : drv_cb
    


### PR DESCRIPTION
The CVE2 lacks two features supported by the CVE4 cores:
1. Nested interrupts.
2. Handshake signals for interrupts and debug_requests (see CV32E40P example below)

```systemverilog
     // CV32E40P Interrupt interface
    .irq_i                    (),
    .irq_ack_o                (),
    .irq_id_o                 (),

    // CV32E40P Debug interface
    .debug_req_i              (),
    .debug_havereset_o        (),
    .debug_running_o          (),
    .debug_halted_o           ()
```
These handshake signals can be used to throttle interrupts.  As this feature is lacking in CVE2, this PR adds the ability to probe the RTL of the CVE2 to know when it is safe to re-assert and interrupt or debug_request.